### PR TITLE
unconditionally add a state

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -196,7 +196,7 @@ func (c *Channel) AddSignedState(s state.State, sig state.Signature) bool {
 func (c Channel) AddSignedStates(mapping map[*state.State]state.Signature) bool {
 	allOk := true
 	for state, sig := range mapping {
-		allOk = allOk && c.AddSignedState(*state, sig)
+		allOk = c.AddSignedState(*state, sig) && allOk
 	}
 	return allOk
 }


### PR DESCRIPTION
Previously, the second condition (which is a function call) would not be evaluated in the case where the first one was false. This meant the function was not behaving as documented, and failing to add a "good" state when accompanied by a "bad" state.