### PR TITLE
Add unit tests for direct-funding.Update()

### DIFF
--- a/protocols/direct-funding.go
+++ b/protocols/direct-funding.go
@@ -148,7 +148,10 @@ func (s DirectFundingObjectiveState) Update(event ObjectiveEvent) (Objective, er
 
 		err := updated.applySignature(sig, turnNum)
 		if err != nil {
-			return s, err
+			// If there was an error applying the signature, log it and swallow it
+			// This is a conscious choice (to ignore signatures we don't expect)
+			// Examples include faulty signatures, signatures by non-participants, signatures on unexpected states, etc
+			fmt.Println(err)
 		}
 	}
 
@@ -295,15 +298,16 @@ func (s DirectFundingObjectiveState) applySignature(signature state.Signature, t
 	index, ok := s.ParticipantIndex[signer]
 	if !ok {
 		return fmt.Errorf("signature recieved from unrecognized participant 0x%x", signer)
-	}
+	} else {
 
-	if turnNum == 0 {
-		s.PreFundSigned[index] = true
-	} else if turnNum == 1 {
-		s.PostFundSigned[index] = true
-	}
+		if turnNum == 0 {
+			s.PreFundSigned[index] = true
+		} else if turnNum == 1 {
+			s.PostFundSigned[index] = true
+		}
 
-	return nil
+		return nil
+	}
 }
 
 // todo: is this sufficient? Particularly: s has pointer members (*big.Int)

--- a/protocols/direct-funding.go
+++ b/protocols/direct-funding.go
@@ -298,16 +298,15 @@ func (s DirectFundingObjectiveState) applySignature(signature state.Signature, t
 	index, ok := s.ParticipantIndex[signer]
 	if !ok {
 		return fmt.Errorf("signature recieved from unrecognized participant 0x%x", signer)
-	} else {
-
-		if turnNum == 0 {
-			s.PreFundSigned[index] = true
-		} else if turnNum == 1 {
-			s.PostFundSigned[index] = true
-		}
-
-		return nil
 	}
+
+	if turnNum == 0 {
+		s.PreFundSigned[index] = true
+	} else if turnNum == 1 {
+		s.PostFundSigned[index] = true
+	}
+	return nil
+
 }
 
 // todo: is this sufficient? Particularly: s has pointer members (*big.Int)

