### PR TITLE
Run tests with count=2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        run: go test -v ./... -count=2
+        run: go test -v ./... -count=2 -shuffle=on
 
       - name: Tidy
         run: go mod tidy

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        run: go test -v ./...
+        run: go test -v ./... -count=2
 
       - name: Tidy
         run: go mod tidy

--- a/protocols/direct-fund/direct-fund_test.go
+++ b/protocols/direct-fund/direct-fund_test.go
@@ -145,6 +145,11 @@ func TestUpdate(t *testing.T) {
 
 }
 
+// TestDoubleFailure is an easy way to debug the count=2 case.
+func TestDoubleFailure(t *testing.T) {
+	TestCrank(t)
+	TestCrank(t)
+}
 func TestCrank(t *testing.T) {
 
 	var correctSignatureByAliceOnPreFund, _ = s.C.PreFundState().Sign(alice.privateKey)

--- a/protocols/direct-fund/direct-fund_test.go
+++ b/protocols/direct-fund/direct-fund_test.go
@@ -76,18 +76,17 @@ func TestNew(t *testing.T) {
 	}
 }
 
-// Construct various variables for use in TestUpdate
-var s, _ = New(false, testState, testState.Participants[0])
-var dummySignature = state.Signature{
-	R: common.Hex2Bytes(`49d8e91bd182fb4d489bb2d76a6735d494d5bea24e4b51dd95c9d219293312d9`),
-	S: common.Hex2Bytes(`22274a3cec23c31e0c073b3c071cf6e0c21260b0d292a10e6a04257a2d8e87fa`),
-	V: byte(1),
-}
-var dummyState = state.State{}
-var stateToSign state.State = s.C.PreFundState()
-var correctSignatureByParticipant, _ = stateToSign.Sign(alice.privateKey)
-
 func TestUpdate(t *testing.T) {
+	// Construct various variables for use in TestUpdate
+	var s, _ = New(false, testState, testState.Participants[0])
+	var dummySignature = state.Signature{
+		R: common.Hex2Bytes(`49d8e91bd182fb4d489bb2d76a6735d494d5bea24e4b51dd95c9d219293312d9`),
+		S: common.Hex2Bytes(`22274a3cec23c31e0c073b3c071cf6e0c21260b0d292a10e6a04257a2d8e87fa`),
+		V: byte(1),
+	}
+	var dummyState = state.State{}
+	var stateToSign state.State = s.C.PreFundState()
+	var correctSignatureByParticipant, _ = stateToSign.Sign(alice.privateKey)
 	// Prepare an event with a mismatched channelId
 	e := protocols.ObjectiveEvent{
 		ChannelId: types.Destination{},
@@ -145,13 +144,8 @@ func TestUpdate(t *testing.T) {
 
 }
 
-// TestDoubleFailure is an easy way to debug the count=2 case.
-func TestDoubleFailure(t *testing.T) {
-	TestCrank(t)
-	TestCrank(t)
-}
 func TestCrank(t *testing.T) {
-
+	var s, _ = New(false, testState, testState.Participants[0])
 	var correctSignatureByAliceOnPreFund, _ = s.C.PreFundState().Sign(alice.privateKey)
 	var correctSignatureByBobOnPreFund, _ = s.C.PreFundState().Sign(bob.privateKey)
 


### PR DESCRIPTION
Fixes #158 

Two changes:
- Resolves the `direct-fund_test` failures when running with `count=2`.  The tests were using an objective `s` that would not get reset between test runs. To address this `s` is now instantiated in each test function.
- Updates the CI config to run with `-count=2` and `-shuffle=on`


In this particular case there wasn't much code duplication to instantiate `s` in both tests. However longer term we might want to explore a `beforeEach` pattern? 