### PR TITLE
Add unit tests for `Funds` methods

### DIFF
--- a/types/funds.go
+++ b/types/funds.go
@@ -51,17 +51,25 @@ func Sum(a ...Funds) Funds {
 	return sum
 }
 
-// Equal returns true if reciever `f` and input `g` are identical.
+// Equal returns true if reciever `f` and input `g` are identical in value.
 //
-// Note that a zero-balance does NOT equal a non-balance: {[0x0a,0x00]} != {}
+// Note that a zero-balance equals a non-balance: {[0x0a,0x00],[0x0b,0x01]} == {[0x0b,0x01]}
 func (f Funds) Equal(g Funds) bool {
-	if len(f) != len(g) {
-		return false
-	}
+	return f.isMatchedBy(g) && g.isMatchedBy(f)
+}
+
+// isMatchedBy returns true if each of `f`'s non-zero asset balances is matched by the
+// same asset-balance in `g`
+func (f Funds) isMatchedBy(g Funds) bool {
+	zero := big.NewInt(0)
 
 	for asset, amount := range f {
-		if g[asset].Cmp(amount) != 0 {
-			return false
+		// only check g for non-zero f balances
+		if amount.Cmp(zero) > 0 {
+			gAmount, ok := g[asset]
+			if !ok || gAmount.Cmp(amount) != 0 {
+				return false
+			}
 		}
 	}
 

--- a/types/funds.go
+++ b/types/funds.go
@@ -42,8 +42,8 @@ func (h Funds) Add(a ...Funds) Funds {
 func Sum(a ...Funds) Funds {
 	sum := Funds{}
 
-	for _, holdings := range a {
-		for asset, amount := range holdings {
+	for _, funds := range a {
+		for asset, amount := range funds {
 			if sum[asset] == nil {
 				sum[asset] = big.NewInt(0)
 			}

--- a/types/funds.go
+++ b/types/funds.go
@@ -19,7 +19,7 @@ func (h Funds) String() string {
 	}
 	var s string = "{"
 	for asset, amount := range h {
-		s += "[" + asset.Hex() + "," + amount.Text(64) + "]"
+		s += "[" + asset.Hex() + "," + amount.Text(10) + "]"
 	}
 	s = s + "}"
 	return s

--- a/types/funds.go
+++ b/types/funds.go
@@ -44,6 +44,10 @@ func Sum(a ...Funds) Funds {
 
 	for _, holdings := range a {
 		for asset, amount := range holdings {
+			if sum[asset] == nil {
+				sum[asset] = big.NewInt(0)
+			}
+
 			sum[asset] = sum[asset].Add(sum[asset], amount)
 		}
 	}

--- a/types/funds.go
+++ b/types/funds.go
@@ -50,3 +50,20 @@ func Sum(a ...Funds) Funds {
 
 	return sum
 }
+
+// Equal returns true if reciever `f` and input `g` are identical.
+//
+// Note that a zero-balance does NOT equal a non-balance: {[0x0a,0x00]} != {}
+func (f Funds) Equal(g Funds) bool {
+	if len(f) != len(g) {
+		return false
+	}
+
+	for asset, amount := range f {
+		if g[asset].Cmp(amount) != 0 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/types/funds.go
+++ b/types/funds.go
@@ -55,19 +55,19 @@ func Sum(a ...Funds) Funds {
 //
 // Note that a zero-balance equals a non-balance: {[0x0a,0x00],[0x0b,0x01]} == {[0x0b,0x01]}
 func (f Funds) Equal(g Funds) bool {
-	return f.isMatchedBy(g) && g.isMatchedBy(f)
+	return f.canAfford(g) && g.canAfford(f)
 }
 
-// isMatchedBy returns true if each of `f`'s non-zero asset balances is matched by the
-// same asset-balance in `g`
-func (f Funds) isMatchedBy(g Funds) bool {
+// canAfford returns true if each of `g`'s non-zero asset balances is matched
+// or exceeded by the same asset-balance in `f`
+func (f Funds) canAfford(g Funds) bool {
 	zero := big.NewInt(0)
 
-	for asset, amount := range f {
-		// only check g for non-zero f balances
+	for asset, amount := range g {
+		// only check f for non-zero g balances
 		if amount.Cmp(zero) > 0 {
-			gAmount, ok := g[asset]
-			if !ok || gAmount.Cmp(amount) != 0 {
+			fAmount, ok := f[asset]
+			if !ok || fAmount.Cmp(amount) == -1 {
 				return false
 			}
 		}

--- a/types/funds_test.go
+++ b/types/funds_test.go
@@ -1,0 +1,48 @@
+package types
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var testData map[string]Funds = map[string]Funds{
+	"a": {
+		common.HexToAddress("0x00"): big.NewInt(1),
+	},
+	"b": {
+		common.HexToAddress("0x00"): big.NewInt(1),
+	},
+	"c": {
+		common.HexToAddress("0x01"): big.NewInt(1),
+	},
+	"d": {
+		common.HexToAddress("0x02"): big.NewInt(1),
+	},
+	// manually calculated sums
+	"ab": {
+		common.HexToAddress("0x00"): big.NewInt(2),
+	},
+	"ac": {
+		common.HexToAddress("0x00"): big.NewInt(1),
+		common.HexToAddress("0x01"): big.NewInt(1),
+	},
+	"abc": {
+		common.HexToAddress("0x00"): big.NewInt(2),
+		common.HexToAddress("0x01"): big.NewInt(1),
+	},
+	"abcd": {
+		common.HexToAddress("0x00"): big.NewInt(2),
+		common.HexToAddress("0x01"): big.NewInt(1),
+		common.HexToAddress("0x02"): big.NewInt(1),
+	},
+}
+
+func TestSum(t *testing.T) {
+
+}
+
+func TestEqual(t *testing.T) {
+
+}

--- a/types/funds_test.go
+++ b/types/funds_test.go
@@ -8,6 +8,16 @@ import (
 )
 
 var testData map[string]Funds = map[string]Funds{
+	"blank": {},
+	"zeros": {
+		common.HexToAddress("0x00"): big.NewInt(0),
+		common.HexToAddress("0x01"): big.NewInt(0),
+		common.HexToAddress("0x02"): big.NewInt(0),
+		common.HexToAddress("0x03"): big.NewInt(0),
+		common.HexToAddress("0x0a"): big.NewInt(0),
+		common.HexToAddress("0x0b"): big.NewInt(0),
+		common.HexToAddress("0x0c"): big.NewInt(0),
+	},
 	"a": {
 		common.HexToAddress("0x00"): big.NewInt(1),
 	},
@@ -23,6 +33,9 @@ var testData map[string]Funds = map[string]Funds{
 	"e": {
 		common.HexToAddress("0x00"):  big.NewInt(1),
 		common.HexToAddress("0xabc"): big.NewInt(0),
+	},
+	"f": {
+		common.HexToAddress("0x00"): big.NewInt(2),
 	},
 	// manually calculated sums
 	"ab": {

--- a/types/funds_test.go
+++ b/types/funds_test.go
@@ -90,6 +90,37 @@ func TestSum(t *testing.T) {
 	}
 }
 
+func TestAdd(t *testing.T) {
+	for _, f := range testData {
+		withZeros := f.Add(testData["zeros"])
+
+		if !withZeros.Equal(f) {
+			t.Errorf("expected %s + %s to equal %s, but it did not", f, testData["zeros"], withZeros)
+		}
+
+		withBlanks := f.Add(testData["blanks"])
+
+		if !withBlanks.Equal(f) {
+			t.Errorf("expected %s + %s to equal %s, but it did not", f, testData["zeros"], withZeros)
+		}
+	}
+
+	equalPairs := []fundsPair{
+		{testData["a"].Add(testData["b"]),
+			testData["ab"]},
+		{testData["a"].Add(testData["b"], testData["c"]),
+			testData["abc"]},
+		{testData["a"].Add(testData["b"]).Add(testData["c"]).Add(testData["d"]),
+			testData["abcd"]},
+	}
+
+	for i, p := range equalPairs {
+		if !p.a.Equal(p.b) {
+			t.Errorf("test_sum_%d: expected %s to equal %s, but it did not", i, p.a, p.b)
+		}
+	}
+}
+
 func TestCanAfford(t *testing.T) {
 	expectedButDidNot := "expected %s to afford %s, but it didn't"
 	expectedNotButDid := "expected %s to not afford %s, but it did"

--- a/types/funds_test.go
+++ b/types/funds_test.go
@@ -57,7 +57,7 @@ func TestEqual(t *testing.T) {
 		}
 	}
 
-	equalPairs := []Pair{
+	equalPairs := []fundsPair{
 		{testData["a"], testData["b"]},
 		{testData["a"], testData["e"]},
 	}
@@ -70,7 +70,7 @@ func TestEqual(t *testing.T) {
 		}
 	}
 
-	unequalPairs := []Pair{
+	unequalPairs := []fundsPair{
 		{testData["a"], testData["c"]},
 		{testData["a"], testData["d"]},
 		{testData["a"], testData["ab"]},
@@ -86,7 +86,7 @@ func TestEqual(t *testing.T) {
 
 }
 
-type Pair struct {
+type fundsPair struct {
 	a Funds
 	b Funds
 }

--- a/types/funds_test.go
+++ b/types/funds_test.go
@@ -139,8 +139,8 @@ func TestEqual(t *testing.T) {
 	}
 
 	equalPairs := []fundsPair{
+		{testData["zeros"], testData["blank"]},
 		{testData["a"], testData["b"]},
-		{testData["a"], testData["e"]},
 	}
 
 	for _, p := range equalPairs {
@@ -155,6 +155,9 @@ func TestEqual(t *testing.T) {
 		{testData["a"], testData["c"]},
 		{testData["a"], testData["d"]},
 		{testData["a"], testData["ab"]},
+		{testData["blank"], testData["a"]},
+		{testData["zeros"], testData["a"]},
+		{testData["abc"], testData["abcd"]},
 	}
 
 	for _, p := range unequalPairs {

--- a/types/funds_test.go
+++ b/types/funds_test.go
@@ -60,6 +60,74 @@ func TestSum(t *testing.T) {
 
 }
 
+func TestCanAfford(t *testing.T) {
+	expectedButDidNot := "expected %s to afford %s, but it didn't"
+	expectedNotButDid := "expected %s to not afford %s, but it did"
+
+	// Check self-affordance, affordance of blank, affordance of zeros
+	for _, f := range testData {
+		canAfford := f.canAfford(f)
+
+		if !canAfford {
+			t.Errorf(expectedButDidNot, f, f)
+		}
+
+		canAffordBlank := f.canAfford(testData["blank"])
+
+		if !canAffordBlank {
+			t.Errorf(expectedButDidNot, f, testData["blank"])
+		}
+
+		canAffordZeros := f.canAfford(testData["zeros"])
+
+		if !canAffordZeros {
+			t.Errorf(expectedButDidNot, f, testData["zeros"])
+		}
+	}
+
+	canAffordPairs := []fundsPair{
+		{testData["a"], testData["b"]}, // equal funds
+		{testData["b"], testData["a"]},
+		{testData["f"], testData["a"]}, // more of single asset
+		{testData["ab"], testData["a"]},
+		{testData["ab"], testData["b"]},
+		{testData["abc"], testData["b"]}, // mixed assets, enough of "relevant asset(s)"
+		{testData["abcd"], testData["b"]},
+		{testData["abcd"], testData["ab"]},
+		{testData["abcd"], testData["abc"]},
+	}
+
+	for _, p := range canAffordPairs {
+		canAfford := p.a.canAfford(p.b)
+
+		if !canAfford {
+			t.Errorf(expectedButDidNot, p.a, p.b)
+		}
+	}
+
+	cannotAffordPairs := []fundsPair{
+		{testData["zeros"], testData["a"]}, // zero cannot afford things
+		{testData["blank"], testData["a"]}, // blank cannot afford things
+		{testData["a"], testData["c"]},     // different assets
+		{testData["c"], testData["a"]},
+		{testData["a"], testData["f"]}, // less of single asset
+		{testData["a"], testData["ab"]},
+		{testData["b"], testData["ab"]},
+		{testData["b"], testData["abc"]}, // mixed assets, less of "relevant asset(s)"
+		{testData["a"], testData["abcd"]},
+		{testData["ab"], testData["abcd"]},
+		{testData["abc"], testData["abcd"]},
+	}
+
+	for _, p := range cannotAffordPairs {
+		canAfford := p.a.canAfford(p.b)
+
+		if canAfford {
+			t.Errorf(expectedNotButDid, p.a, p.b)
+		}
+	}
+}
+
 func TestEqual(t *testing.T) {
 	// Check self-equality
 	for _, f := range testData {

--- a/types/funds_test.go
+++ b/types/funds_test.go
@@ -20,6 +20,10 @@ var testData map[string]Funds = map[string]Funds{
 	"d": {
 		common.HexToAddress("0x02"): big.NewInt(1),
 	},
+	"e": {
+		common.HexToAddress("0x00"):  big.NewInt(1),
+		common.HexToAddress("0xabc"): big.NewInt(0),
+	},
 	// manually calculated sums
 	"ab": {
 		common.HexToAddress("0x00"): big.NewInt(2),
@@ -44,5 +48,45 @@ func TestSum(t *testing.T) {
 }
 
 func TestEqual(t *testing.T) {
+	// Check self-equality
+	for _, f := range testData {
+		equal := f.Equal(f)
 
+		if !equal {
+			t.Errorf("expected %s to equal %s, but it didn't", f, f)
+		}
+	}
+
+	equalPairs := []Pair{
+		{testData["a"], testData["b"]},
+		{testData["a"], testData["e"]},
+	}
+
+	for _, p := range equalPairs {
+		equal := p.a.Equal(p.b) && p.b.Equal(p.a)
+
+		if !equal {
+			t.Errorf("expected %s to equal %s, but it didn't", p.a, p.b)
+		}
+	}
+
+	unequalPairs := []Pair{
+		{testData["a"], testData["c"]},
+		{testData["a"], testData["d"]},
+		{testData["a"], testData["ab"]},
+	}
+
+	for _, p := range unequalPairs {
+		equal := p.a.Equal(p.b)
+
+		if equal {
+			t.Errorf("expected %s to not equal %s, but it did", p.a, p.b)
+		}
+	}
+
+}
+
+type Pair struct {
+	a Funds
+	b Funds
 }

--- a/types/funds_test.go
+++ b/types/funds_test.go
@@ -57,20 +57,6 @@ var testData map[string]Funds = map[string]Funds{
 }
 
 func TestSum(t *testing.T) {
-	for _, f := range testData {
-		withZeros := Sum(f, testData["zeros"])
-
-		if !withZeros.Equal(f) {
-			t.Errorf("expected sum of %s and %s to equal %s, but it did not", f, testData["zeros"], withZeros)
-		}
-
-		withBlanks := Sum(f, testData["blanks"])
-
-		if !withBlanks.Equal(f) {
-			t.Errorf("expected sum of %s and %s to equal %s, but it did not", f, testData["zeros"], withZeros)
-		}
-	}
-
 	equalPairs := []fundsPair{
 		{Sum(testData["a"],
 			testData["b"]), testData["ab"]},
@@ -83,6 +69,12 @@ func TestSum(t *testing.T) {
 			testData["d"]), testData["abcd"]},
 	}
 
+	// f == Sum(f, zeros), f == Sum(f, blank)
+	for _, f := range testData {
+		equalPairs = append(equalPairs, fundsPair{f, Sum(f, testData["zeros"])})
+		equalPairs = append(equalPairs, fundsPair{f, Sum(f, testData["blank"])})
+	}
+
 	for i, p := range equalPairs {
 		if !p.a.Equal(p.b) {
 			t.Errorf("test_sum_%d: expected %s to equal %s, but it did not", i, p.a, p.b)
@@ -91,20 +83,6 @@ func TestSum(t *testing.T) {
 }
 
 func TestAdd(t *testing.T) {
-	for _, f := range testData {
-		withZeros := f.Add(testData["zeros"])
-
-		if !withZeros.Equal(f) {
-			t.Errorf("expected %s + %s to equal %s, but it did not", f, testData["zeros"], withZeros)
-		}
-
-		withBlanks := f.Add(testData["blanks"])
-
-		if !withBlanks.Equal(f) {
-			t.Errorf("expected %s + %s to equal %s, but it did not", f, testData["zeros"], withZeros)
-		}
-	}
-
 	equalPairs := []fundsPair{
 		{testData["a"].Add(testData["b"]),
 			testData["ab"]},
@@ -112,6 +90,12 @@ func TestAdd(t *testing.T) {
 			testData["abc"]},
 		{testData["a"].Add(testData["b"]).Add(testData["c"]).Add(testData["d"]),
 			testData["abcd"]},
+	}
+
+	// f == f.Add(zeros), f == f.Add(blanks)
+	for _, f := range testData {
+		equalPairs = append(equalPairs, fundsPair{f, f.Add(testData["zeros"])})
+		equalPairs = append(equalPairs, fundsPair{f, f.Add(testData["blank"])})
 	}
 
 	for i, p := range equalPairs {
@@ -122,30 +106,6 @@ func TestAdd(t *testing.T) {
 }
 
 func TestCanAfford(t *testing.T) {
-	expectedButDidNot := "expected %s to afford %s, but it didn't"
-	expectedNotButDid := "expected %s to not afford %s, but it did"
-
-	// Check self-affordance, affordance of blank, affordance of zeros
-	for _, f := range testData {
-		canAfford := f.canAfford(f)
-
-		if !canAfford {
-			t.Errorf(expectedButDidNot, f, f)
-		}
-
-		canAffordBlank := f.canAfford(testData["blank"])
-
-		if !canAffordBlank {
-			t.Errorf(expectedButDidNot, f, testData["blank"])
-		}
-
-		canAffordZeros := f.canAfford(testData["zeros"])
-
-		if !canAffordZeros {
-			t.Errorf(expectedButDidNot, f, testData["zeros"])
-		}
-	}
-
 	canAffordPairs := []fundsPair{
 		{testData["a"], testData["b"]}, // equal funds
 		{testData["b"], testData["a"]},
@@ -158,11 +118,18 @@ func TestCanAfford(t *testing.T) {
 		{testData["abcd"], testData["abc"]},
 	}
 
+	// Check self-affordance, affordance of blank, affordance of zeros
+	for _, f := range testData {
+		canAffordPairs = append(canAffordPairs, fundsPair{f, f})
+		canAffordPairs = append(canAffordPairs, fundsPair{f, testData["blank"]})
+		canAffordPairs = append(canAffordPairs, fundsPair{f, testData["zeros"]})
+	}
+
 	for _, p := range canAffordPairs {
 		canAfford := p.a.canAfford(p.b)
 
 		if !canAfford {
-			t.Errorf(expectedButDidNot, p.a, p.b)
+			t.Errorf("expected %s to afford %s, but it didn't", p.a, p.b)
 		}
 	}
 
@@ -184,24 +151,20 @@ func TestCanAfford(t *testing.T) {
 		canAfford := p.a.canAfford(p.b)
 
 		if canAfford {
-			t.Errorf(expectedNotButDid, p.a, p.b)
+			t.Errorf("expected %s to not afford %s, but it did", p.a, p.b)
 		}
 	}
 }
 
 func TestEqual(t *testing.T) {
-	// Check self-equality
-	for _, f := range testData {
-		equal := f.Equal(f)
-
-		if !equal {
-			t.Errorf("expected %s to equal %s, but it didn't", f, f)
-		}
-	}
-
 	equalPairs := []fundsPair{
 		{testData["zeros"], testData["blank"]},
 		{testData["a"], testData["b"]},
+	}
+
+	// Check self-equality
+	for _, f := range testData {
+		equalPairs = append(equalPairs, fundsPair{f, f})
 	}
 
 	for _, p := range equalPairs {

--- a/types/funds_test.go
+++ b/types/funds_test.go
@@ -57,7 +57,37 @@ var testData map[string]Funds = map[string]Funds{
 }
 
 func TestSum(t *testing.T) {
+	for _, f := range testData {
+		withZeros := Sum(f, testData["zeros"])
 
+		if !withZeros.Equal(f) {
+			t.Errorf("expected sum of %s and %s to equal %s, but it did not", f, testData["zeros"], withZeros)
+		}
+
+		withBlanks := Sum(f, testData["blanks"])
+
+		if !withBlanks.Equal(f) {
+			t.Errorf("expected sum of %s and %s to equal %s, but it did not", f, testData["zeros"], withZeros)
+		}
+	}
+
+	equalPairs := []fundsPair{
+		{Sum(testData["a"],
+			testData["b"]), testData["ab"]},
+		{Sum(testData["a"],
+			testData["b"],
+			testData["c"]), testData["abc"]},
+		{Sum(testData["a"],
+			testData["b"],
+			testData["c"],
+			testData["d"]), testData["abcd"]},
+	}
+
+	for i, p := range equalPairs {
+		if !p.a.Equal(p.b) {
+			t.Errorf("test_sum_%d: expected %s to equal %s, but it did not", i, p.a, p.b)
+		}
+	}
 }
 
 func TestCanAfford(t *testing.T) {


### PR DESCRIPTION
This PR

- adds pretty comprehensive testing of accounting arithmetic around the `Funds` account->balance map
- fixes an implementation bug in `Sum`
- fixes the `String` method which had an invalid base (64) (funds.go:22)