### PR TITLE
Simplify constructor for `direct-fund-objective`

### DIFF
--- a/client/engine/messageservice/test-messageservice_test.go
+++ b/client/engine/messageservice/test-messageservice_test.go
@@ -12,7 +12,7 @@ import (
 var aliceMS = NewTestMessageService(types.Address{'a'})
 var bobMS = NewTestMessageService(types.Address{'b'})
 
-var objective, _ = directfund.New(state.TestState, aliceMS.address, true, types.AddressToDestination(aliceMS.address), types.AddressToDestination(bobMS.address))
+var objective, _ = directfund.New(state.TestState, aliceMS.address)
 var testId protocols.ObjectiveId = "testObjectiveID"
 
 var aToB protocols.Message = protocols.Message{

--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -43,9 +43,6 @@ type DirectFundObjective struct {
 func New(
 	initialState state.State,
 	myAddress types.Address,
-	isTwoPartyLedger bool,
-	myDestination types.Destination,
-	theirDestination types.Destination,
 ) (DirectFundObjective, error) {
 	if initialState.IsFinal {
 		return DirectFundObjective{}, errors.New("attempted to initiate new direct-funding objective with IsFinal == true")

--- a/protocols/direct-fund/direct-fund_test.go
+++ b/protocols/direct-fund/direct-fund_test.go
@@ -57,13 +57,7 @@ var testState = state.State{
 
 // TestNew tests the constructor using a TestState fixture
 func TestNew(t *testing.T) {
-	// Assert that valid sets of constructor args do not result in errors
-	if _, err := New(testState, testState.Participants[0]); err != nil {
-		t.Error(err)
-	}
-	if _, err := New(testState, testState.Participants[0]); err != nil {
-		t.Error(err)
-	}
+	// Assert that valid constructor args do not result in error
 	if _, err := New(testState, testState.Participants[0]); err != nil {
 		t.Error(err)
 	}

--- a/protocols/direct-fund/direct-fund_test.go
+++ b/protocols/direct-fund/direct-fund_test.go
@@ -55,20 +55,16 @@ var testState = state.State{
 	IsFinal: false,
 }
 
-var isTwoPartyLedger = false           // for the purposes of this test
-var myDestination = alice.destination  // only needed if isTwoPartyLedger = true
-var theirDestination = bob.destination // only needed if isTwoPartyLedger = true
-
 // TestNew tests the constructor using a TestState fixture
 func TestNew(t *testing.T) {
 	// Assert that valid sets of constructor args do not result in errors
-	if _, err := New(testState, testState.Participants[0], true, myDestination, theirDestination); err != nil {
+	if _, err := New(testState, testState.Participants[0]); err != nil {
 		t.Error(err)
 	}
-	if _, err := New(testState, testState.Participants[0], false, myDestination, theirDestination); err != nil {
+	if _, err := New(testState, testState.Participants[0]); err != nil {
 		t.Error(err)
 	}
-	if _, err := New(testState, testState.Participants[0], false, types.Destination{}, theirDestination); err != nil {
+	if _, err := New(testState, testState.Participants[0]); err != nil {
 		t.Error(err)
 	}
 
@@ -76,13 +72,13 @@ func TestNew(t *testing.T) {
 	finalState := testState.Clone()
 	finalState.IsFinal = true
 
-	if _, err := New(finalState, testState.Participants[0], isTwoPartyLedger, myDestination, theirDestination); err == nil {
+	if _, err := New(finalState, testState.Participants[0]); err == nil {
 		t.Error("expected an error when constructing with an intial state marked final, but got nil")
 	}
 }
 
 // Construct various variables for use in TestUpdate
-var s, _ = New(testState, testState.Participants[0], isTwoPartyLedger, myDestination, theirDestination)
+var s, _ = New(testState, testState.Participants[0])
 var dummySignature = state.Signature{
 	R: common.Hex2Bytes(`49d8e91bd182fb4d489bb2d76a6735d494d5bea24e4b51dd95c9d219293312d9`),
 	S: common.Hex2Bytes(`22274a3cec23c31e0c073b3c071cf6e0c21260b0d292a10e6a04257a2d8e87fa`),


### PR DESCRIPTION
This is a follow-up from #141.

### Context

- `direct-fund.New`'s parameter list grew with the introduction of the channel abstraction in conjunction with the virtual fund objective work.
- The splitting of channel constructors in #141 removes the need for these sort of "flag" constructor parameters.

### Changes (per commit)
- the (now-unused) ctor arguments to direct-fund-objective have been removed
- these changes were propagated to other files
- redundant test cases were removed