--- a/protocols/direct-funding_test.go
+++ b/protocols/direct-funding_test.go
@@ -81,8 +81,8 @@ func TestUpdate(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if updated.(DirectFundingObjectiveState).OnChainHolding[common.Address{}].Cmp(big.NewInt(3)) != 0 {
-		t.Error(`Objective data not updated as expected`)
+	if !updated.(DirectFundingObjectiveState).OnChainHolding.Equal(e.Holdings) {
+		t.Error(`Objective data not updated as expected`, updated.(DirectFundingObjectiveState).OnChainHolding, e.Holdings)
 	}
 
 }

--- a/protocols/direct-funding_test.go
+++ b/protocols/direct-funding_test.go
@@ -31,10 +31,8 @@ var privateKeyOfParticipant0 = common.Hex2Bytes(`caab404f975b4620747174a75f08d98
 var correctSignatureByParticipant, _ = stateToSign.Sign(privateKeyOfParticipant0)
 
 func TestUpdate(t *testing.T) {
-	// First, prepare a new objective using the constructor:
-	s, _ := NewDirectFundingObjectiveState(state.TestState, state.TestState.Participants[0])
 
-	// Next, prepare an event with a mismatched channelId
+	// Prepare an event with a mismatched channelId
 	e := ObjectiveEvent{
 		ChannelId: types.Destination{},
 	}

--- a/protocols/direct-funding_test.go
+++ b/protocols/direct-funding_test.go
@@ -1,14 +1,93 @@
 package protocols
 
 import (
+	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/types"
 )
 
+// TestNew tests the constructor using a TestState fixture
 func TestNew(t *testing.T) {
 	_, err := NewDirectFundingObjectiveState(state.TestState, state.TestState.Participants[0])
 	if err != nil {
 		t.Error(err)
 	}
+}
+
+// Construct various variables for use in TestUpdate
+var s, _ = NewDirectFundingObjectiveState(state.TestState, state.TestState.Participants[0])
+var dummySignature = state.Signature{
+	R: common.Hex2Bytes(`49d8e91bd182fb4d489bb2d76a6735d494d5bea24e4b51dd95c9d219293312d9`),
+	S: common.Hex2Bytes(`22274a3cec23c31e0c073b3c071cf6e0c21260b0d292a10e6a04257a2d8e87fa`),
+	V: byte(1),
+}
+var dummyStateHash = common.Hash{}
+var stateToSign state.State = s.ExpectedStates[0]
+var stateHash, _ = stateToSign.Hash()
+var privateKeyOfParticipant0 = common.Hex2Bytes(`caab404f975b4620747174a75f08d98b4e5a7053b691b41bcfc0d839d48b7634`)
+var correctSignatureByParticipant, _ = stateToSign.Sign(privateKeyOfParticipant0)
+
+func TestUpdate(t *testing.T) {
+	// First, prepare a new objective using the constructor:
+	s, _ := NewDirectFundingObjectiveState(state.TestState, state.TestState.Participants[0])
+
+	// Next, prepare an event with a mismatched channelId
+	e := ObjectiveEvent{
+		ChannelId: types.Destination{},
+	}
+	// Assert that Updating the objective with such an event returns an error
+	// TODO is this the behaviour we want? Below with the signatures, we prefer a log + NOOP (no error)
+	_, err := s.Update(e)
+	if err == nil {
+		t.Error(`ChannelId mismatch -- expected an error but did not get one`)
+	}
+
+	// Now modify the event to give it the "correct" channelId (matching the objective),
+	// and make a new Sigs map.
+	// This prepares us for the rest of the test. We will reuse the same event multiple times
+	e.ChannelId = s.ChannelId
+	e.Sigs = make(map[types.Bytes32]state.Signature)
+
+	// Next, attempt to update the objective with a dummy signature, keyed with a dummy statehash
+	// Assert that this results in a NOOP
+	e.Sigs[dummyStateHash] = dummySignature // Dummmy signature on dummy statehash
+	_, err = s.Update(e)
+	if err != nil {
+		t.Error(`dummy signature -- expected a noop but caught an error:`, err)
+	}
+
+	// Next, attempt to update the objective with an invalid signature, keyed with a dummy statehash
+	// Assert that this results in a NOOP
+	e.Sigs[dummyStateHash] = state.Signature{}
+	_, err = s.Update(e)
+	if err != nil {
+		t.Error(`faulty signature -- expected a noop but caught an error:`, err)
+	}
+
+	// Next, attempt to update the objective with correct signature by a participant on a relevant state
+	// Assert that this results in an appropriate change in the extended state of the objective
+	e.Sigs[stateHash] = correctSignatureByParticipant
+	updated, err := s.Update(e)
+	if err != nil {
+		t.Error(err)
+	}
+	if updated.(DirectFundingObjectiveState).PreFundSigned[0] != true {
+		t.Error(`Objective data not updated as expected`)
+	}
+
+	// Finally, add some Holdings information to the event
+	// Updating the objective with this event should overwrite the holdings that are stored
+	e.Holdings = types.Funds{}
+	e.Holdings[common.Address{}] = big.NewInt(3)
+	updated, err = s.Update(e)
+	if err != nil {
+		t.Error(err)
+	}
+	if updated.(DirectFundingObjectiveState).OnChainHolding[common.Address{}].Cmp(big.NewInt(3)) != 0 {
+		t.Error(`Objective data not updated as expected`)
+	}
+
 }

--- a/protocols/direct-funding_test.go
+++ b/protocols/direct-funding_test.go
@@ -51,16 +51,14 @@ func TestUpdate(t *testing.T) {
 	// Next, attempt to update the objective with a dummy signature, keyed with a dummy statehash
 	// Assert that this results in a NOOP
 	e.Sigs[dummyStateHash] = dummySignature // Dummmy signature on dummy statehash
-	_, err = s.Update(e)
-	if err != nil {
+	if _, err := s.Update(e); err != nil {
 		t.Error(`dummy signature -- expected a noop but caught an error:`, err)
 	}
 
 	// Next, attempt to update the objective with an invalid signature, keyed with a dummy statehash
 	// Assert that this results in a NOOP
 	e.Sigs[dummyStateHash] = state.Signature{}
-	_, err = s.Update(e)
-	if err != nil {
+	if _, err := s.Update(e); err != nil {
 		t.Error(`faulty signature -- expected a noop but caught an error:`, err)
 	}
 


### PR DESCRIPTION
Adds unit tests for the `.Update()` method on the direct funding objective. 

Recall that the [direct funding objective is a struct holding data particular to the off-chain goal of opening a directly funded channel](https://github.com/statechannels/go-nitro/blob/f60dce55abf9faee7f8fecf90a9446664ad45a65/protocols/direct-funding.go#L30-L48). As such, it needs to update that data based on events that arrive (for example, a digital signature on a state update, or an event fired by the chain).  The `Update()` method is performing this function.

The approach I took here was to:
1. prepare an `event`
2. call `DirectFundingObjectiveState.Update(event)`
3. assert on the various data fields on the returned `DirectFundingObjectiveState` , as well as the returned error
4. progressively modify the event, and GOTO 2

Towards #51.

It's easy enough to describe the intended behaviour for expected events. For unexpected events, there is a little freedom. This test can be used to *define* the behaviour we want. Right now, an incorrect channel id on the event returns an error. An unexpected or faulty signature causes errors internally, but these are logged and ignored. In the latter case, this PR includes the changes that implement that behaviour (so that the test passes). For now, logging is just ` fmt.Print`, but we have an issue to improve that (#70) .

