### PR TITLE
Add GuaranteeMetadata type and methods

### DIFF
--- a/channel/state/outcome/guarantee.go
+++ b/channel/state/outcome/guarantee.go
@@ -1,7 +1,6 @@
 package outcome
 
 import (
-	"bytes"
 	"encoding/json"
 	"log"
 
@@ -25,12 +24,6 @@ var guaranteeMetadataTy, _ = abi.NewType("tuple", "struct GuaranteeMetadata", []
 // Encode returns the abi.encoded GuaranteeMetadata (suitable for packing in an Allocation.Metadata field)
 func (m GuaranteeMetadata) Encode() (types.Bytes, error) {
 	return abi.Arguments{{Type: guaranteeMetadataTy}}.Pack(m)
-}
-
-// Equal returns true if the reciever has identically valued fields to the supplied object
-func (m GuaranteeMetadata) Equal(n GuaranteeMetadata) bool {
-	return bytes.Equal(m.Left.Bytes(), n.Left.Bytes()) && bytes.Equal(m.Right.Bytes(), n.Right.Bytes())
-
 }
 
 // rawGuaranteeMetadataType is an alias to the type returned when using the github.com/ethereum/go-ethereum/accounts/abi Unpack method with guaranteeMetadataTy

--- a/channel/state/outcome/guarantee.go
+++ b/channel/state/outcome/guarantee.go
@@ -12,7 +12,7 @@ import (
 // A Guarantee is an Allocation with AllocationType == GuaranteeAllocationType and Metadata = encode(GuaranteeMetaData)
 type GuaranteeMetadata struct {
 	Left  types.Address // The peer who plays the role of Alice (peer 0)
-	Right types.Address // The peer who plays the role of Bob (peer n+1, where n=len(peers))
+	Right types.Address // The peer who plays the role of Bob (peer n+1, where n=len(intermediaries))
 }
 
 // guaranteeMetadataTy describes the shape of GuaranteeMetadata, so that the abi encoder knows how to encode it

--- a/channel/state/outcome/guarantee.go
+++ b/channel/state/outcome/guarantee.go
@@ -1,0 +1,67 @@
+package outcome
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/types"
+)
+
+// A Guarantee is an Allocation with AllocationType == GuaranteeAllocationType and Metadata = encode(GuaranteeMetaData)
+type GuaranteeMetadata struct {
+	Left  types.Address // The peer who plays the role of Alice (peer 0)
+	Right types.Address // The peer who plays the role of Bob (peer n+1, where n=len(peers))
+}
+
+// guaranteeMetadataTy describes the shape of GuaranteeMetadata, so that the abi encoder knows how to encode it
+var guaranteeMetadataTy, _ = abi.NewType("tuple", "struct GuaranteeMetadata", []abi.ArgumentMarshaling{
+	{Name: "Left", Type: "address"},
+	{Name: "Right", Type: "address"},
+})
+
+// Encode returns the abi.encoded GuaranteeMetadata (suitable for packing in an Allocation.Metadata field)
+func (m GuaranteeMetadata) Encode() (types.Bytes, error) {
+	return abi.Arguments{{Type: guaranteeMetadataTy}}.Pack(m)
+}
+
+// Equal returns true if the reciever has identically valued fields to the supplied object
+func (m GuaranteeMetadata) Equal(n GuaranteeMetadata) bool {
+	return bytes.Equal(m.Left.Bytes(), n.Left.Bytes()) && bytes.Equal(m.Right.Bytes(), n.Right.Bytes())
+
+}
+
+// rawGuaranteeMetadataType is an alias to the type returned when using the github.com/ethereum/go-ethereum/accounts/abi Unpack method with guaranteeMetadataTy
+type rawGuaranteeMetadataType = struct {
+	Left  common.Address "json:\"Left\""
+	Right common.Address "json:\"Right\""
+}
+
+// convertToGuaranteeMetadata converts a rawGuaranteeMetadataType to a GuaranteeMetadata
+func convertToGuaranteeMetadata(r rawGuaranteeMetadataType) GuaranteeMetadata {
+	var guaranteeMetadata GuaranteeMetadata
+	j, err := json.Marshal(r)
+
+	if err != nil {
+		log.Fatal(`error marshalling`)
+	}
+
+	err = json.Unmarshal(j, &guaranteeMetadata)
+
+	if err != nil {
+		log.Fatal(`error unmarshalling`, err)
+	}
+
+	return guaranteeMetadata
+}
+
+// Decode returns a GuaranteeMetaData from an abi encoding
+func DecodeIntoGuaranteeMetadata(m []byte) (GuaranteeMetadata, error) {
+	unpacked, err := abi.Arguments{{Type: guaranteeMetadataTy}}.Unpack(m)
+	if err != nil {
+		return GuaranteeMetadata{}, err
+	}
+	return convertToGuaranteeMetadata(unpacked[0].(rawGuaranteeMetadataType)), nil
+}

--- a/channel/state/outcome/guarantee.go
+++ b/channel/state/outcome/guarantee.go
@@ -5,20 +5,19 @@ import (
 	"log"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/types"
 )
 
 // A Guarantee is an Allocation with AllocationType == GuaranteeAllocationType and Metadata = encode(GuaranteeMetaData)
 type GuaranteeMetadata struct {
-	Left  types.Address // The peer who plays the role of Alice (peer 0)
-	Right types.Address // The peer who plays the role of Bob (peer n+1, where n=len(intermediaries))
+	Left  types.Destination // The peer who plays the role of Alice (peer 0)
+	Right types.Destination // The peer who plays the role of Bob (peer n+1, where n=len(intermediaries))
 }
 
 // guaranteeMetadataTy describes the shape of GuaranteeMetadata, so that the abi encoder knows how to encode it
 var guaranteeMetadataTy, _ = abi.NewType("tuple", "struct GuaranteeMetadata", []abi.ArgumentMarshaling{
-	{Name: "Left", Type: "address"},
-	{Name: "Right", Type: "address"},
+	{Name: "Left", Type: "bytes32"},
+	{Name: "Right", Type: "bytes32"},
 })
 
 // Encode returns the abi.encoded GuaranteeMetadata (suitable for packing in an Allocation.Metadata field)
@@ -28,8 +27,8 @@ func (m GuaranteeMetadata) Encode() (types.Bytes, error) {
 
 // rawGuaranteeMetadataType is an alias to the type returned when using the github.com/ethereum/go-ethereum/accounts/abi Unpack method with guaranteeMetadataTy
 type rawGuaranteeMetadataType = struct {
-	Left  common.Address "json:\"Left\""
-	Right common.Address "json:\"Right\""
+	Left  [32]uint8 "json:\"Left\""
+	Right [32]uint8 "json:\"Right\""
 }
 
 // convertToGuaranteeMetadata converts a rawGuaranteeMetadataType to a GuaranteeMetadata

--- a/channel/state/outcome/guarantee_test.go
+++ b/channel/state/outcome/guarantee_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/types"
 )
 
-var guaranteeMetadata = GuaranteeMetadata{Left: common.HexToAddress("0x0a"), Right: common.HexToAddress("0x0b")}
+var guaranteeMetadata = GuaranteeMetadata{Left: types.AdddressToDestination(common.HexToAddress("0x0a")), Right: types.AdddressToDestination(common.HexToAddress("0x0b"))}
 var encodedGuaranteeMetadata, _ = hex.DecodeString("000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000b")
 
 func TestGuaranteeMetadataEncode(t *testing.T) {

--- a/channel/state/outcome/guarantee_test.go
+++ b/channel/state/outcome/guarantee_test.go
@@ -26,7 +26,7 @@ func TestGuaranteeMetadataDecode(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !g.Equal(guaranteeMetadata) {
+	if g != guaranteeMetadata {
 		t.Errorf("incorrect encoding. Got %x, wanted %x", g, encodedGuaranteeMetadata)
 	}
 }

--- a/channel/state/outcome/guarantee_test.go
+++ b/channel/state/outcome/guarantee_test.go
@@ -1,0 +1,32 @@
+package outcome
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var guaranteeMetadata = GuaranteeMetadata{Left: common.HexToAddress("0x0a"), Right: common.HexToAddress("0x0b")}
+var encodedGuaranteeMetadata, _ = hex.DecodeString("000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000b")
+
+func TestGuaranteeMetadataEncode(t *testing.T) {
+	encodedG, err := guaranteeMetadata.Encode()
+	if err != nil {
+		t.Error(err)
+	}
+	if !bytes.Equal(encodedG, encodedGuaranteeMetadata) {
+		t.Errorf("incorrect encoding. Got %x, wanted %x", encodedG, encodedGuaranteeMetadata)
+	}
+}
+
+func TestGuaranteeMetadataDecode(t *testing.T) {
+	g, err := DecodeIntoGuaranteeMetadata(encodedGuaranteeMetadata)
+	if err != nil {
+		t.Error(err)
+	}
+	if !g.Equal(guaranteeMetadata) {
+		t.Errorf("incorrect encoding. Got %x, wanted %x", g, encodedGuaranteeMetadata)
+	}
+}

--- a/channel/state/outcome/outcome.go
+++ b/channel/state/outcome/outcome.go
@@ -24,62 +24,6 @@ type Allocation struct {
 const NormalAllocationType = uint8(0)
 const GuaranteeAllocationType = uint8(1)
 
-// A Guarantee is an Allocation with AllocationType == GuaranteeAllocationType and Metadata = encode(GuaranteeMetaData)
-type GuaranteeMetadata struct {
-	Left  types.Address // The peer who plays the role of Alice (peer 0)
-	Right types.Address // The peer who plays the role of Bob (peer n+1, where n=len(peers))
-}
-
-// guaranteeMetadataTy describes the shape of GuaranteeMetadata, so that the abi encoder knows how to encode it
-var guaranteeMetadataTy, _ = abi.NewType("tuple", "struct GuaranteeMetadata", []abi.ArgumentMarshaling{
-	{Name: "Left", Type: "address"},
-	{Name: "Right", Type: "address"},
-})
-
-// Encode returns the abi.encoded GuaranteeMetadata (suitable for packing in an Allocation.Metadata field)
-func (m GuaranteeMetadata) Encode() (types.Bytes, error) {
-	return abi.Arguments{{Type: guaranteeMetadataTy}}.Pack(m)
-}
-
-// Equal returns true if the reciever has identically valued fields to the supplied object
-func (m GuaranteeMetadata) Equal(n GuaranteeMetadata) bool {
-	return bytes.Equal(m.Left.Bytes(), n.Left.Bytes()) && bytes.Equal(m.Right.Bytes(), n.Right.Bytes())
-
-}
-
-// rawGuaranteeMetadataType is an alias to the type returned when using the github.com/ethereum/go-ethereum/accounts/abi Unpack method with guaranteeMetadataTy
-type rawGuaranteeMetadataType = struct {
-	Left  common.Address "json:\"Left\""
-	Right common.Address "json:\"Right\""
-}
-
-// convertToGuaranteeMetadata converts a rawGuaranteeMetadataType to a GuaranteeMetadata
-func convertToGuaranteeMetadata(r rawGuaranteeMetadataType) GuaranteeMetadata {
-	var guaranteeMetadata GuaranteeMetadata
-	j, err := json.Marshal(r)
-
-	if err != nil {
-		log.Fatal(`error marshalling`)
-	}
-
-	err = json.Unmarshal(j, &guaranteeMetadata)
-
-	if err != nil {
-		log.Fatal(`error unmarshalling`, err)
-	}
-
-	return guaranteeMetadata
-}
-
-// Decode returns a GuaranteeMetaData from an abi encoding
-func DecodeIntoGuaranteeMetadata(m []byte) (GuaranteeMetadata, error) {
-	unpacked, err := abi.Arguments{{Type: guaranteeMetadataTy}}.Unpack(m)
-	if err != nil {
-		return GuaranteeMetadata{}, err
-	}
-	return convertToGuaranteeMetadata(unpacked[0].(rawGuaranteeMetadataType)), nil
-}
-
 // Equal returns true if the supplied Allocation matches the receiver Allocation, and false otherwise.
 // Fields are compared with ==, except for big.Ints which are compared using Cmp
 func (a Allocation) Equal(b Allocation) bool {

--- a/channel/state/outcome/outcome.go
+++ b/channel/state/outcome/outcome.go
@@ -20,6 +20,66 @@ type Allocation struct {
 	Metadata       []byte            // Custom metadata (optional field, can be zero bytes). This can be used flexibly by different protocols.
 }
 
+// TODO AllocationType should be an enum?
+const NormalAllocationType = uint8(0)
+const GuaranteeAllocationType = uint8(1)
+
+// A Guarantee is an Allocation with AllocationType == GuaranteeAllocationType and Metadata = encode(GuaranteeMetaData)
+type GuaranteeMetadata struct {
+	Left  types.Address // The peer who plays the role of Alice (peer 0)
+	Right types.Address // The peer who plays the role of Bob (peer n+1, where n=len(peers))
+}
+
+// guaranteeMetadataTy describes the shape of GuaranteeMetadata, so that the abi encoder knows how to encode it
+var guaranteeMetadataTy, _ = abi.NewType("tuple", "struct GuaranteeMetadata", []abi.ArgumentMarshaling{
+	{Name: "Left", Type: "address"},
+	{Name: "Right", Type: "address"},
+})
+
+// Encode returns the abi.encoded GuaranteeMetadata (suitable for packing in an Allocation.Metadata field)
+func (m GuaranteeMetadata) Encode() (types.Bytes, error) {
+	return abi.Arguments{{Type: guaranteeMetadataTy}}.Pack(m)
+}
+
+// Equal returns true if the reciever has identically valued fields to the supplied object
+func (m GuaranteeMetadata) Equal(n GuaranteeMetadata) bool {
+	return bytes.Equal(m.Left.Bytes(), n.Left.Bytes()) && bytes.Equal(m.Right.Bytes(), n.Right.Bytes())
+
+}
+
+// rawGuaranteeMetadataType is an alias to the type returned when using the github.com/ethereum/go-ethereum/accounts/abi Unpack method with guaranteeMetadataTy
+type rawGuaranteeMetadataType = struct {
+	Left  common.Address "json:\"Left\""
+	Right common.Address "json:\"Right\""
+}
+
+// convertToGuaranteeMetadata converts a rawGuaranteeMetadataType to a GuaranteeMetadata
+func convertToGuaranteeMetadata(r rawGuaranteeMetadataType) GuaranteeMetadata {
+	var guaranteeMetadata GuaranteeMetadata
+	j, err := json.Marshal(r)
+
+	if err != nil {
+		log.Fatal(`error marshalling`)
+	}
+
+	err = json.Unmarshal(j, &guaranteeMetadata)
+
+	if err != nil {
+		log.Fatal(`error unmarshalling`, err)
+	}
+
+	return guaranteeMetadata
+}
+
+// Decode returns a GuaranteeMetaData from an abi encoding
+func DecodeIntoGuaranteeMetadata(m []byte) (GuaranteeMetadata, error) {
+	unpacked, err := abi.Arguments{{Type: guaranteeMetadataTy}}.Unpack(m)
+	if err != nil {
+		return GuaranteeMetadata{}, err
+	}
+	return convertToGuaranteeMetadata(unpacked[0].(rawGuaranteeMetadataType)), nil
+}
+
 // Equal returns true if the supplied Allocation matches the receiver Allocation, and false otherwise.
 // Fields are compared with ==, except for big.Ints which are compared using Cmp
 func (a Allocation) Equal(b Allocation) bool {

--- a/channel/state/outcome/outcome_test.go
+++ b/channel/state/outcome/outcome_test.go
@@ -178,3 +178,26 @@ func TestTotal(t *testing.T) {
 		t.Errorf(`Expected total to be 5, got %v`, total)
 	}
 }
+
+var guaranteeMetadata = GuaranteeMetadata{Left: common.HexToAddress("0x0a"), Right: common.HexToAddress("0x0b")}
+var encodedGuaranteeMetadata, _ = hex.DecodeString("000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000b")
+
+func TestGuaranteeMetadataEncode(t *testing.T) {
+	encodedG, err := guaranteeMetadata.Encode()
+	if err != nil {
+		t.Error(err)
+	}
+	if !bytes.Equal(encodedG, encodedGuaranteeMetadata) {
+		t.Errorf("incorrect encoding. Got %x, wanted %x", encodedG, encodedGuaranteeMetadata)
+	}
+}
+
+func TestGuaranteeMetadataDecode(t *testing.T) {
+	g, err := DecodeIntoGuaranteeMetadata(encodedGuaranteeMetadata)
+	if err != nil {
+		t.Error(err)
+	}
+	if !g.Equal(guaranteeMetadata) {
+		t.Errorf("incorrect encoding. Got %x, wanted %x", g, encodedGuaranteeMetadata)
+	}
+}

--- a/channel/state/outcome/outcome_test.go
+++ b/channel/state/outcome/outcome_test.go
@@ -178,26 +178,3 @@ func TestTotal(t *testing.T) {
 		t.Errorf(`Expected total to be 5, got %v`, total)
 	}
 }
-
-var guaranteeMetadata = GuaranteeMetadata{Left: common.HexToAddress("0x0a"), Right: common.HexToAddress("0x0b")}
-var encodedGuaranteeMetadata, _ = hex.DecodeString("000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000b")
-
-func TestGuaranteeMetadataEncode(t *testing.T) {
-	encodedG, err := guaranteeMetadata.Encode()
-	if err != nil {
-		t.Error(err)
-	}
-	if !bytes.Equal(encodedG, encodedGuaranteeMetadata) {
-		t.Errorf("incorrect encoding. Got %x, wanted %x", encodedG, encodedGuaranteeMetadata)
-	}
-}
-
-func TestGuaranteeMetadataDecode(t *testing.T) {
-	g, err := DecodeIntoGuaranteeMetadata(encodedGuaranteeMetadata)
-	if err != nil {
-		t.Error(err)
-	}
-	if !g.Equal(guaranteeMetadata) {
-		t.Errorf("incorrect encoding. Got %x, wanted %x", g, encodedGuaranteeMetadata)
-	}
-}


### PR DESCRIPTION
This is preparatory work towards #25 .

The virtual funding protocol will need to consume Guarantees and to be able to understand them -- for example, in answering the question "does ledger channel `L` adequately guarantee funds for virtual channel `V`". 

This work brings us toward that goal. Note that I have chosen to go with the SATP format for the guarantee. This isn't set in stone and should be easily changed. (I also chose not-the-latest format from SATP, too). 


