### PR TITLE
Add basic pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
+repos:
 - repo: https://github.com/dnephin/pre-commit-golang
-  rev: master
+  rev: v0.4.0
   hooks:
     - id: go-fmt
     - id: golangci-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+- repo: https://github.com/dnephin/pre-commit-golang
+  rev: master
+  hooks:
+    - id: go-fmt
+    - id: golangci-lint
+    - id: go-mod-tidy

--- a/contributing.md
+++ b/contributing.md
@@ -21,6 +21,23 @@ echo $GOPATH
 
 You should see `$HOME/go`.
 
+## Pre-commit Hooks
+
+There are pre-commit hooks to run `gofmt`, `golangci-lint` and `go mod tidy`. To get these to run `pre-commit` must be installed.
+
+### Install pre-commit
+
+```shell
+brew install pre-commit
+```
+
+### Install git hook script
+
+From the repository directory run
+
+```shell
+pre-commit install
+```
 
 # Building and Testing
 
@@ -43,24 +60,3 @@ godoc --http :6060
 ```
 
 and navigate to http://localhost:6060/pkg/github.com/statechannels/go-nitro/
-
-# Pre PR checks:
-
-Please execute the following on any branch that's ready for review or merge.
-
-### format:
-
-```shell
-gofmt -w .
-```
-
-### lint:
-
-```shell
-golangci-lint run
-```
-### remove unused dependencies:
-
-```shell
-go mod tidy
-```


### PR DESCRIPTION
Added some basic [pre-commit](https://pre-commit.com/) hooks to run:
- `go-fmt`
- `golangci-lint`
- `go-mod-tidy`

Fixes #148