### PR TITLE
Introduce `MockChain` and `SimpleChainService`

### DIFF
--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -14,7 +14,6 @@ type Event struct {
 }
 
 type ChainService interface {
-	GetReceiveChan() chan Event
-	GetSendChan() chan protocols.Transaction
-	Submit(tx protocols.Transaction)
+	Out() <-chan Event
+	In() chan<- protocols.Transaction
 }

--- a/client/engine/chainservice/mockchain.go
+++ b/client/engine/chainservice/mockchain.go
@@ -1,0 +1,71 @@
+package chainservice
+
+import (
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/types"
+)
+
+// MockChain provides an interface which simulates a blockchain network. It is designed for use as a central service which multiple
+// ChainServices connect to with Go chans.
+// It keeps a record of of holdings and adjudication status for each channel, accepts transactions and emits events.
+type MockChain struct {
+	out map[types.Address]chan Event // out is a mapping with a chan for each connected ChainService, used to send Events to that service
+	in  chan protocols.Transaction   // in is the chan used to recieve Transactions from multiple ChainServices
+
+	holdings map[types.Destination]types.Funds // holdings tracks funds for each channel
+}
+
+// Out() returns the out chan for a particular ChainService, and narrows the type so that external consumers mays only recieve on it.
+func (mc MockChain) Out(a types.Address) <-chan Event {
+	return mc.out[a]
+}
+
+// In returns the in chan but narrows the type so that external consumers may only send on it.
+func (mc MockChain) In() chan<- protocols.Transaction {
+	return mc.in
+}
+
+// NewMockChain returns a new MockChain with an out chan initialized for each of the addresses passed in.
+func NewMockChain(addresses []types.Address) MockChain {
+
+	mc := MockChain{}
+	mc.out = make(map[types.Address]chan Event)
+	mc.in = make(chan protocols.Transaction)
+	mc.holdings = make(map[types.Destination]types.Funds)
+
+	const BUFFER_SIZE = 10
+	for _, a := range addresses {
+		mc.out[a] = make(chan Event, BUFFER_SIZE)
+	}
+
+	go mc.Run()
+	return mc
+}
+
+// Run starts a listener for transactions on the MockChain's in chan.
+func (mc MockChain) Run() {
+	for tx := range mc.in {
+		mc.handleTx(tx)
+	}
+}
+
+// handleTx responds to the given tx.
+func (mc MockChain) handleTx(tx protocols.Transaction) {
+	if tx.Deposit.IsNonZero() {
+		mc.holdings[tx.ChannelId] = mc.holdings[tx.ChannelId].Add(tx.Deposit)
+	}
+	event := Event{
+		ChannelId:          tx.ChannelId,
+		Holdings:           mc.holdings[tx.ChannelId],
+		AdjudicationStatus: protocols.AdjudicationStatus{TurnNumRecord: 0},
+	}
+	for _, out := range mc.out {
+		go sendEvent(out, event) // we use a goroutine for each send to prevent being blocked by one bad listener
+	}
+
+}
+
+// sendEvent sends event to the supplied chan
+func sendEvent(out chan Event, event Event) {
+	out <- event
+}

