### PR TITLE
Export R,S,V components of `state.Signature`

### DIFF
--- a/channel/state/signatures.go
+++ b/channel/state/signatures.go
@@ -11,9 +11,9 @@ import (
 
 // Signature is an ECDSA signature
 type Signature struct {
-	r []byte
-	s []byte
-	v byte
+	R []byte
+	S []byte
+	V byte
 }
 
 // SignEthereumMessage accepts an arbitrary message, prepends a known message,
@@ -59,16 +59,16 @@ func computeEthereumSignedMessageDigest(message []byte) []byte {
 
 // splitSignature takes a 65 bytes signature in the [R||S||V] format and returns the individual components
 func splitSignature(concatenatedSignature []byte) (signature Signature) {
-	signature.r = concatenatedSignature[:32]
-	signature.s = concatenatedSignature[32:64]
-	signature.v = concatenatedSignature[64]
+	signature.R = concatenatedSignature[:32]
+	signature.S = concatenatedSignature[32:64]
+	signature.V = concatenatedSignature[64]
 	return
 }
 
 // joinSignature takes a Signature and returns a 65 byte concatenatedSignature in the [R||S||V] format
 func joinSignature(signature Signature) (concatenatedSignature []byte) {
-	concatenatedSignature = append(concatenatedSignature, signature.r...)
-	concatenatedSignature = append(concatenatedSignature, signature.s...)
-	concatenatedSignature = append(concatenatedSignature, signature.v)
+	concatenatedSignature = append(concatenatedSignature, signature.R...)
+	concatenatedSignature = append(concatenatedSignature, signature.S...)
+	concatenatedSignature = append(concatenatedSignature, signature.V)
 	return
 }

--- a/channel/state/state_test.go
+++ b/channel/state/state_test.go
@@ -8,15 +8,15 @@ import (
 )
 
 // The following constants are generated from our ts nitro-protocol package
-var correctChannelId = common.HexToHash(`b79270eb4cf4d11dcd5cf44c6337b1c9e4730dc3c26f022567bcf2eb63557a72`)
-var correctStateHash = common.HexToHash(`3e460a311caf589f1cf80036adfd092d05a30ff72f234918c5cdbc6c4333343a`)
+var correctChannelId = common.HexToHash(`cd578811171bb0291c7dc59081b9a910960b78001dece1954c00da9d8c12a925`)
+var correctStateHash = common.HexToHash(`e77a7a870087be40371b8c9b9f50a7c0e410387ce7ea8a22c9c61ea837277420`)
 var signerPrivateKey = common.Hex2Bytes(`caab404f975b4620747174a75f08d98b4e5a7053b691b41bcfc0d839d48b7634`)
 var signerAddress = common.HexToAddress(`F5A1BB5607C9D079E46d1B3Dc33f257d937b43BD`)
 var correctSignature = Signature{
-	common.Hex2Bytes(`59d8e91bd182fb4d489bb2d76a6735d494d5bea24e4b51dd95c9d219293312d9`),
-	common.Hex2Bytes(`32274a3cec23c31e0c073b3c071cf6e0c21260b0d292a10e6a04257a2d8e87fa`),
-	byte(1), // ethers-js gives v:28, which is a legacy representation. and recoveryParam: 1 which corresponds to v here (i.e. it is the normalized version)
-} // ethers "joinSignature" gives 0x59d8e91bd182fb4d489bb2d76a6735d494d5bea24e4b51dd95c9d219293312d932274a3cec23c31e0c073b3c071cf6e0c21260b0d292a10e6a04257a2d8e87fa1c
+	common.Hex2Bytes(`ae94c67295f65a8de360e80aa50cba3988810239178f03d54e4dd9f95860c182`),
+	common.Hex2Bytes(`143fd9bfc0438313fbf50fcaad82be25f1a9d536bf7efe951f20ced3f721694c`),
+	byte(0),
+}
 
 func TestChannelId(t *testing.T) {
 	want := correctChannelId
@@ -31,9 +31,9 @@ func TestHash(t *testing.T) {
 }
 
 func TestSign(t *testing.T) {
-	want_r, want_s, want_v := correctSignature.r, correctSignature.s, correctSignature.v
+	want_r, want_s, want_v := correctSignature.R, correctSignature.S, correctSignature.V
 	got, error := TestState.Sign(signerPrivateKey)
-	got_r, got_s, got_v := got.r, got.s, got.v
+	got_r, got_s, got_v := got.R, got.S, got.V
 
 	if error != nil {
 		t.Error(error)

--- a/channel/state/test-fixtures.go
+++ b/channel/state/test-fixtures.go
@@ -13,7 +13,7 @@ var chainId, _ = big.NewInt(0).SetString("9001", 10)
 var TestState = State{
 	ChainId: chainId,
 	Participants: []types.Address{
-		common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),
+		common.HexToAddress(`0xF5A1BB5607C9D079E46d1B3Dc33f257d937b43BD`), // private key caab404f975b4620747174a75f08d98b4e5a7053b691b41bcfc0d839d48b7634
 		common.HexToAddress(`0xEe18fF1575055691009aa246aE608132C57a422c`),
 		common.HexToAddress(`0x95125c394F39bBa29178CAf5F0614EE80CBB1702`),
 	},


### PR DESCRIPTION
And swap out participant 0 in TestState (we would like to use an address we know the private key for)

These changes allow us to:
* construct literal signatures in packages other than `state`
* produce valid signatures by participants of the `TestState` (because we have recorded a private key for one of the participants

Both of these abilities are necessary for completing #51.

