### PR TITLE
sum funds before calculating expected guarantee

### DIFF
--- a/protocols/virtual-fund/virtual-fund.go
+++ b/protocols/virtual-fund/virtual-fund.go
@@ -262,10 +262,12 @@ func (connection *Connection) insertExpectedGuarantees(a0 types.Funds, b0 types.
 		return err
 	}
 
-	for asset := range a0 {
+	channelFunds := a0.Add(b0)
+
+	for asset, amount := range channelFunds {
 		expectedGuaranteesForLedgerChannel[asset] = outcome.Allocation{
 			Destination:    vId,
-			Amount:         big.NewInt(0).Add(a0[asset], b0[asset]),
+			Amount:         amount,
 			AllocationType: outcome.GuaranteeAllocationType,
 			Metadata:       encodedGuarantee,
 		}


### PR DESCRIPTION
prevents possible problem where `a0` and `b0` do not have identical
asset lists

IE: previous implementation would fail for initial balances `a0 = {} // no balance`, `b0 = {fil: 5}`, because it applied only the assets indexed in `a0`.