### PR TITLE
Add debugging instructions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Test",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${fileDirname}"
+    }
+  ]
+}

--- a/contributing.md
+++ b/contributing.md
@@ -64,3 +64,13 @@ golangci-lint run
 ```shell
 go mod tidy
 ```
+
+# Debugging Tests
+
+VS code is used to debug tests. To start a debugging session in VS code:
+
+- Have the test file open in the editor.
+- Open `Run and Debug` in VS code.
+- Run the `Debug Test` configuration.
+
+The [go extension](https://marketplace.visualstudio.com/items?itemName=golang.Go) also supports debugging and can be used to start debugging session right from a test function.

--- a/contributing.md
+++ b/contributing.md
@@ -69,8 +69,9 @@ go mod tidy
 
 VS code is used to debug tests. To start a debugging session in VS code:
 
+- Ensure you have the [go extension](https://marketplace.visualstudio.com/items?itemName=golang.Go) installed
 - Open the test file.
 - Open the `Run and Debug` section.
 - Run the `Debug Test` configuration.
 
-The [go extension](https://marketplace.visualstudio.com/items?itemName=golang.Go) also supports debugging and can be used to start debugging session right from a test function.
+With the extension it is also possible to start a debugging session right from a test function.

--- a/contributing.md
+++ b/contributing.md
@@ -69,8 +69,8 @@ go mod tidy
 
 VS code is used to debug tests. To start a debugging session in VS code:
 
-- Have the test file open in the editor.
-- Open `Run and Debug` in VS code.
+- Open the test file.
+- Open the `Run and Debug` section.
 - Run the `Debug Test` configuration.
 
 The [go extension](https://marketplace.visualstudio.com/items?itemName=golang.Go) also supports debugging and can be used to start debugging session right from a test function.


### PR DESCRIPTION
Fixes #175 

Adds some simple instructions on how to debug tests using vs code. Also adds a `launch.json` with a configuration for debugging test files.