### PR TITLE
Reuse `Channel` type in `direct-fund` protocol

### DIFF
--- a/client/engine/messageservice/test-messageservice_test.go
+++ b/client/engine/messageservice/test-messageservice_test.go
@@ -25,7 +25,7 @@ var bobMS = TestMessageService{
 	out: make(chan protocols.Message),
 }
 
-var objective, _ = directfund.New(state.TestState, aliceMS.address)
+var objective, _ = directfund.New(state.TestState, aliceMS.address, true, types.AdddressToDestination(aliceMS.address), types.AdddressToDestination(bobMS.address))
 var testId protocols.ObjectiveId = "testObjectiveID"
 
 var aToB protocols.Message = protocols.Message{

--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -32,8 +32,6 @@ type DirectFundObjective struct {
 	Status protocols.ObjectiveStatus
 	C      *channel.Channel
 
-	participantIndex map[types.Address]uint // the index for each participant
-
 	myDepositSafetyThreshold types.Funds // if the on chain holdings are equal to this amount it is safe for me to deposit
 	myDepositTarget          types.Funds // I want to get the on chain holdings up to this much
 	fullyFundedThreshold     types.Funds // if the on chain holdings are equal
@@ -46,7 +44,7 @@ func New(initialState state.State, myAddress types.Address, isTwoPartyLedger boo
 		return DirectFundObjective{}, errors.New("attempted to initiate new direct-funding objective with IsFinal == true")
 	}
 
-	var init DirectFundObjective
+	var init = DirectFundObjective{}
 	var err error
 
 	init.Status = protocols.Unapproved
@@ -58,14 +56,11 @@ func New(initialState state.State, myAddress types.Address, isTwoPartyLedger boo
 		}
 	}
 
+	init.C = &channel.Channel{}
 	*init.C, err = channel.New(initialState, isTwoPartyLedger, myIndex, myDestination, theirDestination)
 
 	if err != nil {
 		return init, err
-	}
-	init.participantIndex = make(map[types.Address]uint)
-	for i, v := range initialState.Participants {
-		init.participantIndex[v] = uint(i)
 	}
 
 	myAllocatedAmount := initialState.Outcome.TotalAllocatedFor(

--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -221,7 +221,9 @@ func (s DirectFundObjective) amountToDeposit() types.Funds {
 
 // todo: is this sufficient? Particularly: s has pointer members (*big.Int)
 func (s DirectFundObjective) clone() DirectFundObjective {
-	return s
+	clone := s
+	*clone.C = s.C.Clone()
+	return clone
 }
 
 // mermaid diagram

--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -219,10 +219,18 @@ func (s DirectFundObjective) amountToDeposit() types.Funds {
 	return deposits
 }
 
-// todo: is this sufficient? Particularly: s has pointer members (*big.Int)
+// Clone returns a deep copy of the receiver
 func (s DirectFundObjective) clone() DirectFundObjective {
-	clone := s
-	*clone.C = s.C.Clone()
+	clone := DirectFundObjective{}
+	clone.Status = s.Status
+
+	cClone := s.C.Clone()
+	clone.C = &cClone
+
+	clone.myDepositSafetyThreshold = s.myDepositSafetyThreshold.Clone()
+	clone.myDepositTarget = s.myDepositTarget.Clone()
+	clone.fullyFundedThreshold = s.fullyFundedThreshold.Clone()
+
 	return clone
 }
 

--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -39,7 +39,13 @@ type DirectFundObjective struct {
 
 // New initiates a DirectFundingInitialState with data calculated from
 // the supplied initialState and client address
-func New(initialState state.State, myAddress types.Address, isTwoPartyLedger bool, myDestination types.Destination, theirDestination types.Destination) (DirectFundObjective, error) {
+func New(
+	initialState state.State,
+	myAddress types.Address,
+	isTwoPartyLedger bool,
+	myDestination types.Destination,
+	theirDestination types.Destination,
+) (DirectFundObjective, error) {
 	if initialState.IsFinal {
 		return DirectFundObjective{}, errors.New("attempted to initiate new direct-funding objective with IsFinal == true")
 	}
@@ -60,7 +66,7 @@ func New(initialState state.State, myAddress types.Address, isTwoPartyLedger boo
 	*init.C, err = channel.New(initialState, isTwoPartyLedger, myIndex, myDestination, theirDestination)
 
 	if err != nil {
-		return init, err
+		return DirectFundObjective{}, fmt.Errorf("failed to initialize channel for direct-fund objective: %w", err)
 	}
 
 	myAllocatedAmount := initialState.Outcome.TotalAllocatedFor(

--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -2,6 +2,7 @@ package directfund
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/statechannels/go-nitro/channel"

--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -30,7 +30,7 @@ var ErrNotApproved = errors.New("objective not approved")
 // DirectFundObjective is a cache of data computed by reading from the store. It stores (potentially) infinite data
 type DirectFundObjective struct {
 	Status protocols.ObjectiveStatus
-	C      channel.Channel
+	C      *channel.Channel
 
 	participantIndex map[types.Address]uint // the index for each participant
 
@@ -58,7 +58,7 @@ func New(initialState state.State, myAddress types.Address, isTwoPartyLedger boo
 		}
 	}
 
-	init.C, err = channel.New(initialState, isTwoPartyLedger, myIndex, myDestination, theirDestination)
+	*init.C, err = channel.New(initialState, isTwoPartyLedger, myIndex, myDestination, theirDestination)
 
 	if err != nil {
 		return init, err

--- a/protocols/direct-fund/direct-fund_test.go
+++ b/protocols/direct-fund/direct-fund_test.go
@@ -58,9 +58,9 @@ var bob = actor{
 	privateKey:  common.Hex2Bytes(`62ecd49c4ccb41a70ad46532aed63cf815de15864bc415c87d507afd6a5e8da2`),
 }
 
-var isTwoPartyLedger = false               // for the purposes of this test
-var myDestination = types.Destination{}    // only needed if isTwoPartyLedger = true
-var theirDestination = types.Destination{} // only needed if isTwoPartyLedger = true
+var isTwoPartyLedger = false           // for the purposes of this test
+var myDestination = alice.destination  // only needed if isTwoPartyLedger = true
+var theirDestination = bob.destination // only needed if isTwoPartyLedger = true
 
 // TestNew tests the constructor using a TestState fixture
 func TestNew(t *testing.T) {

--- a/protocols/direct-fund/direct-fund_test.go
+++ b/protocols/direct-fund/direct-fund_test.go
@@ -110,19 +110,21 @@ func TestUpdate(t *testing.T) {
 	e.ChannelId = s.C.Id
 	e.Sigs = make(map[*state.State]state.Signature)
 
-	// Next, attempt to update the objective with a dummy signature, keyed with a dummy statehash
-	// Assert that this results in a NOOP
-	e.Sigs[&dummyState] = dummySignature // Dummmy signature on dummy statehash
-	if _, err := s.Update(e); err != nil {
-		t.Error(`dummy signature -- expected a noop but caught an error:`, err)
-	}
+	// DISABLED
+	// // Next, attempt to update the objective with a dummy signature, keyed with a dummy statehash
+	// // Assert that this results in a NOOP
+	// e.Sigs[&dummyState] = dummySignature // Dummmy signature on dummy statehash
+	// if _, err := s.Update(e); err != nil {
+	// 	t.Error(`dummy signature -- expected a noop but caught an error:`, err)
+	// }
 
+	// DISABLED
 	// Next, attempt to update the objective with an invalid signature, keyed with a dummy statehash
 	// Assert that this results in a NOOP
-	e.Sigs[&dummyState] = state.Signature{}
-	if _, err := s.Update(e); err != nil {
-		t.Error(`faulty signature -- expected a noop but caught an error:`, err)
-	}
+	// e.Sigs[&dummyState] = state.Signature{}
+	// if _, err := s.Update(e); err != nil {
+	// 	t.Error(`faulty signature -- expected a noop but caught an error:`, err)
+	// }
 
 	// Next, attempt to update the objective with correct signature by a participant on a relevant state
 	// Assert that this results in an appropriate change in the extended state of the objective

--- a/protocols/direct-fund/direct-fund_test.go
+++ b/protocols/direct-fund/direct-fund_test.go
@@ -40,10 +40,32 @@ var testState = state.State{
 	IsFinal: false,
 }
 
+type actor struct {
+	address     types.Address
+	destination types.Destination
+	privateKey  []byte
+}
+
+var alice = actor{
+	address:     common.HexToAddress(`0xF5A1BB5607C9D079E46d1B3Dc33f257d937b43BD`),
+	destination: types.AdddressToDestination(common.HexToAddress(`0xF5A1BB5607C9D079E46d1B3Dc33f257d937b43BD`)),
+	privateKey:  common.Hex2Bytes(`caab404f975b4620747174a75f08d98b4e5a7053b691b41bcfc0d839d48b7634`),
+}
+
+var bob = actor{
+	address:     common.HexToAddress(`0x760bf27cd45036a6C486802D30B5D90CfFBE31FE`),
+	destination: types.AdddressToDestination(common.HexToAddress(`0x760bf27cd45036a6C486802D30B5D90CfFBE31FE`)),
+	privateKey:  common.Hex2Bytes(`62ecd49c4ccb41a70ad46532aed63cf815de15864bc415c87d507afd6a5e8da2`),
+}
+
+var isTwoPartyLedger = false               // for the purposes of this test
+var myDestination = types.Destination{}    // only needed if isTwoPartyLedger = true
+var theirDestination = types.Destination{} // only needed if isTwoPartyLedger = true
+
 // TestNew tests the constructor using a TestState fixture
 func TestNew(t *testing.T) {
 	// Assert that a valid set of constructor args does not result in an error
-	if _, err := New(testState, testState.Participants[0]); err != nil {
+	if _, err := New(testState, testState.Participants[0], isTwoPartyLedger, myDestination, theirDestination); err != nil {
 		t.Error(err)
 	}
 
@@ -52,21 +74,21 @@ func TestNew(t *testing.T) {
 	finalState.IsFinal = true
 
 	// Assert that constructing with a final state should return an error
-	if _, err := New(finalState, testState.Participants[0]); err == nil {
+	if _, err := New(finalState, testState.Participants[0], isTwoPartyLedger, myDestination, theirDestination); err == nil {
 		t.Error("Expected an error when constructing with an invalid state, but got nil")
 	}
 
 }
 
 // Construct various variables for use in TestUpdate
-var s, _ = New(state.TestState, state.TestState.Participants[0])
+var s, _ = New(testState, testState.Participants[0], isTwoPartyLedger, myDestination, theirDestination)
 var dummySignature = state.Signature{
 	R: common.Hex2Bytes(`49d8e91bd182fb4d489bb2d76a6735d494d5bea24e4b51dd95c9d219293312d9`),
 	S: common.Hex2Bytes(`22274a3cec23c31e0c073b3c071cf6e0c21260b0d292a10e6a04257a2d8e87fa`),
 	V: byte(1),
 }
 var dummyState = state.State{}
-var stateToSign state.State = s.expectedStates[0]
+var stateToSign state.State = s.C.PreFundState()
 var privateKeyOfParticipant0 = common.Hex2Bytes(`caab404f975b4620747174a75f08d98b4e5a7053b691b41bcfc0d839d48b7634`)
 var correctSignatureByParticipant, _ = stateToSign.Sign(privateKeyOfParticipant0)
 
@@ -85,7 +107,7 @@ func TestUpdate(t *testing.T) {
 	// Now modify the event to give it the "correct" channelId (matching the objective),
 	// and make a new Sigs map.
 	// This prepares us for the rest of the test. We will reuse the same event multiple times
-	e.ChannelId = s.channelId
+	e.ChannelId = s.C.Id
 	e.Sigs = make(map[*state.State]state.Signature)
 
 	// Next, attempt to update the objective with a dummy signature, keyed with a dummy statehash
@@ -109,7 +131,7 @@ func TestUpdate(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if updated.(DirectFundObjective).preFundSigned[0] != true {
+	if updated.(DirectFundObjective).C.PreFundSignedByMe() != true {
 		t.Error(`Objective data not updated as expected`)
 	}
 
@@ -121,13 +143,20 @@ func TestUpdate(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !updated.(DirectFundObjective).onChainHolding.Equal(e.Holdings) {
-		t.Error(`Objective data not updated as expected`, updated.(DirectFundObjective).onChainHolding, e.Holdings)
+	if !updated.(DirectFundObjective).C.OnChainFunding.Equal(e.Holdings) {
+		t.Error(`Objective data not updated as expected`, updated.(DirectFundObjective).C.OnChainFunding, e.Holdings)
 	}
 
 }
 
 func TestCrank(t *testing.T) {
+
+	var correctSignatureByAliceOnPreFund, _ = s.C.PreFundState().Sign(alice.privateKey)
+	var correctSignatureByBobOnPreFund, _ = s.C.PreFundState().Sign(bob.privateKey)
+
+	var correctSignatureByAliceOnPostFund, _ = s.C.PostFundState().Sign(alice.privateKey)
+	var correctSignatureByBobOnPostFund, _ = s.C.PostFundState().Sign(bob.privateKey)
+
 	// Assert that cranking an unapproved objective returns an error
 	if _, _, _, err := s.Crank(&privateKeyOfParticipant0); err == nil {
 		t.Error(`Expected error when cranking unapproved objective, but got nil`)
@@ -149,8 +178,8 @@ func TestCrank(t *testing.T) {
 	}
 
 	// Manually progress the extended state by collecting prefund signatures
-	o.(DirectFundObjective).preFundSigned[0] = true
-	o.(DirectFundObjective).preFundSigned[1] = true
+	o.(DirectFundObjective).C.AddSignedState(o.(DirectFundObjective).C.PreFundState(), correctSignatureByAliceOnPreFund)
+	o.(DirectFundObjective).C.AddSignedState(o.(DirectFundObjective).C.PreFundState(), correctSignatureByBobOnPreFund)
 
 	// Cranking should move us to the next waiting point
 	_, _, waitingFor, err = o.Crank(&privateKeyOfParticipant0)
@@ -162,7 +191,7 @@ func TestCrank(t *testing.T) {
 	}
 
 	// Manually make the first "deposit"
-	o.(DirectFundObjective).onChainHolding[testState.Outcome[0].Asset] = testState.Outcome[0].Allocations[0].Amount
+	o.(DirectFundObjective).C.OnChainFunding[testState.Outcome[0].Asset] = testState.Outcome[0].Allocations[0].Amount
 	_, _, waitingFor, err = o.Crank(&privateKeyOfParticipant0)
 	if err != nil {
 		t.Error(err)
@@ -173,7 +202,7 @@ func TestCrank(t *testing.T) {
 
 	// Manually make the second "deposit"
 	totalAmountAllocated := testState.Outcome[0].TotalAllocated()
-	o.(DirectFundObjective).onChainHolding[testState.Outcome[0].Asset] = totalAmountAllocated
+	o.(DirectFundObjective).C.OnChainFunding[testState.Outcome[0].Asset] = totalAmountAllocated
 	_, _, waitingFor, err = o.Crank(&privateKeyOfParticipant0)
 	if err != nil {
 		t.Error(err)
@@ -183,11 +212,11 @@ func TestCrank(t *testing.T) {
 	}
 
 	// Manually progress the extended state by collecting postfund signatures
-	o.(DirectFundObjective).postFundSigned[0] = true
-	o.(DirectFundObjective).postFundSigned[1] = true
+	o.(DirectFundObjective).C.AddSignedState(o.(DirectFundObjective).C.PostFundState(), correctSignatureByAliceOnPostFund)
+	o.(DirectFundObjective).C.AddSignedState(o.(DirectFundObjective).C.PostFundState(), correctSignatureByBobOnPostFund)
 
 	// This should be the final crank
-	o.(DirectFundObjective).onChainHolding[testState.Outcome[0].Asset] = totalAmountAllocated
+	o.(DirectFundObjective).C.OnChainFunding[testState.Outcome[0].Asset] = totalAmountAllocated
 	_, _, waitingFor, err = o.Crank(&privateKeyOfParticipant0)
 	if err != nil {
 		t.Error(err)

--- a/protocols/direct-fund/direct-fund_test.go
+++ b/protocols/direct-fund/direct-fund_test.go
@@ -90,8 +90,6 @@ var stateToSign state.State = s.C.PreFundState()
 var correctSignatureByParticipant, _ = stateToSign.Sign(alice.privateKey)
 
 func TestUpdate(t *testing.T) {
-	// fmt.Println(testState)
-
 	// Prepare an event with a mismatched channelId
 	e := protocols.ObjectiveEvent{
 		ChannelId: types.Destination{},

--- a/protocols/direct-fund/direct-fund_test.go
+++ b/protocols/direct-fund/direct-fund_test.go
@@ -110,21 +110,19 @@ func TestUpdate(t *testing.T) {
 	e.ChannelId = s.C.Id
 	e.Sigs = make(map[*state.State]state.Signature)
 
-	// DISABLED
-	// // Next, attempt to update the objective with a dummy signature, keyed with a dummy statehash
-	// // Assert that this results in a NOOP
-	// e.Sigs[&dummyState] = dummySignature // Dummmy signature on dummy statehash
-	// if _, err := s.Update(e); err != nil {
-	// 	t.Error(`dummy signature -- expected a noop but caught an error:`, err)
-	// }
+	// Next, attempt to update the objective with a dummy signature, keyed with a dummy state
+	// Assert that this results in a NOOP
+	e.Sigs[&dummyState] = dummySignature // Dummmy signature on dummy state
+	if _, err := s.Update(e); err != nil {
+		t.Error(`dummy signature -- expected a noop but caught an error:`, err)
+	}
 
-	// DISABLED
 	// Next, attempt to update the objective with an invalid signature, keyed with a dummy statehash
 	// Assert that this results in a NOOP
-	// e.Sigs[&dummyState] = state.Signature{}
-	// if _, err := s.Update(e); err != nil {
-	// 	t.Error(`faulty signature -- expected a noop but caught an error:`, err)
-	// }
+	e.Sigs[&dummyState] = state.Signature{}
+	if _, err := s.Update(e); err != nil {
+		t.Error(`faulty signature -- expected a noop but caught an error:`, err)
+	}
 
 	// Next, attempt to update the objective with correct signature by a participant on a relevant state
 	// Assert that this results in an appropriate change in the extended state of the objective


### PR DESCRIPTION
Towards #78. This is a refactor aimed at removing code and ensuring the direct fund protocol does not replicate state that is owned by `Channel`. 

~I will leave this as a draft until I have cherry-picked some of the work into smaller PRs.~