### PR TITLE
Refactor Outcome threshold accounting methods

### DIFF
--- a/channel/state/outcome/outcome.go
+++ b/channel/state/outcome/outcome.go
@@ -147,7 +147,7 @@ func (e Exit) TotalAllocated() types.Funds {
 // DepositSafetyThreshold returns the Funds that a user with the specified
 // interests must see on-chain before the safe recoverability of their
 // deposits is guaranteed
-func (e Exit) DepositSafetyThreshold(interests []types.Destination) types.Funds {
+func (e Exit) DepositSafetyThreshold(interests ...types.Destination) types.Funds {
 	threshold := types.Funds{}
 
 	for _, assetExit := range e {

--- a/channel/state/outcome/outcome.go
+++ b/channel/state/outcome/outcome.go
@@ -109,6 +109,20 @@ func (a Exit) Equal(b Exit) bool {
 	return true
 }
 
+// TotalAllocated returns the sum of all Funds that are allocated by the outcome.
+//
+// NOTE that these Funds are potentially different from a channel's capacity to
+// pay out a given set of allocations, which is limited by the channel's holdings
+func (e Exit) TotalAllocated() types.Funds {
+	fullValue := types.Funds{}
+
+	for _, assetExit := range e {
+		fullValue[assetExit.Asset] = assetExit.TotalAllocated()
+	}
+
+	return fullValue
+}
+
 // allocationsTy describes the shape of Allocations such that github.com/ethereum/go-ethereum/accounts/abi can parse it
 var allocationsTy = abi.ArgumentMarshaling{
 	Name: "Allocations",

--- a/channel/state/outcome/outcome.go
+++ b/channel/state/outcome/outcome.go
@@ -79,6 +79,27 @@ func (allocations Allocations) Affords(given Allocation, funding *big.Int) bool 
 	return false
 }
 
+// DepositSafetyThreshold returns the amount of this asset that a user with
+// the specified interests must see on-chain before the safe recoverability of
+// their own deposts is guaranteed
+func (s SingleAssetExit) DepositSafetyThreshold(interests []types.Destination) *big.Int {
+	sum := big.NewInt(0)
+
+	for _, allocation := range s.Allocations {
+
+		for _, interest := range interests {
+			if allocation.Destination == interest {
+				// we have 'hit' a destination whose balances we are interested in protecting
+				return sum
+			}
+		}
+
+		sum.Add(sum, allocation.Amount)
+	}
+
+	return sum
+}
+
 // SingleAssetExit declares an ordered list of Allocations for a single asset.
 type SingleAssetExit struct {
 	Asset       types.Address // Either the zero address (implying the native token) or the address of an ERC20 contract
@@ -121,6 +142,19 @@ func (e Exit) TotalAllocated() types.Funds {
 	}
 
 	return fullValue
+}
+
+// DepositSafetyThreshold returns the Funds that a user with the specified
+// interests must see on-chain before the safe recoverability of their
+// deposits is guaranteed
+func (e Exit) DepositSafetyThreshold(interests []types.Destination) types.Funds {
+	threshold := types.Funds{}
+
+	for _, assetExit := range e {
+		threshold[assetExit.Asset] = assetExit.DepositSafetyThreshold(interests)
+	}
+
+	return threshold
 }
 
 // allocationsTy describes the shape of Allocations such that github.com/ethereum/go-ethereum/accounts/abi can parse it

--- a/channel/state/outcome/outcome.go
+++ b/channel/state/outcome/outcome.go
@@ -55,6 +55,17 @@ func (a Allocations) Total() *big.Int {
 	return total
 }
 
+// TotalFor returns the total amount allocated to the given dest (regardless of AllocationType)
+func (a Allocations) TotalFor(dest types.Destination) *big.Int {
+	total := big.NewInt(0)
+	for _, allocation := range a {
+		if allocation.Destination == dest {
+			total.Add(total, allocation.Amount)
+		}
+	}
+	return total
+}
+
 // Affords returns true if the allocations can afford the given allocation given the input funding, false otherwise.
 //
 // To afford the given allocation, the allocations must include something equal-in-value to it,
@@ -112,6 +123,11 @@ func (sae SingleAssetExit) TotalAllocated() *big.Int {
 	return sae.Allocations.Total()
 }
 
+// TotalAllocatedFor returns the total amount allocated for the specific destination
+func (sae SingleAssetExit) TotalAllocatedFor(dest types.Destination) *big.Int {
+	return sae.Allocations.TotalFor(dest)
+}
+
 // Exit is an ordered list of SingleAssetExits
 type Exit []SingleAssetExit
 
@@ -142,6 +158,17 @@ func (e Exit) TotalAllocated() types.Funds {
 	}
 
 	return fullValue
+}
+
+// TotalAllocatedFor returns the total amount allocated to the given dest (regardless of AllocationType)
+func (e Exit) TotalAllocatedFor(dest types.Destination) types.Funds {
+	total := types.Funds{}
+
+	for _, assetAllocation := range e {
+		total[assetAllocation.Asset] = assetAllocation.TotalAllocatedFor(dest)
+	}
+
+	return total
 }
 
 // DepositSafetyThreshold returns the Funds that a user with the specified

--- a/channel/state/outcome/outcome.go
+++ b/channel/state/outcome/outcome.go
@@ -91,18 +91,16 @@ func (allocations Allocations) Affords(given Allocation, funding *big.Int) bool 
 }
 
 // DepositSafetyThreshold returns the amount of this asset that a user with
-// the specified interests must see on-chain before the safe recoverability of
+// the specified interest must see on-chain before the safe recoverability of
 // their own deposits is guaranteed
-func (s SingleAssetExit) DepositSafetyThreshold(interests []types.Destination) *big.Int {
+func (s SingleAssetExit) DepositSafetyThreshold(interest types.Destination) *big.Int {
 	sum := big.NewInt(0)
 
 	for _, allocation := range s.Allocations {
 
-		for _, interest := range interests {
-			if allocation.Destination == interest {
-				// we have 'hit' a destination whose balances we are interested in protecting
-				return sum
-			}
+		if allocation.Destination == interest {
+			// we have 'hit' the destination whose balances we are interested in protecting
+			return sum
 		}
 
 		sum.Add(sum, allocation.Amount)
@@ -172,13 +170,13 @@ func (e Exit) TotalAllocatedFor(dest types.Destination) types.Funds {
 }
 
 // DepositSafetyThreshold returns the Funds that a user with the specified
-// interests must see on-chain before the safe recoverability of their
+// interest must see on-chain before the safe recoverability of their
 // deposits is guaranteed
-func (e Exit) DepositSafetyThreshold(interests ...types.Destination) types.Funds {
+func (e Exit) DepositSafetyThreshold(interest types.Destination) types.Funds {
 	threshold := types.Funds{}
 
 	for _, assetExit := range e {
-		threshold[assetExit.Asset] = assetExit.DepositSafetyThreshold(interests)
+		threshold[assetExit.Asset] = assetExit.DepositSafetyThreshold(interest)
 	}
 
 	return threshold

--- a/channel/state/outcome/outcome.go
+++ b/channel/state/outcome/outcome.go
@@ -92,7 +92,7 @@ func (allocations Allocations) Affords(given Allocation, funding *big.Int) bool 
 
 // DepositSafetyThreshold returns the amount of this asset that a user with
 // the specified interests must see on-chain before the safe recoverability of
-// their own deposts is guaranteed
+// their own deposits is guaranteed
 func (s SingleAssetExit) DepositSafetyThreshold(interests []types.Destination) *big.Int {
 	sum := big.NewInt(0)
 

--- a/channel/state/outcome/outcome_test.go
+++ b/channel/state/outcome/outcome_test.go
@@ -255,3 +255,30 @@ func TestTotalAllocated(t *testing.T) {
 			e, want, got)
 	}
 }
+
+func TestDepositSafetyThreshold(t *testing.T) {
+	testCases := []struct {
+		Exit        Exit
+		Participant types.Destination
+		Want        types.Funds
+	}{
+		{e, types.Destination(common.HexToHash("0x0a")), types.Funds{
+			types.Address{}:    big.NewInt(0),
+			types.Address{123}: big.NewInt(2),
+		}},
+		{e, types.Destination(common.HexToHash("0x0b")), types.Funds{
+			types.Address{}:    big.NewInt(2),
+			types.Address{123}: big.NewInt(0),
+		}},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprint("Case", i), func(t *testing.T) {
+			got := testCase.Exit.DepositSafetyThreshold([]types.Destination{testCase.Participant})
+			if !got.Equal(testCase.Want) {
+				t.Errorf("Expected safetethreshold for participant %v on exit %v to be %v, but got %v",
+					testCase.Participant, testCase.Exit, testCase.Want, got)
+			}
+		})
+	}
+}

--- a/channel/state/outcome/outcome_test.go
+++ b/channel/state/outcome/outcome_test.go
@@ -3,6 +3,7 @@ package outcome
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -273,7 +274,7 @@ func TestDepositSafetyThreshold(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		t.Run(fmt.Sprint("Case", i), func(t *testing.T) {
+		t.Run(fmt.Sprint("Case ", i), func(t *testing.T) {
 			got := testCase.Exit.DepositSafetyThreshold([]types.Destination{testCase.Participant})
 			if !got.Equal(testCase.Want) {
 				t.Errorf("Expected safetethreshold for participant %v on exit %v to be %v, but got %v",

--- a/channel/state/outcome/outcome_test.go
+++ b/channel/state/outcome/outcome_test.go
@@ -176,6 +176,32 @@ var a = Allocations{ // [{Alice: 2, Bob: 3}]
 		Metadata:       make(types.Bytes, 0)},
 }
 
+var b = Allocations{ // [{Bob: 2, Alice: 1}]
+	{
+		Destination:    types.Destination(common.HexToHash("0x0b")),
+		Amount:         big.NewInt(2),
+		AllocationType: 0,
+		Metadata:       make(types.Bytes, 0)},
+	{
+		Destination:    types.Destination(common.HexToHash("0x0a")),
+		Amount:         big.NewInt(1),
+		AllocationType: 0,
+		Metadata:       make(types.Bytes, 0)},
+}
+
+var e Exit = Exit{
+	{
+		Asset:       types.Address{}, // eth, fil, etc.
+		Metadata:    zeroBytes,
+		Allocations: a,
+	},
+	{
+		Asset:       types.Address{123}, // some token
+		Metadata:    zeroBytes,
+		Allocations: b,
+	},
+}
+
 func TestTotal(t *testing.T) {
 
 	total := a.Total()
@@ -214,4 +240,18 @@ func TestAffords(t *testing.T) {
 
 	}
 
+}
+
+func TestTotalAllocated(t *testing.T) {
+	want := types.Funds{
+		types.Address{}:    big.NewInt(5),
+		types.Address{123}: big.NewInt(3),
+	}
+
+	got := e.TotalAllocated()
+
+	if !got.Equal(want) {
+		t.Errorf("Expected %v.TotalAllocated() to equal %v, but it was %v",
+			e, want, got)
+	}
 }

--- a/channel/state/outcome/outcome_test.go
+++ b/channel/state/outcome/outcome_test.go
@@ -275,7 +275,7 @@ func TestDepositSafetyThreshold(t *testing.T) {
 
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprint("Case ", i), func(t *testing.T) {
-			got := testCase.Exit.DepositSafetyThreshold([]types.Destination{testCase.Participant})
+			got := testCase.Exit.DepositSafetyThreshold(testCase.Participant)
 			if !got.Equal(testCase.Want) {
 				t.Errorf("Expected safetethreshold for participant %v on exit %v to be %v, but got %v",
 					testCase.Participant, testCase.Exit, testCase.Want, got)

--- a/channel/state/outcome/outcome_test.go
+++ b/channel/state/outcome/outcome_test.go
@@ -164,14 +164,17 @@ func TestExitDecode(t *testing.T) {
 	}
 }
 
+var alice = types.Destination(common.HexToHash("0x0a"))
+var bob = types.Destination(common.HexToHash("0x0b"))
+
 var allocsX = Allocations{ // [{Alice: 2, Bob: 3}]
 	{
-		Destination:    types.Destination(common.HexToHash("0x0a")),
+		Destination:    alice,
 		Amount:         big.NewInt(2),
 		AllocationType: 0,
 		Metadata:       make(types.Bytes, 0)},
 	{
-		Destination:    types.Destination(common.HexToHash("0x0b")),
+		Destination:    bob,
 		Amount:         big.NewInt(3),
 		AllocationType: 0,
 		Metadata:       make(types.Bytes, 0)},
@@ -179,12 +182,12 @@ var allocsX = Allocations{ // [{Alice: 2, Bob: 3}]
 
 var allocsY = Allocations{ // [{Bob: 2, Alice: 1}]
 	{
-		Destination:    types.Destination(common.HexToHash("0x0b")),
+		Destination:    bob,
 		Amount:         big.NewInt(2),
 		AllocationType: 0,
 		Metadata:       make(types.Bytes, 0)},
 	{
-		Destination:    types.Destination(common.HexToHash("0x0a")),
+		Destination:    alice,
 		Amount:         big.NewInt(1),
 		AllocationType: 0,
 		Metadata:       make(types.Bytes, 0)},
@@ -263,11 +266,11 @@ func TestDepositSafetyThreshold(t *testing.T) {
 		Participant types.Destination
 		Want        types.Funds
 	}{
-		{e, types.Destination(common.HexToHash("0x0a")), types.Funds{
+		{e, alice, types.Funds{
 			types.Address{}:    big.NewInt(0),
 			types.Address{123}: big.NewInt(2),
 		}},
-		{e, types.Destination(common.HexToHash("0x0b")), types.Funds{
+		{e, bob, types.Funds{
 			types.Address{}:    big.NewInt(2),
 			types.Address{123}: big.NewInt(0),
 		}},

--- a/channel/state/outcome/outcome_test.go
+++ b/channel/state/outcome/outcome_test.go
@@ -163,7 +163,7 @@ func TestExitDecode(t *testing.T) {
 	}
 }
 
-var a = Allocations{ // [{Alice: 2, Bob: 3}]
+var allocsX = Allocations{ // [{Alice: 2, Bob: 3}]
 	{
 		Destination:    types.Destination(common.HexToHash("0x0a")),
 		Amount:         big.NewInt(2),
@@ -176,7 +176,7 @@ var a = Allocations{ // [{Alice: 2, Bob: 3}]
 		Metadata:       make(types.Bytes, 0)},
 }
 
-var b = Allocations{ // [{Bob: 2, Alice: 1}]
+var allocsY = Allocations{ // [{Bob: 2, Alice: 1}]
 	{
 		Destination:    types.Destination(common.HexToHash("0x0b")),
 		Amount:         big.NewInt(2),
@@ -193,18 +193,18 @@ var e Exit = Exit{
 	{
 		Asset:       types.Address{}, // eth, fil, etc.
 		Metadata:    zeroBytes,
-		Allocations: a,
+		Allocations: allocsX,
 	},
 	{
 		Asset:       types.Address{123}, // some token
 		Metadata:    zeroBytes,
-		Allocations: b,
+		Allocations: allocsY,
 	},
 }
 
 func TestTotal(t *testing.T) {
 
-	total := a.Total()
+	total := allocsX.Total()
 	if total.Cmp(big.NewInt(5)) != 0 {
 		t.Errorf(`Expected total to be 5, got %v`, total)
 	}
@@ -218,14 +218,14 @@ func TestAffords(t *testing.T) {
 		Funding         *big.Int
 		Want            bool
 	}{
-		"case 0": {a, a[0], big.NewInt(3), true},
-		"case 1": {a, a[0], big.NewInt(2), true},
-		"case 2": {a, a[0], big.NewInt(1), false},
-		"case 3": {a, a[1], big.NewInt(6), true},
-		"case 4": {a, a[1], big.NewInt(5), true},
-		"case 5": {a, a[1], big.NewInt(4), false},
-		"case 6": {a, a[1], big.NewInt(2), false},
-		"case 7": {a, Allocation{}, big.NewInt(2), false},
+		"case 0": {allocsX, allocsX[0], big.NewInt(3), true},
+		"case 1": {allocsX, allocsX[0], big.NewInt(2), true},
+		"case 2": {allocsX, allocsX[0], big.NewInt(1), false},
+		"case 3": {allocsX, allocsX[1], big.NewInt(6), true},
+		"case 4": {allocsX, allocsX[1], big.NewInt(5), true},
+		"case 5": {allocsX, allocsX[1], big.NewInt(4), false},
+		"case 6": {allocsX, allocsX[1], big.NewInt(2), false},
+		"case 7": {allocsX, Allocation{}, big.NewInt(2), false},
 	}
 
 	for name, testcase := range testCases {

--- a/channel/state/outcome/outcome_test.go
+++ b/channel/state/outcome/outcome_test.go
@@ -280,7 +280,7 @@ func TestDepositSafetyThreshold(t *testing.T) {
 		t.Run(fmt.Sprint("Case ", i), func(t *testing.T) {
 			got := testCase.Exit.DepositSafetyThreshold(testCase.Participant)
 			if !got.Equal(testCase.Want) {
-				t.Errorf("Expected safetethreshold for participant %v on exit %v to be %v, but got %v",
+				t.Errorf("Expected safety threshold for participant %v on exit %v to be %v, but got %v",
 					testCase.Participant, testCase.Exit, testCase.Want, got)
 			}
 		})

--- a/channel/state/outcome/outcome_test.go
+++ b/channel/state/outcome/outcome_test.go
@@ -286,3 +286,30 @@ func TestDepositSafetyThreshold(t *testing.T) {
 		})
 	}
 }
+
+func TestTotalFor(t *testing.T) {
+	testCases := []struct {
+		Exit        Exit
+		Participant types.Destination
+		Want        types.Funds
+	}{
+		{e, alice, types.Funds{
+			types.Address{}:    big.NewInt(2),
+			types.Address{123}: big.NewInt(1),
+		}},
+		{e, bob, types.Funds{
+			types.Address{}:    big.NewInt(3),
+			types.Address{123}: big.NewInt(2),
+		}},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprint("Case ", i), func(t *testing.T) {
+			got := testCase.Exit.TotalAllocatedFor(testCase.Participant)
+			if !got.Equal(testCase.Want) {
+				t.Errorf("Expected TotalAllocatedFor for participant %v on exit %v to be %v, but got %v",
+					testCase.Participant, testCase.Exit, testCase.Want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR addresses the bad assumptions re: participant and allocation ordering that currently exist in `direct-funding.go`.

It:
- adds utility functions to `Allocations`, `SingleAssetExit`, and `Exit`
- adds tests for the above
- replaces a busy and somewhat opaque loop calculation in `NewDirectFundingObjectiveState` with readible calls to the above utility functions

**Limitation**: The `DepositSafetyThreshold` functions makes the implicit assumption that the caller's `interests` are sequential in each allocation. IE: calling `{Alice:2, Bob:3, Alice:5}.DepositSafetyThreshold(Alice)` will return 0, since it finds Alice in the first allocation index. Really, it's initially safe for Alice to deposit 2, and then after holdings is 5, she is safe to deposit 5 more.

**Question**: is this a workflow that we want to support (sooner or later)? If not: should we make assertions on initial outcomes that allocations are not shaped like the above?

Change size is larger than ideal, but:
- This PR should read well per-commit
- 95% of the code is straightforward loops & arithmetic