### PR TITLE
Return boolean from `Channel.AddSignedStates()`

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -191,11 +191,14 @@ func (c *Channel) AddSignedState(s state.State, sig state.Signature) bool {
 	return true
 }
 
-// AddSignedStates adds each signed state in the mapping
-func (c Channel) AddSignedStates(mapping map[*state.State]state.Signature) {
+// AddSignedStates adds each signed state in the mapping. It returns true if all signed states were added successfully, false otherwise.
+// If one or more signed states fails to be added, this does not prevent other signed states from being added.
+func (c Channel) AddSignedStates(mapping map[*state.State]state.Signature) bool {
+	allOk := true
 	for state, sig := range mapping {
-		c.AddSignedState(*state, sig)
+		allOk = allOk && c.AddSignedState(*state, sig)
 	}
+	return allOk
 }
 
 // indexOf returns the index of the given suspect address in the lineup of addresses. A second return value ("ok") is true the suspect was found, false otherwise.


### PR DESCRIPTION
`AddSignedStates` currently calls `AddSignedState` in a loop and discards the `ok` boolean return value. The documentation for the method doesn't give any clue about this behaviour, nor whether the loop will continue if there is an error returned in the one step through the loop. 

This PR introduces a boolean return value which is the union of the return values from each step through the loop. 

It means that less information is discarded (but still most of the information is discarded). In principle it allows calling code to  better handle state insertion errors (although this is not currently something we make use of). 

