### PR TITLE
Serialize messages in `TestMessageService` and change `protocols.Message` type

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -23,7 +23,7 @@ type Channel struct {
 
 	latestSupportedStateTurnNum uint64 // largest uint64 value reserved for "no supported state"
 
-	SignedStateForTurnNum map[uint64]signedState // this stores up to 1 state per turn number.
+	SignedStateForTurnNum map[uint64]state.SignedState // this stores up to 1 state per turn number.
 	// Longer term, we should have a more efficient and smart mechanism to store states https://github.com/statechannels/go-nitro/issues/106
 }
 
@@ -67,13 +67,13 @@ func New(s state.State, myIndex uint) (Channel, error) {
 	// c.Support =  // TODO
 
 	// Store prefund
-	c.SignedStateForTurnNum = make(map[uint64]signedState)
-	c.SignedStateForTurnNum[PreFundTurnNum] = newSignedState(s)
+	c.SignedStateForTurnNum = make(map[uint64]state.SignedState)
+	c.SignedStateForTurnNum[PreFundTurnNum] = state.NewSignedState(s)
 
 	// Store postfund
 	post := s.Clone()
 	post.TurnNum = PostFundTurnNum
-	c.SignedStateForTurnNum[PostFundTurnNum] = newSignedState(post)
+	c.SignedStateForTurnNum[PostFundTurnNum] = state.NewSignedState(post)
 
 	return c, nil
 }
