### PR TITLE
Client API sends response when objective is complete

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -17,17 +17,11 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-// ChannelFundedEvents is returned in a channel when a state channel has been successfly funded.
-type ChannelFundedEvent struct {
-	ChannelId   types.Destination
-	ObjectiveId protocols.ObjectiveId
-}
-
 // Client provides the interface for the consuming application
 type Client struct {
-	engine                 engine.Engine // The core business logic of the client
-	Address                *types.Address
-	allChannelFundedEvents chan ChannelFundedEvent
+	engine              engine.Engine // The core business logic of the client
+	Address             *types.Address
+	completedObjectives chan protocols.ObjectiveId
 }
 
 // New is the constructor for a Client. It accepts a messaging service, a chain service, and a store as injected dependencies.
@@ -35,7 +29,7 @@ func New(messageService messageservice.MessageService, chainservice chainservice
 	c := Client{}
 	c.Address = store.GetAddress()
 	c.engine = engine.New(messageService, chainservice, store, logDestination)
-	c.allChannelFundedEvents = make(chan ChannelFundedEvent, 100)
+	c.completedObjectives = make(chan protocols.ObjectiveId, 100)
 
 	// Start the engine in a go routine
 	go c.engine.Run()
@@ -53,11 +47,8 @@ func (c *Client) handleEngineEvents() {
 	for update := range c.engine.ToApi() {
 
 		for _, completed := range update.CompletedObjectives {
-			// TODO: We're assuming the first channel id is the one we're interested in.
-			channelId := completed.Channels()[0]
-			event := ChannelFundedEvent{ObjectiveId: completed.Id(), ChannelId: channelId}
 
-			c.allChannelFundedEvents <- event
+			c.completedObjectives <- completed.Id()
 
 		}
 
@@ -66,9 +57,9 @@ func (c *Client) handleEngineEvents() {
 
 // Begin API
 
-// ChannelFunded returns a channel that receives a ChannelFundedEvent whenever a state channel has been fully funded.
-func (c *Client) ChannelFunded() <-chan ChannelFundedEvent {
-	return c.allChannelFundedEvents
+// CompletedObjectives returns a chan that receives a objective id whenever that objective is completed
+func (c *Client) CompletedObjectives() <-chan protocols.ObjectiveId {
+	return c.completedObjectives
 }
 
 // CreateDirectChannel creates a directly funded channel with the given counterparty

--- a/client/client.go
+++ b/client/client.go
@@ -28,7 +28,6 @@ type Client struct {
 	engine                 engine.Engine // The core business logic of the client
 	Address                *types.Address
 	allChannelFundedEvents chan ChannelFundedEvent
-	listeners              map[protocols.ObjectiveId]chan<- ChannelFundedEvent
 }
 
 // New is the constructor for a Client. It accepts a messaging service, a chain service, and a store as injected dependencies.
@@ -37,7 +36,7 @@ func New(messageService messageservice.MessageService, chainservice chainservice
 	c.Address = store.GetAddress()
 	c.engine = engine.New(messageService, chainservice, store, logDestination)
 	c.allChannelFundedEvents = make(chan ChannelFundedEvent, 100)
-	c.listeners = make(map[protocols.ObjectiveId]chan<- ChannelFundedEvent)
+
 	// Start the engine in a go routine
 	go c.engine.Run()
 

--- a/client/client.go
+++ b/client/client.go
@@ -18,17 +18,18 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-type ChannelReadyEvent struct {
+// ChannelFundedEvents is returned in a channel when a state channel has been successfly funded.
+type ChannelFundedEvent struct {
 	ChannelId   types.Destination
 	ObjectiveId protocols.ObjectiveId
 }
 
 // Client provides the interface for the consuming application
 type Client struct {
-	engine       engine.Engine // The core business logic of the client
-	Address      *types.Address
-	ChannelReady chan ChannelReadyEvent // All Objective updates from the engine
-	listeners    map[protocols.ObjectiveId]chan<- ChannelReadyEvent
+	engine        engine.Engine // The core business logic of the client
+	Address       *types.Address
+	ChannelFunded chan ChannelFundedEvent
+	listeners     map[protocols.ObjectiveId]chan<- ChannelFundedEvent
 }
 
 // New is the constructor for a Client. It accepts a messaging service, a chain service, and a store as injected dependencies.
@@ -36,18 +37,19 @@ func New(messageService messageservice.MessageService, chainservice chainservice
 	c := Client{}
 	c.Address = store.GetAddress()
 	c.engine = engine.New(messageService, chainservice, store, logDestination)
-	c.ChannelReady = make(chan ChannelReadyEvent, 100)
-	c.listeners = make(map[protocols.ObjectiveId]chan<- ChannelReadyEvent)
+	c.ChannelFunded = make(chan ChannelFundedEvent, 100)
+	c.listeners = make(map[protocols.ObjectiveId]chan<- ChannelFundedEvent)
 	// Start the engine in a go routine
 	go c.engine.Run()
 
 	// Start the event handler in a go routine
+	// It will listen for events from the engine and dispatch events to client channels
 	go c.handleEngineEvents()
 
 	return c
 }
 
-func (c *Client) registerListener(objectiveId protocols.ObjectiveId, listener chan<- ChannelReadyEvent) {
+func (c *Client) registerListener(objectiveId protocols.ObjectiveId, listener chan<- ChannelFundedEvent) {
 	c.listeners[objectiveId] = listener
 }
 func (c *Client) removeListener(objectiveId protocols.ObjectiveId) {
@@ -65,12 +67,13 @@ func (c *Client) handleEngineEvents() {
 	for update := range c.engine.ToApi() {
 
 		for _, completed := range update.CompletedObjectives {
+			// TODO: We're assuming the first channel id is the one we're interested in.
 			channelId := completed.Channels()[0]
-			event := ChannelReadyEvent{ObjectiveId: completed.Id(), ChannelId: channelId}
+			event := ChannelFundedEvent{ObjectiveId: completed.Id(), ChannelId: channelId}
 
 			// We dispatch an event to the channel that handles **all** objective updates.
 			// This provides a central place to monitor for objective updates.
-			c.ChannelReady <- event
+			c.ChannelFunded <- event
 
 			// Dispatch an event to any listeners that have been registered by calls to CreateDirectChannel
 			if l, ok := c.listeners[completed.Id()]; ok {
@@ -87,7 +90,7 @@ func (c *Client) handleEngineEvents() {
 // Begin API
 
 // CreateDirectChannel creates a directly funded channel with the given counterparty
-func (c *Client) CreateDirectChannel(counterparty types.Address, appDefinition types.Address, appData types.Bytes, outcome outcome.Exit, challengeDuration *types.Uint256) (protocols.ObjectiveId, chan ChannelReadyEvent) {
+func (c *Client) CreateDirectChannel(counterparty types.Address, appDefinition types.Address, appData types.Bytes, outcome outcome.Exit, challengeDuration *types.Uint256) (protocols.ObjectiveId, chan ChannelFundedEvent) {
 	// Convert the API call into an internal event.
 	objective, _ := directfund.New(true,
 		state.State{
@@ -111,8 +114,8 @@ func (c *Client) CreateDirectChannel(counterparty types.Address, appDefinition t
 	// Send the event to the engine
 	c.engine.FromAPI <- apiEvent
 
-	clientResponse := make(chan ChannelReadyEvent)
-	// We register a listener  channelfor the objective id
+	clientResponse := make(chan ChannelFundedEvent)
+	// We register a listener so a ChannelFundedEvent will get sent to clientResponse when the objective completes
 	c.registerListener(objective.Id(), clientResponse)
 
 	return objective.Id(), clientResponse

--- a/client/client.go
+++ b/client/client.go
@@ -20,14 +20,14 @@ import (
 type ChannelReadyEvent struct {
 	ChannelId   types.Destination
 	ObjectiveId protocols.ObjectiveId
-	Funding     types.Funds
 }
 
 // Client provides the interface for the consuming application
 type Client struct {
 	engine       engine.Engine // The core business logic of the client
 	Address      *types.Address
-	ChannelReady chan<- ChannelReadyEvent // All Objective updates from the engine
+	ChannelReady chan ChannelReadyEvent // All Objective updates from the engine
+	listeners    map[protocols.ObjectiveId][]chan<- ChannelReadyEvent
 }
 
 // New is the constructor for a Client. It accepts a messaging service, a chain service, and a store as injected dependencies.
@@ -35,9 +35,32 @@ func New(messageService messageservice.MessageService, chainservice chainservice
 	c := Client{}
 	c.Address = store.GetAddress()
 	c.engine = engine.New(messageService, chainservice, store, logDestination)
-	c.ChannelReady = make(chan<- ChannelReadyEvent, 100)
+	c.ChannelReady = make(chan ChannelReadyEvent, 100)
+	c.listeners = make(map[protocols.ObjectiveId][]chan<- ChannelReadyEvent)
 	// Start the engine in a go routine
 	go c.engine.Run()
+
+	go func() {
+		for update := range c.engine.ToApi() {
+
+			for _, completed := range update.CompletedObjectives {
+
+				channelId := completed.Channels()[0]
+
+				event := ChannelReadyEvent{ObjectiveId: completed.Id(), ChannelId: channelId}
+				// We dispatch an event to the channel that handles **all** objective updates.
+				// This provides a central place to monitor for objective updates.
+				c.ChannelReady <- event
+
+				// Dispatch an event to any listeners that have been registered
+				if listeners, ok := c.listeners[completed.Id()]; ok {
+					for _, l := range listeners {
+						l <- event
+					}
+				}
+			}
+		}
+	}()
 
 	return c
 }
@@ -70,29 +93,8 @@ func (c *Client) CreateDirectChannel(counterparty types.Address, appDefinition t
 	c.engine.FromAPI <- apiEvent
 
 	clientResponse := make(chan ChannelReadyEvent)
-
-	// Starts a go function that listens for our objective to be completed and then dispatchs events to different client channels
-	go func() {
-		for update := range c.engine.ToApi() {
-			for _, completed := range update.CompletedObjectives {
-
-				if completed == objective.Id() {
-
-					// We dispatch an event to the channel that handles **all** objective updates.
-					// This provides a central place to monitor for objective updates.
-					c.ChannelReady <- ChannelReadyEvent{ObjectiveId: completed, ChannelId: objective.C.Id, Funding: objective.C.OnChainFunding}
-					// We dispatch an event to the channel returned by this function. This channel is only used for the one objective.
-					// This allows for promise like behaviour where we can wait for the objective to be completed before continuing.
-					clientResponse <- ChannelReadyEvent{ObjectiveId: completed, ChannelId: objective.C.Id, Funding: objective.C.OnChainFunding}
-					// We can close the channel as the objective is completed so there will be no further events.
-					close(clientResponse)
-
-					// Exit the go function now that our objective is completed.
-					return
-				}
-			}
-		}
-	}()
+	// We register a listener for the objective id
+	c.listeners[objective.Id()] = append(c.listeners[objective.Id()], clientResponse)
 
 	return objective.Id(), clientResponse
 }

--- a/client/client.go
+++ b/client/client.go
@@ -12,14 +12,16 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	"github.com/statechannels/go-nitro/client/engine/store"
+	"github.com/statechannels/go-nitro/protocols"
 	directfund "github.com/statechannels/go-nitro/protocols/direct-fund"
 	"github.com/statechannels/go-nitro/types"
 )
 
 // Client provides the interface for the consuming application
 type Client struct {
-	engine  engine.Engine // The core business logic of the client
-	Address *types.Address
+	engine              engine.Engine // The core business logic of the client
+	Address             *types.Address
+	CompletedObjectives chan<- engine.CompletedObjectiveEvent // All Objective updates from the engine
 }
 
 // New is the constructor for a Client. It accepts a messaging service, a chain service, and a store as injected dependencies.
@@ -27,7 +29,7 @@ func New(messageService messageservice.MessageService, chainservice chainservice
 	c := Client{}
 	c.Address = store.GetAddress()
 	c.engine = engine.New(messageService, chainservice, store, logDestination)
-
+	c.CompletedObjectives = make(chan<- engine.CompletedObjectiveEvent, 100)
 	// Start the engine in a go routine
 	go c.engine.Run()
 
@@ -37,7 +39,7 @@ func New(messageService messageservice.MessageService, chainservice chainservice
 // Begin API
 
 // CreateDirectChannel creates a directly funded channel with the given counterparty
-func (c *Client) CreateDirectChannel(counterparty types.Address, appDefinition types.Address, appData types.Bytes, outcome outcome.Exit, challengeDuration *types.Uint256) chan engine.Response {
+func (c *Client) CreateDirectChannel(counterparty types.Address, appDefinition types.Address, appData types.Bytes, outcome outcome.Exit, challengeDuration *types.Uint256) (protocols.ObjectiveId, chan engine.CompletedObjectiveEvent) {
 	// Convert the API call into an internal event.
 	objective, _ := directfund.New(true,
 		state.State{
@@ -57,10 +59,34 @@ func (c *Client) CreateDirectChannel(counterparty types.Address, appDefinition t
 	// Pass in a fresh, dedicated go channel to communicate the response:
 	apiEvent := engine.APIEvent{
 		ObjectiveToSpawn: objective,
-		Response:         make(chan engine.Response)}
-
+	}
 	// Send the event to the engine
 	c.engine.FromAPI <- apiEvent
-	// Return the go channel where the response will be sent.
-	return apiEvent.Response
+
+	clientResponse := make(chan engine.CompletedObjectiveEvent)
+
+	// Starts a go function that listens for our objective to be completed and then dispatchs events to different client channels
+	go func() {
+		for update := range c.engine.ToApi() {
+			for _, completed := range update.CompletedObjectives {
+
+				if completed == objective.Id() {
+
+					// We dispatch an event to the channel that handles **all** objective updates.
+					// This provides a central place to monitor for objective updates.
+					c.CompletedObjectives <- engine.CompletedObjectiveEvent{Id: completed}
+					// We dispatch an event to the channel returned by this function. This channel is only used for the one objective.
+					// This allows for promise like behaviour where we can wait for the objective to be completed before continuing.
+					clientResponse <- engine.CompletedObjectiveEvent{Id: completed}
+					// We can close the channel as the objective is completed so there will be no further events.
+					close(clientResponse)
+
+					// Exit the go function now that our objective is completed.
+					return
+				}
+			}
+		}
+	}()
+
+	return objective.Id(), clientResponse
 }

--- a/client/client.go
+++ b/client/client.go
@@ -4,6 +4,7 @@ package client // import "github.com/statechannels/go-nitro/client"
 
 import (
 	"io"
+	"log"
 	"math/big"
 
 	"github.com/statechannels/go-nitro/channel/state"
@@ -27,7 +28,7 @@ type Client struct {
 	engine       engine.Engine // The core business logic of the client
 	Address      *types.Address
 	ChannelReady chan ChannelReadyEvent // All Objective updates from the engine
-	listeners    map[protocols.ObjectiveId][]chan<- ChannelReadyEvent
+	listeners    map[protocols.ObjectiveId]chan<- ChannelReadyEvent
 }
 
 // New is the constructor for a Client. It accepts a messaging service, a chain service, and a store as injected dependencies.
@@ -36,33 +37,51 @@ func New(messageService messageservice.MessageService, chainservice chainservice
 	c.Address = store.GetAddress()
 	c.engine = engine.New(messageService, chainservice, store, logDestination)
 	c.ChannelReady = make(chan ChannelReadyEvent, 100)
-	c.listeners = make(map[protocols.ObjectiveId][]chan<- ChannelReadyEvent)
+	c.listeners = make(map[protocols.ObjectiveId]chan<- ChannelReadyEvent)
 	// Start the engine in a go routine
 	go c.engine.Run()
 
-	go func() {
-		for update := range c.engine.ToApi() {
-
-			for _, completed := range update.CompletedObjectives {
-
-				channelId := completed.Channels()[0]
-
-				event := ChannelReadyEvent{ObjectiveId: completed.Id(), ChannelId: channelId}
-				// We dispatch an event to the channel that handles **all** objective updates.
-				// This provides a central place to monitor for objective updates.
-				c.ChannelReady <- event
-
-				// Dispatch an event to any listeners that have been registered
-				if listeners, ok := c.listeners[completed.Id()]; ok {
-					for _, l := range listeners {
-						l <- event
-					}
-				}
-			}
-		}
-	}()
+	// Start the event handler in a go routine
+	go c.handleEngineEvents()
 
 	return c
+}
+
+func (c *Client) registerListener(objectiveId protocols.ObjectiveId, listener chan<- ChannelReadyEvent) {
+	c.listeners[objectiveId] = listener
+}
+func (c *Client) removeListener(objectiveId protocols.ObjectiveId) {
+	l, ok := c.listeners[objectiveId]
+	if !ok {
+		log.Fatalf("Could not find listener for objective id %s", objectiveId)
+	}
+	close(l)
+	delete(c.listeners, objectiveId)
+}
+
+// handleEngineEvents is responsible for monitoring the ToApi channel on the engine.
+// It parses events from the ToApi channel and then dispatches events to the necessary client channels
+func (c *Client) handleEngineEvents() {
+	for update := range c.engine.ToApi() {
+
+		for _, completed := range update.CompletedObjectives {
+			channelId := completed.Channels()[0]
+			event := ChannelReadyEvent{ObjectiveId: completed.Id(), ChannelId: channelId}
+
+			// We dispatch an event to the channel that handles **all** objective updates.
+			// This provides a central place to monitor for objective updates.
+			c.ChannelReady <- event
+
+			// Dispatch an event to any listeners that have been registered by calls to CreateDirectChannel
+			if l, ok := c.listeners[completed.Id()]; ok {
+				l <- event
+				// Since the objective is completed we no longer need the listener
+				c.removeListener(completed.Id())
+			}
+
+		}
+
+	}
 }
 
 // Begin API
@@ -93,8 +112,8 @@ func (c *Client) CreateDirectChannel(counterparty types.Address, appDefinition t
 	c.engine.FromAPI <- apiEvent
 
 	clientResponse := make(chan ChannelReadyEvent)
-	// We register a listener for the objective id
-	c.listeners[objective.Id()] = append(c.listeners[objective.Id()], clientResponse)
+	// We register a listener  channelfor the objective id
+	c.registerListener(objective.Id(), clientResponse)
 
 	return objective.Id(), clientResponse
 }

--- a/client/client.go
+++ b/client/client.go
@@ -4,7 +4,6 @@ package client // import "github.com/statechannels/go-nitro/client"
 
 import (
 	"io"
-	"log"
 	"math/big"
 
 	"github.com/statechannels/go-nitro/channel/state"
@@ -49,20 +48,8 @@ func New(messageService messageservice.MessageService, chainservice chainservice
 	return c
 }
 
-func (c *Client) registerListener(objectiveId protocols.ObjectiveId, listener chan<- ChannelFundedEvent) {
-	c.listeners[objectiveId] = listener
-}
-func (c *Client) removeListener(objectiveId protocols.ObjectiveId) {
-	l, ok := c.listeners[objectiveId]
-	if !ok {
-		log.Fatalf("Could not find listener for objective id %s", objectiveId)
-	}
-	close(l)
-	delete(c.listeners, objectiveId)
-}
-
 // handleEngineEvents is responsible for monitoring the ToApi channel on the engine.
-// It parses events from the ToApi channel and then dispatches events to the necessary client channels
+// It parses events from the ToApi chan and then dispatches events to the necessary client chan.
 func (c *Client) handleEngineEvents() {
 	for update := range c.engine.ToApi() {
 
@@ -71,16 +58,7 @@ func (c *Client) handleEngineEvents() {
 			channelId := completed.Channels()[0]
 			event := ChannelFundedEvent{ObjectiveId: completed.Id(), ChannelId: channelId}
 
-			// We dispatch an event to the channel that handles **all** objective updates.
-			// This provides a central place to monitor for objective updates.
 			c.allChannelFundedEvents <- event
-
-			// Dispatch an event to any listeners that have been registered by calls to CreateDirectChannel
-			if l, ok := c.listeners[completed.Id()]; ok {
-				l <- event
-				// Since the objective is completed we no longer need the listener
-				c.removeListener(completed.Id())
-			}
 
 		}
 
@@ -95,7 +73,7 @@ func (c *Client) ChannelFunded() <-chan ChannelFundedEvent {
 }
 
 // CreateDirectChannel creates a directly funded channel with the given counterparty
-func (c *Client) CreateDirectChannel(counterparty types.Address, appDefinition types.Address, appData types.Bytes, outcome outcome.Exit, challengeDuration *types.Uint256) (protocols.ObjectiveId, chan ChannelFundedEvent) {
+func (c *Client) CreateDirectChannel(counterparty types.Address, appDefinition types.Address, appData types.Bytes, outcome outcome.Exit, challengeDuration *types.Uint256) protocols.ObjectiveId {
 	// Convert the API call into an internal event.
 	objective, _ := directfund.New(true,
 		state.State{
@@ -119,9 +97,5 @@ func (c *Client) CreateDirectChannel(counterparty types.Address, appDefinition t
 	// Send the event to the engine
 	c.engine.FromAPI <- apiEvent
 
-	clientResponse := make(chan ChannelFundedEvent)
-	// We register a listener so a ChannelFundedEvent will get sent to clientResponse when the objective completes
-	c.registerListener(objective.Id(), clientResponse)
-
-	return objective.Id(), clientResponse
+	return objective.Id()
 }

--- a/client/client.go
+++ b/client/client.go
@@ -26,10 +26,10 @@ type ChannelFundedEvent struct {
 
 // Client provides the interface for the consuming application
 type Client struct {
-	engine        engine.Engine // The core business logic of the client
-	Address       *types.Address
-	ChannelFunded chan ChannelFundedEvent
-	listeners     map[protocols.ObjectiveId]chan<- ChannelFundedEvent
+	engine                 engine.Engine // The core business logic of the client
+	Address                *types.Address
+	allChannelFundedEvents chan ChannelFundedEvent
+	listeners              map[protocols.ObjectiveId]chan<- ChannelFundedEvent
 }
 
 // New is the constructor for a Client. It accepts a messaging service, a chain service, and a store as injected dependencies.
@@ -37,7 +37,7 @@ func New(messageService messageservice.MessageService, chainservice chainservice
 	c := Client{}
 	c.Address = store.GetAddress()
 	c.engine = engine.New(messageService, chainservice, store, logDestination)
-	c.ChannelFunded = make(chan ChannelFundedEvent, 100)
+	c.allChannelFundedEvents = make(chan ChannelFundedEvent, 100)
 	c.listeners = make(map[protocols.ObjectiveId]chan<- ChannelFundedEvent)
 	// Start the engine in a go routine
 	go c.engine.Run()
@@ -73,7 +73,7 @@ func (c *Client) handleEngineEvents() {
 
 			// We dispatch an event to the channel that handles **all** objective updates.
 			// This provides a central place to monitor for objective updates.
-			c.ChannelFunded <- event
+			c.allChannelFundedEvents <- event
 
 			// Dispatch an event to any listeners that have been registered by calls to CreateDirectChannel
 			if l, ok := c.listeners[completed.Id()]; ok {
@@ -88,6 +88,11 @@ func (c *Client) handleEngineEvents() {
 }
 
 // Begin API
+
+// ChannelFunded returns a channel that receives a ChannelFundedEvent whenever a state channel has been fully funded.
+func (c *Client) ChannelFunded() <-chan ChannelFundedEvent {
+	return c.allChannelFundedEvents
+}
 
 // CreateDirectChannel creates a directly funded channel with the given counterparty
 func (c *Client) CreateDirectChannel(counterparty types.Address, appDefinition types.Address, appData types.Bytes, outcome outcome.Exit, challengeDuration *types.Uint256) (protocols.ObjectiveId, chan ChannelFundedEvent) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -59,16 +59,16 @@ func TestNew(t *testing.T) {
 	}}
 
 	id := clientA.CreateDirectChannel(b, types.Address{}, types.Bytes{}, outcome, big.NewInt(0))
-	got := <-clientA.ChannelFunded()
+	got := <-clientA.CompletedObjectives()
 
-	if got.ObjectiveId != id {
-		t.Errorf("expected completed objective with id %v, but got %v", id, got.ObjectiveId)
+	if got != id {
+		t.Errorf("expected completed objective with id %v, but got %v", id, got)
 	}
 
-	gotFromB := <-clientB.ChannelFunded()
+	gotFromB := <-clientB.CompletedObjectives()
 
-	if gotFromB.ObjectiveId != id {
-		t.Errorf("expected completed objective with id %v, but got %v", id, got.ObjectiveId)
+	if gotFromB != id {
+		t.Errorf("expected completed objective with id %v, but got %v", id, gotFromB)
 	}
 
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -5,7 +5,6 @@ import (
 	"math/big"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
@@ -45,8 +44,11 @@ func TestNew(t *testing.T) {
 
 	messageserviceA.Connect(messageserviceB)
 	messageserviceB.Connect(messageserviceA)
-	clientA.CreateDirectChannel(b, types.Address{}, types.Bytes{}, outcome.Exit{}, big.NewInt(0))
+	id, res := clientA.CreateDirectChannel(b, types.Address{}, types.Bytes{}, outcome.Exit{}, big.NewInt(0))
 
-	<-time.After(time.Second)
+	got := <-res
 
+	if got.Id != id {
+		t.Errorf("expected completed objective with id %v, but got %v", id, got.Id)
+	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -65,7 +65,7 @@ func TestNew(t *testing.T) {
 		t.Errorf("expected completed objective with id %v, but got %v", id, got.ObjectiveId)
 	}
 
-	gotFromB := <-clientB.ChannelReady
+	gotFromB := <-clientB.ChannelFunded
 
 	if gotFromB.ObjectiveId != id {
 		t.Errorf("expected completed objective with id %v, but got %v", id, got.ObjectiveId)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -40,7 +40,7 @@ func TestNew(t *testing.T) {
 	chainservB := chainservice.NewSimpleChainService(chain, b)
 	messageserviceB := messageservice.NewTestMessageService(b)
 	storeB := store.NewMockStore(bKey)
-	New(messageserviceB, chainservB, storeB, logDestination)
+	clientB := New(messageserviceB, chainservB, storeB, logDestination)
 
 	messageserviceA.Connect(messageserviceB)
 	messageserviceB.Connect(messageserviceA)
@@ -64,4 +64,11 @@ func TestNew(t *testing.T) {
 	if got.ObjectiveId != id {
 		t.Errorf("expected completed objective with id %v, but got %v", id, got.ObjectiveId)
 	}
+
+	gotFromB := <-clientB.ChannelReady
+
+	if gotFromB.ObjectiveId != id {
+		t.Errorf("expected completed objective with id %v, but got %v", id, got.ObjectiveId)
+	}
+
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -65,7 +65,7 @@ func TestNew(t *testing.T) {
 		t.Errorf("expected completed objective with id %v, but got %v", id, got.ObjectiveId)
 	}
 
-	gotFromB := <-clientB.ChannelFunded
+	gotFromB := <-clientB.ChannelFunded()
 
 	if gotFromB.ObjectiveId != id {
 		t.Errorf("expected completed objective with id %v, but got %v", id, got.ObjectiveId)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -58,8 +58,8 @@ func TestNew(t *testing.T) {
 		},
 	}}
 
-	id, res := clientA.CreateDirectChannel(b, types.Address{}, types.Bytes{}, outcome, big.NewInt(0))
-	got := <-res
+	id := clientA.CreateDirectChannel(b, types.Address{}, types.Bytes{}, outcome, big.NewInt(0))
+	got := <-clientA.ChannelFunded()
 
 	if got.ObjectiveId != id {
 		t.Errorf("expected completed objective with id %v, but got %v", id, got.ObjectiveId)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -48,7 +48,7 @@ func TestNew(t *testing.T) {
 
 	got := <-res
 
-	if got.Id != id {
-		t.Errorf("expected completed objective with id %v, but got %v", id, got.Id)
+	if got.ObjectiveId != id {
+		t.Errorf("expected completed objective with id %v, but got %v", id, got.ObjectiveId)
 	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -44,8 +44,21 @@ func TestNew(t *testing.T) {
 
 	messageserviceA.Connect(messageserviceB)
 	messageserviceB.Connect(messageserviceA)
-	id, res := clientA.CreateDirectChannel(b, types.Address{}, types.Bytes{}, outcome.Exit{}, big.NewInt(0))
+	// Set up an outcome that requires both participants to deposit
+	outcome := outcome.Exit{outcome.SingleAssetExit{
+		Allocations: outcome.Allocations{
+			outcome.Allocation{
+				Destination: types.AddressToDestination(a),
+				Amount:      big.NewInt(5),
+			},
+			outcome.Allocation{
+				Destination: types.AddressToDestination(b),
+				Amount:      big.NewInt(5),
+			},
+		},
+	}}
 
+	id, res := clientA.CreateDirectChannel(b, types.Address{}, types.Bytes{}, outcome, big.NewInt(0))
 	got := <-res
 
 	if got.ObjectiveId != id {

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -134,9 +134,14 @@ func (e *Engine) handleMessage(message protocols.Message) ObjectiveChangeEvent {
 // generates an updated objective and
 // attempts progress.
 func (e *Engine) handleChainEvent(chainEvent chainservice.Event) ObjectiveChangeEvent {
-	event := protocols.ObjectiveEvent{Holdings: chainEvent.Holdings, AdjudicationStatus: chainEvent.AdjudicationStatus}
+
 	objective, _ := e.store.GetObjectiveByChannelId(chainEvent.ChannelId)
-	updatedObjective, _ := objective.Update(event) // TODO handle error
+	event := protocols.ObjectiveEvent{Holdings: chainEvent.Holdings, AdjudicationStatus: chainEvent.AdjudicationStatus, ObjectiveId: objective.Id()}
+	updatedObjective, err := objective.Update(event)
+	if err != nil {
+		// TODO handle error
+		panic(err)
+	}
 	return e.attemptProgress(updatedObjective)
 
 }

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -42,7 +42,7 @@ type APIEvent struct {
 // ObjectiveChangeEvent is a struct that contains a list of changes caused by handling a message/chain event/api event
 type ObjectiveChangeEvent struct {
 	// These are objectives that are now completed
-	CompletedObjectives []protocols.ObjectiveId
+	CompletedObjectives []protocols.Objective
 }
 
 type CompletedObjectiveEvent struct {
@@ -202,7 +202,7 @@ func (e *Engine) attemptProgress(objective protocols.Objective) (outgoing Object
 	// TODO: If attemptProgress is called on a completed objective CompletedObjectives would include that objective id
 	// Probably should have a better check that only adds it to CompletedObjectives if it was completed in this crank
 	if waitingFor == "WaitingForNothing" {
-		outgoing.CompletedObjectives = append(outgoing.CompletedObjectives, crankedObjective.Id())
+		outgoing.CompletedObjectives = append(outgoing.CompletedObjectives, crankedObjective)
 	}
 	return
 }


### PR DESCRIPTION
# Description
**⚠️ base not main branch.Based on #215**

The client API now communicates when a direct funding objective gets completed. The client test has been expanded so we wait for both `clientA` and `clientB` to complete the objective.

Fixes #205 Fixes #197

There are two ways that the client communicates that a direct funding objective is completed:
**1. ChannelFunded channel on Client**
The client struct now exposes a new channel called `ChannelFunded`. It receives a `ChannelFundedEvent` when any direct fund objective gets completed. This provides a way to check that Bob also successfully completes an objective.
**2. Channel returned from `CreateDirectChannel`.** 
`CreateDirectChannel` now returns a a channel. This channel receives a `ChannelFundedEvent` when the specific objective for `CreateDirectChannel` gets completed. This allows for a promise like call of `CreateDirectChannel`.

## Changes
- [30450ef](https://github.com/statechannels/go-nitro/pull/208/commits/30450ef75531f2c8d359b44aa74b3d8ad1c75255) fixes an error we were swallowing where we weren't setting the objective id on the ObjectiveEvent. This was preventing the client test from completing. I deemed this small enough to just be included in this PR.

## Client Logs

```
0x39704Fb3745d290ea760Aa99A4Dd36aDd88Ce3cD: 2022/02/03 10:14:53 engine.go:74: Constructed Engine
0xd9836205bB713AA3137450f51bab809B6501E78f: 2022/02/03 10:14:53 engine.go:74: Constructed Engine
0x39704Fb3745d290ea760Aa99A4Dd36aDd88Ce3cD: 2022/02/03 10:14:53 engine.go:177: Sending message to 0xd9836205bB713AA3137450f51bab809B6501E78f
0x39704Fb3745d290ea760Aa99A4Dd36aDd88Ce3cD: 2022/02/03 10:14:53 engine.go:198: Objective DirectFunding-0x435a29af59c3575528c05707f55bb1404fbe6b75d58141390b4557acdefe083b is WaitingForCompletePrefund
0xd9836205bB713AA3137450f51bab809B6501E78f: 2022/02/03 10:14:53 engine.go:114: Handling inbound message {0xd9836205bB713AA3137450f51bab809B6501E78f DirectFunding-0x435a29af59c3575528c05707f55bb1404fbe6b75d58141390b4557acdefe083b [{{0x1400005f040 [[57 112 79 179 116 93 41 14 167 96 170 153 164 221 54 173 216 140 227 205] [217 131 98 5 187 113 58 163 19 116 80 245 27 171 128 155 101 1 231 143]] 0x1400005f060 [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] 0x1400005f080 [] [{[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] [] [{[0 0 0 0 0 0 0 0 0 0 0 0 57 112 79 179 116 93 41 14 167 96 170 153 164 221 54 173 216 140 227 205] 0x1400005f0a0 0 []} {[0 0 0 0 0 0 0 0 0 0 0 0 217 131 98 5 187 113 58 163 19 116 80 245 27 171 128 155 101 1 231 143] 0x1400005f0c0 0 []}]}] 0 false} map[0:{[106 23 202 187 75 165 16 68 70 200 31 84 132 82 18 189 156 96 13 228 38 188 119 80 77 95 150 150 92 124 230 22] [35 170 53 47 91 111 101 91 236 200 251 135 140 228 59 238 154 93 219 127 182 168 93 221 52 4 21 35 205 209 221 187] 1}]}]}
0xd9836205bB713AA3137450f51bab809B6501E78f: 2022/02/03 10:14:53 engine.go:177: Sending message to 0x39704Fb3745d290ea760Aa99A4Dd36aDd88Ce3cD
0xd9836205bB713AA3137450f51bab809B6501E78f: 2022/02/03 10:14:53 engine.go:198: Objective DirectFunding-0x435a29af59c3575528c05707f55bb1404fbe6b75d58141390b4557acdefe083b is WaitingForCompletePrefund
0x39704Fb3745d290ea760Aa99A4Dd36aDd88Ce3cD: 2022/02/03 10:14:53 engine.go:114: Handling inbound message {0x39704Fb3745d290ea760Aa99A4Dd36aDd88Ce3cD DirectFunding-0x435a29af59c3575528c05707f55bb1404fbe6b75d58141390b4557acdefe083b [{{0x1400005f8e0 [[57 112 79 179 116 93 41 14 167 96 170 153 164 221 54 173 216 140 227 205] [217 131 98 5 187 113 58 163 19 116 80 245 27 171 128 155 101 1 231 143]] 0x1400005f900 [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] 0x1400005f920 [] [{[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] [] [{[0 0 0 0 0 0 0 0 0 0 0 0 57 112 79 179 116 93 41 14 167 96 170 153 164 221 54 173 216 140 227 205] 0x1400005f940 0 []} {[0 0 0 0 0 0 0 0 0 0 0 0 217 131 98 5 187 113 58 163 19 116 80 245 27 171 128 155 101 1 231 143] 0x1400005f960 0 []}]}] 0 false} map[1:{[240 155 126 102 147 159 225 19 113 21 140 48 82 231 208 249 150 192 251 60 240 187 82 20 108 223 244 81 123 183 18 232] [113 137 24 167 213 8 49 171 230 134 201 41 50 204 89 82 251 132 166 229 79 200 179 233 8 156 2 242 214 153 24 44] 1}]}]}
0x39704Fb3745d290ea760Aa99A4Dd36aDd88Ce3cD: 2022/02/03 10:14:53 engine.go:181: Sending chain transaction for channel 0x435a29af59c3575528c05707f55bb1404fbe6b75d58141390b4557acdefe083b
0x39704Fb3745d290ea760Aa99A4Dd36aDd88Ce3cD: 2022/02/03 10:14:53 engine.go:198: Objective DirectFunding-0x435a29af59c3575528c05707f55bb1404fbe6b75d58141390b4557acdefe083b is WaitingForCompleteFunding
0xd9836205bB713AA3137450f51bab809B6501E78f: 2022/02/03 10:14:53 engine.go:181: Sending chain transaction for channel 0x435a29af59c3575528c05707f55bb1404fbe6b75d58141390b4557acdefe083b
0xd9836205bB713AA3137450f51bab809B6501E78f: 2022/02/03 10:14:53 engine.go:198: Objective DirectFunding-0x435a29af59c3575528c05707f55bb1404fbe6b75d58141390b4557acdefe083b is WaitingForCompleteFunding
0x39704Fb3745d290ea760Aa99A4Dd36aDd88Ce3cD: 2022/02/03 10:14:53 engine.go:198: Objective DirectFunding-0x435a29af59c3575528c05707f55bb1404fbe6b75d58141390b4557acdefe083b is WaitingForCompleteFunding
0xd9836205bB713AA3137450f51bab809B6501E78f: 2022/02/03 10:14:53 engine.go:177: Sending message to 0x39704Fb3745d290ea760Aa99A4Dd36aDd88Ce3cD
0xd9836205bB713AA3137450f51bab809B6501E78f: 2022/02/03 10:14:53 engine.go:198: Objective DirectFunding-0x435a29af59c3575528c05707f55bb1404fbe6b75d58141390b4557acdefe083b is WaitingForCompletePostFund
0x39704Fb3745d290ea760Aa99A4Dd36aDd88Ce3cD: 2022/02/03 10:14:53 engine.go:177: Sending message to 0xd9836205bB713AA3137450f51bab809B6501E78f
0x39704Fb3745d290ea760Aa99A4Dd36aDd88Ce3cD: 2022/02/03 10:14:53 engine.go:198: Objective DirectFunding-0x435a29af59c3575528c05707f55bb1404fbe6b75d58141390b4557acdefe083b is WaitingForCompletePostFund
0x39704Fb3745d290ea760Aa99A4Dd36aDd88Ce3cD: 2022/02/03 10:14:53 engine.go:114: Handling inbound message {0x39704Fb3745d290ea760Aa99A4Dd36aDd88Ce3cD DirectFunding-0x435a29af59c3575528c05707f55bb1404fbe6b75d58141390b4557acdefe083b [{{0x14000216040 [[57 112 79 179 116 93 41 14 167 96 170 153 164 221 54 173 216 140 227 205] [217 131 98 5 187 113 58 163 19 116 80 245 27 171 128 155 101 1 231 143]] 0x14000216060 [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] 0x14000216080 [] [{[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] [] [{[0 0 0 0 0 0 0 0 0 0 0 0 57 112 79 179 116 93 41 14 167 96 170 153 164 221 54 173 216 140 227 205] 0x140002160a0 0 []} {[0 0 0 0 0 0 0 0 0 0 0 0 217 131 98 5 187 113 58 163 19 116 80 245 27 171 128 155 101 1 231 143] 0x140002160c0 0 []}]}] 1 false} map[1:{[121 98 28 224 127 151 233 31 111 62 150 45 230 236 107 222 149 118 82 37 174 94 181 178 1 196 13 70 9 213 218 226] [22 196 218 137 176 29 169 154 11 189 217 254 223 120 199 167 248 65 33 144 1 76 224 178 226 17 168 187 100 112 96 25] 1}]}]}
0xd9836205bB713AA3137450f51bab809B6501E78f: 2022/02/03 10:14:53 engine.go:114: Handling inbound message {0xd9836205bB713AA3137450f51bab809B6501E78f DirectFunding-0x435a29af59c3575528c05707f55bb1404fbe6b75d58141390b4557acdefe083b [{{0x140000a45c0 [[57 112 79 179 116 93 41 14 167 96 170 153 164 221 54 173 216 140 227 205] [217 131 98 5 187 113 58 163 19 116 80 245 27 171 128 155 101 1 231 143]] 0x140000a45e0 [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] 0x140000a4600 [] [{[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] [] [{[0 0 0 0 0 0 0 0 0 0 0 0 57 112 79 179 116 93 41 14 167 96 170 153 164 221 54 173 216 140 227 205] 0x140000a4620 0 []} {[0 0 0 0 0 0 0 0 0 0 0 0 217 131 98 5 187 113 58 163 19 116 80 245 27 171 128 155 101 1 231 143] 0x140000a4640 0 []}]}] 1 false} map[0:{[206 174 85 101 179 162 147 209 173 121 236 201 11 77 243 17 255 60 237 220 34 91 155 129 118 41 77 101 123 232 227 169] [55 200 98 154 105 10 114 73 111 214 183 147 248 231 154 122 14 228 252 153 88 103 59 197 135 227 34 52 17 101 154 42] 1}]}]}
0x39704Fb3745d290ea760Aa99A4Dd36aDd88Ce3cD: 2022/02/03 10:14:53 engine.go:198: Objective DirectFunding-0x435a29af59c3575528c05707f55bb1404fbe6b75d58141390b4557acdefe083b is WaitingForNothing
0xd9836205bB713AA3137450f51bab809B6501E78f: 2022/02/03 10:14:53 engine.go:198: Objective DirectFunding-0x435a29af59c3575528c05707f55bb1404fbe6b75d58141390b4557acdefe083b is WaitingForNothing
```
## Checklist:

### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [ ] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary

### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue