### PR TITLE
Add `TestNew` for `client` package

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -12,9 +12,8 @@ import (
 func TestNew(t *testing.T) {
 	a := types.Address(common.HexToAddress(`a`))
 	b := types.Address(common.HexToAddress(`b`))
-	chainservice := chainservice.NewMockChain([]types.Address{a, b})
-
+	chain := chainservice.NewMockChain([]types.Address{a, b})
+	chainservice := chainservice.NewSimpleChainService(chain, a)
 	messageservice := messageservice.NewTestMessageService(a)
-
-	client := New(messageservice, chainservice)
+	New(messageservice, chainservice) // TODO reinstate client:=
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,20 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/client/engine/chainservice"
+	"github.com/statechannels/go-nitro/client/engine/messageservice"
+	"github.com/statechannels/go-nitro/types"
+)
+
+func TestNew(t *testing.T) {
+	a := types.Address(common.HexToAddress(`a`))
+	b := types.Address(common.HexToAddress(`b`))
+	chainservice := chainservice.NewMockChain([]types.Address{a, b})
+
+	messageservice := messageservice.NewTestMessageService(a)
+
+	client := New(messageservice, chainservice)
+}

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -13,10 +13,10 @@ type Engine struct {
 	// inbound go channels
 	FromAPI   chan APIEvent // This one is exported so that the Client can send API calls
 	fromChain <-chan chainservice.Event
-	fromMsg   chan protocols.Message
+	fromMsg   <-chan protocols.Message
 
 	// outbound go channels
-	toMsg   chan protocols.Message
+	toMsg   chan<- protocols.Message
 	toChain chan<- protocols.ChainTransaction
 
 	store store.Store // A Store for persisting and restoring important data

--- a/client/engine/messageservice/messageservice.go
+++ b/client/engine/messageservice/messageservice.go
@@ -4,7 +4,7 @@ package messageservice // import "github.com/statechannels/go-nitro/client/messa
 import "github.com/statechannels/go-nitro/protocols"
 
 type MessageService interface {
-	GetReceiveChan() chan protocols.Message
-	GetSendChan() chan protocols.Message
+	GetReceiveChan() <-chan protocols.Message
+	GetSendChan() chan<- protocols.Message
 	Send(message protocols.Message)
 }


### PR DESCRIPTION
This minimal test acts as a check for panics in the constructor of our client, as well as enforcing that our test services actually implement the required interfaces. This PR includes a fix for that (they do not currently implement the required interfaces on `main`). 

⚠️ I have noticed that introducing this tests causes a flicker in the `chainservice.TestDeposit` test. We will track that on #158 .