### PR TITLE
`Funds` type: add `Clone()` method

### DIFF
--- a/types/funds.go
+++ b/types/funds.go
@@ -79,3 +79,8 @@ func (f Funds) canAfford(g Funds) bool {
 
 	return true
 }
+
+// Clone returns a deep copy of the receiver
+func (f Funds) Clone() Funds {
+	return Sum(f, Funds{})
+}


### PR DESCRIPTION
Because we wish to have functional methods at the core of our software, there is a need to generate deep clones of certain objects. Such objects frequently embed a `Funds` object. By having a `Clone` method on the child, we can adopt a modular approach to cloning the parent. 