### PR TITLE
prevent panic in `ChannelId()` when `chainId` is nil

### DIFF
--- a/channel/state/state.go
+++ b/channel/state/state.go
@@ -71,6 +71,15 @@ var address, _ = abi.NewType("address", "address", nil)
 // and an error if the id is an external destination.
 func (s State) ChannelId() (types.Destination, error) {
 
+	if s.ChainId == nil {
+		return types.Destination{}, errors.New(`cannot compute ChannelId with nil ChainId`)
+	}
+
+	if s.ChannelNonce == nil {
+		return types.Destination{}, errors.New(`cannot compute ChannelId with nil ChannelNonce`)
+
+	}
+
 	encodedChannelPart, error := abi.Arguments{
 		{Type: uint256},
 		{Type: addressArray},

--- a/channel/state/state.go
+++ b/channel/state/state.go
@@ -77,7 +77,6 @@ func (s State) ChannelId() (types.Destination, error) {
 
 	if s.ChannelNonce == nil {
 		return types.Destination{}, errors.New(`cannot compute ChannelId with nil ChannelNonce`)
-
 	}
 
 	encodedChannelPart, error := abi.Arguments{


### PR DESCRIPTION
Problem: a lot of code paths (particularly tests) involve computing the channel id on data that is potentially nil. Due to our dependence on go-ethereum's abi encoder library, it's easy to trigger a panic. This is fatal and something we should avoid.

Solution: do some input validation and return early with an error before hitting the code which would otherwise panic. 