### PR TITLE
Fix Message Equal Function

### DIFF
--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -41,7 +41,7 @@ func (m Message) Equal(n Message) bool {
 		return false
 	}
 	for i, ss := range m.SignedStates {
-		if !ss.Equal(m.SignedStates[i]) {
+		if !ss.Equal(n.SignedStates[i]) {
 			return false
 		}
 	}

--- a/protocols/messages_test.go
+++ b/protocols/messages_test.go
@@ -7,6 +7,30 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
+func TestEquals(t *testing.T) {
+	stateOne := state.TestState.Clone()
+	stateTwo := state.TestState.Clone()
+	stateTwo.TurnNum = 1
+	msg1 := Message{
+		To:          types.Address{'a'},
+		ObjectiveId: `say-hello-to-my-little-friend`,
+		SignedStates: []state.SignedState{
+			state.NewSignedState(stateOne),
+		},
+	}
+
+	msg2 := Message{
+		To:          types.Address{'a'},
+		ObjectiveId: `say-hello-to-my-little-friend`,
+		SignedStates: []state.SignedState{
+			state.NewSignedState(stateTwo),
+		},
+	}
+	if (msg1).Equal(msg2) {
+		t.Error("Equal returned true for two different messages")
+	}
+}
+
 func TestMessage(t *testing.T) {
 	msg := Message{
 		To:          types.Address{'a'},


### PR DESCRIPTION
Previously Equal would only look at signed states on one message and compare them against themselves. This meant that `Equal` would return true even if the signed states were completely different.

This PR
-  adds a simple test to reproduce the problem
- a small fix so equal compares signed states correctly.