### PR TITLE
rename `Transaction` -> `ChainTransaction`

### DIFF
--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -15,5 +15,5 @@ type Event struct {
 
 type ChainService interface {
 	Out() <-chan Event
-	In() chan<- protocols.Transaction
+	In() chan<- protocols.ChainTransaction
 }

--- a/client/engine/chainservice/mockchain.go
+++ b/client/engine/chainservice/mockchain.go
@@ -10,8 +10,8 @@ import (
 //
 // It keeps a record of of holdings and adjudication status for each channel, accepts transactions and emits events.
 type MockChain struct {
-	out map[types.Address]chan Event // out is a mapping with a chan for each connected ChainService, used to send Events to that service
-	in  chan protocols.Transaction   // in is the chan used to recieve Transactions from multiple ChainServices
+	out map[types.Address]chan Event    // out is a mapping with a chan for each connected ChainService, used to send Events to that service
+	in  chan protocols.ChainTransaction // in is the chan used to recieve Transactions from multiple ChainServices
 
 	holdings map[types.Destination]types.Funds // holdings tracks funds for each channel
 }
@@ -22,7 +22,7 @@ func (mc MockChain) Out(a types.Address) <-chan Event {
 }
 
 // In returns the in chan but narrows the type so that external consumers may only send on it.
-func (mc MockChain) In() chan<- protocols.Transaction {
+func (mc MockChain) In() chan<- protocols.ChainTransaction {
 	return mc.in
 }
 
@@ -31,7 +31,7 @@ func NewMockChain(addresses []types.Address) MockChain {
 
 	mc := MockChain{}
 	mc.out = make(map[types.Address]chan Event)
-	mc.in = make(chan protocols.Transaction)
+	mc.in = make(chan protocols.ChainTransaction)
 	mc.holdings = make(map[types.Destination]types.Funds)
 
 	for _, a := range addresses {
@@ -50,7 +50,7 @@ func (mc MockChain) Run() {
 }
 
 // handleTx responds to the given tx.
-func (mc MockChain) handleTx(tx protocols.Transaction) {
+func (mc MockChain) handleTx(tx protocols.ChainTransaction) {
 	if tx.Deposit.IsNonZero() {
 		mc.holdings[tx.ChannelId] = mc.holdings[tx.ChannelId].Add(tx.Deposit)
 	}

--- a/client/engine/chainservice/mockchain_test.go
+++ b/client/engine/chainservice/mockchain_test.go
@@ -31,7 +31,7 @@ func TestDeposit(t *testing.T) {
 	testDeposit := types.Funds{
 		common.HexToAddress("0x00"): big.NewInt(1),
 	}
-	testTx := protocols.Transaction{
+	testTx := protocols.ChainTransaction{
 		ChannelId: types.Destination(common.HexToHash(`4ebd366d014a173765ba1e50f284c179ade31f20441bec41664712aac6cc461d`)),
 		Deposit:   testDeposit,
 	}

--- a/client/engine/chainservice/simplechainservice.go
+++ b/client/engine/chainservice/simplechainservice.go
@@ -7,8 +7,8 @@ import (
 
 // SimpleChainService forwards inputted transactions to a MockChain, and passes Events straight back.
 type SimpleChainService struct {
-	out chan Event                 // out is the chan used to send Events to the engine
-	in  chan protocols.Transaction // in is the chan used to recieve Transactions from the engine
+	out chan Event                      // out is the chan used to send Events to the engine
+	in  chan protocols.ChainTransaction // in is the chan used to recieve Transactions from the engine
 
 	address types.Address // address is used to subscribe to the MockChain's Out chan
 	chain   MockChain
@@ -18,7 +18,7 @@ type SimpleChainService struct {
 func NewSimpleChainService(mc MockChain, address types.Address) ChainService {
 	mcs := SimpleChainService{}
 	mcs.out = make(chan Event)
-	mcs.in = make(chan protocols.Transaction)
+	mcs.in = make(chan protocols.ChainTransaction)
 	mcs.chain = mc
 	mcs.address = address
 
@@ -34,7 +34,7 @@ func (mcs SimpleChainService) Out() <-chan Event {
 }
 
 // In returns the in chan but narrows the type so that external consumers may only send on it.
-func (mcs SimpleChainService) In() chan<- protocols.Transaction {
+func (mcs SimpleChainService) In() chan<- protocols.ChainTransaction {
 	return mcs.in
 }
 

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -17,7 +17,7 @@ type Engine struct {
 
 	// outbound go channels
 	toMsg   chan protocols.Message
-	toChain chan<- protocols.Transaction
+	toChain chan<- protocols.ChainTransaction
 
 	store store.Store // A Store for persisting and restoring important data
 }

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -13,8 +13,8 @@ type Message struct {
 	Proposal    Objective
 }
 
-// Transaction is an object to be sent to a blockchain provider.
-type Transaction struct {
+// ChainTransaction is an object to be sent to a blockchain provider.
+type ChainTransaction struct {
 	ChannelId types.Destination
 	Deposit   types.Funds
 	// TODO support other transaction types (deposit, challenge, respond, conclude, withdraw)
@@ -37,7 +37,7 @@ func (l LedgerRequest) Equal(m LedgerRequest) bool {
 // SideEffects are effects to be executed by an imperative shell
 type SideEffects struct {
 	MessagesToSend       []Message
-	TransactionsToSubmit []Transaction
+	TransactionsToSubmit []ChainTransaction
 	LedgerRequests       []LedgerRequest
 }
 


### PR DESCRIPTION
Disambiguates from "database transaction" which may appear in the codebase soon.


An alternative which I briefly considered: move `Transaction` into the `chainservice` package. Then, it would be naturally namespaced `chainservice.Transaction`, when imported in the usual manner. I decided against this because the `Transaction` type is designed to be instantiated by a `protocol` , which is the functional core of our design. It seems wrong to have the `protocols` package depend on the `chainservice` package (which it only talks to via the `engine` anyway). We are better off letting the `protocols` define their own types, and converting them if necessary as they reach the more imperative "outer" parts of the architecture. 

