### PR TITLE
Add Allocations.Affords() method

### DIFF
--- a/channel/state/outcome/outcome.go
+++ b/channel/state/outcome/outcome.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -56,14 +55,14 @@ func (a Allocations) Total() *big.Int {
 	return total
 }
 
-// Affords returns true if the allocations can afford the given allocation given input funds of x, false otherwise.
+// Affords returns true if the allocations can afford the given allocation given the input funding, false otherwise.
 //
 // To afford the given allocation, the allocations must include something equal-in-value to it,
-// as well as having sufficient funds left over for it after reserving funds from x for all allocations with higher priority.
+// as well as having sufficient funds left over for it after reserving funds from the input funding for all allocations with higher priority.
 // Note that "equal-in-value" implies the same allocation type and metadata (if any).
-func (allocations Allocations) Affords(given Allocation, x *big.Int) bool {
+func (allocations Allocations) Affords(given Allocation, funding *big.Int) bool {
 	bigZero := big.NewInt(0)
-	surplus := big.NewInt(0).Set(x)
+	surplus := big.NewInt(0).Set(funding)
 	for _, allocation := range allocations {
 
 		if allocation.Equal(given) {

--- a/channel/state/outcome/outcome.go
+++ b/channel/state/outcome/outcome.go
@@ -66,17 +66,15 @@ func (allocations Allocations) Affords(given Allocation, x *big.Int) bool {
 	surplus := big.NewInt(0).Set(x)
 	for _, allocation := range allocations {
 
-		if surplus.Cmp(bigZero) == 0 {
-			break
+		if allocation.Equal(given) {
+			return surplus.Cmp(given.Amount) >= 0
 		}
 
-		affords := math.BigMin(surplus, allocation.Amount)
+		surplus.Sub(surplus, allocation.Amount)
 
-		if allocation.Equal(given) && affords.Cmp(allocation.Amount) >= 0 {
-			return true
+		if surplus.Cmp(bigZero) != 1 {
+			break // no funds remain for further allocations
 		}
-
-		surplus.Sub(surplus, affords)
 
 	}
 	return false

--- a/channel/state/outcome/outcome_test.go
+++ b/channel/state/outcome/outcome_test.go
@@ -163,15 +163,18 @@ func TestExitDecode(t *testing.T) {
 	}
 }
 
-var a = Allocations{{ // [{Alice: 2, Bob: 3}]
-	Destination:    types.Destination(common.HexToHash("0x0a")),
-	Amount:         big.NewInt(2),
-	AllocationType: 0,
-	Metadata:       make(types.Bytes, 0)}, {
-	Destination:    types.Destination(common.HexToHash("0x0b")),
-	Amount:         big.NewInt(3),
-	AllocationType: 0,
-	Metadata:       make(types.Bytes, 0)}}
+var a = Allocations{ // [{Alice: 2, Bob: 3}]
+	{
+		Destination:    types.Destination(common.HexToHash("0x0a")),
+		Amount:         big.NewInt(2),
+		AllocationType: 0,
+		Metadata:       make(types.Bytes, 0)},
+	{
+		Destination:    types.Destination(common.HexToHash("0x0b")),
+		Amount:         big.NewInt(3),
+		AllocationType: 0,
+		Metadata:       make(types.Bytes, 0)},
+}
 
 func TestTotal(t *testing.T) {
 

--- a/channel/state/outcome/outcome_test.go
+++ b/channel/state/outcome/outcome_test.go
@@ -189,7 +189,7 @@ func TestAffords(t *testing.T) {
 	testCases := map[string]struct {
 		Allocations     Allocations
 		GivenAllocation Allocation
-		X               *big.Int
+		Funding         *big.Int
 		Want            bool
 	}{
 		"case 0": {a, a[0], big.NewInt(3), true},
@@ -204,11 +204,11 @@ func TestAffords(t *testing.T) {
 
 	for name, testcase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			got := testcase.Allocations.Affords(testcase.GivenAllocation, testcase.X)
+			got := testcase.Allocations.Affords(testcase.GivenAllocation, testcase.Funding)
 			if got != testcase.Want {
 				t.Errorf(
 					`Incorrect AffordFor: expected %v.Affords(%v,%v) to be %v, but got %v`,
-					testcase.Allocations, testcase.GivenAllocation, testcase.X, testcase.Want, got)
+					testcase.Allocations, testcase.GivenAllocation, testcase.Funding, testcase.Want, got)
 			}
 		})
 

--- a/channel/state/outcome/outcome_test.go
+++ b/channel/state/outcome/outcome_test.go
@@ -183,31 +183,32 @@ func TestTotal(t *testing.T) {
 
 func TestAffords(t *testing.T) {
 
-	type testCase struct {
+	testCases := map[string]struct {
 		Allocations     Allocations
 		GivenAllocation Allocation
 		X               *big.Int
 		Want            bool
+	}{
+		"case 0": {a, a[0], big.NewInt(3), true},
+		"case 1": {a, a[0], big.NewInt(2), true},
+		"case 2": {a, a[0], big.NewInt(1), false},
+		"case 3": {a, a[1], big.NewInt(6), true},
+		"case 4": {a, a[1], big.NewInt(5), true},
+		"case 5": {a, a[1], big.NewInt(4), false},
+		"case 6": {a, a[1], big.NewInt(2), false},
+		"case 7": {a, Allocation{}, big.NewInt(2), false},
 	}
 
-	var testCases []testCase = []testCase{
-		{a, a[0], big.NewInt(3), true},
-		{a, a[0], big.NewInt(2), true},
-		{a, a[0], big.NewInt(1), false},
-		{a, a[1], big.NewInt(6), true},
-		{a, a[1], big.NewInt(5), true},
-		{a, a[1], big.NewInt(4), false},
-		{a, a[1], big.NewInt(2), false},
-		{a, Allocation{}, big.NewInt(2), false},
-	}
+	for name, testcase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := testcase.Allocations.Affords(testcase.GivenAllocation, testcase.X)
+			if got != testcase.Want {
+				t.Errorf(
+					`Incorrect AffordFor: expected %v.Affords(%v,%v) to be %v, but got %v`,
+					testcase.Allocations, testcase.GivenAllocation, testcase.X, testcase.Want, got)
+			}
+		})
 
-	for _, testcase := range testCases {
-		got := testcase.Allocations.Affords(testcase.GivenAllocation, testcase.X)
-		if got != testcase.Want {
-			t.Errorf(
-				`Incorrect AffordFor: expected %v.Affords(%v,%v) to be %v, but got %v`,
-				testcase.Allocations, testcase.GivenAllocation, testcase.X, testcase.Want, got)
-		}
 	}
 
 }


### PR DESCRIPTION
This method will allow the virtual funding protocol to check the following important condition before signing a postfund state for a virtual channel: "have the ledger channel(s) I care about been updated correctly?"

"Correctly" here means both:
1. That they include a specific allocation (for each asset).This allocation will be computed when the virtual funding objective is spawned. All fields, including the allocation type and metadata (which will encode a guarantee), must be correct. Furthermore:
2. The ledger channel must itself be sufficiently funded to "cover" the allocation in question.


---
For more context, I anticipate this method will be used in the following place (this is a commit from a work in progress branch):
https://github.com/statechannels/go-nitro/blob/e1b7446150128e6eb5fcd3f9a97fa1d60e862a78/protocols/virtual-fund/virtual-funding.go#L154-L165

The method would replace the `.GuaranteesFor` placeholder that I have here. It will eventually be wired up to the protocol via a `Channel` class #78 (work in progress for that viewable on the same commit) .
