### PR TITLE
change type of TurnNum to uint64

### DIFF
--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -13,7 +13,7 @@ import (
 func TestChannel(t *testing.T) {
 	s := state.TestState.Clone()
 	_, err1 := New(s, true, 0, state.TestOutcome[0].Allocations[0].Destination, state.TestOutcome[0].Allocations[1].Destination)
-	s.TurnNum = big.NewInt(0)
+	s.TurnNum = 0
 	c, err2 := New(s, true, 0, state.TestOutcome[0].Allocations[0].Destination, state.TestOutcome[0].Allocations[1].Destination)
 
 	testNew := func(t *testing.T) {
@@ -54,7 +54,7 @@ func TestChannel(t *testing.T) {
 	testPostFund := func(t *testing.T) {
 		got, err1 := c.PostFundState().Hash()
 		spf := s.Clone()
-		spf.TurnNum = big.NewInt(1)
+		spf.TurnNum = 1
 		want, err2 := spf.Hash()
 		if err1 != nil {
 			t.Error(err1)
@@ -143,7 +143,7 @@ func TestChannel(t *testing.T) {
 			ChallengeDuration: big.NewInt(60),
 			AppData:           []byte{},
 			Outcome:           state.TestOutcome,
-			TurnNum:           big.NewInt(5),
+			TurnNum:           5,
 			IsFinal:           false,
 		}
 		v.ChannelNonce.Add(v.ChannelNonce, big.NewInt(1))
@@ -189,7 +189,7 @@ func TestChannel(t *testing.T) {
 		if err4 != nil {
 			t.Error(err4)
 		}
-		if got4.TurnNum.Uint64() != want3 {
+		if got4.TurnNum != want3 {
 			t.Errorf(`expected LatestSupportedState with turnNum %v`, want3)
 		}
 

--- a/channel/state/state.go
+++ b/channel/state/state.go
@@ -140,7 +140,7 @@ func (s State) encode() (types.Bytes, error) {
 		ChannelId,
 		[]byte(s.AppData), // Note: even though s.AppData is types.bytes, which is an alias for []byte], Pack will not accept types.bytes
 		s.Outcome,
-		s.TurnNum,
+		big.NewInt(int64(s.TurnNum)),
 		s.IsFinal,
 	)
 }

--- a/channel/state/state.go
+++ b/channel/state/state.go
@@ -22,7 +22,7 @@ type (
 		ChallengeDuration *types.Uint256
 		AppData           types.Bytes
 		Outcome           outcome.Exit
-		TurnNum           *types.Uint256
+		TurnNum           uint64
 		IsFinal           bool
 	}
 
@@ -39,7 +39,7 @@ type (
 	VariablePart struct {
 		AppData types.Bytes
 		Outcome outcome.Exit
-		TurnNum *types.Uint256
+		TurnNum uint64
 		IsFinal bool
 	}
 )
@@ -196,7 +196,7 @@ func (s State) Equal(r State) bool {
 		s.ChallengeDuration.Cmp(r.ChallengeDuration) == 0 &&
 		bytes.Equal(s.AppData, r.AppData) &&
 		s.Outcome.Equal(r.Outcome) &&
-		s.TurnNum.Cmp(r.TurnNum) == 0 &&
+		s.TurnNum == r.TurnNum &&
 		s.IsFinal == r.IsFinal
 }
 
@@ -215,7 +215,7 @@ func (s State) Clone() State {
 	clone.AppData = make(types.Bytes, 0, len(s.AppData))
 	copy(clone.AppData, s.AppData)
 	clone.Outcome = s.Outcome.Clone()
-	clone.TurnNum = new(big.Int).Set(s.TurnNum)
+	clone.TurnNum = s.TurnNum
 	clone.IsFinal = s.IsFinal
 
 	return clone

--- a/channel/state/state_test.go
+++ b/channel/state/state_test.go
@@ -82,7 +82,7 @@ func TestEqual(t *testing.T) {
 		ChallengeDuration: big.NewInt(60),
 		AppData:           []byte{},
 		Outcome:           TestOutcome,
-		TurnNum:           big.NewInt(5),
+		TurnNum:           5,
 		IsFinal:           false,
 	}
 

--- a/channel/state/test-fixtures.go
+++ b/channel/state/test-fixtures.go
@@ -37,6 +37,6 @@ var TestState = State{
 	ChallengeDuration: big.NewInt(60),
 	AppData:           []byte{},
 	Outcome:           TestOutcome,
-	TurnNum:           big.NewInt(5),
+	TurnNum:           5,
 	IsFinal:           false,
 }

--- a/protocols/direct-fund/direct-fund_test.go
+++ b/protocols/direct-fund/direct-fund_test.go
@@ -51,7 +51,7 @@ var testState = state.State{
 			},
 		},
 	},
-	TurnNum: big.NewInt(0),
+	TurnNum: 0,
 	IsFinal: false,
 }
 

--- a/protocols/virtual-fund/virtual-fund-single-hop_test.go
+++ b/protocols/virtual-fund/virtual-fund-single-hop_test.go
@@ -76,7 +76,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				},
 			},
 		}},
-		TurnNum: big.NewInt(0),
+		TurnNum: 0,
 		IsFinal: false,
 	}
 
@@ -103,7 +103,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				},
 			},
 		}},
-		TurnNum: big.NewInt(0), // We use turnNum 0 so that we can use github.com/statechannels/go-nitro/channel.New().
+		TurnNum: 0, // We use turnNum 0 so that we can use github.com/statechannels/go-nitro/channel.New().
 		// It would be more realistic to have a higher TurnNum, but that would involve more boilerplate code.
 		IsFinal: false,
 	}
@@ -140,7 +140,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				},
 			},
 		}},
-		TurnNum: big.NewInt(2), // This needs to be greater than the previous state else it will be rejected by Channel.AddSignedState
+		TurnNum: 2, // This needs to be greater than the previous state else it will be rejected by Channel.AddSignedState
 		IsFinal: false,
 	}
 


### PR DESCRIPTION
Closes #95 

Pros: 
* we get to use a more ergonomic type, with
    -  `+` instead of `.Add()` , etc
    - no worries about cloning safely
* it mirrors our (anticipated?) on chain code better
* 
Cons:
* it is not safe to use if we had turnnums exceeding 9,223,372,036,854,775,807
* it's an additional type, different to the others we are already using in e.g. `State`. 