### PR TITLE
add `Exit.Affords()` method

### DIFF
--- a/channel/state/outcome/exit.go
+++ b/channel/state/outcome/exit.go
@@ -127,7 +127,7 @@ func (e *Exit) Hash() (types.Bytes32, error) {
 	}
 }
 
-type EasyExit map[common.Address]SingleAssetExit
+type easyExit map[common.Address]SingleAssetExit
 
 // toEasyExit() convets an Exit into a more ergonomic data type called an EasyExit
 //
@@ -136,8 +136,8 @@ type EasyExit map[common.Address]SingleAssetExit
 // The position has no semantic meaning, but does of course affect the hash of the exit.
 // Furthermore, this transformation assumes there are *no* repeated entries.
 // For these reasosn, the transformation should be considered non-invertibile and used with care.
-func (e Exit) toEasyExit() EasyExit {
-	easy := make(EasyExit)
+func (e Exit) toEasyExit() easyExit {
+	easy := make(easyExit)
 	for i := range e {
 		easy[e[i].Asset] = e[i]
 	}

--- a/channel/state/outcome/exit.go
+++ b/channel/state/outcome/exit.go
@@ -147,13 +147,13 @@ func (e Exit) toEasyExit() easyExit {
 
 // Affords returns true if every allocation in the allocationMap can be afforded by the Exit, given the funds
 //
-// Both arguments are maps keyed by the same asset
+// Both arguments are maps keyed by the same assets
 func (e Exit) Affords(
 	allocationMap map[common.Address]Allocation,
-	funds types.Funds) bool {
+	funding types.Funds) bool {
 	easyExit := e.toEasyExit()
 	for asset := range allocationMap {
-		x := funds[asset]
+		x := funding[asset]
 		if x == nil {
 			return false
 		}

--- a/channel/state/outcome/exit.go
+++ b/channel/state/outcome/exit.go
@@ -126,3 +126,41 @@ func (e *Exit) Hash() (types.Bytes32, error) {
 		return types.Bytes32{}, err
 	}
 }
+
+type EasyExit map[common.Address]SingleAssetExit
+
+// toEasyExit() convets an Exit into a more ergonomic data type called an EasyExit
+//
+// An EasyExit is a mapping from asset to SingleAssetExit, rather than an array.
+// The conversion loses some information, because the position in the original array is not recorded in the map.
+// The position has no semantic meaning, but does of course affect the hash of the exit.
+// Furthermore, this transformation assumes there are *no* repeated entries.
+// For these reasosn, the transformation should be considered non-invertibile and used with care.
+func (e Exit) toEasyExit() EasyExit {
+	easy := make(EasyExit)
+	for i := range e {
+		easy[e[i].Asset] = e[i]
+	}
+	return easy
+}
+
+// Affords returns true if every allocation in the allocationMap can be afforded by the Exit, given the funds in the xMap
+//
+// Both arguments are maps keyed by the same asset
+func (e Exit) Affords(
+	allocationMap map[common.Address]Allocation,
+	xMap types.Funds) bool {
+	easyExit := e.toEasyExit()
+	for asset := range allocationMap {
+		x := xMap[asset]
+		if x == nil {
+			return false
+		}
+		allocation := allocationMap[asset]
+		if !easyExit[asset].Allocations.Affords(allocation, x) {
+			return false
+		}
+	}
+	return true
+
+}

--- a/channel/state/outcome/exit.go
+++ b/channel/state/outcome/exit.go
@@ -144,15 +144,15 @@ func (e Exit) toEasyExit() easyExit {
 	return easy
 }
 
-// Affords returns true if every allocation in the allocationMap can be afforded by the Exit, given the funds in the xMap
+// Affords returns true if every allocation in the allocationMap can be afforded by the Exit, given the funds
 //
 // Both arguments are maps keyed by the same asset
 func (e Exit) Affords(
 	allocationMap map[common.Address]Allocation,
-	xMap types.Funds) bool {
+	funds types.Funds) bool {
 	easyExit := e.toEasyExit()
 	for asset := range allocationMap {
-		x := xMap[asset]
+		x := funds[asset]
 		if x == nil {
 			return false
 		}

--- a/channel/state/outcome/exit.go
+++ b/channel/state/outcome/exit.go
@@ -127,15 +127,16 @@ func (e *Exit) Hash() (types.Bytes32, error) {
 	}
 }
 
+// easyExit is a more ergonomic data type which can be derived from an Exit
 type easyExit map[common.Address]SingleAssetExit
 
-// toEasyExit() convets an Exit into a more ergonomic data type called an EasyExit
+// toEasyExit() convets an Exit into an easyExit.
 //
 // An EasyExit is a mapping from asset to SingleAssetExit, rather than an array.
 // The conversion loses some information, because the position in the original array is not recorded in the map.
 // The position has no semantic meaning, but does of course affect the hash of the exit.
 // Furthermore, this transformation assumes there are *no* repeated entries.
-// For these reasosn, the transformation should be considered non-invertibile and used with care.
+// For these reasons, the transformation should be considered non-invertibile and used with care.
 func (e Exit) toEasyExit() easyExit {
 	easy := make(easyExit)
 	for i := range e {

--- a/channel/state/outcome/exit_test.go
+++ b/channel/state/outcome/exit_test.go
@@ -176,3 +176,16 @@ func TestTotalFor(t *testing.T) {
 		})
 	}
 }
+
+func TestExitAffords(t *testing.T) {
+
+	allocationMap := map[types.Address]Allocation{
+		{}: testExit[0].Allocations[0],
+	}
+
+	got := testExit.Affords(allocationMap, types.Funds{}) // This should not panic
+	want := false
+	if !(got == want) {
+		t.Error(`Affords: expected test exit to not afford the given allocation with nil funds`)
+	}
+}


### PR DESCRIPTION
We already have an `Affords` method which applies to a single asset. This PR extends that to cope with a full `Exit` (i.e. many assets). 

It makes use of an `easyExit` type, also introduced here. For now this is just a helper method, but it is a hint about how we could use more ergonomic types in our Go code (and have adapters ready for when we need to interface with say some solidity code). 

Towards #25.