### PR TITLE
Improve testing of DirectFundingObjectiveState constructor

### DIFF
--- a/protocols/direct-funding_test.go
+++ b/protocols/direct-funding_test.go
@@ -11,10 +11,16 @@ import (
 
 // TestNew tests the constructor using a TestState fixture
 func TestNew(t *testing.T) {
-	_, err := NewDirectFundingObjectiveState(state.TestState, state.TestState.Participants[0])
-	if err != nil {
+	if _, err := NewDirectFundingObjectiveState(state.TestState, state.TestState.Participants[0]); err != nil {
 		t.Error(err)
 	}
+	invalidState := state.TestState.Clone()
+	tooLargeChainId, _ := big.NewInt(0).SetString("49d8e91bd182fb4d489bb2d76a6735d494d5bea24e4b51dd95c9d219293312d949d8e91bd182fb4d489bb2d76a6735d494d5bea24e4b51dd95c9d219293312d9", 16) // This is 128 hexits = 64 bytes = 512 bits. A chainId should be 256 bit
+	invalidState.ChainId = tooLargeChainId
+	if _, err := NewDirectFundingObjectiveState(invalidState, state.TestState.Participants[0]); err == nil {
+		t.Error("Expected an error when constructing with an invalid state, but got nil")
+	}
+
 }
 
 // Construct various variables for use in TestUpdate

--- a/protocols/direct-funding_test.go
+++ b/protocols/direct-funding_test.go
@@ -20,6 +20,11 @@ func TestNew(t *testing.T) {
 	if _, err := NewDirectFundingObjectiveState(invalidState, state.TestState.Participants[0]); err == nil {
 		t.Error("Expected an error when constructing with an invalid state, but got nil")
 	}
+	finalState := state.TestState.Clone()
+	finalState.IsFinal = true
+	if _, err := NewDirectFundingObjectiveState(finalState, state.TestState.Participants[0]); err == nil {
+		t.Error("Expected an error when constructing with an invalid state, but got nil")
+	}
 
 }
 

--- a/protocols/direct-funding_test.go
+++ b/protocols/direct-funding_test.go
@@ -11,17 +11,16 @@ import (
 
 // TestNew tests the constructor using a TestState fixture
 func TestNew(t *testing.T) {
+	// Assert that a valid set of constructor args does not result in an error
 	if _, err := NewDirectFundingObjectiveState(state.TestState, state.TestState.Participants[0]); err != nil {
 		t.Error(err)
 	}
-	invalidState := state.TestState.Clone()
-	tooLargeChainId, _ := big.NewInt(0).SetString("49d8e91bd182fb4d489bb2d76a6735d494d5bea24e4b51dd95c9d219293312d949d8e91bd182fb4d489bb2d76a6735d494d5bea24e4b51dd95c9d219293312d9", 16) // This is 128 hexits = 64 bytes = 512 bits. A chainId should be 256 bit
-	invalidState.ChainId = tooLargeChainId
-	if _, err := NewDirectFundingObjectiveState(invalidState, state.TestState.Participants[0]); err == nil {
-		t.Error("Expected an error when constructing with an invalid state, but got nil")
-	}
+
+	// Construct a final state
 	finalState := state.TestState.Clone()
 	finalState.IsFinal = true
+
+	// Assert that constructing with a final state should return an error
 	if _, err := NewDirectFundingObjectiveState(finalState, state.TestState.Participants[0]); err == nil {
 		t.Error("Expected an error when constructing with an invalid state, but got nil")
 	}


### PR DESCRIPTION
Closes #71 .

There are two ways which the constructor can return an error (at the top layer of the stack)

* Error calculating the channel id
    - because we get an extremely rare hash collision. _This is so rare its actually a pretty big challenge to generate the appropriate test data_
    - because of some error thrown in go-ethereum's encoding library code. _I tried and failed to trigger this error, and have left the git history on this branch showing how_
* Error because of the use of a final state _I added a test for this_
