### PR TITLE
refactor: hoist crypto related code to own package

### DIFF
--- a/abi/types.go
+++ b/abi/types.go
@@ -13,13 +13,13 @@ import "github.com/ethereum/go-ethereum/accounts/abi"
 var Uint256, _ = abi.NewType("uint256", "uint256", nil)
 
 // bool is the bool type for abi encoding
-var BoolTy, _ = abi.NewType("bool", "bool", nil)
+var Bool, _ = abi.NewType("bool", "bool", nil)
 
 // Destination is the bytes32 type for abi encoding
 var Destination, _ = abi.NewType("bytes32", "address", nil)
 
 // bytes is the bytes type for abi encoding
-var BytesTy, _ = abi.NewType("bytes", "bytes", nil)
+var Bytes, _ = abi.NewType("bytes", "bytes", nil)
 
 // address is the address[] type for abi encoding
 var AddressArray, _ = abi.NewType("address[]", "address[]", nil)

--- a/abi/types.go
+++ b/abi/types.go
@@ -12,16 +12,16 @@ import "github.com/ethereum/go-ethereum/accounts/abi"
 // Uint256 is the Uint256 type for abi encoding
 var Uint256, _ = abi.NewType("uint256", "uint256", nil)
 
-// bool is the bool type for abi encoding
+// Bool is the bool type for abi encoding
 var Bool, _ = abi.NewType("bool", "bool", nil)
 
 // Destination is the bytes32 type for abi encoding
 var Destination, _ = abi.NewType("bytes32", "address", nil)
 
-// bytes is the bytes type for abi encoding
+// Bytes is the bytes type for abi encoding
 var Bytes, _ = abi.NewType("bytes", "bytes", nil)
 
-// address is the address[] type for abi encoding
+// AddressArray is the address[] type for abi encoding
 var AddressArray, _ = abi.NewType("address[]", "address[]", nil)
 
 // Address is the Address type for abi encoding

--- a/abi/types.go
+++ b/abi/types.go
@@ -1,4 +1,4 @@
-package crypto
+package abi
 
 import "github.com/ethereum/go-ethereum/accounts/abi"
 

--- a/channel/state/state.go
+++ b/channel/state/state.go
@@ -77,11 +77,11 @@ func (fp FixedPart) ChannelId() (types.Destination, error) {
 	}
 
 	encodedChannelPart, error := abi.Arguments{
-		{Type: uint256},
-		{Type: addressArray},
-		{Type: uint256},
-		{Type: address},
-		{Type: uint256},
+		{Type: nc.Uint256},
+		{Type: nc.AddressArray},
+		{Type: nc.Uint256},
+		{Type: nc.Address},
+		{Type: nc.Uint256},
 	}.Pack(fp.ChainId, fp.Participants, fp.ChannelNonce, fp.AppDefinition, fp.ChallengeDuration)
 
 	channelId := types.Destination(crypto.Keccak256Hash(encodedChannelPart))
