### PR TITLE
Don't encode the `Outcome` separately when encoding the `State`

### DIFF
--- a/channel/state/outcome/exit.go
+++ b/channel/state/outcome/exit.go
@@ -97,8 +97,8 @@ func (e Exit) TotalAllocatedFor(dest types.Destination) types.Funds {
 	return total
 }
 
-// exitTy describes the shape of Exit such that github.com/ethereum/go-ethereum/accounts/abi can parse it
-var exitTy, _ = abi.NewType("tuple[]", "struct ExitFormat.SingleAssetExit[]", []abi.ArgumentMarshaling{
+// ExitTy describes the shape of Exit such that github.com/ethereum/go-ethereum/accounts/abi can parse it
+var ExitTy, _ = abi.NewType("tuple[]", "struct ExitFormat.SingleAssetExit[]", []abi.ArgumentMarshaling{
 	{Name: "asset", Type: "address"},
 	{Name: "metadata", Type: "bytes"},
 	allocationsTy,
@@ -131,12 +131,12 @@ func convertToExit(r rawExitType) Exit {
 
 // Encode returns the abi encoded Exit
 func (e *Exit) Encode() (types.Bytes, error) {
-	return abi.Arguments{{Type: exitTy}}.Pack(e)
+	return abi.Arguments{{Type: ExitTy}}.Pack(e)
 }
 
 // Decode returns an Exit from an abi encoding
 func Decode(data types.Bytes) (Exit, error) {
-	unpacked, err := abi.Arguments{{Type: exitTy}}.Unpack(data)
+	unpacked, err := abi.Arguments{{Type: ExitTy}}.Unpack(data)
 	if err != nil {
 		return nil, err
 	}

--- a/channel/state/state.go
+++ b/channel/state/state.go
@@ -63,7 +63,7 @@ var boolTy, _ = abi.NewType("bool", "bool", nil)
 // TODO: Is this type correct? Shouldn't it be bytes32?
 
 // address type for abi encoding
-var destination, _ = abi.NewType("address", "address", nil)
+var destination, _ = abi.NewType("bytes32", "byte32", nil)
 
 // bytes type for abi encoding
 var bytesTy, _ = abi.NewType("bytes", "bytes", nil)
@@ -127,27 +127,25 @@ func (s State) encode() (types.Bytes, error) {
 		return types.Bytes{}, fmt.Errorf("failed to construct channelId: %w", error)
 	}
 
-	outcome, error := s.Outcome.Encode()
-
 	if error != nil {
 		return types.Bytes{}, fmt.Errorf("failed to encode outcome: %w", error)
 
 	}
 
 	return abi.Arguments{
-		{Type: destination}, // channel id (includes ChainID, Participants, ChannelNonce)
-		{Type: address},     // app definition
-		{Type: uint256},     // challenge duration
-		{Type: bytesTy},     // app data
-		{Type: bytesTy},     // outcome
-		{Type: uint256},     // turnNum
-		{Type: boolTy},      // isFinal
+		{Type: destination},    // channel id (includes ChainID, Participants, ChannelNonce)
+		{Type: address},        // app definition
+		{Type: uint256},        // challenge duration
+		{Type: bytesTy},        // app data
+		{Type: outcome.ExitTy}, // outcome
+		{Type: uint256},        // turnNum
+		{Type: boolTy},         // isFinal
 	}.Pack(
 		ChannelId,
 		s.AppDefinition,
 		s.ChallengeDuration,
 		[]byte(s.AppData), // Note: even though s.AppData is types.bytes, which is an alias for []byte], Pack will not accept types.bytes
-		[]byte(outcome),
+		s.Outcome,
 		s.TurnNum,
 		s.IsFinal,
 	)

--- a/channel/state/state_test.go
+++ b/channel/state/state_test.go
@@ -11,13 +11,13 @@ import (
 
 // The following constants are generated from our ts nitro-protocol package
 var correctChannelId = common.HexToHash(`4ebd366d014a173765ba1e50f284c179ade31f20441bec41664712aac6cc461d`)
-var correctStateHash = common.HexToHash(`69c8a1304264e91cf2cbab10906dff5df8242f5df6b361c6231aace57eeeffe3`)
+var correctStateHash = common.HexToHash(`75a55cea83b36dbdcc35b2eb6fcd45c5d2014875cb42f70991603df433280512`)
 var signerPrivateKey = common.Hex2Bytes(`caab404f975b4620747174a75f08d98b4e5a7053b691b41bcfc0d839d48b7634`)
 var signerAddress = common.HexToAddress(`F5A1BB5607C9D079E46d1B3Dc33f257d937b43BD`)
 var correctSignature = Signature{
-	common.Hex2Bytes(`f8d2975d9720895344199752b92d0870554546c106af417b6092e2864c4bcb10`),
-	common.Hex2Bytes(`0d5f41f54f0da45c4d21b5b72cc87cc193f31beb096f83b8b90d535b0469015a`),
-	byte(0),
+	common.Hex2Bytes(`a4d78b18c654990334df5e996c6e09fb9b1d35f4dabd6f91bf0efa90c4f71180`),
+	common.Hex2Bytes(`1027d5aa7125c28e1734845a81bc4b1596e32f4af72691f286eaa4b236bdf512`),
+	byte(1),
 }
 
 func TestChannelId(t *testing.T) {


### PR DESCRIPTION
Currently we expect a solidity contract to define a struct
```
struct state {
  // ...
  outcome bytes
}
```
This means that to verify signatures of a `state`, we first need to encode its outcome as bytes, plug it into a state struct, and then encode that state as bytes.

The change in this PR allows a solidity contract to define a state which has a property `outcome` that is itself a struct.
```
struct state {
  // ...
  outcome Outcome
}
```
As such, to encode a `state`, we would no longer need to encode `outcome` first.


This is a more elegant and efficient approach which should save some gas: see https://github.com/statechannels/go-nitro/pull/133#issuecomment-1009128748.