### PR TITLE
Add unit test file for direct-funder

### DIFF
--- a/channel/state/state_test.go
+++ b/channel/state/state_test.go
@@ -2,31 +2,10 @@ package state
 
 import (
 	"bytes"
-	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/statechannels/go-nitro/channel/state/outcome"
-	"github.com/statechannels/go-nitro/types"
 )
-
-var chainId, _ = big.NewInt(0).SetString("9001", 10)
-
-var state = State{
-	ChainId: chainId,
-	Participants: []types.Address{
-		common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),
-		common.HexToAddress(`0xEe18fF1575055691009aa246aE608132C57a422c`),
-		common.HexToAddress(`0x95125c394F39bBa29178CAf5F0614EE80CBB1702`),
-	},
-	ChannelNonce:      big.NewInt(37140676580),
-	AppDefinition:     common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),
-	ChallengeDuration: big.NewInt(60),
-	AppData:           []byte{},
-	Outcome:           outcome.Exit{},
-	TurnNum:           big.NewInt(5),
-	IsFinal:           false,
-}
 
 // The following constants are generated from our ts nitro-protocol package
 var correctChannelId = common.HexToHash(`b79270eb4cf4d11dcd5cf44c6337b1c9e4730dc3c26f022567bcf2eb63557a72`)
@@ -41,19 +20,19 @@ var correctSignature = Signature{
 
 func TestChannelId(t *testing.T) {
 	want := correctChannelId
-	got, error := state.ChannelId()
+	got, error := TestState.ChannelId()
 	checkErrorAndTestForEqualBytes(t, error, "channelId", got.Bytes(), want.Bytes())
 }
 
 func TestHash(t *testing.T) {
 	want := correctStateHash
-	got, error := state.Hash()
+	got, error := TestState.Hash()
 	checkErrorAndTestForEqualBytes(t, error, "state hash", got.Bytes(), want.Bytes())
 }
 
 func TestSign(t *testing.T) {
 	want_r, want_s, want_v := correctSignature.r, correctSignature.s, correctSignature.v
-	got, error := state.Sign(signerPrivateKey)
+	got, error := TestState.Sign(signerPrivateKey)
 	got_r, got_s, got_v := got.r, got.s, got.v
 
 	if error != nil {
@@ -71,7 +50,7 @@ func TestSign(t *testing.T) {
 }
 
 func TestRecoverSigner(t *testing.T) {
-	got, error := state.RecoverSigner(correctSignature)
+	got, error := TestState.RecoverSigner(correctSignature)
 	want := signerAddress
 	checkErrorAndTestForEqualBytes(t, error, "signer recovered", got.Bytes(), want.Bytes())
 }

--- a/channel/state/test-fixtures.go
+++ b/channel/state/test-fixtures.go
@@ -1,0 +1,27 @@
+package state
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/types"
+)
+
+var chainId, _ = big.NewInt(0).SetString("9001", 10)
+
+var TestState = State{
+	ChainId: chainId,
+	Participants: []types.Address{
+		common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),
+		common.HexToAddress(`0xEe18fF1575055691009aa246aE608132C57a422c`),
+		common.HexToAddress(`0x95125c394F39bBa29178CAf5F0614EE80CBB1702`),
+	},
+	ChannelNonce:      big.NewInt(37140676580),
+	AppDefinition:     common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),
+	ChallengeDuration: big.NewInt(60),
+	AppData:           []byte{},
+	Outcome:           outcome.Exit{},
+	TurnNum:           big.NewInt(5),
+	IsFinal:           false,
+}

--- a/protocols/direct-funding.go
+++ b/protocols/direct-funding.go
@@ -59,10 +59,11 @@ func NewDirectFundingObjectiveState(initialState state.State, myAddress types.Ad
 	if err != nil {
 		return init, err
 	}
+	init.ParticipantIndex = make(map[types.Address]uint)
 	for i, v := range initialState.Participants {
 		init.ParticipantIndex[v] = uint(i)
 	}
-
+	init.ExpectedStates = make([]state.State, 2)
 	init.ExpectedStates[0] = initialState
 
 	fixed := initialState.FixedPart()

--- a/protocols/direct-funding_test.go
+++ b/protocols/direct-funding_test.go
@@ -2,34 +2,12 @@ package protocols
 
 import (
 	"fmt"
-	"math/big"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/channel/state"
-	"github.com/statechannels/go-nitro/channel/state/outcome"
-	"github.com/statechannels/go-nitro/types"
 )
 
-var chainId, _ = big.NewInt(0).SetString("9001", 10)
-
-var initialState = state.State{ // todo factor into a test fixture
-	ChainId: chainId,
-	Participants: []types.Address{
-		common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),
-		common.HexToAddress(`0xEe18fF1575055691009aa246aE608132C57a422c`),
-		common.HexToAddress(`0x95125c394F39bBa29178CAf5F0614EE80CBB1702`),
-	},
-	ChannelNonce:      big.NewInt(37140676580),
-	AppDefinition:     common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),
-	ChallengeDuration: big.NewInt(60),
-	AppData:           []byte{},
-	Outcome:           outcome.Exit{},
-	TurnNum:           big.NewInt(5),
-	IsFinal:           false,
-}
-
 func TestNew(t *testing.T) {
-	s, _ := NewDirectFundingObjectiveState(initialState, initialState.Participants[0])
+	s, _ := NewDirectFundingObjectiveState(state.TestState, state.TestState.Participants[0])
 	fmt.Println(s)
 }

--- a/protocols/direct-funding_test.go
+++ b/protocols/direct-funding_test.go
@@ -1,13 +1,14 @@
 package protocols
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/statechannels/go-nitro/channel/state"
 )
 
 func TestNew(t *testing.T) {
-	s, _ := NewDirectFundingObjectiveState(state.TestState, state.TestState.Participants[0])
-	fmt.Println(s)
+	_, err := NewDirectFundingObjectiveState(state.TestState, state.TestState.Participants[0])
+	if err != nil {
+		t.Error(err)
+	}
 }

--- a/protocols/direct-funding_test.go
+++ b/protocols/direct-funding_test.go
@@ -1,0 +1,35 @@
+package protocols
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/types"
+)
+
+var chainId, _ = big.NewInt(0).SetString("9001", 10)
+
+var initialState = state.State{ // todo factor into a test fixture
+	ChainId: chainId,
+	Participants: []types.Address{
+		common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),
+		common.HexToAddress(`0xEe18fF1575055691009aa246aE608132C57a422c`),
+		common.HexToAddress(`0x95125c394F39bBa29178CAf5F0614EE80CBB1702`),
+	},
+	ChannelNonce:      big.NewInt(37140676580),
+	AppDefinition:     common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),
+	ChallengeDuration: big.NewInt(60),
+	AppData:           []byte{},
+	Outcome:           outcome.Exit{},
+	TurnNum:           big.NewInt(5),
+	IsFinal:           false,
+}
+
+func TestNew(t *testing.T) {
+	s, _ := NewDirectFundingObjectiveState(initialState, initialState.Participants[0])
+	fmt.Println(s)
+}


### PR DESCRIPTION
This PR:

* adds a test file for the direct-funding protocol
* adds a test for the constructor
* ... which reveals the constructor currently panics...
* ...fixes the panics
* factors out a `TestState` object so tests do not need to construct new literal `state.State` objects.