@@ -106,11 +106,11 @@ func (s State) encode() (types.Bytes, error) {
 	}
 
 	return abi.Arguments{
-		{Type: destination},    // channel id (includes ChainID, Participants, ChannelNonce)
-		{Type: bytesTy},        // app data
+		{Type: nc.Destination}, // channel id (includes ChainID, Participants, ChannelNonce)
+		{Type: nc.BytesTy},     // app data
 		{Type: outcome.ExitTy}, // outcome
-		{Type: uint256},        // turnNum
-		{Type: boolTy},         // isFinal
+		{Type: nc.Uint256},     // turnNum
+		{Type: nc.BoolTy},      // isFinal
 	}.Pack(
 		ChannelId,
 		[]byte(s.AppData), // Note: even though s.AppData is types.bytes, which is an alias for []byte], Pack will not accept types.bytes

--- a/channel/state/state.go
+++ b/channel/state/state.go
@@ -137,7 +137,7 @@ func (s State) Sign(secretKey []byte) (Signature, error) {
 	if error != nil {
 		return Signature{}, error
 	}
-	return SignEthereumMessage(hash.Bytes(), secretKey)
+	return nc.SignEthereumMessage(hash.Bytes(), secretKey)
 }
 
 // RecoverSigner computes the Ethereum address which generated Signature sig on State state
@@ -146,7 +146,7 @@ func (s State) RecoverSigner(sig Signature) (types.Address, error) {
 	if error != nil {
 		return types.Address{}, error
 	}
-	return RecoverEthereumMessageSigner(stateHash[:], sig)
+	return nc.RecoverEthereumMessageSigner(stateHash[:], sig)
 }
 
 // equalParticipants returns true if the given arrays contain equal addresses (in the same order).

--- a/channel/state/state.go
+++ b/channel/state/state.go
@@ -108,10 +108,10 @@ func (s State) encode() (types.Bytes, error) {
 
 	return ethAbi.Arguments{
 		{Type: abi.Destination}, // channel id (includes ChainID, Participants, ChannelNonce)
-		{Type: abi.BytesTy},     // app data
+		{Type: abi.Bytes},       // app data
 		{Type: outcome.ExitTy},  // outcome
 		{Type: abi.Uint256},     // turnNum
-		{Type: abi.BoolTy},      // isFinal
+		{Type: abi.Bool},        // isFinal
 	}.Pack(
 		ChannelId,
 		[]byte(s.AppData), // Note: even though s.AppData is types.bytes, which is an alias for []byte], Pack will not accept types.bytes

--- a/channel/state/state.go
+++ b/channel/state/state.go
@@ -9,8 +9,11 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
+	nc "github.com/statechannels/go-nitro/crypto"
 	"github.com/statechannels/go-nitro/types"
 )
+
+type Signature = nc.Signature
 
 type (
 	// State holds all of the data describing the state of a channel

--- a/channel/state/state.go
+++ b/channel/state/state.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/accounts/abi"
+	ethAbi "github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/statechannels/go-nitro/abi"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	nc "github.com/statechannels/go-nitro/crypto"
 	"github.com/statechannels/go-nitro/types"
@@ -76,12 +77,12 @@ func (fp FixedPart) ChannelId() (types.Destination, error) {
 		return types.Destination{}, errors.New(`cannot compute ChannelId with nil ChannelNonce`)
 	}
 
-	encodedChannelPart, error := abi.Arguments{
-		{Type: nc.Uint256},
-		{Type: nc.AddressArray},
-		{Type: nc.Uint256},
-		{Type: nc.Address},
-		{Type: nc.Uint256},
+	encodedChannelPart, error := ethAbi.Arguments{
+		{Type: abi.Uint256},
+		{Type: abi.AddressArray},
+		{Type: abi.Uint256},
+		{Type: abi.Address},
+		{Type: abi.Uint256},
 	}.Pack(fp.ChainId, fp.Participants, fp.ChannelNonce, fp.AppDefinition, fp.ChallengeDuration)
 
 	channelId := types.Destination(crypto.Keccak256Hash(encodedChannelPart))
@@ -105,12 +106,12 @@ func (s State) encode() (types.Bytes, error) {
 
 	}
 
-	return abi.Arguments{
-		{Type: nc.Destination}, // channel id (includes ChainID, Participants, ChannelNonce)
-		{Type: nc.BytesTy},     // app data
-		{Type: outcome.ExitTy}, // outcome
-		{Type: nc.Uint256},     // turnNum
-		{Type: nc.BoolTy},      // isFinal
+	return ethAbi.Arguments{
+		{Type: abi.Destination}, // channel id (includes ChainID, Participants, ChannelNonce)
+		{Type: abi.BytesTy},     // app data
+		{Type: outcome.ExitTy},  // outcome
+		{Type: abi.Uint256},     // turnNum
+		{Type: abi.BoolTy},      // isFinal
 	}.Pack(
 		ChannelId,
 		[]byte(s.AppData), // Note: even though s.AppData is types.bytes, which is an alias for []byte], Pack will not accept types.bytes

--- a/channel/state/state_test.go
+++ b/channel/state/state_test.go
@@ -15,9 +15,9 @@ var correctStateHash = common.HexToHash(`867a304a6c24962522085dc09c09b47413897a1
 var signerPrivateKey = common.Hex2Bytes(`caab404f975b4620747174a75f08d98b4e5a7053b691b41bcfc0d839d48b7634`)
 var signerAddress = common.HexToAddress(`F5A1BB5607C9D079E46d1B3Dc33f257d937b43BD`)
 var correctSignature = Signature{
-	common.Hex2Bytes(`704b3afcc6e702102ca1af3f73cf3b37f3007f368c40e8b81ca823a65740a053`),
-	common.Hex2Bytes(`14040ad4c598dbb055a50430142a13518e1330b79d24eed86fcbdff1a7a95589`),
-	byte(0),
+	R: common.Hex2Bytes(`704b3afcc6e702102ca1af3f73cf3b37f3007f368c40e8b81ca823a65740a053`),
+	S: common.Hex2Bytes(`14040ad4c598dbb055a50430142a13518e1330b79d24eed86fcbdff1a7a95589`),
+	V: byte(0),
 }
 
 func TestChannelId(t *testing.T) {

--- a/crypto/abi-types.go
+++ b/crypto/abi-types.go
@@ -1,4 +1,4 @@
-package state
+package crypto
 
 import "github.com/ethereum/go-ethereum/accounts/abi"
 
@@ -9,20 +9,20 @@ import "github.com/ethereum/go-ethereum/accounts/abi"
 // To construct an abi.Arguments instance, we need to supply an array of "types", which are
 // actually go values. The following types are used when encoding a state
 
-// uint256 is the uint256 type for abi encoding
-var uint256, _ = abi.NewType("uint256", "uint256", nil)
+// Uint256 is the Uint256 type for abi encoding
+var Uint256, _ = abi.NewType("uint256", "uint256", nil)
 
 // bool is the bool type for abi encoding
-var boolTy, _ = abi.NewType("bool", "bool", nil)
+var BoolTy, _ = abi.NewType("bool", "bool", nil)
 
-// destination is the bytes32 type for abi encoding
-var destination, _ = abi.NewType("bytes32", "address", nil)
+// Destination is the bytes32 type for abi encoding
+var Destination, _ = abi.NewType("bytes32", "address", nil)
 
 // bytes is the bytes type for abi encoding
-var bytesTy, _ = abi.NewType("bytes", "bytes", nil)
+var BytesTy, _ = abi.NewType("bytes", "bytes", nil)
 
 // address is the address[] type for abi encoding
-var addressArray, _ = abi.NewType("address[]", "address[]", nil)
+var AddressArray, _ = abi.NewType("address[]", "address[]", nil)
 
-// address is the address type for abi encoding
-var address, _ = abi.NewType("address", "address", nil)
+// Address is the Address type for abi encoding
+var Address, _ = abi.NewType("address", "address", nil)

--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -1,4 +1,4 @@
-package state
+package crypto
 
 import (
 	"fmt"


### PR DESCRIPTION
The `abi-types` and `signature` files seem like they're in the wrong place. This moves them into a crypto package, enabling consumers of cryptography related code to share the same implementations. (See #147 for instance.)

Side note: I don't know if `crypto` is a good name for this package -- it's the best I came up with after 5 minutes of thought.