### PR TITLE
add `VirtualFundObjective` and unit tests

### DIFF
--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -19,10 +19,25 @@ type Transaction struct {
 	Data []byte
 }
 
+// LedgerRequest is an object processed by the ledger cranker
+type LedgerRequest struct {
+	LedgerId    types.Destination
+	Destination types.Destination
+	Amount      types.Funds
+	Left        types.Destination
+	Right       types.Destination
+}
+
+// Equal checks for equality between the receiver and a second LedgerRequest
+func (l LedgerRequest) Equal(m LedgerRequest) bool {
+	return l.LedgerId == m.LedgerId && l.Amount.Equal(m.Amount) && l.Left == m.Left && l.Right == m.Right
+}
+
 // SideEffects are effects to be executed by an imperative shell
 type SideEffects struct {
 	MessagesToSend       []Message
 	TransactionsToSubmit []Transaction
+	LedgerRequests       []LedgerRequest
 }
 
 // WaitingFor is an enumerable "pause-point" computed from an Objective. It describes how the objective is blocked on actions by third parties (i.e. co-participants or the blockchain).

--- a/protocols/virtual-fund/virtual-fund-single-hop_test.go
+++ b/protocols/virtual-fund/virtual-fund-single-hop_test.go
@@ -1,0 +1,346 @@
+package virtualfund
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/google/go-cmp/cmp"
+	"github.com/statechannels/go-nitro/channel"
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/types"
+)
+
+func TestSingleHopVirtualFund(t *testing.T) {
+
+	// In general
+	// Alice = P_0 <=L_0=> P_1 <=L_1=> ... P_n <=L_n>= P_n+1 = Bob
+
+	// For these tests
+	// Alice <=L_0=> P_1 <=L_1=> Bob
+
+	////////////
+	// ACTORS //
+	////////////
+	type actor struct {
+		address     types.Address
+		destination types.Destination
+		privateKey  []byte
+		role        uint
+	}
+
+	var alice = actor{
+		address:     common.HexToAddress(`0xD9995BAE12FEe327256FFec1e3184d492bD94C31`),
+		destination: types.AdddressToDestination(common.HexToAddress(`0xD9995BAE12FEe327256FFec1e3184d492bD94C31`)),
+		privateKey:  common.Hex2Bytes(`7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8`),
+		role:        0,
+	}
+
+	var p1 = actor{ // Aliases: The Hub, Irene
+		address:     common.HexToAddress(`0xd4Fa489Eacc52BA59438993f37Be9fcC20090E39`),
+		destination: types.AdddressToDestination(common.HexToAddress(`0xd4Fa489Eacc52BA59438993f37Be9fcC20090E39`)),
+		privateKey:  common.Hex2Bytes(`2030b463177db2da82908ef90fa55ddfcef56e8183caf60db464bc398e736e6f`),
+		role:        1,
+	}
+
+	var bob = actor{
+		address:     common.HexToAddress(`0x760bf27cd45036a6C486802D30B5D90CfFBE31FE`),
+		destination: types.AdddressToDestination(common.HexToAddress(`0x760bf27cd45036a6C486802D30B5D90CfFBE31FE`)),
+		privateKey:  common.Hex2Bytes(`62ecd49c4ccb41a70ad46532aed63cf815de15864bc415c87d507afd6a5e8da2`),
+		role:        2,
+	}
+
+	/////////////////////
+	// VIRTUAL CHANNEL //
+	/////////////////////
+
+	// Virtual Channel
+	var vPreFund = state.State{
+		ChainId:           big.NewInt(9001),
+		Participants:      []types.Address{alice.address, p1.address, bob.address}, // A single hop virtual channel
+		ChannelNonce:      big.NewInt(0),
+		AppDefinition:     types.Address{},
+		ChallengeDuration: big.NewInt(45),
+		AppData:           []byte{},
+		Outcome: outcome.Exit{outcome.SingleAssetExit{
+			Allocations: outcome.Allocations{
+				outcome.Allocation{
+					Destination: alice.destination,
+					Amount:      big.NewInt(5),
+				},
+				outcome.Allocation{
+					Destination: bob.destination,
+					Amount:      big.NewInt(5),
+				},
+			},
+		}},
+		TurnNum: big.NewInt(0),
+		IsFinal: false,
+	}
+
+	/////////////////////
+	// LEDGER CHANNELS //
+	/////////////////////
+
+	var l0state = state.State{
+		ChainId:           big.NewInt(9001),
+		Participants:      []types.Address{alice.address, p1.address},
+		ChannelNonce:      big.NewInt(0),
+		AppDefinition:     types.Address{},
+		ChallengeDuration: big.NewInt(45),
+		AppData:           []byte{},
+		Outcome: outcome.Exit{outcome.SingleAssetExit{
+			Allocations: outcome.Allocations{
+				outcome.Allocation{
+					Destination: alice.destination,
+					Amount:      big.NewInt(5),
+				},
+				outcome.Allocation{
+					Destination: p1.destination,
+					Amount:      big.NewInt(5),
+				},
+			},
+		}},
+		TurnNum: big.NewInt(0), // We use turnNum 0 so that we can use github.com/statechannels/go-nitro/channel.New().
+		// It would be more realistic to have a higher TurnNum, but that would involve more boilerplate code.
+		IsFinal: false,
+	}
+
+	var vId, _ = vPreFund.ChannelId()
+
+	var l0guaranteemetadataemcoded, _ = outcome.GuaranteeMetadata{
+		Left:  alice.destination,
+		Right: p1.destination,
+	}.Encode()
+
+	var l0updatedstate = state.State{
+		ChainId:           big.NewInt(9001),
+		Participants:      []types.Address{alice.address, p1.address},
+		ChannelNonce:      big.NewInt(0),
+		AppDefinition:     types.Address{},
+		ChallengeDuration: big.NewInt(45),
+		AppData:           []byte{},
+		Outcome: outcome.Exit{outcome.SingleAssetExit{
+			Allocations: outcome.Allocations{
+				outcome.Allocation{
+					Destination: alice.destination,
+					Amount:      big.NewInt(0),
+				},
+				outcome.Allocation{
+					Destination: p1.destination,
+					Amount:      big.NewInt(0),
+				},
+				outcome.Allocation{
+					Destination:    vId,
+					Amount:         big.NewInt(10),
+					AllocationType: outcome.GuaranteeAllocationType,
+					Metadata:       l0guaranteemetadataemcoded,
+				},
+			},
+		}},
+		TurnNum: big.NewInt(2), // This needs to be greater than the previous state else it will be rejected by Channel.AddSignedState
+		IsFinal: false,
+	}
+
+	var AsAlice = func(t *testing.T) {
+
+		/////////////////////
+		// BEGIN test data //
+		/////////////////////
+
+		// In this test, we play Alice
+		my := alice
+
+		// Alice plays role 0 so has no ledger channel on her left
+		var ledgerChannelToMyLeft channel.Channel
+
+		// She has a single ledger channel L_0 connecting her to P_1
+		var ledgerChannelToMyRight, _ = channel.New(
+			l0state,
+			true,
+			0,
+			my.destination,
+			p1.destination,
+		)
+
+		// Ensure this channel is fully funded on chain
+		ledgerChannelToMyRight.OnChainFunding = ledgerChannelToMyRight.PreFundState().Outcome.TotalAllocated()
+
+		// Objective
+		var n = uint(2) // number of ledger channels (num_hops + 1)
+		var s, _ = New(vPreFund, my.address, n, my.role, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+		var expectedGuaranteeMetadata = outcome.GuaranteeMetadata{Left: ledgerChannelToMyRight.MyDestination, Right: ledgerChannelToMyRight.TheirDestination}
+		var expectedEncodedGuaranteeMetadata, _ = expectedGuaranteeMetadata.Encode()
+		var expectedGuarantee outcome.Allocation = outcome.Allocation{
+			Destination:    s.V.Id,
+			Amount:         big.NewInt(0).Set(vPreFund.VariablePart().Outcome[0].TotalAllocated()),
+			AllocationType: outcome.GuaranteeAllocationType,
+			Metadata:       expectedEncodedGuaranteeMetadata,
+		}
+		var expectedLedgerRequests = []protocols.LedgerRequest{{
+			LedgerId:    ledgerChannelToMyRight.Id,
+			Destination: s.V.Id,
+			Amount:      types.Funds{types.Address{}: s.V.PreFundState().VariablePart().Outcome[0].Allocations.Total()},
+			Left:        ledgerChannelToMyRight.MyDestination, Right: ledgerChannelToMyRight.TheirDestination,
+		}}
+
+		var correctSignatureByAliceOnVPreFund, _ = s.V.PreFundState().Sign(alice.privateKey)
+		var correctSignatureByP_1OnVPreFund, _ = s.V.PreFundState().Sign(p1.privateKey)
+		var correctSignatureByBobOnVPreFund, _ = s.V.PreFundState().Sign(bob.privateKey)
+
+		var correctSignatureByAliceOnVPostFund, _ = s.V.PostFundState().Sign(alice.privateKey)
+		var correctSignatureByP_1OnVPostFund, _ = s.V.PostFundState().Sign(p1.privateKey)
+		var correctSignatureByBobOnVPostFund, _ = s.V.PostFundState().Sign(bob.privateKey)
+
+		var correctSignatureByAliceOnL_0updatedsate, _ = l0updatedstate.Sign(alice.privateKey)
+		var correctSignatureByP_1OnL_0updatedsate, _ = l0updatedstate.Sign(p1.privateKey)
+
+		///////////////////
+		// END test data //
+		///////////////////
+
+		testNew := func(t *testing.T) {
+			// Assert that a valid set of constructor args does not result in an error
+			o, err := New(vPreFund, my.address, 2, my.role, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			if err != nil {
+				t.Error(err)
+			}
+
+			got := o.ToMyRight.ExpectedGuarantees[types.Address{}] // VState only has one (native) asset represented by the zero address
+			want := expectedGuarantee
+
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("TestNew: expectedGuarantee mismatch (-want +got):\n%s", diff)
+			}
+		}
+
+		testCrank := func(t *testing.T) {
+
+			// Assert that cranking an unapproved objective returns an error
+			if _, _, _, err := s.Crank(&my.privateKey); err == nil {
+				t.Error(`Expected error when cranking unapproved objective, but got nil`)
+			}
+
+			// Approve the objective, so that the rest of the test cases can run.
+			o := s.Approve()
+
+			// To test the finite state progression, we are going to progressively mutate o
+			// And then crank it to see which "pause point" (WaitingFor) we end up at.
+
+			// Initial Crank
+			_, _, waitingFor, err := o.Crank(&my.privateKey)
+			if err != nil {
+				t.Error(err)
+			}
+			if waitingFor != WaitingForCompletePrefund {
+				t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForCompletePrefund, waitingFor)
+			}
+
+			// Manually progress the extended state by collecting prefund signatures
+			o.(VirtualFundObjective).V.AddSignedState(vPreFund, correctSignatureByAliceOnVPreFund)
+			o.(VirtualFundObjective).V.AddSignedState(vPreFund, correctSignatureByBobOnVPreFund)
+			o.(VirtualFundObjective).V.AddSignedState(vPreFund, correctSignatureByP_1OnVPreFund)
+
+			// Cranking should move us to the next waiting point, generate ledger requests as a side effect, and alter the extended state to reflect that
+			o, sideEffects, waitingFor, err := o.Crank(&my.privateKey)
+			if err != nil {
+				t.Error(err)
+			}
+			if waitingFor != WaitingForCompleteFunding {
+				t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForCompleteFunding, waitingFor)
+			}
+			if o.(VirtualFundObjective).requestedLedgerUpdates != true {
+				t.Error(`Expected ledger update idempotency flag to be raised, but it wasn't`)
+			}
+
+			got, want := sideEffects.LedgerRequests, expectedLedgerRequests
+
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("TestCrank: side effects mismatch (-want +got):\n%s", diff)
+			}
+
+			// Manually progress the extended state by "completing funding" from this wallet's point of view
+			o.(VirtualFundObjective).ToMyRight.Channel.AddSignedState(l0updatedstate, correctSignatureByAliceOnL_0updatedsate)
+			o.(VirtualFundObjective).ToMyRight.Channel.AddSignedState(l0updatedstate, correctSignatureByP_1OnL_0updatedsate)
+			o.(VirtualFundObjective).ToMyRight.Channel.OnChainFunding[types.Address{}] = l0state.Outcome[0].Allocations.Total() // Make this channel fully funded
+			// Cranking now should not generate side effects, because we already did that
+			o, _, waitingFor, err = o.Crank(&my.privateKey)
+			if err != nil {
+				t.Error(err)
+			}
+			if waitingFor != WaitingForCompletePostFund {
+				t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForCompletePostFund, waitingFor)
+			}
+
+			// Manually progress the extended state by collecting postfund signatures
+			o.(VirtualFundObjective).V.AddSignedState(o.(VirtualFundObjective).V.PostFundState(), correctSignatureByAliceOnVPostFund)
+			o.(VirtualFundObjective).V.AddSignedState(o.(VirtualFundObjective).V.PostFundState(), correctSignatureByBobOnVPostFund)
+			o.(VirtualFundObjective).V.AddSignedState(o.(VirtualFundObjective).V.PostFundState(), correctSignatureByP_1OnVPostFund)
+
+			// This should be the final crank...
+			_, _, waitingFor, err = o.Crank(&my.privateKey)
+			if err != nil {
+				t.Error(err)
+			}
+			if waitingFor != WaitingForNothing {
+				t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForNothing, waitingFor)
+			}
+
+		}
+
+		testUpdate := func(t *testing.T) {
+
+			// Prepare an event with a mismatched channelId
+			e := protocols.ObjectiveEvent{
+				ChannelId: types.Destination{},
+			}
+			// Assert that Updating the objective with such an event returns an error
+			// TODO is this the behaviour we want? Below with the signatures, we prefer a log + NOOP (no error)
+			if _, err := s.Update(e); err == nil {
+				t.Error(`ChannelId mismatch -- expected an error but did not get one`)
+			}
+
+			// Now modify the event to give it the "correct" channelId (matching the objective),
+			// and make a new Sigs map.
+			// This prepares us for the rest of the test. We will reuse the same event multiple times
+			e.ChannelId = s.V.Id
+			e.Sigs = make(map[*state.State]state.Signature)
+
+			// Next, attempt to update the objective with correct signature by a participant on a relevant state
+			// Assert that this results in an appropriate change in the extended state of the objective
+			// Part 1: a signature on a state in channel V
+			prefundstate := s.V.PreFundState()
+			e.Sigs[&prefundstate] = correctSignatureByAliceOnVPreFund
+			updated, err := s.Update(e)
+			if err != nil {
+				t.Error(err)
+			}
+			if updated.(VirtualFundObjective).V.PreFundSignedByMe() != true {
+				t.Error(`Objective data not updated as expected`)
+			}
+
+			// Part 2: a signature on Alice's ledger channel (on her right)
+			f := protocols.ObjectiveEvent{
+				ChannelId: s.ToMyRight.Channel.Id,
+			}
+			f.Sigs = make(map[*state.State]state.Signature)
+			f.Sigs[&l0updatedstate] = correctSignatureByAliceOnL_0updatedsate
+			updated, err = s.Update(f)
+			if err != nil {
+				t.Error(err)
+			}
+			if !updated.(VirtualFundObjective).ToMyRight.ledgerChannelAffordsExpectedGuarantees() != true {
+				t.Error(`Objective data not updated as expected`)
+			}
+
+		}
+
+		t.Run(`New`, testNew)
+		t.Run(`Update`, testUpdate)
+		t.Run(`Crank`, testCrank)
+
+	}
+	t.Run(`AsAlice`, AsAlice)
+}