--- a/client/engine/chainservice/mockchain.go
+++ b/client/engine/chainservice/mockchain.go
@@ -34,9 +34,8 @@ func NewMockChain(addresses []types.Address) MockChain {
 	mc.in = make(chan protocols.Transaction)
 	mc.holdings = make(map[types.Destination]types.Funds)
 
-	const BUFFER_SIZE = 10
 	for _, a := range addresses {
-		mc.out[a] = make(chan Event, BUFFER_SIZE)
+		mc.out[a] = make(chan Event)
 	}
 
 	go mc.Run()

--- a/client/engine/chainservice/mockchain.go
+++ b/client/engine/chainservice/mockchain.go
@@ -7,6 +7,7 @@ import (
 
 // MockChain provides an interface which simulates a blockchain network. It is designed for use as a central service which multiple
 // ChainServices connect to with Go chans.
+//
 // It keeps a record of of holdings and adjudication status for each channel, accepts transactions and emits events.
 type MockChain struct {
 	out map[types.Address]chan Event // out is a mapping with a chan for each connected ChainService, used to send Events to that service
@@ -15,7 +16,7 @@ type MockChain struct {
 	holdings map[types.Destination]types.Funds // holdings tracks funds for each channel
 }
 
-// Out() returns the out chan for a particular ChainService, and narrows the type so that external consumers mays only recieve on it.
+// Out returns the out chan for a particular ChainService, and narrows the type so that external consumers may only receive on it.
 func (mc MockChain) Out(a types.Address) <-chan Event {
 	return mc.out[a]
 }

--- a/client/engine/chainservice/mockchain_test.go
+++ b/client/engine/chainservice/mockchain_test.go
@@ -1,0 +1,86 @@
+package chainservice
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/types"
+)
+
+func TestDeposit(t *testing.T) {
+	// The MockChain and SimpleChainService should work together to react to a deposit transaction for a given channel by:
+	// - sending an event with updated holdings for that channel to all SimpleChainServices which are subscribed
+
+	var a = types.Address(common.HexToAddress(`0xF5A1BB5607C9D079E46d1B3Dc33f257d937b43BD`))
+	var b = types.Address(common.HexToAddress(`0xa5A1BB5607C9D079E46d1B3Dc33f257d937b43BD`))
+
+	// Construct MockChain and tell it the addresses of the SimpleChainServices which will subscribe to it.
+	// This is not super elegant but gets around data races -- the constructor will make channels and then run a listener which will send on them.
+	var chain = NewMockChain([]types.Address{a, b})
+
+	// Construct SimpleChainServices
+	mcsA := NewSimpleChainService(chain, a)
+	mcsB := NewSimpleChainService(chain, b)
+
+	inA := mcsA.In()
+	outA := mcsA.Out()
+
+	// Prepare test data to trigger MockChainService
+	testDeposit := types.Funds{
+		common.HexToAddress("0x00"): big.NewInt(1),
+	}
+	testTx := protocols.Transaction{
+		ChannelId: types.Destination(common.HexToHash(`4ebd366d014a173765ba1e50f284c179ade31f20441bec41664712aac6cc461d`)),
+		Deposit:   testDeposit,
+	}
+
+	// Send one transaction into one of the SimpleChainServices and recieve one event from it.
+	inA <- testTx
+	event := <-outA
+
+	if event.ChannelId != testTx.ChannelId {
+		t.Error(`channelId mismatch`)
+	}
+	if !event.Holdings.Equal(testTx.Deposit) {
+		t.Error(`holdings mismatch`)
+	}
+
+	// Send the transaction again and recieve another event
+	inA <- testTx
+	event = <-outA
+
+	// The expectation is that the MockChainService remembered the previous deposit and added this one to it:
+	expectedHoldings := types.Funds{
+		common.HexToAddress("0x00"): big.NewInt(2),
+	}
+
+	if event.ChannelId != testTx.ChannelId {
+		t.Error(`channelId mismatch`)
+	}
+	if !event.Holdings.Equal(expectedHoldings) {
+		t.Error(`holdings mismatch`)
+	}
+
+	// Pull an event out of the other mock chain service and check that
+	eventB := <-mcsB.Out()
+
+	if eventB.ChannelId != testTx.ChannelId {
+		t.Error(`channelId mismatch`)
+	}
+	if !eventB.Holdings.Equal(testTx.Deposit) {
+		t.Error(`holdings mismatch`)
+	}
+
+	// Pull another event out of the other mock chain service and check that
+	eventB = <-mcsB.Out()
+
+	if eventB.ChannelId != testTx.ChannelId {
+		t.Error(`channelId mismatch`)
+	}
+	if !eventB.Holdings.Equal(expectedHoldings) {
+		t.Error(`holdings mismatch`)
+	}
+
+}

--- a/client/engine/chainservice/mockchain_test.go
+++ b/client/engine/chainservice/mockchain_test.go
@@ -13,8 +13,8 @@ func TestDeposit(t *testing.T) {
 	// The MockChain and SimpleChainService should work together to react to a deposit transaction for a given channel by:
 	// - sending an event with updated holdings for that channel to all SimpleChainServices which are subscribed
 
-	var a = types.Address(common.HexToAddress(`0xF5A1BB5607C9D079E46d1B3Dc33f257d937b43BD`))
-	var b = types.Address(common.HexToAddress(`0xa5A1BB5607C9D079E46d1B3Dc33f257d937b43BD`))
+	var a = types.Address(common.HexToAddress(`a`))
+	var b = types.Address(common.HexToAddress(`b`))
 
 	// Construct MockChain and tell it the addresses of the SimpleChainServices which will subscribe to it.
 	// This is not super elegant but gets around data races -- the constructor will make channels and then run a listener which will send on them.

--- a/client/engine/chainservice/mockchain_test.go
+++ b/client/engine/chainservice/mockchain_test.go
@@ -52,9 +52,7 @@ func TestDeposit(t *testing.T) {
 	event = <-outA
 
 	// The expectation is that the MockChainService remembered the previous deposit and added this one to it:
-	expectedHoldings := types.Funds{
-		common.HexToAddress("0x00"): big.NewInt(2),
-	}
+	expectedHoldings := testTx.Deposit.Add(testTx.Deposit)
 
 	if event.ChannelId != testTx.ChannelId {
 		t.Error(`channelId mismatch`)

--- a/client/engine/chainservice/simplechainservice.go
+++ b/client/engine/chainservice/simplechainservice.go
@@ -1,0 +1,53 @@
+package chainservice
+
+import (
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/types"
+)
+
+// SimpleChainService forwards inputted transactions to a MockChain, and passes Events straight back.
+type SimpleChainService struct {
+	out chan Event                 // out is the chan used to send Events to the engine
+	in  chan protocols.Transaction // in is the chan used to recieve Transactions from the engine
+
+	address types.Address // address is used to subscribe to the MockChain's Out chan
+	chain   MockChain
+}
+
+// NewSimpleChainService returns a SimpleChainService which is listening for transactions and events.
+func NewSimpleChainService(mc MockChain, address types.Address) ChainService {
+	mcs := SimpleChainService{}
+	mcs.out = make(chan Event)
+	mcs.in = make(chan protocols.Transaction)
+	mcs.chain = mc
+	mcs.address = address
+
+	go mcs.listenForEvents()
+	go mcs.listenForTransactions()
+
+	return mcs
+}
+
+// Out() returns the but chan but narrows the type so that external consumers mays only recieve on it.
+func (mcs SimpleChainService) Out() <-chan Event {
+	return mcs.out
+}
+
+// In returns the in chan but narrows the type so that external consumers mays only send on it.
+func (mcs SimpleChainService) In() chan<- protocols.Transaction {
+	return mcs.in
+}
+
+// listenForTransactions pipes transactions to the MockChain
+func (mcs SimpleChainService) listenForTransactions() {
+	for tx := range mcs.in {
+		mcs.chain.In() <- tx
+	}
+}
+
+// listenForEvents peipes events from the MockChain
+func (mcs SimpleChainService) listenForEvents() {
+	for event := range mcs.chain.Out(mcs.address) {
+		mcs.out <- event
+	}
+}

--- a/client/engine/chainservice/simplechainservice.go
+++ b/client/engine/chainservice/simplechainservice.go
@@ -28,12 +28,12 @@ func NewSimpleChainService(mc MockChain, address types.Address) ChainService {
 	return mcs
 }
 
-// Out() returns the but chan but narrows the type so that external consumers mays only recieve on it.
+// Out returns the out chan but narrows the type so that external consumers may only receive on it.
 func (mcs SimpleChainService) Out() <-chan Event {
 	return mcs.out
 }
 
-// In returns the in chan but narrows the type so that external consumers mays only send on it.
+// In returns the in chan but narrows the type so that external consumers may only send on it.
 func (mcs SimpleChainService) In() chan<- protocols.Transaction {
 	return mcs.in
 }
@@ -45,7 +45,7 @@ func (mcs SimpleChainService) listenForTransactions() {
 	}
 }
 
-// listenForEvents peipes events from the MockChain
+// listenForEvents pipes events from the MockChain
 func (mcs SimpleChainService) listenForEvents() {
 	for event := range mcs.chain.Out(mcs.address) {
 		mcs.out <- event

--- a/client/engine/chainservice/simplechainservice.go
+++ b/client/engine/chainservice/simplechainservice.go
@@ -22,8 +22,8 @@ func NewSimpleChainService(mc MockChain, address types.Address) ChainService {
 	mcs.chain = mc
 	mcs.address = address
 
-	go mcs.listenForEvents()
-	go mcs.listenForTransactions()
+	go mcs.forwardEvents()
+	go mcs.forwardTransactions()
 
 	return mcs
 }
@@ -38,15 +38,15 @@ func (mcs SimpleChainService) In() chan<- protocols.Transaction {
 	return mcs.in
 }
 
-// listenForTransactions pipes transactions to the MockChain
-func (mcs SimpleChainService) listenForTransactions() {
+// forwardTransactions pipes transactions to the MockChain
+func (mcs SimpleChainService) forwardTransactions() {
 	for tx := range mcs.in {
 		mcs.chain.In() <- tx
 	}
 }
 
-// listenForEvents pipes events from the MockChain
-func (mcs SimpleChainService) listenForEvents() {
+// forwardEvents pipes events from the MockChain
+func (mcs SimpleChainService) forwardEvents() {
 	for event := range mcs.chain.Out(mcs.address) {
 		mcs.out <- event
 	}

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -12,12 +12,12 @@ import (
 type Engine struct {
 	// inbound go channels
 	FromAPI   chan APIEvent // This one is exported so that the Client can send API calls
-	fromChain chan chainservice.Event
+	fromChain <-chan chainservice.Event
 	fromMsg   chan protocols.Message
 
 	// outbound go channels
 	toMsg   chan protocols.Message
-	toChain chan protocols.Transaction
+	toChain chan<- protocols.Transaction
 
 	store store.Store // A Store for persisting and restoring important data
 }
@@ -40,11 +40,11 @@ func New(msg messageservice.MessageService, chain chainservice.ChainService) Eng
 
 	// bind the engine's inbound chans
 	e.FromAPI = make(chan APIEvent)
-	e.fromChain = chain.GetReceiveChan()
+	e.fromChain = chain.Out()
 	e.fromMsg = msg.GetReceiveChan()
 
 	// bind the engine's outbound chans
-	e.toChain = chain.GetSendChan()
+	e.toChain = chain.In()
 	e.toMsg = msg.GetSendChan()
 
 	return e

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -15,8 +15,9 @@ type Message struct {
 
 // Transaction is an object to be sent to a blockchain provider.
 type Transaction struct {
-	To   types.Address
-	Data []byte
+	ChannelId types.Destination
+	Deposit   types.Funds
+	// TODO support other transaction types (deposit, challenge, respond, conclude, withdraw)
 }
 
 // LedgerRequest is an object processed by the ledger cranker


### PR DESCRIPTION
The `SimpleChainService` is _per engine_. The `MockChain` is a singleton used for coordination in tests. It is somewhat analogous to ganache or a test rpc network -- although the interface at the moment is essentially the same as the `ChainService`. For this reason the `SimpleChainService` is essentially transparent or "pass through". 

I kept the `SimpleChainService` around because that matches the anticipated real topology of wallet components better.

Closes #129 