### PR TITLE
add test for `ExitAffords` and fix resulting panic

### DIFF
--- a/channel/state/outcome/exit_test.go
+++ b/channel/state/outcome/exit_test.go
@@ -176,3 +176,16 @@ func TestTotalFor(t *testing.T) {
 		})
 	}
 }
+
+func TestExitAffords(t *testing.T) {
+
+	allocationMap := map[types.Address]Allocation{
+		{}: testExit[0].Allocations[0],
+	}
+
+	got := testExit.Affords(allocationMap, types.Funds{}) // This should not panic
+	want := false
+	if !(got == want) {
+		t.Error(`Affords: expected test exit to not afford the given allocation with nil funds`)
+	}
+}


### PR DESCRIPTION
Because we use `big.Int` (a rich type) instead of `uint`, we can often end up with a nil pointer when we search for some funds that don't exist (i.e. by slicing into a map with some asset as a key, when that map has no entry for that key). We must be very careful to catch those cases and treat them as if they are `big.NewInt(0)` to avoid runtime panics. 