### PR TITLE
Generate secret keys in integration test and pass into store(s) before injecting

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -3,21 +3,30 @@ package client
 import (
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	"github.com/statechannels/go-nitro/client/engine/store"
+	"github.com/statechannels/go-nitro/crypto"
 	"github.com/statechannels/go-nitro/types"
 )
 
 func TestNew(t *testing.T) {
 
-	skA := common.Hex2Bytes("c417e8a75ebe2bfe16fe108e1e04802c324974eef6ea2cc3d55194fa38677b5e")
-	a := types.Address(common.HexToAddress(`0xaaa3D879df547333a9ac87341C92f11e5FB79CD4`))
-	b := types.Address(common.HexToAddress(`b`))
+	aKey, a := crypto.GeneratePrivateKeyAndAddress()
+	bKey, b := crypto.GeneratePrivateKeyAndAddress()
 	chain := chainservice.NewMockChain([]types.Address{a, b})
-	chainservice := chainservice.NewSimpleChainService(chain, a)
-	messageservice := messageservice.NewTestMessageService(a)
-	store := store.NewMockStore(skA)
-	New(messageservice, chainservice, store) // TODO reinstate client:=
+
+	chainservA := chainservice.NewSimpleChainService(chain, a)
+	messageserviceA := messageservice.NewTestMessageService(a)
+	storeA := store.NewMockStore(aKey)
+	New(messageserviceA, chainservA, storeA)
+
+	chainservB := chainservice.NewSimpleChainService(chain, b)
+	messageserviceB := messageservice.NewTestMessageService(a)
+	storeB := store.NewMockStore(bKey)
+	New(messageserviceB, chainservB, storeB)
+
+	messageserviceA.Connect(messageserviceB)
+	messageserviceB.Connect(messageserviceA)
+
 }

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -11,11 +11,14 @@ import (
 )
 
 func TestNewMockStore(t *testing.T) {
-	NewMockStore([]byte{'a', 'b', 'c'})
+	sk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
+	NewMockStore(sk)
 }
 
 func TestSetGetObjective(t *testing.T) {
-	ms := NewMockStore([]byte{})
+	sk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
+
+	ms := NewMockStore(sk)
 
 	id := protocols.ObjectiveId("404")
 	got, ok := ms.GetObjectiveById(id)
@@ -46,7 +49,9 @@ func TestSetGetObjective(t *testing.T) {
 }
 
 func TestGetObjectiveByChannelId(t *testing.T) {
-	ms := NewMockStore([]byte{})
+	sk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
+
+	ms := NewMockStore(sk)
 
 	ts := state.TestState
 	ts.TurnNum = 0

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -9,6 +9,7 @@ import (
 // Store is responsible for persisting objectives, objective metadata, states, signatures, private keys and blockchain data
 type Store interface {
 	GetChannelSecretKey() *[]byte // Get a pointer to a secret key for signing channel updates
+	GetAddress() *types.Address   // Get the (Ethereum) address associated with the ChannelSecretKey
 
 	GetObjectiveById(protocols.ObjectiveId) (obj protocols.Objective, ok bool)    // Read an existing objective
 	GetObjectiveByChannelId(types.Destination) (obj protocols.Objective, ok bool) // Get the objective that currently owns the channel with the supplied ChannelId

--- a/crypto/keys.go
+++ b/crypto/keys.go
@@ -1,0 +1,25 @@
+package crypto
+
+import (
+	"crypto/ecdsa"
+	"log"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/statechannels/go-nitro/types"
+)
+
+func GeneratePrivateKeyAndAddress() (types.Bytes, types.Address) {
+	channelSecretKey, err := crypto.GenerateKey()
+	if err != nil {
+		log.Fatal(err)
+	}
+	channelSecretKeyBytes := crypto.FromECDSA(channelSecretKey)
+
+	publicKey := channelSecretKey.Public()
+	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
+	if !ok {
+		log.Fatal("error casting public key to ECDSA")
+	}
+	address := crypto.PubkeyToAddress(*publicKeyECDSA)
+	return channelSecretKeyBytes, address
+}

--- a/crypto/keys.go
+++ b/crypto/keys.go
@@ -8,6 +8,7 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
+// GeneratePrivateKeyAndAddress generates a pseudo-random ECDSA and its corresponding Ethereum address.
 func GeneratePrivateKeyAndAddress() (types.Bytes, types.Address) {
 	channelSecretKey, err := crypto.GenerateKey()
 	if err != nil {


### PR DESCRIPTION
Towards #167 

Using injected dependencies in the `go-nitro` client is great for easily swapping out mock dependencies for production dependencies and testing generally. But it poses some issues with respect to having all of those dependencies wired up and sharing information.

In the medium term, we desire a nice developer experience so may want to support constructing a `go-nitro` client *without* needing to inject dependencies. In that case, they can be constructed inside the constructor of the `go-nitro` client, which can also share the secret key and address information between those components. 

In the short term, we need to write integration tests so will continue with the injected dependency approach. All components of the client (message, chain and store) need to know the `address` of the client, and the store needs to know the secret key. The solution of this PR is to construct both in the test script (which plays the role of a consuming application, roughly), and pass into all dependencies prior to injection. The `client` itself can query this information from the store when it needs to. 