--- a/protocols/virtual-fund/virtual-fund.go
+++ b/protocols/virtual-fund/virtual-fund.go
@@ -85,9 +85,9 @@ func New(
 	// Initialize virtual channel
 	v, err := channel.New(initialStateOfV, false, myRole, types.Destination{}, types.Destination{})
 	if err != nil {
-		return init, err
-
+		return VirtualFundObjective{}, err
 	}
+
 	init.V = &v
 	init.n = n
 	init.MyRole = myRole

--- a/protocols/virtual-fund/virtual-fund.go
+++ b/protocols/virtual-fund/virtual-fund.go
@@ -1,0 +1,364 @@
+package virtualfund
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/statechannels/go-nitro/channel"
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/types"
+)
+
+const (
+	WaitingForCompletePrefund  protocols.WaitingFor = "WaitingForCompletePrefund"  // Round 1
+	WaitingForCompleteFunding  protocols.WaitingFor = "WaitingForCompleteFunding"  // Round 2
+	WaitingForCompletePostFund protocols.WaitingFor = "WaitingForCompletePostFund" // Round 3
+	WaitingForNothing          protocols.WaitingFor = "WaitingForNothing"          // Finished
+)
+
+var NoSideEffects = protocols.SideEffects{}
+
+// errors
+var ErrNotApproved = errors.New("objective not approved")
+
+type Connection struct {
+	Channel            channel.Channel
+	ExpectedGuarantees map[types.Address]outcome.Allocation
+}
+
+// VirtualFundObjective is a cache of data computed by reading from the store. It stores (potentially) infinite data.
+type VirtualFundObjective struct {
+	Status protocols.ObjectiveStatus
+	V      *channel.Channel
+
+	ToMyLeft  *Connection
+	ToMyRight *Connection
+
+	n      uint // number of ledger channels (num_hops + 1)
+	MyRole uint // index in the virtual funding protocol. 0 for Alice, n+1 for Bob. Otherwise, one of the intermediaries.
+
+	a0 types.Funds // Initial balance for Alice
+	b0 types.Funds // Initial balance for Bob
+
+	requestedLedgerUpdates bool // records that the ledger update side effects were previously generated (they may not have been executed yet)
+}
+
+////////////////////////////////////////////////
+// Public methods on the VirtualFundObjective //
+////////////////////////////////////////////////
+
+// New initiates a VirtualFundObjective.
+func New(
+	initialStateOfV state.State,
+	myAddress types.Address,
+	n uint, // number of ledger channels (num_hops + 1)
+	myRole uint,
+	ledgerChannelToMyLeft channel.Channel,
+	ledgerChannelToMyRight channel.Channel,
+) (VirtualFundObjective, error) {
+
+	var init VirtualFundObjective
+
+	if ledgerChannelToMyLeft.IsTwoPartyLedger && ledgerChannelToMyRight.IsTwoPartyLedger {
+		return init, errors.New(`supplied channels are not two party ledger channels`)
+	}
+
+	// Initialize virtual channel
+	v, err := channel.New(initialStateOfV, false, myRole, types.Destination{}, types.Destination{})
+	if err != nil {
+		return init, err
+
+	}
+	init.V = &v
+	init.n = n
+	init.MyRole = myRole
+	init.a0 = make(map[types.Address]*big.Int)
+	init.b0 = make(map[types.Address]*big.Int)
+
+	// Compute a0 and b0 from the initial state of J
+	for i := range initialStateOfV.Outcome {
+		asset := initialStateOfV.Outcome[i].Asset
+		amount0 := initialStateOfV.Outcome[i].Allocations[0].Amount
+		amount1 := initialStateOfV.Outcome[i].Allocations[1].Amount
+		if init.a0[asset] == nil {
+			init.a0[asset] = big.NewInt(0)
+		}
+		if init.b0[asset] == nil {
+			init.b0[asset] = big.NewInt(0)
+		}
+		init.a0[asset].Add(init.a0[asset], amount0)
+		init.b0[asset].Add(init.b0[asset], amount1)
+	}
+
+	// Setup Ledger Channel Connections and expected guarantees
+	switch {
+	case myRole == 0: // Alice
+		init.ToMyRight = &Connection{}
+		init.ToMyRight.Channel = ledgerChannelToMyRight
+		err = init.ToMyRight.insertExpectedGuarantees(init.a0, init.b0, init.V.Id, init.ToMyRight.Channel.MyDestination, init.ToMyRight.Channel.TheirDestination)
+		if err != nil {
+			return VirtualFundObjective{}, err
+		}
+	case myRole < n+1: // Intermediary
+		init.ToMyRight = &Connection{}
+		init.ToMyRight.Channel = ledgerChannelToMyRight
+		err = init.ToMyRight.insertExpectedGuarantees(init.a0, init.b0, init.V.Id, init.ToMyRight.Channel.MyDestination, init.ToMyRight.Channel.TheirDestination)
+		if err != nil {
+			return VirtualFundObjective{}, err
+		}
+		init.ToMyLeft = &Connection{}
+		init.ToMyLeft.Channel = ledgerChannelToMyLeft
+		err = init.ToMyLeft.insertExpectedGuarantees(init.a0, init.b0, init.V.Id, init.ToMyRight.Channel.TheirDestination, init.ToMyRight.Channel.MyDestination)
+		if err != nil {
+			return VirtualFundObjective{}, err
+		}
+	case myRole == n+1: // Bob
+		init.ToMyLeft = &Connection{}
+		init.ToMyLeft.Channel = ledgerChannelToMyLeft
+		err = init.ToMyLeft.insertExpectedGuarantees(init.a0, init.b0, init.V.Id, init.ToMyRight.Channel.TheirDestination, init.ToMyRight.Channel.MyDestination)
+		if err != nil {
+			return VirtualFundObjective{}, err
+		}
+	default:
+		return VirtualFundObjective{}, errors.New(`myRole > n+1`)
+	}
+
+	return init, nil
+}
+
+// Id returns the objective id.
+func (s VirtualFundObjective) Id() protocols.ObjectiveId {
+	return protocols.ObjectiveId("VirtualFund-" + s.V.Id.String())
+}
+
+// Approve returns an approved copy of the objective.
+func (s VirtualFundObjective) Approve() protocols.Objective {
+	updated := s.clone()
+	// todo: consider case of s.Status == Rejected
+	updated.Status = protocols.Approved
+	return updated
+}
+
+// Approve returns a rejected copy of the objective.
+func (s VirtualFundObjective) Reject() protocols.Objective {
+	updated := s.clone()
+	updated.Status = protocols.Rejected
+	return updated
+}
+
+// Update receives an protocols.ObjectiveEvent, applies all applicable event data to the VirtualFundObjective,
+// and returns the updated state.
+func (s VirtualFundObjective) Update(event protocols.ObjectiveEvent) (protocols.Objective, error) {
+
+	updated := s.clone()
+
+	var toMyLeftId types.Destination
+	var toMyRightId types.Destination
+
+	if s.MyRole != 0 {
+		toMyLeftId = s.ToMyLeft.Channel.Id // Avoid this if it is nil
+	}
+	if s.MyRole != s.n+1 {
+		toMyRightId = s.ToMyRight.Channel.Id // Avoid this if it is nil
+	}
+
+	switch event.ChannelId {
+	case types.Destination{}:
+		return s, errors.New("null channel id") // catch this case to avoid a panic below -- because if Alice or Bob we allow a null channel.
+	case s.V.Id:
+		updated.V.AddSignedStates(event.Sigs)
+		// We expect pre and post fund state signatures.
+	case toMyLeftId:
+		updated.ToMyLeft.Channel.AddSignedStates(event.Sigs)
+		// We expect a countersigned state including an outcome with expected guarantee. We don't know the exact statehash, though.
+	case toMyRightId:
+		updated.ToMyRight.Channel.AddSignedStates(event.Sigs)
+		// We expect a countersigned state including an outcome with expected guarantee. We don't know the exact statehash, though.
+	default:
+		return s, errors.New("event channelId out of scope of objective")
+	}
+	return updated, nil
+
+}
+
+// Crank inspects the extended state and declares a list of Effects to be executed
+// It's like a state machine transition function where the finite / enumerable state is returned (computed from the extended state)
+// rather than being independent of the extended state; and where there is only one type of event ("the crank") with no data on it at all.
+func (s VirtualFundObjective) Crank(secretKey *[]byte) (protocols.Objective, protocols.SideEffects, protocols.WaitingFor, error) {
+	updated := s.clone()
+
+	// Input validation
+	if updated.Status != protocols.Approved {
+		return updated, NoSideEffects, WaitingForNothing, ErrNotApproved
+	}
+
+	// Prefunding
+
+	if !updated.V.PreFundSignedByMe() {
+		sig, err := updated.V.PreFundState().Sign(*secretKey)
+		if err != nil {
+			return s, NoSideEffects, WaitingForNothing, err
+		}
+		ok := updated.V.AddSignedState(updated.V.PreFundState(), sig)
+		if !ok {
+			return s, NoSideEffects, WaitingForNothing, errors.New(`could not add prefund state`)
+		}
+		return updated, NoSideEffects, WaitingForCompletePrefund, nil
+
+	}
+
+	if !updated.V.PreFundComplete() {
+		return updated, NoSideEffects, WaitingForCompletePrefund, nil
+	}
+
+	// Funding
+
+	if !updated.requestedLedgerUpdates {
+		updated.requestedLedgerUpdates = true
+		return updated, s.generateLedgerRequestSideEffects(), WaitingForCompleteFunding, nil
+	}
+
+	if !updated.fundingComplete() {
+		return updated, NoSideEffects, WaitingForCompleteFunding, nil
+	}
+
+	// Postfunding
+	if !updated.V.PostFundSignedByMe() {
+		sig, err := updated.V.PostFundState().Sign(*secretKey)
+		if err != nil {
+			return s, NoSideEffects, WaitingForNothing, err
+		}
+		ok := updated.V.AddSignedState(updated.V.PostFundState(), sig)
+		if !ok {
+			return s, NoSideEffects, WaitingForNothing, errors.New(`could not add postfund state`)
+		}
+		return updated, NoSideEffects, WaitingForCompletePostFund, nil
+
+	}
+
+	if !updated.V.PostFundComplete() {
+		return updated, NoSideEffects, WaitingForCompletePostFund, nil
+	}
+
+	// Completion
+	return updated, NoSideEffects, WaitingForNothing, nil
+}
+
+//////////////////////////////////////////////////
+//  Private methods on the VirtualFundObjective //
+//////////////////////////////////////////////////
+
+// insertExpectedGuaranteesForLedgerChannel mutates the reciever Connection struct.
+func (connection *Connection) insertExpectedGuarantees(a0 types.Funds, b0 types.Funds, vId types.Destination, left types.Destination, right types.Destination) error {
+	expectedGuaranteesForLedgerChannel := make(map[types.Address]outcome.Allocation)
+	metadata := outcome.GuaranteeMetadata{
+		Left:  left,
+		Right: right,
+	}
+	encodedGuarantee, err := metadata.Encode()
+	if err != nil {
+		return err
+	}
+
+	for asset := range a0 {
+		expectedGuaranteesForLedgerChannel[asset] = outcome.Allocation{
+			Destination:    vId,
+			Amount:         big.NewInt(0).Add(a0[asset], b0[asset]),
+			AllocationType: outcome.GuaranteeAllocationType,
+			Metadata:       encodedGuarantee,
+		}
+	}
+	connection.ExpectedGuarantees = expectedGuaranteesForLedgerChannel
+	return nil
+}
+
+// fundingComplete returns true if the appropriate ledger channel guarantees sufficient funds for J
+func (s VirtualFundObjective) fundingComplete() bool {
+
+	// Each peer commits to an update in L_{i-1} and L_i including the guarantees G_{i-1} and {G_i} respectively, and deducting b_0 from L_{I-1} and a_0 from L_i.
+	// A = P_0 and B=P_n+1 are special cases. A only does the guarantee for L_0 (deducting a0), and B only foes the guarantee for L_n (deducting b0).
+
+	n := s.n
+
+	switch {
+	case s.MyRole == 0: // Alice
+		return s.ToMyRight.ledgerChannelAffordsExpectedGuarantees()
+	case s.MyRole < n+1: // Intermediary
+		return s.ToMyRight.ledgerChannelAffordsExpectedGuarantees() && s.ToMyLeft.ledgerChannelAffordsExpectedGuarantees()
+	case s.MyRole == n+1: // Bob
+		return s.ToMyLeft.ledgerChannelAffordsExpectedGuarantees()
+	default: // Invalid
+		return false
+	}
+
+}
+
+// ledgerChannelAffordsExpectedGuarantees returns true if, for the channel inside the connection, and for each asset keying the input variables, the channel can afford the allocation given the funding.
+// The decision is made based on the latest supported state of the channel.
+//
+// Both arguments are maps keyed by the same asset.
+func (connection *Connection) ledgerChannelAffordsExpectedGuarantees() bool {
+	return connection.Channel.Affords(connection.ExpectedGuarantees, connection.Channel.OnChainFunding)
+}
+
+// generateLedgerRequestSideEffects generates the appropriate side effects, which (when executed and countersigned) will update 1 or 2 ledger channels to guarantee the joint channel.
+func (s VirtualFundObjective) generateLedgerRequestSideEffects() protocols.SideEffects {
+	sideEffects := protocols.SideEffects{}
+	sideEffects.LedgerRequests = make([]protocols.LedgerRequest, 0)
+	if s.MyRole > 0 { // Not Alice
+		sideEffects.LedgerRequests = append(sideEffects.LedgerRequests,
+			protocols.LedgerRequest{
+				LedgerId:    s.ToMyLeft.Channel.Id,
+				Destination: s.V.Id,
+				Amount:      s.V.Total(),
+				Left:        s.ToMyLeft.Channel.TheirDestination,
+				Right:       s.ToMyLeft.Channel.MyDestination,
+			})
+	}
+	n := s.n
+	if s.MyRole < n { // Not Bob
+		sideEffects.LedgerRequests = append(sideEffects.LedgerRequests,
+			protocols.LedgerRequest{
+				LedgerId:    s.ToMyRight.Channel.Id,
+				Destination: s.V.Id,
+				Amount:      s.V.Total(),
+				Left:        s.ToMyRight.Channel.MyDestination,
+				Right:       s.ToMyRight.Channel.TheirDestination,
+			})
+	}
+	return sideEffects
+}
+
+// Clone returns a deep copy of the receiver
+func (s *VirtualFundObjective) clone() VirtualFundObjective {
+	clone := VirtualFundObjective{}
+	clone.Status = s.Status
+	vClone := s.V.Clone()
+	clone.V = &vClone
+
+	if s.ToMyLeft != nil {
+		clone.ToMyLeft = &Connection{
+			Channel:            s.ToMyLeft.Channel.Clone(),
+			ExpectedGuarantees: s.ToMyLeft.ExpectedGuarantees,
+		}
+	}
+
+	if s.ToMyRight != nil {
+		clone.ToMyRight = &Connection{
+			Channel:            s.ToMyRight.Channel.Clone(),
+			ExpectedGuarantees: s.ToMyRight.ExpectedGuarantees,
+		}
+	}
+
+	clone.n = s.n
+	clone.MyRole = s.MyRole
+
+	clone.a0 = s.a0
+	clone.b0 = s.b0
+
+	clone.requestedLedgerUpdates = s.requestedLedgerUpdates
+
+	return clone
+}

