### PR TITLE
Return SideEffects in Direct Funding Protocol

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -122,7 +122,7 @@ func (c Channel) PreFundSignedByMe() bool {
 // PostFundSignedByMe() returns true if I have signed the post fund setup state, false otherwise.
 func (c Channel) PostFundSignedByMe() bool {
 	if _, ok := c.SignedStateForTurnNum[PostFundTurnNum]; ok {
-		if c.SignedStateForTurnNum[PreFundTurnNum].HasSignatureForParticipant(c.MyIndex) {
+		if c.SignedStateForTurnNum[PostFundTurnNum].HasSignatureForParticipant(c.MyIndex) {
 			return true
 		}
 	}

--- a/channel/state/signedstate.go
+++ b/channel/state/signedstate.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
+	"github.com/statechannels/go-nitro/crypto"
 )
 
 type SignedState struct {
@@ -61,6 +63,16 @@ func (ss SignedState) HasAllSignatures() bool {
 		return true
 	} else {
 		return false
+	}
+}
+
+// GetParticipantSignature returns the signature for the participant specified by participantIndex
+func (ss SignedState) GetParticipantSignature(participantIndex uint) (crypto.Signature, error) {
+	sig, found := ss.sigs[uint(participantIndex)]
+	if !found {
+		return crypto.Signature{}, fmt.Errorf("participant %d does not have a signature", participantIndex)
+	} else {
+		return sig, nil
 	}
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2,11 +2,9 @@ package client
 
 import (
 	"log"
-	"math/big"
 	"os"
 	"testing"
 
-	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	"github.com/statechannels/go-nitro/client/engine/store"
@@ -35,7 +33,7 @@ func TestNew(t *testing.T) {
 	chainservA := chainservice.NewSimpleChainService(chain, a)
 	messageserviceA := messageservice.NewTestMessageService(a)
 	storeA := store.NewMockStore(aKey)
-	clientA := New(messageserviceA, chainservA, storeA, logDestination)
+	New(messageserviceA, chainservA, storeA, logDestination)
 
 	chainservB := chainservice.NewSimpleChainService(chain, b)
 	messageserviceB := messageservice.NewTestMessageService(b)
@@ -44,7 +42,7 @@ func TestNew(t *testing.T) {
 
 	messageserviceA.Connect(messageserviceB)
 	messageserviceB.Connect(messageserviceA)
-
-	clientA.CreateDirectChannel(b, types.Address{}, types.Bytes{}, outcome.Exit{}, big.NewInt(0))
+	// TODO: Temporarily disabled: See https://github.com/statechannels/go-nitro/issues/201
+	// clientA.CreateDirectChannel(b, types.Address{}, types.Bytes{}, outcome.Exit{}, big.NewInt(0))
 
 }

--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -87,7 +87,6 @@ func New(
 		types.AddressToDestination(myAddress),
 	)
 	init.myDepositTarget = init.myDepositSafetyThreshold.Add(myAllocatedAmount)
-	fmt.Println(init.myDepositTarget)
 	return init, nil
 }
 
@@ -250,7 +249,6 @@ func (s DirectFundObjective) amountToDeposit() types.Funds {
 			holding = big.NewInt(0)
 		}
 		deposits[asset] = big.NewInt(0).Sub(target, holding)
-		fmt.Printf("dep %d\n", deposits[asset])
 	}
 
 	return deposits

--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -182,12 +182,12 @@ func (s DirectFundObjective) Crank(secretKey *[]byte) (protocols.Objective, prot
 		pf := s.C.PostFundState()
 		ss, err := s.signAndStore(pf, secretKey)
 		if err != nil {
-			return updated, NoSideEffects, WaitingForCompletePrefund, fmt.Errorf("could not sign and store state %w", err)
+			return updated, NoSideEffects, WaitingForCompletePostFund, fmt.Errorf("could not sign and store state %w", err)
 		}
 		messages := s.createSignedStateMessages(ss)
 		se.MessagesToSend = append(se.MessagesToSend, messages...)
 
-		return updated, se, WaitingForCompletePrefund, nil
+		return updated, se, WaitingForCompletePostFund, nil
 	}
 
 	if !updated.C.PostFundComplete() {

--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -166,13 +166,10 @@ func (s DirectFundObjective) Crank(secretKey *[]byte) (protocols.Objective, prot
 		return updated, NoSideEffects, WaitingForMyTurnToFund, nil
 	}
 
-	if !fundingComplete && amountToDeposit.IsNonZero() && safeToDeposit {
-
-		var effects = make([]protocols.ChainTransaction, 0) // TODO loop over assets
-		effects = append(effects, protocols.ChainTransaction{ChannelId: updated.C.Id, Deposit: amountToDeposit})
-		if len(effects) > 0 {
-			return updated, se, WaitingForCompleteFunding, nil
-		}
+	if !fundingComplete && safeToDeposit && amountToDeposit.IsNonZero() {
+		deposit := protocols.ChainTransaction{ChannelId: updated.C.Id, Deposit: s.myDepositTarget}
+		se.TransactionsToSubmit = append(se.TransactionsToSubmit, deposit)
+		return updated, se, WaitingForCompleteFunding, nil
 	}
 
 	if !fundingComplete {

--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -167,11 +167,11 @@ func (s DirectFundObjective) Crank(secretKey *[]byte) (protocols.Objective, prot
 	}
 
 	if !fundingComplete && amountToDeposit.IsNonZero() && safeToDeposit {
-		var effects = make([]string, 0) // TODO loop over assets
-		effects = append(effects, FundOnChainEffect(updated.C.Id, `eth`, amountToDeposit))
+
+		var effects = make([]protocols.ChainTransaction, 0) // TODO loop over assets
+		effects = append(effects, protocols.ChainTransaction{ChannelId: updated.C.Id, Deposit: amountToDeposit})
 		if len(effects) > 0 {
-			// todo: convert effects to SideEffects{} and return
-			return updated, NoSideEffects, WaitingForCompleteFunding, nil
+			return updated, se, WaitingForCompleteFunding, nil
 		}
 	}
 

--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -87,7 +87,7 @@ func New(
 		types.AddressToDestination(myAddress),
 	)
 	init.myDepositTarget = init.myDepositSafetyThreshold.Add(myAllocatedAmount)
-
+	fmt.Println(init.myDepositTarget)
 	return init, nil
 }
 
@@ -244,8 +244,13 @@ func (s DirectFundObjective) safeToDeposit() bool {
 func (s DirectFundObjective) amountToDeposit() types.Funds {
 	deposits := make(types.Funds, len(s.C.OnChainFunding))
 
-	for asset, holding := range s.C.OnChainFunding {
-		deposits[asset] = big.NewInt(0).Sub(s.myDepositTarget[asset], holding)
+	for asset, target := range s.myDepositTarget {
+		holding := s.C.OnChainFunding[asset]
+		if holding == nil {
+			holding = big.NewInt(0)
+		}
+		deposits[asset] = big.NewInt(0).Sub(target, holding)
+		fmt.Printf("dep %d\n", deposits[asset])
 	}
 
 	return deposits

--- a/protocols/direct-fund/direct-fund_test.go
+++ b/protocols/direct-fund/direct-fund_test.go
@@ -2,10 +2,10 @@ package directfund
 
 import (
 	"math/big"
-	"reflect"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/google/go-cmp/cmp"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/protocols"
@@ -84,66 +84,16 @@ func TestPreFundSideEffects(t *testing.T) {
 	// Approve the objective, so that the rest of the test cases can run.
 	o := s.Approve()
 
-	_, se, _, err := o.Crank(&alice.privateKey)
+	_, got, _, err := o.Crank(&alice.privateKey)
 	if err != nil {
 		t.Error(err)
 	}
 
-	signMessage := se.MessagesToSend[0]
+	expectedMessage := protocols.Message{To: bob.address, ObjectiveId: o.Id(), SignedStates: []state.SignedState{s.C.SignedStateForTurnNum[0]}, Proposal: nil}
+	want := protocols.SideEffects{MessagesToSend: []protocols.Message{expectedMessage}}
 
-	if signMessage.To != bob.address {
-		t.Error("incorrect recipient")
-	}
-	if signMessage.ObjectiveId != o.Id() {
-		t.Error("incorrect objective id")
-	}
-	if stateLength := len(signMessage.SignedStates); stateLength != 1 {
-		t.Error("incorrect number of Signed States")
-	}
-
-	messageSig, err := signMessage.SignedStates[0].GetParticipantSignature(s.C.MyIndex)
-	if err != nil {
-		t.Error(err)
-	}
-	stateSig, err := s.C.SignedStateForTurnNum[0].GetParticipantSignature(s.C.MyIndex)
-	if err != nil {
-		t.Error(err)
-	}
-	if sigMatch := reflect.DeepEqual(messageSig, stateSig); !sigMatch {
-		t.Error("incorrect signature")
-	}
-
-}
-func TestFundingSideEffects(t *testing.T) {
-	var s, _ = New(false, testState, testState.Participants[0])
-	var correctSignatureByAliceOnPreFund, _ = s.C.PreFundState().Sign(alice.privateKey)
-	var correctSignatureByBobOnPreFund, _ = s.C.PreFundState().Sign(bob.privateKey)
-
-	// Approve the objective, so that the rest of the test cases can run.
-	o := s.Approve().(DirectFundObjective)
-
-	// Manually progress the extended state by collecting prefund signatures
-	o.C.AddStateWithSignature(o.C.PreFundState(), correctSignatureByAliceOnPreFund)
-	o.C.AddStateWithSignature(o.C.PreFundState(), correctSignatureByBobOnPreFund)
-	// Manually make the first "deposit" so it is safe for Alice to deposit
-	o.C.OnChainFunding[testState.Outcome[0].Asset] = testState.Outcome[0].Allocations[0].Amount
-
-	_, se, _, err := o.Crank(&alice.privateKey)
-	if err != nil {
-		t.Error(err)
-	}
-	if len(se.TransactionsToSubmit) != 1 {
-		t.Error("There should be one transaction request")
-	}
-	depositTransaction := se.TransactionsToSubmit[0]
-	if depositTransaction.ChannelId != o.C.Id {
-		t.Errorf("Expected transaction to have channel id %v, got %v instead", o.C.Id, depositTransaction.ChannelId)
-	}
-	expectedAmount := testState.Outcome[0].Allocations[0].Amount
-	actualAmount := depositTransaction.Deposit[testState.Outcome[0].Asset]
-	if expectedAmount.Cmp(actualAmount) != 0 {
-		t.Errorf("Expected a deposit of %d got %d instead", expectedAmount, actualAmount)
-
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("TestPreFundSideEffects: side effects mismatch (-want +got):\n%s", diff)
 	}
 
 }
@@ -167,32 +117,16 @@ func TestPostFundSideEffects(t *testing.T) {
 	totalAmountAllocated := testState.Outcome[0].TotalAllocated()
 	o.C.OnChainFunding[testState.Outcome[0].Asset] = totalAmountAllocated
 
-	_, se, _, err := o.Crank(&alice.privateKey)
+	_, got, _, err := o.Crank(&alice.privateKey)
 	if err != nil {
 		t.Error(err)
-	}
-	signMessage := se.MessagesToSend[0]
-
-	if signMessage.To != bob.address {
-		t.Error("incorrect recipient")
-	}
-	if signMessage.ObjectiveId != o.Id() {
-		t.Error("incorrect objective id")
-	}
-	if stateLength := len(signMessage.SignedStates); stateLength != 1 {
-		t.Error("incorrect number of Signed States")
 	}
 
-	messageSig, err := signMessage.SignedStates[0].GetParticipantSignature(s.C.MyIndex)
-	if err != nil {
-		t.Error(err)
-	}
-	stateSig, err := s.C.SignedStateForTurnNum[1].GetParticipantSignature(s.C.MyIndex)
-	if err != nil {
-		t.Error(err)
-	}
-	if sigMatch := reflect.DeepEqual(messageSig, stateSig); !sigMatch {
-		t.Error("incorrect signature")
+	expectedMessage := protocols.Message{To: bob.address, ObjectiveId: o.Id(), SignedStates: []state.SignedState{s.C.SignedStateForTurnNum[1]}, Proposal: nil}
+	want := protocols.SideEffects{MessagesToSend: []protocols.Message{expectedMessage}}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("TestPostFundSideEffects: side effects mismatch (-want +got):\n%s", diff)
 	}
 
 }

--- a/protocols/direct-fund/direct-fund_test.go
+++ b/protocols/direct-fund/direct-fund_test.go
@@ -79,17 +79,14 @@ func TestNew(t *testing.T) {
 
 func TestPreFundSideEffects(t *testing.T) {
 	// Construct various variables for use in the test.
-	var s, _ = New(false, testState, testState.Participants[0])
-
-	// Approve the objective, so that the rest of the test cases can run.
-	o := s.Approve()
+	var o, _ = New(true, testState, testState.Participants[0])
 
 	_, got, _, err := o.Crank(&alice.privateKey)
 	if err != nil {
 		t.Error(err)
 	}
 
-	expectedMessage := protocols.Message{To: bob.address, ObjectiveId: o.Id(), SignedStates: []state.SignedState{s.C.SignedStateForTurnNum[0]}, Proposal: nil}
+	expectedMessage := protocols.Message{To: bob.address, ObjectiveId: o.Id(), SignedStates: []state.SignedState{o.C.SignedStateForTurnNum[0]}, Proposal: nil}
 	want := protocols.SideEffects{MessagesToSend: []protocols.Message{expectedMessage}}
 
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -99,12 +96,9 @@ func TestPreFundSideEffects(t *testing.T) {
 }
 
 func TestPostFundSideEffects(t *testing.T) {
-	var s, _ = New(false, testState, testState.Participants[0])
-	var correctSignatureByAliceOnPreFund, _ = s.C.PreFundState().Sign(alice.privateKey)
-	var correctSignatureByBobOnPreFund, _ = s.C.PreFundState().Sign(bob.privateKey)
-
-	// Approve the objective, so that the rest of the test cases can run.
-	o := s.Approve().(DirectFundObjective)
+	var o, _ = New(true, testState, testState.Participants[0])
+	var correctSignatureByAliceOnPreFund, _ = o.C.PreFundState().Sign(alice.privateKey)
+	var correctSignatureByBobOnPreFund, _ = o.C.PreFundState().Sign(bob.privateKey)
 
 	// Manually progress the extended state by collecting prefund signatures
 	o.C.AddStateWithSignature(o.C.PreFundState(), correctSignatureByAliceOnPreFund)
@@ -122,7 +116,7 @@ func TestPostFundSideEffects(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedMessage := protocols.Message{To: bob.address, ObjectiveId: o.Id(), SignedStates: []state.SignedState{s.C.SignedStateForTurnNum[1]}, Proposal: nil}
+	expectedMessage := protocols.Message{To: bob.address, ObjectiveId: o.Id(), SignedStates: []state.SignedState{o.C.SignedStateForTurnNum[1]}, Proposal: nil}
 	want := protocols.SideEffects{MessagesToSend: []protocols.Message{expectedMessage}}
 
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/protocols/direct-fund/direct-fund_test.go
+++ b/protocols/direct-fund/direct-fund_test.go
@@ -78,7 +78,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestPreFundSideEffects(t *testing.T) {
-	// Construct various variables for use in TestUpdate
+	// Construct various variables for use in the test.
 	var s, _ = New(false, testState, testState.Participants[0])
 
 	// Approve the objective, so that the rest of the test cases can run.


### PR DESCRIPTION
Fixes #53

The direct funding protocol now sends returns appropriate side effects when Crank is called. There are three scenarios where side effects will be returned:
- If the prefund setup isn't signed by the user then it will be signed, stored and a message containing that signature will be returned as a side effect.
- If it's safe to deposit then a deposit `ChainTransaction` is returned in the side effects
- If it's safe to sign the post fund setup then it will be signed, stored and a message containing that signature will be returned as a side effect.

Tests have been added to check the side effects in each scenario.

## Changes
- [fc8aaf9](https://github.com/statechannels/go-nitro/pull/188/commits/fc8aaf928e0db28295a9e73adee643c5259835b9)  updates `amountToDeposit` to iterate over deposit targets. Otherwise if there are no holdings on chain we would never return a deposit amount.
- [ca44d2f](https://github.com/statechannels/go-nitro/pull/188/commits/ca44d2fe79156f638f82567dc0edf6d1d0a9b604) cleans up some of the logic to send out deposit transactions