@@ -182,8 +182,8 @@ func (c *Channel) AddSignedState(s state.State, sig state.Signature) bool {
 
 	// Store the signature. If we have no record yet, add one.
 	if signedState, ok := c.SignedStateForTurnNum[s.TurnNum]; !ok {
-		ss := newSignedState(s)
-		err := ss.addSignature(sig)
+		ss := state.NewSignedState(s)
+		err := ss.AddSignature(sig)
 		if err == nil {
 			c.SignedStateForTurnNum[s.TurnNum] = ss
 		} else {
@@ -191,7 +191,7 @@ func (c *Channel) AddSignedState(s state.State, sig state.Signature) bool {
 		}
 
 	} else {
-		err := signedState.addSignature(sig)
+		err := signedState.AddSignature(sig)
 		if err != nil {
 			return false
 		}

--- a/channel/state/signedstate.go
+++ b/channel/state/signedstate.go
@@ -59,3 +59,17 @@ func (ss SignedState) HasAllSignatures() bool {
 		return false
 	}
 }
+
+// Merge checks the passed SignedState's state and the reciever's state for equality, andd adds each signature from the former to the latter.
+func (ss SignedState) Merge(ss2 SignedState) error {
+	if !ss.state.Equal(ss2.state) {
+		return errors.New(`cannot merge signed states with distinct state hashes`)
+	}
+	for _, sig := range ss2.sigs {
+		err := ss.AddSignature(sig)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/channel/state/signedstate.go
+++ b/channel/state/signedstate.go
@@ -1,26 +1,24 @@
-package channel
+package state
 
 import (
 	"errors"
 	"fmt"
-
-	"github.com/statechannels/go-nitro/channel/state"
 )
 
-type signedState struct {
-	state state.State
-	sigs  map[uint]state.Signature // keyed by participant index
+type SignedState struct {
+	state State
+	sigs  map[uint]Signature // keyed by participant index
 }
 
-// newSignedState initializes a SignedState struct for the given state.
+// newSignedState initializes a SignedState struct for the given
 // The signedState returned will have no signatures.
-func newSignedState(s state.State) signedState {
-	return signedState{s, make(map[uint]state.Signature, len(s.Participants))}
+func NewSignedState(s State) SignedState {
+	return SignedState{s, make(map[uint]Signature, len(s.Participants))}
 }
 
-// addSignature adds a participant's signature for the state.
+// addSignature adds a participant's signature for the
 // An error is thrown if the signature is invalid.
-func (ss signedState) addSignature(sig state.Signature) error {
+func (ss SignedState) AddSignature(sig Signature) error {
 	signer, err := ss.state.RecoverSigner(sig)
 	if err != nil {
 		return fmt.Errorf("addSignature failed to recover signer %w", err)
@@ -42,18 +40,18 @@ func (ss signedState) addSignature(sig state.Signature) error {
 	return errors.New("signature does not match any participant")
 
 }
-func (ss signedState) State() state.State {
+func (ss SignedState) State() State {
 	return ss.state
 }
 
 // HasSignatureForParticipant returns true if the participant (at participantIndex) has a valid signature.
-func (ss signedState) HasSignatureForParticipant(participantIndex uint) bool {
+func (ss SignedState) HasSignatureForParticipant(participantIndex uint) bool {
 	_, found := ss.sigs[uint(participantIndex)]
 	return found
 }
 
 // HasAllSignatures returns true if every participant has a valid signature.
-func (ss signedState) HasAllSignatures() bool {
+func (ss SignedState) HasAllSignatures() bool {
 	// Since signatures are validated
 	if len(ss.sigs) == len(ss.state.Participants) {
 		return true

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -48,11 +48,11 @@ func New(msg messageservice.MessageService, chain chainservice.ChainService, sto
 	// bind the engine's inbound chans
 	e.FromAPI = make(chan APIEvent)
 	e.fromChain = chain.Out()
-	e.fromMsg = msg.GetReceiveChan()
+	e.fromMsg = msg.Out()
 
 	// bind the engine's outbound chans
 	e.toChain = chain.In()
-	e.toMsg = msg.GetSendChan()
+	e.toMsg = msg.In()
 
 	// initialize a Logger
 	e.logger = log.New(logDestination, e.store.GetAddress().String()+": ", log.Ldate|log.Ltime|log.Lshortfile)

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -88,7 +88,7 @@ func (e *Engine) Run() {
 // executes the side effects and
 // evaluates objecive progress.
 func (e *Engine) handleMessage(message protocols.Message) {
-	event := protocols.ObjectiveEvent{Sigs: message.Sigs}
+	event := protocols.ObjectiveEvent{SignedStates: message.SignedStates}
 	objective, _ := e.store.GetObjectiveById(message.ObjectiveId)
 	updatedObjective, _ := objective.Update(event) // TODO handle error
 	e.attemptProgress(updatedObjective)

--- a/client/engine/messageservice/messageservice.go
+++ b/client/engine/messageservice/messageservice.go
@@ -4,7 +4,7 @@ package messageservice // import "github.com/statechannels/go-nitro/client/messa
 import "github.com/statechannels/go-nitro/protocols"
 
 type MessageService interface {
-	GetReceiveChan() <-chan protocols.Message
-	GetSendChan() chan<- protocols.Message
+	Out() <-chan protocols.Message // Returns a chan for recieving messages from the message service
+	In() chan<- protocols.Message  // Returns a chan for sending messages to the message service
 	Send(message protocols.Message)
 }

--- a/client/engine/messageservice/test-messageservice.go
+++ b/client/engine/messageservice/test-messageservice.go
@@ -42,11 +42,11 @@ func (t TestMessageService) run() {
 	go t.routeOutgoing()
 }
 
-func (t TestMessageService) GetReceiveChan() <-chan protocols.Message {
+func (t TestMessageService) Out() <-chan protocols.Message {
 	return t.out
 }
 
-func (t TestMessageService) GetSendChan() chan<- protocols.Message {
+func (t TestMessageService) In() chan<- protocols.Message {
 	return t.in
 }
 

--- a/client/engine/messageservice/test-messageservice.go
+++ b/client/engine/messageservice/test-messageservice.go
@@ -19,7 +19,7 @@ type TestMessageService struct {
 	address types.Address
 
 	// connection to peer message services
-	toPeers map[types.Address]chan<- protocols.Message
+	toPeers map[types.Address]chan<- string
 
 	// connection to Engine:
 	in  chan protocols.Message // for recieving messages from engine
@@ -30,7 +30,7 @@ type TestMessageService struct {
 func NewTestMessageService(address types.Address) TestMessageService {
 	tms := TestMessageService{
 		address: address,
-		toPeers: make(map[types.Address]chan<- protocols.Message),
+		toPeers: make(map[types.Address]chan<- string),
 		in:      make(chan protocols.Message),
 		out:     make(chan protocols.Message),
 	}
@@ -56,13 +56,14 @@ func (t TestMessageService) Send(message protocols.Message) {
 
 // Connect creates a gochan for message service to send messages to the given peer.
 func (t TestMessageService) Connect(peer TestMessageService) {
-	toPeer := make(chan protocols.Message)
+	toPeer := make(chan string)
 
 	t.toPeers[peer.address] = toPeer
 
 	go func() {
 		for msg := range toPeer {
-			peer.out <- msg // send messages directly to peer's engine, bypassing their message service
+			protocols.DeserialiseMessage(msg)
+			peer.out <- protocols.DeserialiseMessage(msg) // send messages directly to peer's engine, bypassing their message service
 		}
 	}()
 }
@@ -72,7 +73,7 @@ func (t TestMessageService) Connect(peer TestMessageService) {
 func (t TestMessageService) forward(message protocols.Message) {
 	peerChan, ok := t.toPeers[message.To]
 	if ok {
-		peerChan <- message
+		peerChan <- message.Serialize()
 	} else {
 		panic(fmt.Sprintf("client %v has no connection to client %v",
 			t.address, message.To))

--- a/client/engine/messageservice/test-messageservice_test.go
+++ b/client/engine/messageservice/test-messageservice_test.go
@@ -23,12 +23,12 @@ var aToB protocols.Message = protocols.Message{
 }
 
 func TestConnect(t *testing.T) {
-	bobIn := bobMS.GetReceiveChan()
+	bobOut := bobMS.Out()
 
 	aliceMS.Connect(bobMS)
 	aliceMS.Send(aToB)
 
-	got := <-bobIn
+	got := <-bobOut
 
 	if got.ObjectiveId != testId {
 		t.Errorf("expected bob to recieve ObjectiveId %v, but recieved %v",

--- a/client/engine/messageservice/test-messageservice_test.go
+++ b/client/engine/messageservice/test-messageservice_test.go
@@ -32,6 +32,6 @@ func TestConnect(t *testing.T) {
 
 	if got.ObjectiveId != testId {
 		t.Errorf("expected bob to recieve ObjectiveId %v, but recieved %v",
-			got.ObjectiveId, testId)
+			testId, got.ObjectiveId)
 	}
 }

--- a/client/engine/messageservice/test-messageservice_test.go
+++ b/client/engine/messageservice/test-messageservice_test.go
@@ -16,10 +16,10 @@ var objective, _ = directfund.New(false, state.TestState, aliceMS.address)
 var testId protocols.ObjectiveId = "testObjectiveID"
 
 var aToB protocols.Message = protocols.Message{
-	To:          bobMS.address,
-	ObjectiveId: testId,
-	Sigs:        make(map[*state.State]state.Signature),
-	Proposal:    objective,
+	To:           bobMS.address,
+	ObjectiveId:  testId,
+	SignedStates: make([]state.SignedState, 0),
+	Proposal:     objective,
 }
 
 func TestConnect(t *testing.T) {

--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -119,7 +119,7 @@ func (s DirectFundObjective) Update(event protocols.ObjectiveEvent) (protocols.O
 	}
 
 	updated := s.clone()
-	updated.C.AddSignedStates(event.Sigs)
+	updated.C.AddSignedStates(event.SignedStates)
 
 	if event.Holdings != nil {
 		updated.C.OnChainFunding = event.Holdings

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -5,14 +5,6 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-// Message is an object to be sent across the wire. It can contain a proposal and signed state hashes, and is addressed to a counterparty.
-type Message struct {
-	To          types.Address
-	ObjectiveId ObjectiveId
-	Sigs        map[*state.State]state.Signature // mapping from state hash to signature
-	Proposal    Objective
-}
-
 // ChainTransaction is an object to be sent to a blockchain provider.
 type ChainTransaction struct {
 	ChannelId types.Destination

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -46,9 +46,9 @@ type AdjudicationStatus struct {
 
 // ObjectiveEvent holds information used to update an Objective. Some fields may be nil.
 type ObjectiveEvent struct {
-	ChannelId          types.Destination                // Must be defined
-	Sigs               map[*state.State]state.Signature // mapping from state to signature
-	Holdings           types.Funds                      // mapping from asset identifier to amount
+	ChannelId          types.Destination // Must be defined
+	SignedStates       []state.SignedState
+	Holdings           types.Funds // mapping from asset identifier to amount
 	AdjudicationStatus AdjudicationStatus
 }
 

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -1,0 +1,29 @@
+package protocols
+
+import (
+	"encoding/json"
+
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/types"
+)
+
+// Message is an object to be sent across the wire. It can contain a proposal and signed state hashes, and is addressed to a counterparty.
+type Message struct {
+	To          types.Address
+	ObjectiveId ObjectiveId
+	Sigs        map[types.Bytes32]state.Signature // mapping from state hash to signature
+	Proposal    Objective
+}
+
+// Serialize serializes the message into a string
+func (m Message) Serialize() string {
+	bytes, _ := json.Marshal(m) // TODO handle error
+	return string(bytes)
+}
+
+// DeserialiseMessage deserializes the passed string into a protocols.Message
+func DeserialiseMessage(s string) Message {
+	msg := Message{}
+	json.Unmarshal([]byte(s), msg)
+	return msg
+}

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -11,7 +11,7 @@ import (
 type Message struct {
 	To          types.Address
 	ObjectiveId ObjectiveId
-	Sigs        map[types.Bytes32]state.Signature // mapping from state hash to signature
+	Sigs        map[*state.State]state.Signature // mapping from state hash to signature
 	Proposal    Objective
 }
 

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -9,10 +9,10 @@ import (
 
 // Message is an object to be sent across the wire. It can contain a proposal and signed state hashes, and is addressed to a counterparty.
 type Message struct {
-	To          types.Address
-	ObjectiveId ObjectiveId
-	Sigs        map[*state.State]state.Signature // mapping from state hash to signature
-	Proposal    Objective
+	To           types.Address
+	ObjectiveId  ObjectiveId
+	SignedStates []state.SignedState
+	Proposal     Objective
 }
 
 // Serialize serializes the message into a string

--- a/protocols/virtual-fund/virtual-fund.go
+++ b/protocols/virtual-fund/virtual-fund.go
@@ -174,13 +174,13 @@ func (s VirtualFundObjective) Update(event protocols.ObjectiveEvent) (protocols.
 	case types.Destination{}:
 		return s, errors.New("null channel id") // catch this case to avoid a panic below -- because if Alice or Bob we allow a null channel.
 	case s.V.Id:
-		updated.V.AddSignedStates(event.Sigs)
+		updated.V.AddSignedStates(event.SignedStates)
 		// We expect pre and post fund state signatures.
 	case toMyLeftId:
-		updated.ToMyLeft.Channel.AddSignedStates(event.Sigs)
+		updated.ToMyLeft.Channel.AddSignedStates(event.SignedStates)
 		// We expect a countersigned state including an outcome with expected guarantee. We don't know the exact statehash, though.
 	case toMyRightId:
-		updated.ToMyRight.Channel.AddSignedStates(event.Sigs)
+		updated.ToMyRight.Channel.AddSignedStates(event.SignedStates)
 		// We expect a countersigned state including an outcome with expected guarantee. We don't know the exact statehash, though.
 	default:
 		return s, errors.New("event channelId out of scope of objective")
@@ -207,7 +207,9 @@ func (s VirtualFundObjective) Crank(secretKey *[]byte) (protocols.Objective, pro
 		if err != nil {
 			return s, NoSideEffects, WaitingForNothing, err
 		}
-		ok := updated.V.AddSignedState(updated.V.PreFundState(), sig)
+		ss := state.NewSignedState(updated.V.PreFundState())
+		ss.AddSignature(sig)
+		ok := updated.V.AddSignedState(ss)
 		if !ok {
 			return s, NoSideEffects, WaitingForNothing, errors.New(`could not add prefund state`)
 		}
@@ -236,7 +238,9 @@ func (s VirtualFundObjective) Crank(secretKey *[]byte) (protocols.Objective, pro
 		if err != nil {
 			return s, NoSideEffects, WaitingForNothing, err
 		}
-		ok := updated.V.AddSignedState(updated.V.PostFundState(), sig)
+		ss := state.NewSignedState(updated.V.PostFundState())
+		ss.AddSignature(sig)
+		ok := updated.V.AddSignedState(ss)
 		if !ok {
 			return s, NoSideEffects, WaitingForNothing, errors.New(`could not add postfund state`)
 		}


### PR DESCRIPTION
Work in progress. 

The existing `protocols.Message` type has a `Sigs` property which is a mapping from a pointer to a state, to a signature. That type is needlessly hard to deal with, particularly with respect to serialising for transmission over the wire. 

 Here I'm replacing it with an array of `SignedStates`, and then having the test message service serialize and deserialize messages to simulate a more realistic situation. 

This should also get around problems deferencing pointers that seem to crop up when sharing pointers between go routines -- that approach seems obviously bad but we should document the problem more clearly anyway (TODO). 