### PR TITLE
Pass a (pointer to a) secret key from the store to objective.Crank()

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -77,6 +77,7 @@ func (e *Engine) Run() {
 // handleMessage handles a Message from a peer go-nitro Wallet.
 // It
 // reads an objective from the store,
+// gets a pointer to a channel secret key from the store,
 // generates an updated objective and declaration of side effects,
 // commits the updated objective to the store,
 // executes the side effects and
@@ -84,8 +85,9 @@ func (e *Engine) Run() {
 func (e *Engine) handleMessage(message Message) {
 	objective := e.store.GetObjectiveById(message.ObjectiveId)
 	event := protocols.ObjectiveEvent{Sigs: message.Sigs}
-	updatedProtocol, sideEffects, waitingFor, _ := objective.Update(event).Crank() // TODO handle error
-	_ = e.store.SetObjective(updatedProtocol)                                      // TODO handle error
+	secretKey := e.store.GetChannelSecretKey()
+	updatedProtocol, sideEffects, waitingFor, _ := objective.Update(event).Crank(secretKey) // TODO handle error
+	_ = e.store.SetObjective(updatedProtocol)                                               // TODO handle error
 	e.executeSideEffects(sideEffects)
 	e.store.UpdateProgressLastMadeAt(message.ObjectiveId, waitingFor)
 }
@@ -93,6 +95,7 @@ func (e *Engine) handleMessage(message Message) {
 // handleChainEvent handles a Chain Event from the blockchain.
 // It
 // reads an objective from the store,
+// gets a pointer to a channel secret key from the store,
 // generates an updated objective and declaration of side effects,
 // commits the updated objective to the store,
 // executes the side effects and
@@ -100,11 +103,11 @@ func (e *Engine) handleMessage(message Message) {
 func (e *Engine) handleChainEvent(chainEvent ChainEvent) {
 	objective := e.store.GetObjectiveByChannelId(chainEvent.ChannelId)
 	event := protocols.ObjectiveEvent{Holdings: chainEvent.Holdings, AdjudicationStatus: chainEvent.AdjudicationStatus}
-	updatedProtocol, sideEffects, waitingFor, _ := objective.Update(event).Crank() // TODO handle error
-	_ = e.store.SetObjective(updatedProtocol)                                      // TODO handle error
+	secretKey := e.store.GetChannelSecretKey()
+	updatedProtocol, sideEffects, waitingFor, _ := objective.Update(event).Crank(secretKey) // TODO handle error
+	_ = e.store.SetObjective(updatedProtocol)                                               // TODO handle error
 	e.executeSideEffects(sideEffects)
 	e.store.UpdateProgressLastMadeAt(objective.Id(), waitingFor)
-
 }
 
 // handleAPIEvent handles an API Event (triggered by an API call)

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -8,6 +8,8 @@ import (
 
 // Store is responsible for persisting objectives, objective metadata, states, signatures, private keys and blockchain data
 type Store interface {
+	GetChannelSecretKey() *[]byte // Get a pointer to a secret key for signing channel updates
+
 	GetObjectiveById(protocols.ObjectiveId) protocols.Objective // Read an existing objective
 	GetObjectiveByChannelId(types.Bytes32) protocols.Objective  // Get the objective that currently owns the channel with the supplied ChannelId
 	SetObjective(protocols.Objective) error                     // Write an objective

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -44,7 +44,7 @@ type Objective interface {
 	Reject() Objective                     // returns an updated Objective (a copy, no mutation allowed), does not declare effects
 	Update(event ObjectiveEvent) Objective // returns an updated Objective (a copy, no mutation allowed), does not declare effects
 
-	Crank() (Objective, SideEffects, WaitingFor, error) // does *not* accept an event, but *does* declare side effects, and *does* return an updated Objective
+	Crank(secretKey *[]byte) (Objective, SideEffects, WaitingFor, error) // does *not* accept an event, but *does* accept a pointer to a signing key; declare side effects; return an updated Objective
 }
 
 // ObjectiveId is a unique identifier for an Objective.


### PR DESCRIPTION
We need to decide whether objectives synchronously sign state updates, or whether they declare them as side effects. 

My view is, if something *can* be performed synchronously during a crank, it should.

Therefore this PR adds a method to get a pointer to a secret key from the store. The engine calls this method and passes the pointer to an objective when it cranks it.

By passing the secret key by reference in this way, we avoid having multiple copies of the key in memory. 