### PR TITLE
add some voucher-related code

### DIFF
--- a/payments/payment-manager.go
+++ b/payments/payment-manager.go
@@ -51,8 +51,9 @@ func (pp *PaymentManager) PayBob(amount uint64) error {
 	channelId := pp.largestVoucher.channelId
 	pp.largestVoucher = Voucher{
 		channelId: channelId,
-		amount:    uint(amount),
+		amount:    uint(amount) + pp.largestVoucher.amount,
 	}
+
 	if err := pp.largestVoucher.sign(pp.pk); err != nil {
 		panic(err)
 	}

--- a/payments/payment-manager.go
+++ b/payments/payment-manager.go
@@ -47,11 +47,11 @@ func NewPaymentManager(channelId types.Destination, pk []byte) (PaymentManager, 
 
 // PayBob will add `amount` to the biggest voucher to create
 // a new voucher. This voucher is then signed and sent to Bob.
-func (pp *PaymentManager) PayBob(amount uint64) error {
+func (pp *PaymentManager) PayBob(amount uint) error {
 	channelId := pp.largestVoucher.channelId
 	pp.largestVoucher = Voucher{
 		channelId: channelId,
-		amount:    uint(amount) + pp.largestVoucher.amount,
+		amount:    amount + pp.largestVoucher.amount,
 	}
 
 	if err := pp.largestVoucher.sign(pp.pk); err != nil {

--- a/payments/payment-manager.go
+++ b/payments/payment-manager.go
@@ -8,8 +8,8 @@ import (
 const alice = 0
 
 type (
-	// A PaymentProvider can be used to make a payment for a given channel.
-	PaymentProvider struct {
+	// A PaymentManager can be used to make a payment for a given channel.
+	PaymentManager struct {
 		fp             state.FixedPart
 		largestVoucher Voucher
 		pk             []byte
@@ -20,7 +20,7 @@ type (
 	// A receipt provider enables the consumer to listen to incoming
 	// vouchers, validate them, and notify the consumer of a payment
 	// received
-	ReceiptProvider struct {
+	ReceiptManager struct {
 		fp             state.FixedPart
 		largestVoucher Voucher
 
@@ -30,9 +30,9 @@ type (
 )
 
 // implemented just to make use of fp ...
-func NewPaymentProvider(fp state.FixedPart, pk []byte) (PaymentProvider, error) {
+func NewPaymentManager(fp state.FixedPart, pk []byte) (PaymentManager, error) {
 	chanId, err := fp.ChannelId()
-	pp := PaymentProvider{}
+	pp := PaymentManager{}
 
 	if err != nil {
 		return pp, err
@@ -53,7 +53,7 @@ func NewPaymentProvider(fp state.FixedPart, pk []byte) (PaymentProvider, error) 
 
 // PayBob will use add amount to the biggest voucher to create
 // a new voucher. This voucher is then signed and sent to Bob.
-func (pp *PaymentProvider) PayBob(amount uint64) error {
+func (pp *PaymentManager) PayBob(amount uint64) error {
 	channelId := pp.largestVoucher.channelId
 	pp.largestVoucher = Voucher{
 		channelId: channelId,
@@ -68,7 +68,7 @@ func (pp *PaymentProvider) PayBob(amount uint64) error {
 	return nil
 }
 
-func (rp *ReceiptProvider) ValidateVouchers(listener chan uint64) {
+func (rp *ReceiptManager) ValidateVouchers(listener chan uint64) {
 	for voucher := range rp.vouchers {
 
 		signer, err := voucher.recoverSigner()
@@ -88,12 +88,12 @@ func (rp *ReceiptProvider) ValidateVouchers(listener chan uint64) {
 
 		received := voucher.amount - rp.largestVoucher.amount
 
-		// Clarification needed: What information would a receipt provider need to provide
+		// Clarification needed: What information would a receipt manager need to provide
 		// to its consumer?
 		rp.payments <- received
 	}
 }
 
-func (rp ReceiptProvider) alice() common.Address {
+func (rp ReceiptManager) alice() common.Address {
 	return rp.fp.Participants[alice]
 }

--- a/payments/payment-manager.go
+++ b/payments/payment-manager.go
@@ -45,7 +45,7 @@ func NewPaymentManager(channelId types.Destination, pk []byte) (PaymentManager, 
 	return pp, nil
 }
 
-// PayBob will use add amount to the biggest voucher to create
+// PayBob will add `amount` to the biggest voucher to create
 // a new voucher. This voucher is then signed and sent to Bob.
 func (pp *PaymentManager) PayBob(amount uint64) error {
 	channelId := pp.largestVoucher.channelId

--- a/payments/payment-provider.go
+++ b/payments/payment-provider.go
@@ -1,0 +1,95 @@
+package payments
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/channel/state"
+)
+
+const alice = 0
+
+type (
+	// A PaymentProvider can be used to make a payment for a given channel.
+	PaymentProvider struct {
+		fp             state.FixedPart
+		largestVoucher Voucher
+		pk             []byte
+
+		payments chan Voucher // gochan used to send vouchers to Bob
+	}
+
+	// A receipt provider enables the consumer to listen to incoming
+	// vouchers, validate them, and notify the consumer of a payment
+	// received
+	ReceiptProvider struct {
+		fp             state.FixedPart
+		largestVoucher Voucher
+
+		vouchers chan Voucher // todo: should be unidirectional
+		payments chan uint    // todo: API needs to be clarified
+	}
+)
+
+// implemented just to make use of fp ...
+func NewPaymentProvider(fp state.FixedPart, pk []byte) (PaymentProvider, error) {
+	chanId, err := fp.ChannelId()
+	pp := PaymentProvider{}
+
+	if err != nil {
+		return pp, err
+	}
+
+	pp.largestVoucher = Voucher{
+		channelId: chanId,
+	}
+
+	pp.largestVoucher.sign(pk)
+
+	pp.fp = fp
+
+	return pp, nil
+}
+
+// PayBob will use add amount to the biggest voucher to create
+// a new voucher. This voucher is then signed and sent to Bob.
+func (pp *PaymentProvider) PayBob(amount uint64) error {
+	channelId := pp.largestVoucher.channelId
+	pp.largestVoucher = Voucher{
+		channelId: channelId,
+		amount:    uint(amount),
+	}
+	pp.largestVoucher.sign(pp.pk)
+
+	pp.payments <- pp.largestVoucher
+
+	return nil
+}
+
+func (rp *ReceiptProvider) ValidateVouchers(listener chan uint64) {
+	for voucher := range rp.vouchers {
+
+		signer, err := voucher.recoverSigner()
+
+		if err != nil {
+			// todo: figure out what to do with errors within a goroutine
+			panic(err)
+		}
+
+		if signer != rp.alice() {
+			panic("invalid signature")
+		}
+
+		if rp.largestVoucher.amount >= voucher.amount {
+			panic("received a stale voucher")
+		}
+
+		received := voucher.amount - rp.largestVoucher.amount
+
+		// Clarification needed: What information would a receipt provider need to provide
+		// to its consumer?
+		rp.payments <- received
+	}
+}
+
+func (rp ReceiptProvider) alice() common.Address {
+	return rp.fp.Participants[alice]
+}

--- a/payments/payment-provider.go
+++ b/payments/payment-provider.go
@@ -42,7 +42,9 @@ func NewPaymentProvider(fp state.FixedPart, pk []byte) (PaymentProvider, error) 
 		channelId: chanId,
 	}
 
-	pp.largestVoucher.sign(pk)
+	if err := pp.largestVoucher.sign(pk); err != nil {
+		panic(err)
+	}
 
 	pp.fp = fp
 
@@ -57,7 +59,9 @@ func (pp *PaymentProvider) PayBob(amount uint64) error {
 		channelId: channelId,
 		amount:    uint(amount),
 	}
-	pp.largestVoucher.sign(pp.pk)
+	if err := pp.largestVoucher.sign(pp.pk); err != nil {
+		panic(err)
+	}
 
 	pp.payments <- pp.largestVoucher
 

--- a/payments/vouchers.go
+++ b/payments/vouchers.go
@@ -1,0 +1,66 @@
+package payments
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/statechannels/go-nitro/channel/state"
+	nc "github.com/statechannels/go-nitro/crypto"
+	"github.com/statechannels/go-nitro/types"
+)
+
+type (
+	// A Voucher signed by Alice can be used by Bob to redeem payments in case of
+	// a misbehaving Alice.
+	//
+	// During normal operation, Alice & Bob would terminate the channel with an
+	// outcome reflecting the largest amount signed by Alice. For instance,
+	// - if the channel started with balances {alice: 100, bob: 0}
+	// - and the biggest voucher signed by alice had amount = 20
+	// - then Alice and Bob would cooperatively conclude the channel with outcome
+	//   {alice: 80, bob: 20}
+	Voucher struct {
+		channelId types.Destination
+		amount    uint
+		signature state.Signature
+	}
+)
+
+func (v Voucher) hash() (types.Bytes32, error) {
+	encoded, err := abi.Arguments{
+		{Type: nc.Destination},
+		{Type: nc.Uint256},
+	}.Pack(v.channelId, v.amount)
+
+	if err != nil {
+		return types.Bytes32{}, fmt.Errorf("failed to encode voucher: %w", err)
+	}
+	return crypto.Keccak256Hash(encoded), nil
+}
+
+func (v *Voucher) sign(pk []byte) error {
+	hash, err := v.hash()
+	if err != nil {
+		return err
+	}
+
+	sig, err := nc.SignEthereumMessage(hash.Bytes(), pk)
+
+	if err != nil {
+		return err
+	}
+
+	v.signature = sig
+
+	return nil
+}
+
+func (v Voucher) recoverSigner() (types.Address, error) {
+	h, error := v.hash()
+	if error != nil {
+		return types.Address{}, error
+	}
+	return nc.RecoverEthereumMessageSigner(h[:], v.signature)
+}
+

--- a/payments/vouchers.go
+++ b/payments/vouchers.go
@@ -63,4 +63,3 @@ func (v Voucher) recoverSigner() (types.Address, error) {
 	}
 	return nc.RecoverEthereumMessageSigner(h[:], v.signature)
 }
-

--- a/payments/vouchers.go
+++ b/payments/vouchers.go
@@ -5,8 +5,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/crypto"
+	nitroAbi "github.com/statechannels/go-nitro/abi"
 	"github.com/statechannels/go-nitro/channel/state"
-	nc "github.com/statechannels/go-nitro/crypto"
+	nitroCrypto "github.com/statechannels/go-nitro/crypto"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -29,8 +30,8 @@ type (
 
 func (v Voucher) hash() (types.Bytes32, error) {
 	encoded, err := abi.Arguments{
-		{Type: nc.Destination},
-		{Type: nc.Uint256},
+		{Type: nitroAbi.Destination},
+		{Type: nitroAbi.Uint256},
 	}.Pack(v.channelId, v.amount)
 
 	if err != nil {
@@ -45,7 +46,7 @@ func (v *Voucher) sign(pk []byte) error {
 		return err
 	}
 
-	sig, err := nc.SignEthereumMessage(hash.Bytes(), pk)
+	sig, err := nitroCrypto.SignEthereumMessage(hash.Bytes(), pk)
 
 	if err != nil {
 		return err
@@ -61,5 +62,5 @@ func (v Voucher) recoverSigner() (types.Address, error) {
 	if error != nil {
 		return types.Address{}, error
 	}
-	return nc.RecoverEthereumMessageSigner(h[:], v.signature)
+	return nitroCrypto.RecoverEthereumMessageSigner(h[:], v.signature)
 }


### PR DESCRIPTION
This adds some scaffolding code that we can use to discuss the requirements of a payment provider and receipt provider. The initial prototype aims to outline the core payment flow.

With this prototype, I make the following assumptions:
1. Payments are always unidirectional, and Alice always pays Bob.
2. The virtual-defunder protocol will use a voucher to determine how to conclude a virtually funded channel

Both assumptions are easy to relax, depending on feature requests.

See https://www.notion.so/statechannels/Voucher-channels-f8609ab3f45142eda3e552e58a676bb1 for more detailed discussion.