### PR TITLE
add `Channel` type, methods, unit tests

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -1,0 +1,214 @@
+package channel
+
+import (
+	"bytes"
+	"errors"
+	"math/big"
+	"reflect"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/types"
+)
+
+// Class containing states and metadata, and exposing convenience methods.
+type Channel struct {
+	Id      types.Destination
+	MyIndex uint
+
+	OnChainFunding types.Funds
+
+	state.FixedPart
+	// Support []uint64 // TODO: this property will be important, and allow the Channel to store the necessary data to close out the channel on chain
+	// It could be an array of turnNums, which can be used to slice into Channel.SignedStateForTurnNum
+
+	latestSupportedStateTurnNum uint64 // largest uint64 value reserved for "no supported state"
+
+	IsTwoPartyLedger bool
+	MyDestination    types.Destination
+	TheirDestination types.Destination // must be nonzero if a two party ledger channel
+
+	SignedStateForTurnNum map[uint64]SignedState // this stores up to 1 state per turn number.
+}
+
+// New constructs a new Channel from the supplied state.
+func New(s state.State, isTwoPartyLedger bool, myIndex uint, myDestination types.Destination, theirDestination types.Destination) (Channel, error) {
+	c := Channel{}
+	if s.TurnNum.Cmp(big.NewInt(0)) != 0 {
+		return c, errors.New(`objective must be constructed with a turnNum 0 state`)
+	}
+	if isTwoPartyLedger && (myDestination == types.Destination{} || theirDestination == types.Destination{}) {
+		return c, errors.New(`two party ledger channels must have non-null specify myDestination and theirDestination`)
+	}
+	var err error
+	c.Id, err = s.ChannelId()
+	if err != nil {
+		return c, err
+	}
+	c.MyIndex = myIndex
+	c.OnChainFunding = make(types.Funds)
+	c.FixedPart = s.FixedPart()
+	c.latestSupportedStateTurnNum = MAGICTURNNUM // largest uint64 value reserved for "no supported state"
+	// c.Support =  // TODO
+	c.IsTwoPartyLedger = isTwoPartyLedger
+	c.MyDestination = myDestination
+	c.TheirDestination = theirDestination
+
+	// Store prefund
+	c.SignedStateForTurnNum = make(map[uint64]SignedState)
+	c.SignedStateForTurnNum[0] = SignedState{s.VariablePart(), make(map[uint]state.Signature)}
+
+	// Store postfund
+	post := s.Clone()
+	post.TurnNum = big.NewInt(1)
+	c.SignedStateForTurnNum[1] = SignedState{post.VariablePart(), make(map[uint]state.Signature)}
+
+	return c, nil
+}
+
+// Clone returns a deep copy of the receiver
+func (c Channel) Clone() Channel {
+	return c // no pointer members, so this is sufficient
+}
+
+// Equal returns true if the channel is deeply equal to the reciever, false otherwise
+func (c Channel) Equal(d Channel) bool {
+	return reflect.DeepEqual(c, d)
+}
+
+// PreFundState() returns the pre fund setup state for the channel.
+func (c Channel) PreFundState() state.State {
+	return state.StateFromFixedAndVariablePart(c.FixedPart, c.SignedStateForTurnNum[0].State)
+}
+
+// PostFundState() returns the post fund setup state for the channel.
+func (c Channel) PostFundState() state.State {
+	return state.StateFromFixedAndVariablePart(c.FixedPart, c.SignedStateForTurnNum[1].State)
+
+}
+
+// PreFundSignedByMe() returns true if I have signed the pre fund setup state, false otherwise.
+func (c Channel) PreFundSignedByMe() bool {
+	if _, ok := c.SignedStateForTurnNum[0]; ok {
+		if _, ok := c.SignedStateForTurnNum[0].Sigs[c.MyIndex]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// PostFundSignedByMe() returns true if I have signed the pre fund setup state, false otherwise.
+func (c Channel) PostFundSignedByMe() bool {
+	if _, ok := c.SignedStateForTurnNum[1]; ok {
+		if _, ok := c.SignedStateForTurnNum[1].Sigs[c.MyIndex]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// PreFundComplete() returns true if I have a complete set of signatures on  the pre fund setup state, false otherwise.
+func (c Channel) PreFundComplete() bool {
+	return c.SignedStateForTurnNum[0].hasAllSignatures(len(c.FixedPart.Participants))
+}
+
+// PostFundComplete() returns true if I have a complete set of signatures on  the pre fund setup state, false otherwise.
+func (c Channel) PostFundComplete() bool {
+	return c.SignedStateForTurnNum[1].hasAllSignatures(len(c.FixedPart.Participants))
+}
+
+// LatestSupportedState returns the latest supported state.
+func (c Channel) LatestSupportedState() (state.State, error) {
+	if c.latestSupportedStateTurnNum == MAGICTURNNUM {
+		return state.State{}, errors.New(`no state is yet supported`)
+	}
+	return state.StateFromFixedAndVariablePart(c.FixedPart,
+		c.SignedStateForTurnNum[c.latestSupportedStateTurnNum].State), nil
+
+}
+
+// Total() returns the total allocated of each asset allocated by the pre fund setup state of the Channel.
+func (c Channel) Total() types.Funds {
+	funds := types.Funds{}
+	for _, sae := range c.PreFundState().Outcome {
+		funds[sae.Asset] = sae.Allocations.Total()
+	}
+	return funds
+}
+
+// Affords returns true if, for each asset keying the input variables, the channel can afford the allocation given the funding.
+// The decision is made based on the latest supported state of the channel.
+//
+// Both arguments are maps keyed by the same asset
+func (c Channel) Affords(
+	allocationMap map[common.Address]outcome.Allocation,
+	fundingMap types.Funds) bool {
+	lss, err := c.LatestSupportedState()
+	if err != nil {
+		return false
+	}
+	return lss.Outcome.Affords(allocationMap, fundingMap)
+}
+
+// AddSignedState adds a signed state to the Channel, updating the LatestSupportedState and Support if appropriate.
+// Returns false and does not alter the channel if the state is "stale", belongs to a different channel, or is signed by a non participant.
+func (c *Channel) AddSignedState(s state.State, sig state.Signature) bool {
+	signer, err := s.RecoverSigner(sig)
+	if err != nil {
+		// Invalid signature
+		return false
+	}
+
+	signerIndex, isParticipant := indexOf(signer, c.FixedPart.Participants)
+	if !isParticipant {
+		// Signature by non participant
+		return false
+	}
+	if cId, err := s.ChannelId(); cId != c.Id || err != nil {
+		// Channel mismatch
+		return false
+	}
+
+	turnNum := s.TurnNum.Uint64() // TODO https://github.com/statechannels/go-nitro/issues/95
+
+	if c.latestSupportedStateTurnNum != MAGICTURNNUM && turnNum < c.latestSupportedStateTurnNum {
+		// Stale state
+		return false
+	}
+
+	// Store the signature. If we have no record yet, add one.
+	if signedState, ok := c.SignedStateForTurnNum[turnNum]; !ok {
+		c.SignedStateForTurnNum[turnNum] = SignedState{s.VariablePart(), make(map[uint]state.Signature)}
+		c.SignedStateForTurnNum[turnNum].Sigs[signerIndex] = sig
+	} else {
+		signedState.Sigs[signerIndex] = sig
+	}
+
+	// Update latest supported state
+	if c.SignedStateForTurnNum[turnNum].hasAllSignatures(len(c.FixedPart.Participants)) {
+		c.latestSupportedStateTurnNum = turnNum
+	}
+
+	// TODO update support
+
+	return true
+}
+
+// AddSignedStates adds each signed state in the mapping
+func (c Channel) AddSignedStates(mapping map[*state.State]state.Signature) {
+	for state, sig := range mapping {
+		c.AddSignedState(*state, sig)
+	}
+}
+
+// indexOf returns the index of the given suspect address in the lineup of addresses. A second return value ("ok") is true the suspect was found, false otherwise.
+func indexOf(suspect types.Address, lineup []types.Address) (index uint, ok bool) {
+
+	for index, a := range lineup {
+		if bytes.Equal(suspect.Bytes(), a.Bytes()) {
+			return uint(index), true
+		}
+	}
+	return ^uint(0), false
+}

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -125,16 +125,11 @@ func (c Channel) LatestSupportedState() (state.State, error) {
 	}
 	return state.StateFromFixedAndVariablePart(c.FixedPart,
 		c.SignedStateForTurnNum[c.latestSupportedStateTurnNum].State), nil
-
 }
 
 // Total() returns the total allocated of each asset allocated by the pre fund setup state of the Channel.
 func (c Channel) Total() types.Funds {
-	funds := types.Funds{}
-	for _, sae := range c.PreFundState().Outcome {
-		funds[sae.Asset] = sae.Allocations.Total()
-	}
-	return funds
+	return c.PreFundState().Outcome.TotalAllocated()
 }
 
 // Affords returns true if, for each asset keying the input variables, the channel can afford the allocation given the funding.

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -98,7 +98,7 @@ func (c Channel) PreFundSignedByMe() bool {
 	return false
 }
 
-// PostFundSignedByMe() returns true if I have signed the pre fund setup state, false otherwise.
+// PostFundSignedByMe() returns true if I have signed the post fund setup state, false otherwise.
 func (c Channel) PostFundSignedByMe() bool {
 	if _, ok := c.SignedStateForTurnNum[1]; ok {
 		if _, ok := c.SignedStateForTurnNum[1].Sigs[c.MyIndex]; ok {

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -30,6 +30,7 @@ type Channel struct {
 	TheirDestination types.Destination // must be nonzero if a two party ledger channel
 
 	SignedStateForTurnNum map[uint64]SignedState // this stores up to 1 state per turn number.
+	// Longer term, we should have a more efficient and smart mechanism to store states https://github.com/statechannels/go-nitro/issues/106
 }
 
 // New constructs a new Channel from the supplied state.

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -47,7 +47,7 @@ func TestChannel(t *testing.T) {
 			t.Error(err2)
 		}
 		if got != want {
-			t.Errorf(`incorrect incorrect PreFundState returned, got %v wanted %v`, c.PreFundState(), s)
+			t.Errorf(`incorrect PreFundState returned, got %v wanted %v`, c.PreFundState(), s)
 		}
 	}
 
@@ -63,7 +63,7 @@ func TestChannel(t *testing.T) {
 			t.Error(err2)
 		}
 		if got != want {
-			t.Errorf(`incorrect incorrect PreFundState returned, got %v wanted %v`, c.PostFundState(), s)
+			t.Errorf(`incorrect PreFundState returned, got %v wanted %v`, c.PostFundState(), s)
 		}
 	}
 

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -1,0 +1,210 @@
+package channel
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/google/go-cmp/cmp"
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/types"
+)
+
+func TestChannel(t *testing.T) {
+	s := state.TestState.Clone()
+	_, err1 := New(s, true, 0, state.TestOutcome[0].Allocations[0].Destination, state.TestOutcome[0].Allocations[1].Destination)
+	s.TurnNum = big.NewInt(0)
+	c, err2 := New(s, true, 0, state.TestOutcome[0].Allocations[0].Destination, state.TestOutcome[0].Allocations[1].Destination)
+
+	testNew := func(t *testing.T) {
+		if err1 == nil {
+			t.Error(`expected error constructing with a non turnNum=0 state, but got none`)
+		}
+		if err2 != nil {
+			t.Error(err2)
+		}
+	}
+
+	testClone := func(t *testing.T) {
+		r := c.Clone()
+		if diff := cmp.Diff(r, c, cmp.Comparer(types.Equal)); diff != "" {
+			t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+		}
+
+		r.latestSupportedStateTurnNum++
+		if r.Equal(c) {
+			t.Error("Clone: modifying the clone should not modify the original")
+		}
+	}
+
+	testPreFund := func(t *testing.T) {
+		got, err1 := c.PreFundState().Hash()
+		want, err2 := s.Hash()
+		if err1 != nil {
+			t.Error(err1)
+		}
+		if err2 != nil {
+			t.Error(err2)
+		}
+		if got != want {
+			t.Errorf(`incorrect incorrect PreFundState returned, got %v wanted %v`, c.PreFundState(), s)
+		}
+	}
+
+	testPostFund := func(t *testing.T) {
+		got, err1 := c.PostFundState().Hash()
+		spf := s.Clone()
+		spf.TurnNum = big.NewInt(1)
+		want, err2 := spf.Hash()
+		if err1 != nil {
+			t.Error(err1)
+		}
+		if err2 != nil {
+			t.Error(err2)
+		}
+		if got != want {
+			t.Errorf(`incorrect incorrect PreFundState returned, got %v wanted %v`, c.PostFundState(), s)
+		}
+	}
+
+	testPreFundSignedByMe := func(t *testing.T) {
+		got := c.PreFundSignedByMe()
+		want := false
+		if got != want {
+			t.Error(`expected c.PreFundSignedByMe() to be false, but it is true`)
+		}
+
+	}
+
+	testPostFundSignedByMe := func(t *testing.T) {
+		got := c.PostFundSignedByMe()
+		want := false
+		if got != want {
+			t.Error(`expected c.PostFundSignedByMe() to be false, but it is true`)
+		}
+
+	}
+
+	testPreFundComplete := func(t *testing.T) {
+		got := c.PreFundComplete()
+		want := false
+		if got != want {
+			t.Error(`expected c.PreFundComplete() to be false, but it is true`)
+		}
+
+	}
+
+	testPostFundComplete := func(t *testing.T) {
+		got := c.PostFundComplete()
+		want := false
+		if got != want {
+			t.Error(`expected c.PostFundComplete() to be false, but it is true`)
+		}
+	}
+
+	testLatestSupportedState := func(t *testing.T) {
+		_, err1 := c.LatestSupportedState()
+		if err1 == nil {
+			t.Error(`c.LatestSupportedState(): expected an error since no state is yet supported, but got none`)
+		}
+	}
+
+	testTotal := func(t *testing.T) {
+		got := c.Total()
+		want := types.Funds{
+			common.Address{}: big.NewInt(10),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("TestCrank: side effects mismatch (-want +got):\n%s", diff)
+		}
+	}
+
+	testAddSignedState := func(t *testing.T) {
+		// Begin testing the cases that are NOOPs returning false
+		want := false
+
+		got := c.AddSignedState(s, state.Signature{}) // note null signature
+		if got != want {
+			t.Error(`expected c.AddSignedState() to be false, but it was true`)
+		}
+		nonParticipantSignature, _ := s.Sign(common.Hex2Bytes(`2030b463177db2da82908ef90fa55ddfcef56e8183caf60db464bc398e736e6f`))
+		got = c.AddSignedState(s, nonParticipantSignature) // note signature by non participant
+		if got != want {
+			t.Error(`expected c.AddSignedState() to be false, but it was true`)
+		}
+		alicePrivateKey := common.Hex2Bytes(`caab404f975b4620747174a75f08d98b4e5a7053b691b41bcfc0d839d48b7634`)
+		v := state.State{ // TODO it would be terser to clone s and modify it -- but s.Clone() is broken https://github.com/statechannels/go-nitro/issues/96
+			ChainId: s.ChainId,
+			Participants: []types.Address{
+				common.HexToAddress(`0xF5A1BB5607C9D079E46d1B3Dc33f257d937b43BD`),
+			},
+			ChannelNonce:      big.NewInt(37140676581),
+			AppDefinition:     common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),
+			ChallengeDuration: big.NewInt(60),
+			AppData:           []byte{},
+			Outcome:           state.TestOutcome,
+			TurnNum:           big.NewInt(5),
+			IsFinal:           false,
+		}
+		v.ChannelNonce.Add(v.ChannelNonce, big.NewInt(1))
+		aliceSignatureOnWrongState, _ := v.Sign(alicePrivateKey)
+		got = c.AddSignedState(v, aliceSignatureOnWrongState) // note state from wrong channel
+		if got != want {
+			t.Error(`expected c.AddSignedState() to be false, but it was true`)
+		}
+		c.latestSupportedStateTurnNum = uint64(3)
+		aliceSignatureOnCorrectState, _ := c.PostFundState().Sign(alicePrivateKey)
+		got = c.AddSignedState(c.PostFundState(), aliceSignatureOnCorrectState) // note stale state
+		if got != want {
+			t.Error(`expected c.AddSignedState() to be false, but it was true`)
+		}
+		c.latestSupportedStateTurnNum = MAGICTURNNUM // Rest so there is no longer a supported state
+
+		// Now test cases which update the Channel and return true
+		want = true
+
+		got = c.AddSignedState(c.PostFundState(), aliceSignatureOnCorrectState)
+		if got != want {
+			t.Error(`expected c.AddSignedState() to be true, but it was false`)
+		}
+
+		got2 := c.SignedStateForTurnNum[1]
+		if got2.State.Outcome == nil || got2.Sigs == nil {
+			t.Error(`state not added correctly`)
+		}
+
+		// Add Bob's signature and check that we now have a supported state
+		bobPrivateKey := common.Hex2Bytes(`62ecd49c4ccb41a70ad46532aed63cf815de15864bc415c87d507afd6a5e8da2`)
+		bobSignatureOnCorrectState, _ := c.PostFundState().Sign(bobPrivateKey)
+		got = c.AddSignedState(c.PostFundState(), bobSignatureOnCorrectState)
+		if got != want {
+			t.Error(`expected c.AddSignedState() to be true, but it was false`)
+		}
+		got3 := c.latestSupportedStateTurnNum
+		want3 := uint64(1)
+		if got3 != want3 {
+			t.Errorf(`expected c.latestSupportedStateTurnNum to be %v, but got %v`, want, got)
+		}
+		got4, err4 := c.LatestSupportedState()
+		if err4 != nil {
+			t.Error(err4)
+		}
+		if got4.TurnNum.Uint64() != want3 {
+			t.Errorf(`expected LatestSupportedState with turnNum %v`, want3)
+		}
+
+	}
+
+	t.Run(`TestNew`, testNew)
+	t.Run(`TestClone`, testClone)
+	t.Run(`TestPreFund`, testPreFund)
+	t.Run(`TestPostFund`, testPostFund)
+	t.Run(`TestPreFundSignedByMe`, testPreFundSignedByMe)
+	t.Run(`TestPostFundSignedByMe`, testPostFundSignedByMe)
+	t.Run(`TestPreFundComplete`, testPreFundComplete)
+	t.Run(`TestPostFundComplete`, testPostFundComplete)
+	t.Run(`TestLatestSupportedState`, testLatestSupportedState)
+	t.Run(`TestTotal`, testTotal)
+	t.Run(`TestAddSignedState`, testAddSignedState)
+
+}

--- a/channel/constants.go
+++ b/channel/constants.go
@@ -1,0 +1,4 @@
+package channel
+
+// MAGICTURNNUM is a reserved value which is taken to mean "there is not yet a supported state"
+const MAGICTURNNUM = ^uint64(0)

--- a/channel/signedstate.go
+++ b/channel/signedstate.go
@@ -1,0 +1,19 @@
+package channel
+
+import (
+	"github.com/statechannels/go-nitro/channel/state"
+)
+
+type SignedState struct {
+	State state.VariablePart
+	Sigs  map[uint]state.Signature // keyed by participant index
+}
+
+// hasAllSignatures returns true if there are numParticipants distinct signatures on the state and false otherwise.
+func (ss SignedState) hasAllSignatures(numParticipants int) bool {
+	if len(ss.Sigs) == numParticipants {
+		return true
+	} else {
+		return false
+	}
+}

--- a/types/bigutils.go
+++ b/types/bigutils.go
@@ -10,3 +10,7 @@ import "math/big"
 func Gt(a *big.Int, b *big.Int) bool {
 	return a.Cmp(b) > 0
 }
+
+func Equal(a *big.Int, b *big.Int) bool {
+	return a.Cmp(b) == 0
+}


### PR DESCRIPTION
Towards #78 and #25 .

The **Channel** type is essentially a container for states and signatures that belong together. It has methods which allow protocols to easily answer such queries as:
* is the prefund round complete?
* have I signed the post fund state?
* is the channel funded?
* what is the latest supported state?

This abstraction will be particularly useful for protocols / objectives that manage multiple channels (e.g. the `virtual-fund` protocol), and pushes us toward a dual objective/channel data model. I think this is more appropriate given the a channel may also be governed by multiple objectives (although not at the same time) over its lifecycle. See #78 for more detail. 

The unit test suite uses sub tests (`t.Run(name,func)`) in order to share test data without polluting the rest of the package. 