### PR TITLE
Objective methods mutate the receiver

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -86,10 +86,11 @@ func (e *Engine) handleMessage(message Message) {
 	objective := e.store.GetObjectiveById(message.ObjectiveId)
 	event := protocols.ObjectiveEvent{Sigs: message.Sigs}
 	secretKey := e.store.GetChannelSecretKey()
-	updatedProtocol, sideEffects, waitingFor, _ := objective.Update(event).Crank(secretKey) // TODO handle error
-	_ = e.store.SetObjective(updatedProtocol)                                               // TODO handle error
+	objective.Update(event)
+	sideEffects, waitingFor, _ := objective.Crank(secretKey) // TODO handle error
+	_ = e.store.SetObjective(objective)                      // TODO handle error
 	e.executeSideEffects(sideEffects)
-	e.store.UpdateProgressLastMadeAt(message.ObjectiveId, waitingFor)
+	e.store.UpdateProgressLastMadeAt(objective.Id(), waitingFor)
 }
 
 // handleChainEvent handles a Chain Event from the blockchain.
@@ -104,8 +105,9 @@ func (e *Engine) handleChainEvent(chainEvent ChainEvent) {
 	objective := e.store.GetObjectiveByChannelId(chainEvent.ChannelId)
 	event := protocols.ObjectiveEvent{Holdings: chainEvent.Holdings, AdjudicationStatus: chainEvent.AdjudicationStatus}
 	secretKey := e.store.GetChannelSecretKey()
-	updatedProtocol, sideEffects, waitingFor, _ := objective.Update(event).Crank(secretKey) // TODO handle error
-	_ = e.store.SetObjective(updatedProtocol)                                               // TODO handle error
+	objective.Update(event)
+	sideEffects, waitingFor, _ := objective.Crank(secretKey) // TODO handle error
+	_ = e.store.SetObjective(objective)                      // TODO handle error
 	e.executeSideEffects(sideEffects)
 	e.store.UpdateProgressLastMadeAt(objective.Id(), waitingFor)
 }
@@ -121,13 +123,13 @@ func (e *Engine) handleAPIEvent(apiEvent APIEvent) {
 	}
 	if apiEvent.ObjectiveToReject != `` {
 		objective := e.store.GetObjectiveById(apiEvent.ObjectiveToReject)
-		updatedProtocol := objective.Reject()
-		_ = e.store.SetObjective(updatedProtocol) // TODO handle error
+		objective.Reject()
+		_ = e.store.SetObjective(objective) // TODO handle error
 	}
 	if apiEvent.ObjectiveToApprove != `` {
 		objective := e.store.GetObjectiveById(apiEvent.ObjectiveToReject)
-		updatedProtocol := objective.Approve()
-		_ = e.store.SetObjective(updatedProtocol) // TODO handle error
+		objective.Approve()
+		_ = e.store.SetObjective(objective) // TODO handle error
 	}
 }
 

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -10,7 +10,7 @@ import (
 type Store interface {
 	GetChannelSecretKey() *[]byte // Get a pointer to a secret key for signing channel updates
 
-	GetObjectiveById(protocols.ObjectiveId) protocols.Objective // Read an existing objective
+	GetObjectiveById(protocols.ObjectiveId) protocols.Objective // Read an existing objective and return a Deep Clone of it
 	GetObjectiveByChannelId(types.Bytes32) protocols.Objective  // Get the objective that currently owns the channel with the supplied ChannelId
 	SetObjective(protocols.Objective) error                     // Write an objective
 

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -53,14 +53,15 @@ type ObjectiveEvent struct {
 // 	* It is updated with external information arriving to the client
 // 	* After each update, it is cranked. This generates side effects and other metadata
 // 	* The metadata will eventually indicate that the Objective has stalled OR the Objective has completed successfully
+// NOTE the methods are not pure, since we expect to operate on a copy of the Objective.
 type Objective interface {
 	Id() ObjectiveId
 
-	Approve() Objective                    // returns an updated Objective (a copy, no mutation allowed), does not declare effects
-	Reject() Objective                     // returns an updated Objective (a copy, no mutation allowed), does not declare effects
-	Update(event ObjectiveEvent) Objective // returns an updated Objective (a copy, no mutation allowed), does not declare effects
+	Approve()                    // updates the Objective (mutates), does not declare effects
+	Reject()                     // updates the Objective (mutates), does not declare effects
+	Update(event ObjectiveEvent) // updates the Objective (mutates), does not declare effects
 
-	Crank(secretKey *[]byte) (Objective, SideEffects, WaitingFor, error) // does *not* accept an event, but *does* accept a pointer to a signing key; declare side effects; return an updated Objective
+	Crank(secretKey *[]byte) (SideEffects, WaitingFor, error) // does *not* accept an event, but *does* accept a pointer to a signing key; declare side effects; updates the Objective (mutates)
 }
 
 // ObjectiveId is a unique identifier for an Objective.


### PR DESCRIPTION
* by allowing objective.Crank to mutate the objective, we don’t need to return it. This sidesteps some typing headaches (see https://www.notion.so/statechannels/Golang-onboarding-218e0e14a51d4aed93b5acd119df86c4#714c8e2ffbbe4a64936712a5e8660e50 )

- we can maintain an overall functional approach by having the store objective getter always returning a copy (deep clone) of the objective. This will happen "for free" in most store implementations (with the exception of a memory store)
- another advantage is that now cloning is done in far fewer places overall (just in the store, not in several objective methods). We can write one test to ensure the store passes a copy and not a reference