### PR TITLE
testState: use only 2 participants

### DIFF
--- a/channel/state/state_test.go
+++ b/channel/state/state_test.go
@@ -8,14 +8,14 @@ import (
 )
 
 // The following constants are generated from our ts nitro-protocol package
-var correctChannelId = common.HexToHash(`cd578811171bb0291c7dc59081b9a910960b78001dece1954c00da9d8c12a925`)
-var correctStateHash = common.HexToHash(`15bec3235b9147d730661d7bc97653dbb17c3971402853f212f539e3ad6f84bf`)
+var correctChannelId = common.HexToHash(`4ebd366d014a173765ba1e50f284c179ade31f20441bec41664712aac6cc461d`)
+var correctStateHash = common.HexToHash(`c8d5eae9ca84647bafc1bd26a7058a230cd45cb3bf21b37b6330053f4e3ebd0e`)
 var signerPrivateKey = common.Hex2Bytes(`caab404f975b4620747174a75f08d98b4e5a7053b691b41bcfc0d839d48b7634`)
 var signerAddress = common.HexToAddress(`F5A1BB5607C9D079E46d1B3Dc33f257d937b43BD`)
 var correctSignature = Signature{
-	common.Hex2Bytes(`a37e883f5ba6b6ce83b06b5ac847c7f99470f945b943a1b6a4c3ff52c01388dc`),
-	common.Hex2Bytes(`468c4fa2aeea392e44a9d7404e37f2a7b0ded8db97186abc37c107d672c0d4a9`),
-	byte(0),
+	common.Hex2Bytes(`b3b69fbfbdcb3100d6e5758c5661d0d793bc227716d16fd6235ccd588cae2849`),
+	common.Hex2Bytes(`500969f691a848245910e9ac7688bbc28198b6a6e723299751bda6234bff77f3`),
+	byte(1),
 }
 
 func TestChannelId(t *testing.T) {

--- a/channel/state/test-fixtures.go
+++ b/channel/state/test-fixtures.go
@@ -30,8 +30,7 @@ var TestState = State{
 	ChainId: chainId,
 	Participants: []types.Address{
 		common.HexToAddress(`0xF5A1BB5607C9D079E46d1B3Dc33f257d937b43BD`), // private key caab404f975b4620747174a75f08d98b4e5a7053b691b41bcfc0d839d48b7634
-		common.HexToAddress(`0xEe18fF1575055691009aa246aE608132C57a422c`),
-		common.HexToAddress(`0x95125c394F39bBa29178CAf5F0614EE80CBB1702`),
+		common.HexToAddress(`0x760bf27cd45036a6C486802D30B5D90CfFBE31FE`), // private key 62ecd49c4ccb41a70ad46532aed63cf815de15864bc415c87d507afd6a5e8da2
 	},
 	ChannelNonce:      big.NewInt(37140676580),
 	AppDefinition:     common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),

--- a/protocols/direct-fund/direct-fund_test.go
+++ b/protocols/direct-fund/direct-fund_test.go
@@ -121,7 +121,6 @@ func TestCrank(t *testing.T) {
 	// Manually progress the extended state by collecting prefund signatures
 	o.(DirectFundObjective).preFundSigned[0] = true
 	o.(DirectFundObjective).preFundSigned[1] = true
-	o.(DirectFundObjective).preFundSigned[2] = true
 
 	// Cranking should move us to the next waiting point
 	_, _, waitingFor, err = o.Crank(&privateKeyOfParticipant0)
@@ -156,7 +155,6 @@ func TestCrank(t *testing.T) {
 	// Manually progress the extended state by collecting postfund signatures
 	o.(DirectFundObjective).postFundSigned[0] = true
 	o.(DirectFundObjective).postFundSigned[1] = true
-	o.(DirectFundObjective).postFundSigned[2] = true
 
 	// This should be the final crank
 	o.(DirectFundObjective).onChainHolding[state.TestState.Outcome[0].Asset] = totalAmountAllocated


### PR DESCRIPTION
with known private keys.

This simplifies tests, particularly useful when it comes to tackling #78 and #25 