### PR TITLE
Remove proposal flag

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -3,7 +3,6 @@ package engine // import "github.com/statechannels/go-nitro/client/engine"
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"log"
 	"strings"
@@ -170,24 +169,18 @@ func (e *Engine) attemptProgress(objective protocols.Objective) {
 // getOrCreateObjective creates the objective if the supplied message is a proposal. Otherwise, it attempts to get the objective from the store.
 func (e *Engine) getOrCreateObjective(message protocols.Message) (protocols.Objective, error) {
 	id := message.ObjectiveId
-	if message.Proposal {
-		e.logger.Printf("Recieved proposal for %s", id)
-		return e.constructObjectiveFromProposal(message)
-	}
+
 	objective, ok := e.store.GetObjectiveById(id)
 	if !ok {
-		err := fmt.Errorf("store has no objective with id %v", id)
-		return objective, err
+		return e.constructObjectiveFromMessage(message)
 	} else {
 		return objective, nil
 	}
 }
 
-// constructObjectiveFromProposal Constructs a new objective (of the appropriate concrete type) from the supplied message.
-func (e *Engine) constructObjectiveFromProposal(message protocols.Message) (protocols.Objective, error) {
-	if !message.Proposal {
-		panic("Tried to construct objective from a non-proposal message")
-	}
+// constructObjectiveFromMessage Constructs a new objective (of the appropriate concrete type) from the supplied message.
+func (e *Engine) constructObjectiveFromMessage(message protocols.Message) (protocols.Objective, error) {
+
 	switch {
 	case strings.Contains(string(message.ObjectiveId), `DirectFund`):
 		initialState := message.SignedStates[0].State()

--- a/client/engine/messageservice/test-messageservice_test.go
+++ b/client/engine/messageservice/test-messageservice_test.go
@@ -17,7 +17,6 @@ var aToB protocols.Message = protocols.Message{
 	To:           bobMS.address,
 	ObjectiveId:  testId,
 	SignedStates: []state.SignedState{},
-	Proposal:     true,
 }
 
 func TestConnect(t *testing.T) {

--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -149,13 +149,6 @@ func (s DirectFundObjective) Crank(secretKey *[]byte) (protocols.Objective, prot
 		messages := s.createSignedStateMessages(ss)
 		se.MessagesToSend = append(se.MessagesToSend, messages...)
 
-		// Special case for prefunding: we send an objective proposal along with the messages
-		if s.C.MyIndex == 0 {
-			for i := range se.MessagesToSend {
-				se.MessagesToSend[i].Proposal = true
-			}
-		}
-
 		return updated, se, WaitingForCompletePrefund, nil
 	}
 
@@ -284,7 +277,7 @@ func (s DirectFundObjective) createSignedStateMessages(ss state.SignedState) []p
 		if uint(i) == s.C.MyIndex {
 			continue
 		}
-		message := protocols.Message{To: participant, ObjectiveId: s.Id(), SignedStates: []state.SignedState{ss}, Proposal: false}
+		message := protocols.Message{To: participant, ObjectiveId: s.Id(), SignedStates: []state.SignedState{ss}}
 		messages = append(messages, message)
 	}
 	return messages

--- a/protocols/direct-fund/direct-fund_test.go
+++ b/protocols/direct-fund/direct-fund_test.go
@@ -86,7 +86,7 @@ func TestPreFundSideEffects(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedMessage := protocols.Message{To: bob.address, ObjectiveId: o.Id(), SignedStates: []state.SignedState{o.C.SignedStateForTurnNum[0]}, Proposal: true}
+	expectedMessage := protocols.Message{To: bob.address, ObjectiveId: o.Id(), SignedStates: []state.SignedState{o.C.SignedStateForTurnNum[0]}}
 	want := protocols.SideEffects{MessagesToSend: []protocols.Message{expectedMessage}}
 
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -116,7 +116,7 @@ func TestPostFundSideEffects(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedMessage := protocols.Message{To: bob.address, ObjectiveId: o.Id(), SignedStates: []state.SignedState{o.C.SignedStateForTurnNum[1]}, Proposal: false}
+	expectedMessage := protocols.Message{To: bob.address, ObjectiveId: o.Id(), SignedStates: []state.SignedState{o.C.SignedStateForTurnNum[1]}}
 	want := protocols.SideEffects{MessagesToSend: []protocols.Message{expectedMessage}}
 
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -13,7 +13,6 @@ type Message struct {
 	To           types.Address
 	ObjectiveId  ObjectiveId
 	SignedStates []state.SignedState
-	Proposal     bool
 }
 
 // Serialize serializes the message into a string.

--- a/protocols/messages_test.go
+++ b/protocols/messages_test.go
@@ -39,10 +39,9 @@ func TestMessage(t *testing.T) {
 		SignedStates: []state.SignedState{
 			state.NewSignedState(state.TestState),
 		},
-		Proposal: true,
 	}
 
-	msgString := `{"To":"0x6100000000000000000000000000000000000000","ObjectiveId":"say-hello-to-my-little-friend","SignedStates":[{"State":{"ChainId":9001,"Participants":["0xf5a1bb5607c9d079e46d1b3dc33f257d937b43bd","0x760bf27cd45036a6c486802d30b5d90cffbe31fe"],"ChannelNonce":37140676580,"AppDefinition":"0x5e29e5ab8ef33f050c7cc10b5a0456d975c5f88d","ChallengeDuration":60,"AppData":"","Outcome":[{"Asset":"0x0000000000000000000000000000000000000000","Metadata":null,"Allocations":[{"Destination":[0,0,0,0,0,0,0,0,0,0,0,0,245,161,187,86,7,201,208,121,228,109,27,61,195,63,37,125,147,123,67,189],"Amount":5,"AllocationType":0,"Metadata":null},{"Destination":[0,0,0,0,0,0,0,0,0,0,0,0,238,24,255,21,117,5,86,145,0,154,162,70,174,96,129,50,197,122,66,44],"Amount":5,"AllocationType":0,"Metadata":null}]}],"TurnNum":5,"IsFinal":false},"Sigs":{}}],"Proposal":true}`
+	msgString := `{"To":"0x6100000000000000000000000000000000000000","ObjectiveId":"say-hello-to-my-little-friend","SignedStates":[{"State":{"ChainId":9001,"Participants":["0xf5a1bb5607c9d079e46d1b3dc33f257d937b43bd","0x760bf27cd45036a6c486802d30b5d90cffbe31fe"],"ChannelNonce":37140676580,"AppDefinition":"0x5e29e5ab8ef33f050c7cc10b5a0456d975c5f88d","ChallengeDuration":60,"AppData":"","Outcome":[{"Asset":"0x0000000000000000000000000000000000000000","Metadata":null,"Allocations":[{"Destination":[0,0,0,0,0,0,0,0,0,0,0,0,245,161,187,86,7,201,208,121,228,109,27,61,195,63,37,125,147,123,67,189],"Amount":5,"AllocationType":0,"Metadata":null},{"Destination":[0,0,0,0,0,0,0,0,0,0,0,0,238,24,255,21,117,5,86,145,0,154,162,70,174,96,129,50,197,122,66,44],"Amount":5,"AllocationType":0,"Metadata":null}]}],"TurnNum":5,"IsFinal":false},"Sigs":{}}]}`
 
 	t.Run(`serialize`, func(t *testing.T) {
 		got, err := msg.Serialize()


### PR DESCRIPTION
⚠️ base not main branch.
Based on https://github.com/statechannels/go-nitro/pull/202

Instead of using a `Proposal` flag on messages this PR just assumes that any objective it hasn't seen is a proposed objective. This simplifies some logic and the Message struct. Since there is nothing special about a proposal message I think it's safe to just treat any new objective as a proposed objective?


