### PR TITLE
Add basic logging to the engine. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Logs
+*.log

--- a/client/client.go
+++ b/client/client.go
@@ -3,6 +3,7 @@
 package client // import "github.com/statechannels/go-nitro/client"
 
 import (
+	"io"
 	"math/big"
 
 	"github.com/statechannels/go-nitro/channel/state"
@@ -22,10 +23,10 @@ type Client struct {
 }
 
 // New is the constructor for a Client. It accepts a messaging service, a chain service, and a store as injected dependencies.
-func New(messageService messageservice.MessageService, chainservice chainservice.ChainService, store store.Store) Client {
+func New(messageService messageservice.MessageService, chainservice chainservice.ChainService, store store.Store, logDestination io.Writer) Client {
 	c := Client{}
 	c.Address = store.GetAddress()
-	c.engine = engine.New(messageService, chainservice, store)
+	c.engine = engine.New(messageService, chainservice, store, logDestination)
 
 	// Start the engine in a go routine
 	go c.engine.Run()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"log"
 	"math/big"
+	"os"
 	"testing"
 
 	"github.com/statechannels/go-nitro/channel/state/outcome"
@@ -14,6 +16,15 @@ import (
 
 func TestNew(t *testing.T) {
 
+	// Set up logging
+	logDestination, err := os.OpenFile("client_test_logs.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Reset log destination file
+	logDestination.Truncate(0)
+
 	aKey, a := crypto.GeneratePrivateKeyAndAddress()
 	bKey, b := crypto.GeneratePrivateKeyAndAddress()
 	chain := chainservice.NewMockChain([]types.Address{a, b})
@@ -21,12 +32,12 @@ func TestNew(t *testing.T) {
 	chainservA := chainservice.NewSimpleChainService(chain, a)
 	messageserviceA := messageservice.NewTestMessageService(a)
 	storeA := store.NewMockStore(aKey)
-	clientA := New(messageserviceA, chainservA, storeA)
+	clientA := New(messageserviceA, chainservA, storeA, logDestination)
 
 	chainservB := chainservice.NewSimpleChainService(chain, b)
 	messageserviceB := messageservice.NewTestMessageService(a)
 	storeB := store.NewMockStore(bKey)
-	New(messageserviceB, chainservB, storeB)
+	New(messageserviceB, chainservB, storeB, logDestination)
 
 	messageserviceA.Connect(messageserviceB)
 	messageserviceB.Connect(messageserviceA)


### PR DESCRIPTION
Fixes #70 .


The logging can be enhanced in future. For now this solution produces logs like this in our integration test:

```log
0x239C5CEfb877f2255F4654Cc1D7f35f66C28C469: 2022/01/25 13:05:08 engine.go:60: Constructed Engine
0x925bD8777818Bf6693985dB1167E2565Ae1c9ccd: 2022/01/25 13:05:08 engine.go:60: Constructed Engine
0x239C5CEfb877f2255F4654Cc1D7f35f66C28C469: 2022/01/25 13:05:08 engine.go:157: Objective DirectFunding-0xc1703458a5bac9eee4482649863b801154e6976740225ce9d55b30dd24dd2e24 is WaitingForCompletePrefund
```
which should be sufficient to unblock progress on that integration test (for now). 