### PR TITLE
Improve __checks__ on `VirtualFund.New`

### DIFF
--- a/protocols/virtual-fund/virtual-fund.go
+++ b/protocols/virtual-fund/virtual-fund.go
@@ -59,11 +59,22 @@ func New(
 	ledgerChannelToMyRight channel.Channel,
 ) (VirtualFundObjective, error) {
 
-	var init VirtualFundObjective
-
-	if !(ledgerChannelToMyLeft.IsTwoPartyLedger && ledgerChannelToMyRight.IsTwoPartyLedger) {
-		return init, errors.New(`supplied channels are not two party ledger channels`)
+	switch myRole {
+	case 0: // Alice
+		if !ledgerChannelToMyRight.IsTwoPartyLedger {
+			return VirtualFundObjective{}, errors.New(`alice's right-channel is not a two-party ledger channel`)
+		}
+	case n + 1: // Bob
+		if !ledgerChannelToMyLeft.IsTwoPartyLedger {
+			return VirtualFundObjective{}, errors.New(`bob's left-channel is not a two-party ledger channel`)
+		}
+	default: // Intermediary
+		if !(ledgerChannelToMyLeft.IsTwoPartyLedger && ledgerChannelToMyRight.IsTwoPartyLedger) {
+			return VirtualFundObjective{}, errors.New(`supplied channels are not two party ledger channels`)
+		}
 	}
+
+	var init VirtualFundObjective
 
 	// Initialize virtual channel
 	v, err := channel.New(initialStateOfV, false, myRole, types.Destination{}, types.Destination{})

--- a/protocols/virtual-fund/virtual-fund.go
+++ b/protocols/virtual-fund/virtual-fund.go
@@ -58,6 +58,11 @@ func New(
 	ledgerChannelToMyLeft channel.Channel,
 	ledgerChannelToMyRight channel.Channel,
 ) (VirtualFundObjective, error) {
+	// role and ledger-channel checks
+	if myRole > n+1 {
+		return VirtualFundObjective{}, fmt.Errorf(`invalid role <%d> specified in %d-hop virtual-fund objective`,
+			myRole, n-1)
+	}
 
 	switch myRole {
 	case 0: // Alice

--- a/protocols/virtual-fund/virtual-fund.go
+++ b/protocols/virtual-fund/virtual-fund.go
@@ -61,7 +61,7 @@ func New(
 
 	var init VirtualFundObjective
 
-	if ledgerChannelToMyLeft.IsTwoPartyLedger && ledgerChannelToMyRight.IsTwoPartyLedger {
+	if !(ledgerChannelToMyLeft.IsTwoPartyLedger && ledgerChannelToMyRight.IsTwoPartyLedger) {
 		return init, errors.New(`supplied channels are not two party ledger channels`)
 	}
 


### PR DESCRIPTION
This PR fixes some of the __checks__ on creating a new VirtualFund objective. It:

- fixes a broken check
- makes the ledger-channel checks dependent on the role of the creator (alice, bob, intermediary)
- adds a check to top-of-function on a valid role declaration, which removes need for later duplicating this check

Read per-commit.