### PR TITLE
Fix TestDeposit Flicker

### DIFF
--- a/client/engine/chainservice/mockchain.go
+++ b/client/engine/chainservice/mockchain.go
@@ -35,7 +35,8 @@ func NewMockChain(addresses []types.Address) MockChain {
 	mc.holdings = make(map[types.Destination]types.Funds)
 
 	for _, a := range addresses {
-		mc.out[a] = make(chan Event)
+		// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
+		mc.out[a] = make(chan Event, 10)
 	}
 
 	go mc.Run()
@@ -60,7 +61,7 @@ func (mc MockChain) handleTx(tx protocols.ChainTransaction) {
 		AdjudicationStatus: protocols.AdjudicationStatus{TurnNumRecord: 0},
 	}
 	for _, out := range mc.out {
-		go sendEvent(out, event) // we use a goroutine for each send to prevent being blocked by one bad listener
+		sendEvent(out, event)
 	}
 
 }


### PR DESCRIPTION
Fixes #180 

Caveat: I'm still new to go routines and channels so this might not be the correct solution.

Previously in `MockChain` we were using a go routine to send events to to chain services via a channel. By using go routines we avoided blocking on waiting for the chain service to read from the channel.

However using go routines means that events may not get sent when we expect them, since they're parallel threads of execution. (I'm a little fuzzy on the exact details of how go routines are scheduled/run)

To avoid this I've just switched the `HandleTX` to not use go routines and instead write out to a **buffered channel** instead. Since the channel is buffered `HandleTX` will not block on writing the event to the channel. I've chosen a buffer size of 10 arbitrarily. 

To verify this locally I've been running the command:
```
go test  ./client/engine/chainservice/ -count=10000 -shuffle=on
```

On `main` this fails for me but works on this branch.
