### PR TITLE
SignedState signature validation and getter functions

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -100,12 +100,12 @@ func (c Channel) Equal(d Channel) bool {
 
 // PreFundState() returns the pre fund setup state for the channel.
 func (c Channel) PreFundState() state.State {
-	return c.SignedStateForTurnNum[PreFundTurnNum].State
+	return c.SignedStateForTurnNum[PreFundTurnNum].State()
 }
 
 // PostFundState() returns the post fund setup state for the channel.
 func (c Channel) PostFundState() state.State {
-	return c.SignedStateForTurnNum[PostFundTurnNum].State
+	return c.SignedStateForTurnNum[PostFundTurnNum].State()
 
 }
 
@@ -144,7 +144,7 @@ func (c Channel) LatestSupportedState() (state.State, error) {
 	if c.latestSupportedStateTurnNum == MaxTurnNum {
 		return state.State{}, errors.New(`no state is yet supported`)
 	}
-	return c.SignedStateForTurnNum[c.latestSupportedStateTurnNum].State, nil
+	return c.SignedStateForTurnNum[c.latestSupportedStateTurnNum].State(), nil
 }
 
 // Total() returns the total allocated of each asset allocated by the pre fund setup state of the Channel.

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -1,7 +1,6 @@
 package channel
 
 import (
-	"bytes"
 	"errors"
 	"reflect"
 
@@ -170,17 +169,7 @@ func (c Channel) Affords(
 // AddSignedState adds a signed state to the Channel, updating the LatestSupportedState and Support if appropriate.
 // Returns false and does not alter the channel if the state is "stale", belongs to a different channel, or is signed by a non participant.
 func (c *Channel) AddSignedState(s state.State, sig state.Signature) bool {
-	signer, err := s.RecoverSigner(sig)
-	if err != nil {
-		// Invalid signature
-		return false
-	}
 
-	_, isParticipant := indexOf(signer, c.FixedPart.Participants)
-	if !isParticipant {
-		// Signature by non participant
-		return false
-	}
 	if cId, err := s.ChannelId(); cId != c.Id || err != nil {
 		// Channel mismatch
 		return false
@@ -227,15 +216,4 @@ func (c Channel) AddSignedStates(mapping map[*state.State]state.Signature) bool 
 		}
 	}
 	return allOk
-}
-
-// indexOf returns the index of the given suspect address in the lineup of addresses. A second return value ("ok") is true the suspect was found, false otherwise.
-func indexOf(suspect types.Address, lineup []types.Address) (index uint, ok bool) {
-
-	for index, a := range lineup {
-		if bytes.Equal(suspect.Bytes(), a.Bytes()) {
-			return uint(index), true
-		}
-	}
-	return ^uint(0), false
 }

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -68,12 +68,12 @@ func New(s state.State, myIndex uint) (Channel, error) {
 
 	// Store prefund
 	c.SignedStateForTurnNum = make(map[uint64]SignedState)
-	c.SignedStateForTurnNum[PreFundTurnNum] = SignedState{s, make(map[uint]state.Signature)}
+	c.SignedStateForTurnNum[PreFundTurnNum] = NewSignedState(s)
 
 	// Store postfund
 	post := s.Clone()
 	post.TurnNum = PostFundTurnNum
-	c.SignedStateForTurnNum[PostFundTurnNum] = SignedState{post, make(map[uint]state.Signature)}
+	c.SignedStateForTurnNum[PostFundTurnNum] = NewSignedState(post)
 
 	return c, nil
 }
@@ -182,12 +182,14 @@ func (c *Channel) AddSignedState(s state.State, sig state.Signature) bool {
 
 	// Store the signature. If we have no record yet, add one.
 	if signedState, ok := c.SignedStateForTurnNum[s.TurnNum]; !ok {
-		ss, err := NewSignedState(s, []state.Signature{sig})
-		if err != nil {
-			return false
-		} else {
+		ss := NewSignedState(s)
+		err := ss.AddSignature(sig)
+		if err == nil {
 			c.SignedStateForTurnNum[s.TurnNum] = ss
+		} else {
+			return false
 		}
+
 	} else {
 		err := signedState.AddSignature(sig)
 		if err != nil {

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -112,7 +112,7 @@ func (c Channel) PostFundState() state.State {
 // PreFundSignedByMe() returns true if I have signed the pre fund setup state, false otherwise.
 func (c Channel) PreFundSignedByMe() bool {
 	if _, ok := c.SignedStateForTurnNum[PreFundTurnNum]; ok {
-		if c.SignedStateForTurnNum[PreFundTurnNum].HasSignature(c.MyIndex) {
+		if c.SignedStateForTurnNum[PreFundTurnNum].HasSignatureForParticipant(c.MyIndex) {
 			return true
 		}
 	}
@@ -122,7 +122,7 @@ func (c Channel) PreFundSignedByMe() bool {
 // PostFundSignedByMe() returns true if I have signed the post fund setup state, false otherwise.
 func (c Channel) PostFundSignedByMe() bool {
 	if _, ok := c.SignedStateForTurnNum[PostFundTurnNum]; ok {
-		if c.SignedStateForTurnNum[PreFundTurnNum].HasSignature(c.MyIndex) {
+		if c.SignedStateForTurnNum[PreFundTurnNum].HasSignatureForParticipant(c.MyIndex) {
 			return true
 		}
 	}

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -23,7 +23,7 @@ type Channel struct {
 
 	latestSupportedStateTurnNum uint64 // largest uint64 value reserved for "no supported state"
 
-	SignedStateForTurnNum map[uint64]SignedState // this stores up to 1 state per turn number.
+	SignedStateForTurnNum map[uint64]signedState // this stores up to 1 state per turn number.
 	// Longer term, we should have a more efficient and smart mechanism to store states https://github.com/statechannels/go-nitro/issues/106
 }
 
@@ -67,13 +67,13 @@ func New(s state.State, myIndex uint) (Channel, error) {
 	// c.Support =  // TODO
 
 	// Store prefund
-	c.SignedStateForTurnNum = make(map[uint64]SignedState)
-	c.SignedStateForTurnNum[PreFundTurnNum] = NewSignedState(s)
+	c.SignedStateForTurnNum = make(map[uint64]signedState)
+	c.SignedStateForTurnNum[PreFundTurnNum] = newSignedState(s)
 
 	// Store postfund
 	post := s.Clone()
 	post.TurnNum = PostFundTurnNum
-	c.SignedStateForTurnNum[PostFundTurnNum] = NewSignedState(post)
+	c.SignedStateForTurnNum[PostFundTurnNum] = newSignedState(post)
 
 	return c, nil
 }
@@ -182,8 +182,8 @@ func (c *Channel) AddSignedState(s state.State, sig state.Signature) bool {
 
 	// Store the signature. If we have no record yet, add one.
 	if signedState, ok := c.SignedStateForTurnNum[s.TurnNum]; !ok {
-		ss := NewSignedState(s)
-		err := ss.AddSignature(sig)
+		ss := newSignedState(s)
+		err := ss.addSignature(sig)
 		if err == nil {
 			c.SignedStateForTurnNum[s.TurnNum] = ss
 		} else {
@@ -191,7 +191,7 @@ func (c *Channel) AddSignedState(s state.State, sig state.Signature) bool {
 		}
 
 	} else {
-		err := signedState.AddSignature(sig)
+		err := signedState.addSignature(sig)
 		if err != nil {
 			return false
 		}

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -112,7 +112,7 @@ func (c Channel) PostFundState() state.State {
 // PreFundSignedByMe() returns true if I have signed the pre fund setup state, false otherwise.
 func (c Channel) PreFundSignedByMe() bool {
 	if _, ok := c.SignedStateForTurnNum[PreFundTurnNum]; ok {
-		if ok := c.SignedStateForTurnNum[PreFundTurnNum].HasSignature(c.MyIndex); ok {
+		if c.SignedStateForTurnNum[PreFundTurnNum].HasSignature(c.MyIndex) {
 			return true
 		}
 	}
@@ -122,7 +122,7 @@ func (c Channel) PreFundSignedByMe() bool {
 // PostFundSignedByMe() returns true if I have signed the post fund setup state, false otherwise.
 func (c Channel) PostFundSignedByMe() bool {
 	if _, ok := c.SignedStateForTurnNum[PostFundTurnNum]; ok {
-		if ok := c.SignedStateForTurnNum[PreFundTurnNum].HasSignature(c.MyIndex); ok {
+		if c.SignedStateForTurnNum[PreFundTurnNum].HasSignature(c.MyIndex) {
 			return true
 		}
 	}

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -170,7 +170,7 @@ func TestChannel(t *testing.T) {
 		}
 
 		got2 := c.SignedStateForTurnNum[1]
-		if got2.State.Outcome == nil || !got2.HasSignature(0) {
+		if got2.State().Outcome == nil || !got2.HasSignature(0) {
 			t.Error(`state not added correctly`)
 		}
 

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -170,7 +170,7 @@ func TestChannel(t *testing.T) {
 		}
 
 		got2 := c.SignedStateForTurnNum[1]
-		if got2.State.Outcome == nil || got2.Sigs == nil {
+		if got2.State.Outcome == nil || !got2.HasSignature(0) {
 			t.Error(`state not added correctly`)
 		}
 

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -170,7 +170,7 @@ func TestChannel(t *testing.T) {
 		}
 
 		got2 := c.SignedStateForTurnNum[1]
-		if got2.State().Outcome == nil || !got2.HasSignature(0) {
+		if got2.State().Outcome == nil || !got2.HasSignatureForParticipant(0) {
 			t.Error(`state not added correctly`)
 		}
 

--- a/channel/signedstate.go
+++ b/channel/signedstate.go
@@ -46,8 +46,8 @@ func (ss signedState) State() state.State {
 	return ss.state
 }
 
-// HasSignature returns true if the participant (at participantIndex) has a valid signature.
-func (ss signedState) HasSignature(participantIndex uint) bool {
+// HasSignatureForParticipant returns true if the participant (at participantIndex) has a valid signature.
+func (ss signedState) HasSignatureForParticipant(participantIndex uint) bool {
 	_, found := ss.sigs[uint(participantIndex)]
 	return found
 }

--- a/channel/signedstate.go
+++ b/channel/signedstate.go
@@ -7,7 +7,7 @@ import (
 )
 
 type signedState struct {
-	State state.State
+	state state.State
 	sigs  map[uint]state.Signature // keyed by participant index
 }
 
@@ -20,12 +20,12 @@ func newSignedState(s state.State) signedState {
 // addSignature adds a participant's signature for the state.
 // An error is thrown if the signature is invalid.
 func (ss signedState) addSignature(sig state.Signature) error {
-	signer, err := ss.State.RecoverSigner(sig)
+	signer, err := ss.state.RecoverSigner(sig)
 	if err != nil {
 		return err
 	}
 
-	for i, p := range ss.State.Participants {
+	for i, p := range ss.state.Participants {
 		if p == signer {
 			_, found := ss.sigs[uint(i)]
 			if found {
@@ -41,6 +41,9 @@ func (ss signedState) addSignature(sig state.Signature) error {
 	return errors.New("signature does not match any participant")
 
 }
+func (ss signedState) State() state.State {
+	return ss.state
+}
 
 // HasSignature returns true if the participant (at participantIndex) has a valid signature.
 func (ss signedState) HasSignature(participantIndex uint) bool {
@@ -51,7 +54,7 @@ func (ss signedState) HasSignature(participantIndex uint) bool {
 // HasAllSignatures returns true if every participant has a valid signature.
 func (ss signedState) HasAllSignatures() bool {
 	// Since signatures are validated
-	if len(ss.sigs) == len(ss.State.Participants) {
+	if len(ss.sigs) == len(ss.state.Participants) {
 		return true
 	} else {
 		return false

--- a/channel/signedstate.go
+++ b/channel/signedstate.go
@@ -6,21 +6,20 @@ import (
 	"github.com/statechannels/go-nitro/channel/state"
 )
 
-type SignedState struct {
+type signedState struct {
 	State state.State
 	sigs  map[uint]state.Signature // keyed by participant index
 }
 
-// NewSignedState creates a signed state for the given state with 0 signatures.
-func NewSignedState(s state.State) SignedState {
-	ss := SignedState{s, make(map[uint]state.Signature, len(s.Participants))}
-
-	return ss
+// newSignedState initializes a SignedState struct for the given state.
+// The signedState returned will have no signatures.
+func newSignedState(s state.State) signedState {
+	return signedState{s, make(map[uint]state.Signature, len(s.Participants))}
 }
 
-// AddSignature adds a participant's signature for the state.
+// addSignature adds a participant's signature for the state.
 // An error is thrown if the signature is invalid.
-func (ss SignedState) AddSignature(sig state.Signature) error {
+func (ss signedState) addSignature(sig state.Signature) error {
 	signer, err := ss.State.RecoverSigner(sig)
 	if err != nil {
 		return err
@@ -44,13 +43,14 @@ func (ss SignedState) AddSignature(sig state.Signature) error {
 }
 
 // HasSignature returns true if the participant (at participantIndex) has a valid signature.
-func (ss SignedState) HasSignature(participantIndex uint) bool {
+func (ss signedState) HasSignature(participantIndex uint) bool {
 	_, found := ss.sigs[uint(participantIndex)]
 	return found
 }
 
 // HasAllSignatures returns true if every participant has a valid signature.
-func (ss SignedState) HasAllSignatures() bool {
+func (ss signedState) HasAllSignatures() bool {
+	// Since signatures are validated
 	if len(ss.sigs) == len(ss.State.Participants) {
 		return true
 	} else {

--- a/channel/signedstate.go
+++ b/channel/signedstate.go
@@ -2,6 +2,7 @@ package channel
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/statechannels/go-nitro/channel/state"
 )
@@ -22,7 +23,7 @@ func newSignedState(s state.State) signedState {
 func (ss signedState) addSignature(sig state.Signature) error {
 	signer, err := ss.state.RecoverSigner(sig)
 	if err != nil {
-		return err
+		return fmt.Errorf("addSignature failed to recover signer %w", err)
 	}
 
 	for i, p := range ss.state.Participants {

--- a/channel/signedstate.go
+++ b/channel/signedstate.go
@@ -1,17 +1,63 @@
 package channel
 
 import (
+	"errors"
+
 	"github.com/statechannels/go-nitro/channel/state"
 )
 
 type SignedState struct {
-	State state.VariablePart
-	Sigs  map[uint]state.Signature // keyed by participant index
+	State state.State
+	sigs  map[uint]state.Signature // keyed by participant index
 }
 
-// hasAllSignatures returns true if there are numParticipants distinct signatures on the state and false otherwise.
-func (ss SignedState) hasAllSignatures(numParticipants int) bool {
-	if len(ss.Sigs) == numParticipants {
+// NewSignedState creates a new SignedState from the supplied state and signatures.
+// An error returned if there is an invalid signature.
+func NewSignedState(s state.State, sigs []state.Signature) (SignedState, error) {
+	ss := SignedState{s, make(map[uint]state.Signature, len(sigs))}
+	err := ss.AddSignatures(sigs)
+	return ss, err
+}
+
+/// AddSignatures adds multiple participant's signature for the state.
+/// An error is thrown if any signature is invalid.
+func (ss SignedState) AddSignatures(sigs []state.Signature) (err error) {
+	for _, sig := range sigs {
+		err = ss.AddSignature(sig)
+	}
+	return
+}
+
+// AddSignature adds a participant's signature for the state.
+// An error is thrown if the signature is invalid.
+func (ss SignedState) AddSignature(sig state.Signature) (err error) {
+
+	signer, err := ss.State.RecoverSigner(sig)
+
+	for i, p := range ss.State.Participants {
+		if p == signer {
+			_, found := ss.sigs[uint(i)]
+			if found {
+				err = errors.New("signature already exists for participant")
+			} else {
+				ss.sigs[uint(i)] = sig
+			}
+			return
+		}
+
+	}
+	return err
+}
+
+// HasSignature returns true if the participant has a valid signature.
+func (ss SignedState) HasSignature(participantIndex uint) bool {
+	_, found := ss.sigs[uint(participantIndex)]
+	return found
+}
+
+// HasAllSignatures returns true if every participant has a valid signature.
+func (ss SignedState) HasAllSignatures() bool {
+	if len(ss.sigs) == len(ss.State.Participants) {
 		return true
 	} else {
 		return false


### PR DESCRIPTION
Fixes #105 

Moves responsibility of validating signatures from `Channel` to `SignedState`.

I'm still getting used to `go` idioms so please point out anything that's not quite right!

# Changes

## Signed State now includes the full state.

Previously we were only storing the `VariablePart` of a state in SignedState. I've switched this to the full state so we can call `s.RecoverSigner`  in `signedstate.go`. This does mean we're now storing FixedPart for every state which is less efficient than only storing it in the channel.


## New addSignature and newSignedState function
I've introduced an `addSignature` function  to `signedState` so signatures can be added to a signedState. This function validates the signature by checking that is signed by a participant. The `newSignedState` is just syntax sugar for initiating a new `signedState` struct.

## Channel no longer checks signatures
Since signatures are now checked in addSignature we no longer need to perform the check in `channel.go` 

## Modified Visibility
Based on the idea that signedState should be read only for external consumers of `channel` I've modified some visibilities:
- signedState is private to the channel package.  External consumers shouldn't be instantiating their own `signedState.
- The state and signatures variables on signedState are now private. These are exposed by the `State()` getter function and the `HasSignature`  helper.
- The new `addSignature` and `newSignedState` function is private as it should only be called by the parent `channel`.
