### PR TITLE
add contributing.md to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,9 @@ Implementation of nitro protocol in golang.
 
 ---
 
+# Getting started
+Please see [contributing.md](./contributing.md)
+
 ## Roadmap
 
 The following roadmap gives an idea of the various packages that compose the `go-nitro` module, and their implementation status:


### PR DESCRIPTION
Since readme.md is the first thing that most developers see, it ought to
point developers to contributing.md for getting started instructions.