### PR TITLE
Introduce `MockChainService`

### DIFF
--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -14,7 +14,7 @@ type Event struct {
 }
 
 type ChainService interface {
-	GetReceiveChan() chan Event
-	GetSendChan() chan protocols.Transaction
+	GetReceiveChan() <-chan Event
+	GetSendChan() chan<- protocols.Transaction
 	Submit(tx protocols.Transaction)
 }

--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -16,5 +16,4 @@ type Event struct {
 type ChainService interface {
 	Out() <-chan Event
 	In() chan<- protocols.Transaction
-	Submit(tx protocols.Transaction)
 }

--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -8,7 +8,7 @@ import (
 
 // ChainEvent is an internal representation of a blockchain event
 type Event struct {
-	ChannelId          types.Bytes32
+	ChannelId          types.Destination
 	Holdings           types.Funds // indexed by asset
 	AdjudicationStatus protocols.AdjudicationStatus
 }

--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -14,7 +14,7 @@ type Event struct {
 }
 
 type ChainService interface {
-	GetReceiveChan() <-chan Event
-	GetSendChan() chan<- protocols.Transaction
+	Out() <-chan Event
+	In() chan<- protocols.Transaction
 	Submit(tx protocols.Transaction)
 }

--- a/client/engine/chainservice/mockchainservice.go
+++ b/client/engine/chainservice/mockchainservice.go
@@ -33,8 +33,6 @@ func (mcs MockChainService) In() chan<- protocols.Transaction {
 	return mcs.in
 }
 
-func (mcs MockChainService) Submit(tx protocols.Transaction) {}
-
 func (mcs MockChainService) ListenForTransactions() {
 	for tx := range mcs.in {
 		channelId := tx.ChannelId

--- a/client/engine/chainservice/mockchainservice.go
+++ b/client/engine/chainservice/mockchainservice.go
@@ -1,0 +1,44 @@
+package chainservice
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/types"
+)
+
+type MockChainService struct {
+	recieveChan chan Event
+	sendChan    chan protocols.Transaction
+}
+
+func NewMockChainService() ChainService {
+	mcs := MockChainService{}
+	mcs.recieveChan = make(chan Event)
+	mcs.sendChan = make(chan protocols.Transaction)
+
+	go mcs.ListenForTransactions()
+	return mcs
+}
+
+func (mcs MockChainService) GetReceiveChan() chan Event {
+	return mcs.recieveChan
+}
+func (mcs MockChainService) GetSendChan() chan protocols.Transaction {
+	return mcs.sendChan
+}
+func (mcs MockChainService) Submit(tx protocols.Transaction) {}
+
+func (mcs MockChainService) ListenForTransactions() {
+	for tx := range mcs.sendChan {
+		syntheticEvent := Event{
+			ChannelId:          common.Hash{},
+			Holdings:           types.Funds{},
+			AdjudicationStatus: protocols.AdjudicationStatus{TurnNumRecord: 0},
+		}
+		if tx.Deposit.IsNonZero() {
+			syntheticEvent.Holdings = tx.Deposit
+		}
+		mcs.recieveChan <- syntheticEvent
+	}
+
+}

--- a/client/engine/chainservice/mockchainservice.go
+++ b/client/engine/chainservice/mockchainservice.go
@@ -23,14 +23,16 @@ func NewMockChainService() ChainService {
 	return mcs
 }
 
-// GetReceiveChan returns the a channel that can be sent on (but it used by the MockChainService to listen on)
+// GetReceiveChan returns the recieveChan but narrows the type so that consumers mays only recieve on it.
 func (mcs MockChainService) GetReceiveChan() <-chan Event {
-
 	return chan Event(mcs.recieveChan)
 }
+
+// GetSendChan returns the rsendChan but narrows the type so that consumers mays only send on it.
 func (mcs MockChainService) GetSendChan() chan<- protocols.Transaction {
 	return mcs.sendChan
 }
+
 func (mcs MockChainService) Submit(tx protocols.Transaction) {}
 
 func (mcs MockChainService) ListenForTransactions() {

--- a/client/engine/chainservice/mockchainservice.go
+++ b/client/engine/chainservice/mockchainservice.go
@@ -6,8 +6,8 @@ import (
 )
 
 type MockChainService struct {
-	recieveChan chan Event
-	sendChan    chan protocols.Transaction
+	recieveChan chan Event                 // receiveChan is the chan used to send Events to the engine
+	sendChan    chan protocols.Transaction // sendChan is the chan used to recieve Transactions from the engine
 
 	holdings map[types.Destination]types.Funds
 }
@@ -23,10 +23,12 @@ func NewMockChainService() ChainService {
 	return mcs
 }
 
-func (mcs MockChainService) GetReceiveChan() chan Event {
-	return mcs.recieveChan
+// GetReceiveChan returns the a channel that can be sent on (but it used by the MockChainService to listen on)
+func (mcs MockChainService) GetReceiveChan() <-chan Event {
+
+	return chan Event(mcs.recieveChan)
 }
-func (mcs MockChainService) GetSendChan() chan protocols.Transaction {
+func (mcs MockChainService) GetSendChan() chan<- protocols.Transaction {
 	return mcs.sendChan
 }
 func (mcs MockChainService) Submit(tx protocols.Transaction) {}

--- a/client/engine/chainservice/mockchainservice_test.go
+++ b/client/engine/chainservice/mockchainservice_test.go
@@ -1,0 +1,60 @@
+package chainservice
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/types"
+)
+
+func TestNew(t *testing.T) {
+	NewMockChainService()
+}
+func TestInstantDeposit(t *testing.T) {
+	// MockChainService should react to a deposit transaction for a given channel by:
+	// - immediately sending an event with updated holdings for that channel.
+
+	// Construct Mock Chain Service and get references to chans
+	mcs := NewMockChainService()
+	send := mcs.GetSendChan()
+	recieve := mcs.GetReceiveChan()
+
+	// Prepare test data to trigger MockChainService
+	testDeposit := types.Funds{
+		common.HexToAddress("0x00"): big.NewInt(1),
+	}
+	testTx := protocols.Transaction{
+		ChannelId: types.Destination(common.HexToHash(`4ebd366d014a173765ba1e50f284c179ade31f20441bec41664712aac6cc461d`)),
+		Deposit:   testDeposit,
+	}
+
+	// Send one transaction and recieve one event
+	send <- testTx
+	event := <-recieve
+
+	if event.ChannelId != testTx.ChannelId {
+		t.Error(`channelId mismatch`)
+	}
+	if !event.Holdings.Equal(testTx.Deposit) {
+		t.Error(`holdings mismatch`)
+	}
+
+	// Send the transaction again and recieve another event
+	send <- testTx
+	event = <-recieve
+
+	// The expectation is that the MockChainService remembered the previous deposit and added this one to it:
+	expectedHoldings := types.Funds{
+		common.HexToAddress("0x00"): big.NewInt(2),
+	}
+
+	if event.ChannelId != testTx.ChannelId {
+		t.Error(`channelId mismatch`)
+	}
+	if !event.Holdings.Equal(expectedHoldings) {
+		t.Error(`holdings mismatch`)
+	}
+
+}

--- a/client/engine/chainservice/mockchainservice_test.go
+++ b/client/engine/chainservice/mockchainservice_test.go
@@ -18,8 +18,8 @@ func TestInstantDeposit(t *testing.T) {
 
 	// Construct Mock Chain Service and get references to chans
 	mcs := NewMockChainService()
-	send := mcs.GetSendChan()
-	recieve := mcs.GetReceiveChan()
+	in := mcs.In()
+	out := mcs.Out()
 
 	// Prepare test data to trigger MockChainService
 	testDeposit := types.Funds{
@@ -31,8 +31,8 @@ func TestInstantDeposit(t *testing.T) {
 	}
 
 	// Send one transaction and recieve one event
-	send <- testTx
-	event := <-recieve
+	in <- testTx
+	event := <-out
 
 	if event.ChannelId != testTx.ChannelId {
 		t.Error(`channelId mismatch`)
@@ -42,8 +42,8 @@ func TestInstantDeposit(t *testing.T) {
 	}
 
 	// Send the transaction again and recieve another event
-	send <- testTx
-	event = <-recieve
+	in <- testTx
+	event = <-out
 
 	// The expectation is that the MockChainService remembered the previous deposit and added this one to it:
 	expectedHoldings := types.Funds{

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -12,12 +12,12 @@ import (
 type Engine struct {
 	// inbound go channels
 	FromAPI   chan APIEvent // This one is exported so that the Client can send API calls
-	fromChain chan chainservice.Event
+	fromChain <-chan chainservice.Event
 	fromMsg   chan protocols.Message
 
 	// outbound go channels
 	toMsg   chan protocols.Message
-	toChain chan protocols.Transaction
+	toChain chan<- protocols.Transaction
 
 	store store.Store // A Store for persisting and restoring important data
 }

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -40,11 +40,11 @@ func New(msg messageservice.MessageService, chain chainservice.ChainService) Eng
 
 	// bind the engine's inbound chans
 	e.FromAPI = make(chan APIEvent)
-	e.fromChain = chain.GetReceiveChan()
+	e.fromChain = chain.Out()
 	e.fromMsg = msg.GetReceiveChan()
 
 	// bind the engine's outbound chans
-	e.toChain = chain.GetSendChan()
+	e.toChain = chain.In()
 	e.toMsg = msg.GetSendChan()
 
 	return e

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -10,9 +10,9 @@ import (
 type Store interface {
 	GetChannelSecretKey() *[]byte // Get a pointer to a secret key for signing channel updates
 
-	GetObjectiveById(protocols.ObjectiveId) protocols.Objective // Read an existing objective
-	GetObjectiveByChannelId(types.Bytes32) protocols.Objective  // Get the objective that currently owns the channel with the supplied ChannelId
-	SetObjective(protocols.Objective) error                     // Write an objective
+	GetObjectiveById(protocols.ObjectiveId) protocols.Objective    // Read an existing objective
+	GetObjectiveByChannelId(types.Destination) protocols.Objective // Get the objective that currently owns the channel with the supplied ChannelId
+	SetObjective(protocols.Objective) error                        // Write an objective
 
 	UpdateProgressLastMadeAt(protocols.ObjectiveId, protocols.WaitingFor) // updates progressLastMadeAt information for an objective
 }

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -15,8 +15,9 @@ type Message struct {
 
 // Transaction is an object to be sent to a blockchain provider.
 type Transaction struct {
-	To   types.Address
-	Data []byte
+	ChannelId types.Destination
+	Deposit   types.Funds
+	// TODO support other transaction types (deposit, challenge, respond, conclude, withdraw)
 }
 
 // LedgerRequest is an object processed by the ledger cranker


### PR DESCRIPTION
At present, an engine` cranking the `direct-fund` protocol will be blocked by the lack of a chain service to receive `Transactions` and trigger `Events`. This PR adds a mock service which only:

* listens for deposit transactions
* immediately updates an in-memory `holdings` mapping
* immediately triggers an `Event` with the updated `holdings`

In the future the mock chain service will also:
* listen for conclude or withdraw transactions and respond in a similar manner to the above
* listen for challenge/respond transactions, and update an in-memory `adjudicationStatus` mapping, and respond with an appropriate event

The mock service added here should be sufficient to unblock the `direct-fund` protocol in a test which integrates it with an engine, message service and store. 

Notes
---
- for now the `chans` involved are **not buffered**. This means the engine will block until the chain service has finished responding to the transaction. This is likely not an issue for a mock service, but something we can revisit in future for a real service. We can add buffering or goroutines to make a sensible async model.
- I spent some effort putting in directionality to the `chans` that connect the chain service to the engine. Please see commit messages for more detail. 