### PR TITLE
run golangci-lint first in github action, instead of setup-go

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,16 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.17
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v2.5.2
 
       - name: Build
         run: go build -v ./...
-
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2.5.2
 
       - name: Test
         run: go test -v ./...


### PR DESCRIPTION
golangci-lint already sets up go and is designed to be run first

Closes #31 . This PR drastically improves the output of the linting stage of our CI. 

This was manually tested by introducing an intentional linting error: https://github.com/statechannels/go-nitro/runs/4238244289?check_suite_focus=true . I have since removed the offending commit. 