### PR TITLE
Introduce allocations.Affords method

### DIFF
--- a/channel/state/outcome/outcome.go
+++ b/channel/state/outcome/outcome.go
@@ -69,7 +69,7 @@ func (allocations Allocations) AffordsFor(given Allocation, x *big.Int) *big.Int
 			affordsInTotal = affordsInTotal.Add(affordsInTotal, affords)
 		}
 
-		surplus = surplus.Sub(surplus, affords)
+		surplus.Sub(surplus, affords)
 
 	}
 	return affordsInTotal

--- a/channel/state/outcome/outcome.go
+++ b/channel/state/outcome/outcome.go
@@ -55,8 +55,8 @@ func (a Allocations) Total() *big.Int {
 // AffordsFor computes the amount that the allocations can afford for a given allocation, assuming it is funded with x coins
 func (allocations Allocations) AffordsFor(given Allocation, x *big.Int) *big.Int {
 	bigZero := big.NewInt(0)
-	affordsInTotal := bigZero
-	surplus := x
+	affordsInTotal := big.NewInt(0).Set(bigZero)
+	surplus := big.NewInt(0).Set(x)
 	for _, allocation := range allocations {
 
 		if surplus.Cmp(bigZero) == 0 {

--- a/channel/state/outcome/outcome.go
+++ b/channel/state/outcome/outcome.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -49,6 +50,29 @@ func (a Allocations) Total() *big.Int {
 		total.Add(total, allocation.Amount)
 	}
 	return total
+}
+
+// AffordsFor computes the amount that the allocations can afford for a given allocation, assuming it is funded with x coins
+func (allocations Allocations) AffordsFor(given Allocation, x *big.Int) *big.Int {
+	bigZero := big.NewInt(0)
+	affordsInTotal := bigZero
+	surplus := x
+	for _, allocation := range allocations {
+
+		if surplus.Cmp(bigZero) == 0 {
+			break
+		}
+
+		affords := math.BigMin(surplus, allocation.Amount)
+
+		if allocation.Equal(given) {
+			affordsInTotal = affordsInTotal.Add(affordsInTotal, affords)
+		}
+
+		surplus = surplus.Sub(surplus, affords)
+
+	}
+	return affordsInTotal
 }
 
 // SingleAssetExit declares an ordered list of Allocations for a single asset.

--- a/channel/state/outcome/outcome_test.go
+++ b/channel/state/outcome/outcome_test.go
@@ -181,7 +181,7 @@ func TestTotal(t *testing.T) {
 	}
 }
 
-func TestAffordsFor(t *testing.T) {
+func TestAffords(t *testing.T) {
 
 	allocationsWithRepeatedEntry := append(a, a[0]) // [{Alice: 2, Bob: 3, Alice: 2}]
 
@@ -189,26 +189,26 @@ func TestAffordsFor(t *testing.T) {
 		Allocations     Allocations
 		GivenAllocation Allocation
 		X               *big.Int
-		Want            *big.Int
+		Want            bool
 	}
 
 	var testCases []testCase = []testCase{
-		{a, a[0], big.NewInt(3), big.NewInt(2)},
-		{a, a[0], big.NewInt(2), big.NewInt(2)},
-		{a, a[0], big.NewInt(1), big.NewInt(1)},
-		{a, a[1], big.NewInt(6), big.NewInt(3)},
-		{a, a[1], big.NewInt(5), big.NewInt(3)},
-		{a, a[1], big.NewInt(4), big.NewInt(2)},
-		{a, a[1], big.NewInt(2), big.NewInt(0)},
-		{allocationsWithRepeatedEntry, a[0], big.NewInt(7), big.NewInt(4)},
+		{a, a[0], big.NewInt(3), true},
+		{a, a[0], big.NewInt(2), true},
+		{a, a[0], big.NewInt(1), false},
+		{a, a[1], big.NewInt(6), true},
+		{a, a[1], big.NewInt(5), true},
+		{a, a[1], big.NewInt(4), false},
+		{a, a[1], big.NewInt(2), false},
+		{allocationsWithRepeatedEntry, a[0], big.NewInt(7), true},
 	}
 
 	for _, testcase := range testCases {
-		got := testcase.Allocations.AffordsFor(testcase.GivenAllocation, testcase.X)
-		if got.Cmp(testcase.Want) != 0 {
+		got := testcase.Allocations.Affords(testcase.GivenAllocation, testcase.X)
+		if got != testcase.Want {
 			t.Errorf(
-				`Incorrect AffordFor: expected allocation %v to afford %v, for given allocation %v, but got %v`,
-				testcase.Allocations, testcase.Want, testcase.GivenAllocation, got)
+				`Incorrect AffordFor: expected %v.Affords(%v,%v) to be %v, but got %v`,
+				testcase.Allocations, testcase.GivenAllocation, testcase.X, testcase.Want, got)
 		}
 	}
 

--- a/channel/state/outcome/outcome_test.go
+++ b/channel/state/outcome/outcome_test.go
@@ -183,8 +183,6 @@ func TestTotal(t *testing.T) {
 
 func TestAffords(t *testing.T) {
 
-	allocationsWithRepeatedEntry := append(a, a[0]) // [{Alice: 2, Bob: 3, Alice: 2}]
-
 	type testCase struct {
 		Allocations     Allocations
 		GivenAllocation Allocation
@@ -200,7 +198,6 @@ func TestAffords(t *testing.T) {
 		{a, a[1], big.NewInt(5), true},
 		{a, a[1], big.NewInt(4), false},
 		{a, a[1], big.NewInt(2), false},
-		{allocationsWithRepeatedEntry, a[0], big.NewInt(7), true},
 	}
 
 	for _, testcase := range testCases {

--- a/channel/state/outcome/outcome_test.go
+++ b/channel/state/outcome/outcome_test.go
@@ -183,6 +183,8 @@ func TestTotal(t *testing.T) {
 
 func TestAffordsFor(t *testing.T) {
 
+	allocationsWithRepeatedEntry := append(a, a[0]) // [{Alice: 2, Bob: 3, Alice: 2}]
+
 	type testCase struct {
 		Allocations     Allocations
 		GivenAllocation Allocation
@@ -198,6 +200,7 @@ func TestAffordsFor(t *testing.T) {
 		{a, a[1], big.NewInt(5), big.NewInt(3)},
 		{a, a[1], big.NewInt(4), big.NewInt(2)},
 		{a, a[1], big.NewInt(2), big.NewInt(0)},
+		{allocationsWithRepeatedEntry, a[0], big.NewInt(7), big.NewInt(4)},
 	}
 
 	for _, testcase := range testCases {
@@ -205,7 +208,7 @@ func TestAffordsFor(t *testing.T) {
 		if got.Cmp(testcase.Want) != 0 {
 			t.Errorf(
 				`Incorrect AffordFor: expected allocation %v to afford %v, for given allocation %v, but got %v`,
-				testcase.Allocations, testcase.GivenAllocation, testcase.Want, got)
+				testcase.Allocations, testcase.Want, testcase.GivenAllocation, got)
 		}
 	}
 

--- a/channel/state/outcome/outcome_test.go
+++ b/channel/state/outcome/outcome_test.go
@@ -183,30 +183,29 @@ func TestTotal(t *testing.T) {
 
 func TestAffordsFor(t *testing.T) {
 
-	var gots []*big.Int = []*big.Int{
-		a.AffordsFor(a[0], big.NewInt(3)),
-		a.AffordsFor(a[0], big.NewInt(2)),
-		a.AffordsFor(a[0], big.NewInt(1)),
-		a.AffordsFor(a[1], big.NewInt(6)),
-		a.AffordsFor(a[1], big.NewInt(5)),
-		a.AffordsFor(a[1], big.NewInt(4)),
-		a.AffordsFor(a[1], big.NewInt(2)),
+	type testCase struct {
+		Allocations     Allocations
+		GivenAllocation Allocation
+		X               *big.Int
+		Want            *big.Int
 	}
 
-	var wants []*big.Int = []*big.Int{
-		big.NewInt(2),
-		big.NewInt(2),
-		big.NewInt(1),
-		big.NewInt(3),
-		big.NewInt(3),
-		big.NewInt(2),
-		big.NewInt(0),
+	var testCases []testCase = []testCase{
+		{a, a[0], big.NewInt(3), big.NewInt(2)},
+		{a, a[0], big.NewInt(2), big.NewInt(2)},
+		{a, a[0], big.NewInt(1), big.NewInt(1)},
+		{a, a[1], big.NewInt(6), big.NewInt(3)},
+		{a, a[1], big.NewInt(5), big.NewInt(3)},
+		{a, a[1], big.NewInt(4), big.NewInt(2)},
+		{a, a[1], big.NewInt(2), big.NewInt(0)},
 	}
 
-	for i, got := range gots {
-		want := wants[i]
-		if got.Cmp(want) != 0 {
-			t.Errorf(`Incorrect AffordFor: expected %v, got %v`, want, got)
+	for _, testcase := range testCases {
+		got := testcase.Allocations.AffordsFor(testcase.GivenAllocation, testcase.X)
+		if got.Cmp(testcase.Want) != 0 {
+			t.Errorf(
+				`Incorrect AffordFor: expected allocation %v to afford %v, for given allocation %v, but got %v`,
+				testcase.Allocations, testcase.GivenAllocation, testcase.Want, got)
 		}
 	}
 

--- a/channel/state/outcome/outcome_test.go
+++ b/channel/state/outcome/outcome_test.go
@@ -163,18 +163,51 @@ func TestExitDecode(t *testing.T) {
 	}
 }
 
+var a = Allocations{{ // [{Alice: 2, Bob: 3}]
+	Destination:    types.Destination(common.HexToHash("0x0a")),
+	Amount:         big.NewInt(2),
+	AllocationType: 0,
+	Metadata:       make(types.Bytes, 0)}, {
+	Destination:    types.Destination(common.HexToHash("0x0b")),
+	Amount:         big.NewInt(3),
+	AllocationType: 0,
+	Metadata:       make(types.Bytes, 0)}}
+
 func TestTotal(t *testing.T) {
-	a := Allocations{{ // [{Alice: 2, Bob: 3}]
-		Destination:    types.Destination(common.HexToHash("0x0a")),
-		Amount:         big.NewInt(2),
-		AllocationType: 0,
-		Metadata:       make(types.Bytes, 0)}, {
-		Destination:    types.Destination(common.HexToHash("0x0b")),
-		Amount:         big.NewInt(3),
-		AllocationType: 0,
-		Metadata:       make(types.Bytes, 0)}}
+
 	total := a.Total()
 	if total.Cmp(big.NewInt(5)) != 0 {
 		t.Errorf(`Expected total to be 5, got %v`, total)
 	}
+}
+
+func TestAffordsFor(t *testing.T) {
+
+	var gots []*big.Int = []*big.Int{
+		a.AffordsFor(a[0], big.NewInt(3)),
+		a.AffordsFor(a[0], big.NewInt(2)),
+		a.AffordsFor(a[0], big.NewInt(1)),
+		a.AffordsFor(a[1], big.NewInt(6)),
+		a.AffordsFor(a[1], big.NewInt(5)),
+		a.AffordsFor(a[1], big.NewInt(4)),
+		a.AffordsFor(a[1], big.NewInt(2)),
+	}
+
+	var wants []*big.Int = []*big.Int{
+		big.NewInt(2),
+		big.NewInt(2),
+		big.NewInt(1),
+		big.NewInt(3),
+		big.NewInt(3),
+		big.NewInt(2),
+		big.NewInt(0),
+	}
+
+	for i, got := range gots {
+		want := wants[i]
+		if got.Cmp(want) != 0 {
+			t.Errorf(`Incorrect AffordFor: expected %v, got %v`, want, got)
+		}
+	}
+
 }


### PR DESCRIPTION
Preparatory work towards #25 

This will be useful for deciding whether a given channel is funded by another.
    
By combining information about how the other channel is funded (e.g. on chain), this method infers whether enough coins "flow" to the given channel.
    
By matching against the entire allocation (not just the channel id), it is possible to filter for the given allocation having the correct type and metadata -- for example, the given allocation might be a guarantee taking a specific form.