### PR TITLE
PreApprove objectives when spawned via the API

### DIFF
--- a/client/engine/messageservice/test-messageservice_test.go
+++ b/client/engine/messageservice/test-messageservice_test.go
@@ -12,7 +12,7 @@ import (
 var aliceMS = NewTestMessageService(types.Address{'a'})
 var bobMS = NewTestMessageService(types.Address{'b'})
 
-var objective, _ = directfund.New(state.TestState, aliceMS.address)
+var objective, _ = directfund.New(false, state.TestState, aliceMS.address)
 var testId protocols.ObjectiveId = "testObjectiveID"
 
 var aToB protocols.Message = protocols.Message{

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -26,7 +26,7 @@ func TestSetGetObjective(t *testing.T) {
 	ts := state.TestState
 	ts.TurnNum = 0
 
-	testObj, _ := directfund.New(
+	testObj, _ := directfund.New(false,
 		ts,
 		ts.Participants[0],
 	)
@@ -51,7 +51,7 @@ func TestGetObjectiveByChannelId(t *testing.T) {
 	ts := state.TestState
 	ts.TurnNum = 0
 
-	testObj, _ := directfund.New(
+	testObj, _ := directfund.New(false,
 		ts,
 		ts.Participants[0],
 	)

--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -41,6 +41,7 @@ type DirectFundObjective struct {
 // New initiates a DirectFundObjective with data calculated from
 // the supplied initialState and client address
 func New(
+	preApprove bool,
 	initialState state.State,
 	myAddress types.Address,
 ) (DirectFundObjective, error) {
@@ -51,7 +52,11 @@ func New(
 	var init = DirectFundObjective{}
 	var err error
 
-	init.Status = protocols.Unapproved
+	if preApprove {
+		init.Status = protocols.Approved
+	} else {
+		init.Status = protocols.Unapproved
+	}
 
 	var myIndex uint
 	for i, v := range initialState.Participants {

--- a/protocols/direct-fund/direct-fund_test.go
+++ b/protocols/direct-fund/direct-fund_test.go
@@ -58,7 +58,7 @@ var testState = state.State{
 // TestNew tests the constructor using a TestState fixture
 func TestNew(t *testing.T) {
 	// Assert that valid constructor args do not result in error
-	if _, err := New(testState, testState.Participants[0]); err != nil {
+	if _, err := New(false, testState, testState.Participants[0]); err != nil {
 		t.Error(err)
 	}
 
@@ -66,13 +66,13 @@ func TestNew(t *testing.T) {
 	finalState := testState.Clone()
 	finalState.IsFinal = true
 
-	if _, err := New(finalState, testState.Participants[0]); err == nil {
+	if _, err := New(false, finalState, testState.Participants[0]); err == nil {
 		t.Error("expected an error when constructing with an intial state marked final, but got nil")
 	}
 }
 
 // Construct various variables for use in TestUpdate
-var s, _ = New(testState, testState.Participants[0])
+var s, _ = New(false, testState, testState.Participants[0])
 var dummySignature = state.Signature{
 	R: common.Hex2Bytes(`49d8e91bd182fb4d489bb2d76a6735d494d5bea24e4b51dd95c9d219293312d9`),
 	S: common.Hex2Bytes(`22274a3cec23c31e0c073b3c071cf6e0c21260b0d292a10e6a04257a2d8e87fa`),

--- a/protocols/virtual-fund/virtual-fund-single-hop_test.go
+++ b/protocols/virtual-fund/virtual-fund-single-hop_test.go
@@ -167,7 +167,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 		// Objective
 		var n = uint(2) // number of ledger channels (num_hops + 1)
-		var s, _ = New(vPreFund, my.address, n, my.role, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+		var s, _ = New(false, vPreFund, my.address, n, my.role, ledgerChannelToMyLeft, ledgerChannelToMyRight)
 		var expectedGuaranteeMetadata = outcome.GuaranteeMetadata{Left: ledgerChannelToMyRight.MyDestination(), Right: ledgerChannelToMyRight.TheirDestination()}
 		var expectedEncodedGuaranteeMetadata, _ = expectedGuaranteeMetadata.Encode()
 		var expectedGuarantee outcome.Allocation = outcome.Allocation{
@@ -200,7 +200,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 		testNew := func(t *testing.T) {
 			// Assert that a valid set of constructor args does not result in an error
-			o, err := New(vPreFund, my.address, 2, my.role, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			o, err := New(false, vPreFund, my.address, 2, my.role, ledgerChannelToMyLeft, ledgerChannelToMyRight)
 			if err != nil {
 				t.Error(err)
 			}

--- a/protocols/virtual-fund/virtual-fund.go
+++ b/protocols/virtual-fund/virtual-fund.go
@@ -52,6 +52,7 @@ type VirtualFundObjective struct {
 
 // New initiates a VirtualFundObjective.
 func New(
+	preApprove bool,
 	initialStateOfV state.State,
 	myAddress types.Address,
 	n uint, // number of ledger channels (num_hops + 1)
@@ -66,6 +67,12 @@ func New(
 	}
 
 	var init VirtualFundObjective
+
+	if preApprove {
+		init.Status = protocols.Approved
+	} else {
+		init.Status = protocols.Unapproved
+	}
 
 	// Initialize virtual channel
 	v, err := channel.New(initialStateOfV, myRole)


### PR DESCRIPTION
Currently:
* objectives cannot progress until they are approved
* objectives cannot be approved by an API call (it is unimplemented thus far)

This PR unblocks protocol execution by having objectives automatically approved when they are constructed via an API call (i.e. from the consuming application). The upside is that no second API call is needed to get them approved -- this seems right to me, since it genuinely seems implied by making the API call that the objective is approved. 

The other way objectives will be constructed is by receiving proposals from counterparties. Then, the objective may remain unapproved (or be modified to be unapproved) before some other procedure approves them. 