### PR TITLE
Convert `Destination` to embed `Bytes32`...

### DIFF
--- a/channel/state/outcome/outcome_test.go
+++ b/channel/state/outcome/outcome_test.go
@@ -13,13 +13,13 @@ import (
 func TestEqualAllocations(t *testing.T) {
 
 	var a1 = Allocations{{ // [{Alice: 2}]
-		Destination:    types.Destination(common.HexToHash("0x0a")),
+		Destination:    types.Destination{Bytes32: common.HexToHash("0x0a")},
 		Amount:         big.NewInt(2),
 		AllocationType: 0,
 		Metadata:       make(types.Bytes, 0)}}
 
 	var a2 = Allocations{{ // [{Alice: 2}]
-		Destination:    types.Destination(common.HexToHash("0x0a")),
+		Destination:    types.Destination{Bytes32: common.HexToHash("0x0a")},
 		Amount:         big.NewInt(2),
 		AllocationType: 0,
 		Metadata:       make(types.Bytes, 0)}}
@@ -39,7 +39,7 @@ func TestEqualExits(t *testing.T) {
 		Asset:    common.HexToAddress("0x00"),
 		Metadata: make(types.Bytes, 0),
 		Allocations: Allocations{{
-			Destination:    types.Destination(common.HexToHash("0x0a")),
+			Destination:    types.Destination{Bytes32: common.HexToHash("0x0a")},
 			Amount:         big.NewInt(2),
 			AllocationType: 0,
 			Metadata:       make(types.Bytes, 0)}},
@@ -50,7 +50,7 @@ func TestEqualExits(t *testing.T) {
 		Asset:    common.HexToAddress("0x00"),
 		Metadata: make(types.Bytes, 0),
 		Allocations: Allocations{{
-			Destination:    types.Destination(common.HexToHash("0x0a")),
+			Destination:    types.Destination{Bytes32: common.HexToHash("0x0a")},
 			Amount:         big.NewInt(2),
 			AllocationType: 0,
 			Metadata:       make(types.Bytes, 0)}},
@@ -70,7 +70,7 @@ func TestEqualExits(t *testing.T) {
 			Asset:    common.HexToAddress("0x01"), // distinct Asset
 			Metadata: make(types.Bytes, 0),
 			Allocations: Allocations{{
-				Destination:    types.Destination(common.HexToHash("0x0a")),
+				Destination:    types.Destination{Bytes32: common.HexToHash("0x0a")},
 				Amount:         big.NewInt(2),
 				AllocationType: 0,
 				Metadata:       make(types.Bytes, 0)}},
@@ -79,7 +79,7 @@ func TestEqualExits(t *testing.T) {
 			Asset:    common.HexToAddress("0x00"),
 			Metadata: []byte{1}, // distinct metadata
 			Allocations: Allocations{{
-				Destination:    types.Destination(common.HexToHash("0x0a")),
+				Destination:    types.Destination{Bytes32: common.HexToHash("0x0a")},
 				Amount:         big.NewInt(2),
 				AllocationType: 0,
 				Metadata:       make(types.Bytes, 0)}},
@@ -88,7 +88,7 @@ func TestEqualExits(t *testing.T) {
 			Asset:    common.HexToAddress("0x00"),
 			Metadata: make(types.Bytes, 0),
 			Allocations: Allocations{{
-				Destination:    types.Destination(common.HexToHash("0x0b")), // distinct destination
+				Destination:    types.Destination{Bytes32: common.HexToHash("0x0b")}, // distinct destination
 				Amount:         big.NewInt(2),
 				AllocationType: 0,
 				Metadata:       make(types.Bytes, 0)}},
@@ -97,7 +97,7 @@ func TestEqualExits(t *testing.T) {
 			Asset:    common.HexToAddress("0x00"),
 			Metadata: make(types.Bytes, 0),
 			Allocations: Allocations{{
-				Destination:    types.Destination(common.HexToHash("0x0a")),
+				Destination:    types.Destination{Bytes32: common.HexToHash("0x0a")},
 				Amount:         big.NewInt(3), // distinct amount
 				AllocationType: 0,
 				Metadata:       make(types.Bytes, 0)}},
@@ -106,7 +106,7 @@ func TestEqualExits(t *testing.T) {
 			Asset:    common.HexToAddress("0x00"),
 			Metadata: make(types.Bytes, 0),
 			Allocations: Allocations{{
-				Destination:    types.Destination(common.HexToHash("0x0a")),
+				Destination:    types.Destination{Bytes32: common.HexToHash("0x0a")},
 				Amount:         big.NewInt(2),
 				AllocationType: 1, // distinct allocationType
 				Metadata:       make(types.Bytes, 0)}},
@@ -115,7 +115,7 @@ func TestEqualExits(t *testing.T) {
 			Asset:    common.HexToAddress("0x00"),
 			Metadata: make(types.Bytes, 0),
 			Allocations: Allocations{{
-				Destination:    types.Destination(common.HexToHash("0x0a")),
+				Destination:    types.Destination{Bytes32: common.HexToHash("0x0a")},
 				Amount:         big.NewInt(2),
 				AllocationType: 0,
 				Metadata:       []byte{1}}}, // distinct metadata
@@ -131,7 +131,7 @@ func TestEqualExits(t *testing.T) {
 
 var zeroBytes = []byte{}
 var testAllocations = Allocations{{
-	Destination:    types.Destination(common.HexToHash("0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f")),
+	Destination:    types.Destination{Bytes32: common.HexToHash("0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f")},
 	Amount:         big.NewInt(1),
 	AllocationType: 0,
 	Metadata:       zeroBytes}}

--- a/channel/state/outcome/transfer_test.go
+++ b/channel/state/outcome/transfer_test.go
@@ -13,19 +13,19 @@ func TestComputeTransferEffectsAndInteractions(t *testing.T) {
 	initialHoldings := *big.NewInt(100)
 
 	var initialAllocations = Allocations{{ // [{Alice: 2}]
-		Destination:    types.Destination(common.HexToHash("0x0a")),
+		Destination:    types.Destination{Bytes32: common.HexToHash("0x0a")},
 		Amount:         big.NewInt(2),
 		AllocationType: 0,
 		Metadata:       make(types.Bytes, 0)}}
 
 	var expectedNewAllocations = Allocations{{ // [{Alice: 0}]
-		Destination:    types.Destination(common.HexToHash("0x0a")),
+		Destination:    types.Destination{Bytes32: common.HexToHash("0x0a")},
 		Amount:         big.NewInt(0),
 		AllocationType: 0,
 		Metadata:       make(types.Bytes, 0)}}
 
 	var expectedExitAllocations = Allocations{{ // [{Alice: 2}]
-		Destination:    types.Destination(common.HexToHash("0x0a")),
+		Destination:    types.Destination{Bytes32: common.HexToHash("0x0a")},
 		Amount:         big.NewInt(2),
 		AllocationType: 0,
 		Metadata:       make(types.Bytes, 0)}}

--- a/channel/state/state.go
+++ b/channel/state/state.go
@@ -75,7 +75,7 @@ func (s State) ChannelId() (types.Destination, error) {
 		{Type: uint256},
 	}.Pack(s.ChainId, s.Participants, s.ChannelNonce)
 
-	channelId := types.Destination(crypto.Keccak256Hash(encodedChannelPart))
+	channelId := types.Destination{Bytes32: crypto.Keccak256Hash(encodedChannelPart)}
 
 	if error == nil && channelId.IsExternal() {
 		error = errors.New("channelId is an external destination") // This is extremely unlikely

--- a/types/destination.go
+++ b/types/destination.go
@@ -6,7 +6,7 @@ import (
 
 // IsExternal returns true if the destination has the 12 leading bytes as zero, false otherwise
 func (d Destination) IsExternal() bool {
-	for _, b := range d[0:12] {
+	for _, b := range d.Bytes32[0:12] {
 		if b != 0 {
 			return false
 		}
@@ -22,16 +22,8 @@ func (d Destination) ToAddress() (Address, error) {
 	}
 
 	address := Address{}
-	for i, b := range d[12:] {
+	for i, b := range d.Bytes32[12:] {
 		address[i] = b
 	}
 	return address, nil
-}
-
-func (d Destination) String() string {
-	return Bytes32(d).String()
-}
-
-func (d Destination) Bytes() []byte {
-	return Bytes32(d).Bytes()
 }

--- a/types/destination_test.go
+++ b/types/destination_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestIsExternal(t *testing.T) {
 
-	external := Destination(common.HexToHash("0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f"))
-	internal := Destination(common.HexToHash("0x6f7123E3A80C9813eF50213A96f7123E3A80C9813eF50213ADEd0e4511CB820f"))
+	external := Destination{common.HexToHash("0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f")}
+	internal := Destination{common.HexToHash("0x6f7123E3A80C9813eF50213A96f7123E3A80C9813eF50213ADEd0e4511CB820f")}
 
 	if !external.IsExternal() {
 		t.Errorf("Received bytes %x was declared internal, when it is external", external)
@@ -28,15 +28,15 @@ func TestToAddress(t *testing.T) {
 		common.HexToAddress(`0x96f7123E3A80C9813eF50213ADEd0e4511CB820f`),
 	}
 	areExternal := []Destination{
-		Destination(common.HexToHash("0x000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")),
-		Destination(common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000")),
-		Destination(common.HexToHash("0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f")),
+		{common.HexToHash("0x000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")},
+		{common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000")},
+		{common.HexToHash("0x00000000000000000000000096f7123E3A80C9813eF50213ADEd0e4511CB820f")},
 	}
 
 	areNotExternal := []Destination{
-		Destination(common.HexToHash("0x000000000000000000000001aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")),
-		Destination(common.HexToHash("0x100000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")),
-		Destination(common.HexToHash("0x0000000000b0000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")),
+		{common.HexToHash("0x000000000000000000000001aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")},
+		{common.HexToHash("0x100000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")},
+		{common.HexToHash("0x0000000000b0000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")},
 	}
 
 	for i, extAddress := range areExternal {

--- a/types/types.go
+++ b/types/types.go
@@ -14,7 +14,7 @@ type Address = common.Address
 type Bytes32 = common.Hash
 
 // A nitro destination - either a left-zero-padded ethereum address or an application specific identifier
-type Destination Bytes32
+type Destination struct{ Bytes32 }
 
 // An arbitrary length byte slice
 type Bytes []byte


### PR DESCRIPTION
**NOTE**: this branch is broken. Draft PR opened for comment.

From https://github.com/statechannels/go-nitro/issues/49#issuecomment-970409722 :

> I tried this out on branch `embedded-destination-type` - [42ae59d](https://github.com/statechannels/go-nitro/commit/42ae59d0c875a4562a506c273514d64d1c35b3af).
> 
> **Pro**: forwarding methods are removed from `Destination`, but still available via the embedded `Bytes32` struct **Con**: constructing **nested** literals becomes still-more verbose, because the linter wants the field `Bytes32` to be labelled. See, for example, `outcome_test.go` in the linked commit. **Blocker**: the current code fails `go test ./...` because of the abi unmarshaling:
> 
> ```
> 2021/11/16 11:21:29 error unmarshallingjson: cannot unmarshal non-string into Go struct field Allocation.Allocations.Destination of type common.Hash
> ```
> 
> My initial fiddling with `allocationsTy` and `rawAllocationsType` were not successful. @geoknee: you had more success with me in the marshal / unmarshal department. If there is a quick fix that you see we may prefer to merge this. If not, I think the current implementation is not so awful.