--- a/protocols/virtual-fund/virtual-fund.go
+++ b/protocols/virtual-fund/virtual-fund.go
@@ -2,6 +2,7 @@ package virtualfund
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/statechannels/go-nitro/channel"


### PR DESCRIPTION
This PR adds a new type to our `protocols` package, that implements the `Objective` interface. 

In the same way that the existing `DirectFundObjective` implements the logic for running the "direct fund" protocol, the new type implements the logic for running the "virtual fund" protocol. It is a collection of finite states, infinite state, and methods that can be `Updated` and `Cranked` in order to generate side effects that drive progress towards the goal of virtually funding a channel between Alice and Bob, given a pair of existing ledger channels connecting each to a common intermediary. 

The finite states are essentially the same as in the `direct-fund` protocol.  `Update` and `Crank` remain *pure* functions.

The way that funding is deemed to have been completed or not, is different. When the objective is spawned (the constructor `New()` is called), some "expected guarantees" are generated and stored. When an expected guarantee(s) is appropriately included in its respective ledger channels, the implementation will consider that funding has been completed.

The SATP paper draft has been my reference when writing this implementation.

As with the `direct-fund` protocol, side effects are not yet unit tested and should be considered only partially implemented. This is a conscious choice, and we will revisit the issue when the chain and message services are more mature.

One difference in implementation is that this objective makes use of the `Channel` type in the `channel` package. That's an abstraction we plan to back-port to the `direct-fund` protocol #78.


The unit tests follow a pattern where we use sub tests to cordon off test data in nested scopes. See [this notion doc](https://www.notion.so/statechannels/Thoughts-on-test-data-in-Go-00dd2eecb715419f901ab733891deb55#ad7b6933a900420090da192a5ad87867) for more information.  For now I have concentrated on single hop tests, although the protocol has been written to handle an arbitrary number of hops. I have also written a tests "as alice", and if the test is deemed good we can replicate a test "as bob" and "as Irene".

Closes #25. 