### PR TITLE
Overhaul turn num constants by introducing an enum

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -57,12 +57,12 @@ func New(s state.State, isTwoPartyLedger bool, myIndex uint, myDestination types
 
 	// Store prefund
 	c.SignedStateForTurnNum = make(map[uint64]SignedState)
-	c.SignedStateForTurnNum[0] = SignedState{s.VariablePart(), make(map[uint]state.Signature)}
+	c.SignedStateForTurnNum[PREFUNDTURNUM] = SignedState{s.VariablePart(), make(map[uint]state.Signature)}
 
 	// Store postfund
 	post := s.Clone()
 	post.TurnNum = POSTFUNDTURNNUM
-	c.SignedStateForTurnNum[1] = SignedState{post.VariablePart(), make(map[uint]state.Signature)}
+	c.SignedStateForTurnNum[POSTFUNDTURNNUM] = SignedState{post.VariablePart(), make(map[uint]state.Signature)}
 
 	return c, nil
 }
@@ -79,19 +79,19 @@ func (c Channel) Equal(d Channel) bool {
 
 // PreFundState() returns the pre fund setup state for the channel.
 func (c Channel) PreFundState() state.State {
-	return state.StateFromFixedAndVariablePart(c.FixedPart, c.SignedStateForTurnNum[0].State)
+	return state.StateFromFixedAndVariablePart(c.FixedPart, c.SignedStateForTurnNum[PREFUNDTURNUM].State)
 }
 
 // PostFundState() returns the post fund setup state for the channel.
 func (c Channel) PostFundState() state.State {
-	return state.StateFromFixedAndVariablePart(c.FixedPart, c.SignedStateForTurnNum[1].State)
+	return state.StateFromFixedAndVariablePart(c.FixedPart, c.SignedStateForTurnNum[POSTFUNDTURNNUM].State)
 
 }
 
 // PreFundSignedByMe() returns true if I have signed the pre fund setup state, false otherwise.
 func (c Channel) PreFundSignedByMe() bool {
-	if _, ok := c.SignedStateForTurnNum[0]; ok {
-		if _, ok := c.SignedStateForTurnNum[0].Sigs[c.MyIndex]; ok {
+	if _, ok := c.SignedStateForTurnNum[PREFUNDTURNUM]; ok {
+		if _, ok := c.SignedStateForTurnNum[PREFUNDTURNUM].Sigs[c.MyIndex]; ok {
 			return true
 		}
 	}
@@ -100,8 +100,8 @@ func (c Channel) PreFundSignedByMe() bool {
 
 // PostFundSignedByMe() returns true if I have signed the post fund setup state, false otherwise.
 func (c Channel) PostFundSignedByMe() bool {
-	if _, ok := c.SignedStateForTurnNum[1]; ok {
-		if _, ok := c.SignedStateForTurnNum[1].Sigs[c.MyIndex]; ok {
+	if _, ok := c.SignedStateForTurnNum[POSTFUNDTURNNUM]; ok {
+		if _, ok := c.SignedStateForTurnNum[POSTFUNDTURNNUM].Sigs[c.MyIndex]; ok {
 			return true
 		}
 	}
@@ -110,12 +110,12 @@ func (c Channel) PostFundSignedByMe() bool {
 
 // PreFundComplete() returns true if I have a complete set of signatures on  the pre fund setup state, false otherwise.
 func (c Channel) PreFundComplete() bool {
-	return c.SignedStateForTurnNum[0].hasAllSignatures(len(c.FixedPart.Participants))
+	return c.SignedStateForTurnNum[PREFUNDTURNUM].hasAllSignatures(len(c.FixedPart.Participants))
 }
 
 // PostFundComplete() returns true if I have a complete set of signatures on  the pre fund setup state, false otherwise.
 func (c Channel) PostFundComplete() bool {
-	return c.SignedStateForTurnNum[1].hasAllSignatures(len(c.FixedPart.Participants))
+	return c.SignedStateForTurnNum[POSTFUNDTURNNUM].hasAllSignatures(len(c.FixedPart.Participants))
 }
 
 // LatestSupportedState returns the latest supported state.

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -54,7 +54,7 @@ func TestChannel(t *testing.T) {
 	testPostFund := func(t *testing.T) {
 		got, err1 := c.PostFundState().Hash()
 		spf := s.Clone()
-		spf.TurnNum = 1
+		spf.TurnNum = POSTFUNDTURNNUM
 		want, err2 := spf.Hash()
 		if err1 != nil {
 			t.Error(err1)
@@ -158,7 +158,7 @@ func TestChannel(t *testing.T) {
 		if got != want {
 			t.Error(`expected c.AddSignedState() to be false, but it was true`)
 		}
-		c.latestSupportedStateTurnNum = MAGICTURNNUM // Rest so there is no longer a supported state
+		c.latestSupportedStateTurnNum = MAXTURNNUM // Reset so there is no longer a supported state
 
 		// Now test cases which update the Channel and return true
 		want = true

--- a/channel/constants.go
+++ b/channel/constants.go
@@ -1,4 +1,7 @@
 package channel
 
-// MAGICTURNNUM is a reserved value which is taken to mean "there is not yet a supported state"
-const MAGICTURNNUM = ^uint64(0)
+const (
+	PREFUNDTURNUM uint64 = iota
+	POSTFUNDTURNNUM
+	MAXTURNNUM = ^uint64(0) // MAXTURNNUM is a reserved value which is taken to mean "there is not yet a supported state"
+)


### PR DESCRIPTION
Pros:
* easy to change the meaning of e.g. "post fund turn number" by making a one line change
* better readability

Cons:
* I think we cannot force the use of the enum in Go (as we could in Typescript). This is not really a "con" but just a "not as nice as we might like"


I placed these constants in the `channel` package where I think they belong. The `protocols` package does not need to deal with turn numbers explicitly (only things like "post fund state"). So turn numbers are an implementation detail that is encapsulated within the `channel` package. 