### PR TITLE
Check that address is a participant when initiating DirectFundObjective

### DIFF
--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -59,10 +59,16 @@ func New(
 	}
 
 	var myIndex uint
+	foundMyAddress := false
 	for i, v := range initialState.Participants {
 		if v == myAddress {
 			myIndex = uint(i)
+			foundMyAddress = true
+			break
 		}
+	}
+	if !foundMyAddress {
+		return DirectFundObjective{}, errors.New("my address not found in participants")
 	}
 
 	init.C = &channel.Channel{}

--- a/protocols/direct-fund/direct-fund_test.go
+++ b/protocols/direct-fund/direct-fund_test.go
@@ -69,6 +69,11 @@ func TestNew(t *testing.T) {
 	if _, err := New(false, finalState, testState.Participants[0]); err == nil {
 		t.Error("expected an error when constructing with an intial state marked final, but got nil")
 	}
+
+	nonParticipant := common.HexToAddress("0x5b53f71453aeCb03D837bfe170570d40aE736CB4")
+	if _, err := New(false, testState, nonParticipant); err == nil {
+		t.Error("expected an error when constructing with a participant not in the channel, but got nil")
+	}
 }
 
 // Construct various variables for use in TestUpdate


### PR DESCRIPTION
Adds a simple check to make sure that `myAddress` is a participant in `initialState`. Otherwise returns an error.

Fixes #73 