### PR TITLE
Call `CreateDirectChannel()` in integration test

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -3,20 +3,28 @@
 package client // import "github.com/statechannels/go-nitro/client"
 
 import (
+	"math/big"
+
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client/engine"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	"github.com/statechannels/go-nitro/client/engine/store"
+	directfund "github.com/statechannels/go-nitro/protocols/direct-fund"
+	"github.com/statechannels/go-nitro/types"
 )
 
 // Client provides the interface for the consuming application
 type Client struct {
-	engine engine.Engine // The core business logic of the client
+	engine  engine.Engine // The core business logic of the client
+	Address *types.Address
 }
 
 // New is the constructor for a Client. It accepts a messaging service, a chain service, and a store as injected dependencies.
 func New(messageService messageservice.MessageService, chainservice chainservice.ChainService, store store.Store) Client {
 	c := Client{}
+	c.Address = store.GetAddress()
 	c.engine = engine.New(messageService, chainservice, store)
 
 	// Start the engine in a go routine
@@ -27,11 +35,29 @@ func New(messageService messageservice.MessageService, chainservice chainservice
 
 // Begin API
 
-// CreateChannel creates a channel
-func (c *Client) CreateChannel() chan engine.Response {
+// CreateDirectChannel creates a directly funded channel with the given counterparty
+func (c *Client) CreateDirectChannel(counterparty types.Address, appDefinition types.Address, appData types.Bytes, outcome outcome.Exit, challengeDuration *types.Uint256) chan engine.Response {
 	// Convert the API call into an internal event.
+	objective, _ := directfund.New(true,
+		state.State{
+			ChainId:           big.NewInt(0), // TODO
+			Participants:      []types.Address{*c.Address, counterparty},
+			ChannelNonce:      big.NewInt(0), // TODO -- how do we get a fresh nonce safely without race conditions? Could we conisder a random nonce?
+			AppDefinition:     appDefinition,
+			ChallengeDuration: challengeDuration,
+			AppData:           appData,
+			Outcome:           outcome,
+			TurnNum:           0,
+			IsFinal:           false,
+		},
+		*c.Address,
+	)
+
 	// Pass in a fresh, dedicated go channel to communicate the response:
-	apiEvent := engine.APIEvent{Response: make(chan engine.Response)}
+	apiEvent := engine.APIEvent{
+		ObjectiveToSpawn: objective,
+		Response:         make(chan engine.Response)}
+
 	// Send the event to the engine
 	c.engine.FromAPI <- apiEvent
 	// Return the go channel where the response will be sent.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,8 +1,10 @@
 package client
 
 import (
+	"math/big"
 	"testing"
 
+	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	"github.com/statechannels/go-nitro/client/engine/store"
@@ -19,7 +21,7 @@ func TestNew(t *testing.T) {
 	chainservA := chainservice.NewSimpleChainService(chain, a)
 	messageserviceA := messageservice.NewTestMessageService(a)
 	storeA := store.NewMockStore(aKey)
-	New(messageserviceA, chainservA, storeA)
+	clientA := New(messageserviceA, chainservA, storeA)
 
 	chainservB := chainservice.NewSimpleChainService(chain, b)
 	messageserviceB := messageservice.NewTestMessageService(a)
@@ -28,5 +30,7 @@ func TestNew(t *testing.T) {
 
 	messageserviceA.Connect(messageserviceB)
 	messageserviceB.Connect(messageserviceA)
+
+	clientA.CreateDirectChannel(b, types.Address{}, types.Bytes{}, outcome.Exit{}, big.NewInt(0))
 
 }


### PR DESCRIPTION
Towards #167 .

⚠️ stacked on #169 