### PR TITLE
Introduce `NewTestMessageService` constructor function

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -18,9 +18,6 @@ func New(messageService messageservice.MessageService, chainservice chainservice
 	c := Client{}
 	c.engine = engine.New(messageService, chainservice)
 
-	// TODO go messageService.Run()
-	// TODO go chainService.Run()
-
 	// Start the engine in a go routine
 	go c.engine.Run()
 

--- a/client/engine/messageservice/test-messageservice.go
+++ b/client/engine/messageservice/test-messageservice.go
@@ -32,11 +32,11 @@ func NewTestMessageService(address types.Address) TestMessageService {
 		in:      make(chan protocols.Message),
 		out:     make(chan protocols.Message),
 	}
-	tms.Run()
+	tms.run()
 	return tms
 }
 
-func (t TestMessageService) Run() {
+func (t TestMessageService) run() {
 	go t.routeOutgoing()
 }
 

--- a/client/engine/messageservice/test-messageservice.go
+++ b/client/engine/messageservice/test-messageservice.go
@@ -24,6 +24,18 @@ type TestMessageService struct {
 	in chan protocols.Message
 }
 
+// NewTestMessageService returns a running TestMessageService
+func NewTestMessageService(address types.Address) TestMessageService {
+	tms := TestMessageService{
+		address: address,
+		toPeers: make(map[types.Address]chan<- protocols.Message),
+		in:      make(chan protocols.Message),
+		out:     make(chan protocols.Message),
+	}
+	tms.Run()
+	return tms
+}
+
 func (t TestMessageService) Run() {
 	go t.routeOutgoing()
 }

--- a/client/engine/messageservice/test-messageservice_test.go
+++ b/client/engine/messageservice/test-messageservice_test.go
@@ -9,21 +9,8 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-var aliceMS = TestMessageService{
-	address: types.Address{'a'},
-	toPeers: make(map[types.Address]chan<- protocols.Message),
-
-	in:  make(chan protocols.Message),
-	out: make(chan protocols.Message),
-}
-
-var bobMS = TestMessageService{
-	address: types.Address{'b'},
-	toPeers: make(map[types.Address]chan<- protocols.Message),
-
-	in:  make(chan protocols.Message),
-	out: make(chan protocols.Message),
-}
+var aliceMS = NewTestMessageService(types.Address{'a'})
+var bobMS = NewTestMessageService(types.Address{'b'})
 
 var objective, _ = directfund.New(state.TestState, aliceMS.address, true, types.AddressToDestination(aliceMS.address), types.AddressToDestination(bobMS.address))
 var testId protocols.ObjectiveId = "testObjectiveID"
@@ -36,8 +23,6 @@ var aToB protocols.Message = protocols.Message{
 }
 
 func TestConnect(t *testing.T) {
-	aliceMS.Run()
-	bobMS.Run()
 	bobIn := bobMS.GetReceiveChan()
 
 	aliceMS.Connect(bobMS)


### PR DESCRIPTION
I think this improves clarity about when to `.Run()` the service, as well as removing some repetition in test files and a nicer dev experience overall. 