### PR TITLE
Replace` direct-fund.signAndStore` with `channel.SignAndAddSetupState`

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -2,6 +2,7 @@ package channel
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -223,4 +224,39 @@ func (c Channel) AddSignedStates(sss []state.SignedState) bool {
 		}
 	}
 	return allOk
+}
+
+// SignAndAddPrefund signs and adds the prefund state for the channel, returning a state.SignedState suitable for sending to peers.
+func (c Channel) SignAndAddPrefund(sk *[]byte) (state.SignedState, error) {
+	return c.signAndAddSetupState(true, sk)
+}
+
+// SignAndAddPrefund signs and adds the postfund state for the channel, returning a state.SignedState suitable for sending to peers.
+func (c Channel) SignAndAddPostfund(sk *[]byte) (state.SignedState, error) {
+	return c.signAndAddSetupState(false, sk)
+}
+
+// signAndAddPrefund signs and adds a setup state for the channel, returning a state.SignedState suitable for sending to peers.
+// If the preFund is true, the setup state is the Prefund state, otherwise it is the Postfund state.
+func (c Channel) signAndAddSetupState(preFund bool, sk *[]byte) (state.SignedState, error) {
+	var setupState state.State
+	if preFund {
+		setupState = c.PreFundState()
+	} else {
+		setupState = c.PostFundState()
+	}
+	sig, err := setupState.Sign(*sk)
+	if err != nil {
+		return state.SignedState{}, fmt.Errorf("could not sign prefund %w", err)
+	}
+	ss := state.NewSignedState(setupState)
+	err = ss.AddSignature(sig)
+	if err != nil {
+		panic("could not add own signature")
+	}
+	ok := c.AddSignedState(ss)
+	if !ok {
+		panic("could not add signed prefund to channel")
+	}
+	return ss, nil
 }

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -228,28 +228,22 @@ func (c Channel) AddSignedStates(sss []state.SignedState) bool {
 
 // SignAndAddPrefund signs and adds the prefund state for the channel, returning a state.SignedState suitable for sending to peers.
 func (c Channel) SignAndAddPrefund(sk *[]byte) (state.SignedState, error) {
-	return c.signAndAddSetupState(true, sk)
+	return c.signAndAddState(c.PreFundState(), sk)
 }
 
 // SignAndAddPrefund signs and adds the postfund state for the channel, returning a state.SignedState suitable for sending to peers.
 func (c Channel) SignAndAddPostfund(sk *[]byte) (state.SignedState, error) {
-	return c.signAndAddSetupState(false, sk)
+	return c.signAndAddState(c.PostFundState(), sk)
 }
 
-// signAndAddPrefund signs and adds a setup state for the channel, returning a state.SignedState suitable for sending to peers.
-// If the preFund is true, the setup state is the Prefund state, otherwise it is the Postfund state.
-func (c Channel) signAndAddSetupState(preFund bool, sk *[]byte) (state.SignedState, error) {
-	var setupState state.State
-	if preFund {
-		setupState = c.PreFundState()
-	} else {
-		setupState = c.PostFundState()
-	}
-	sig, err := setupState.Sign(*sk)
+// signAndAddState signs and adds the state to the channel, returning a state.SignedState suitable for sending to peers.
+func (c Channel) signAndAddState(s state.State, sk *[]byte) (state.SignedState, error) {
+
+	sig, err := s.Sign(*sk)
 	if err != nil {
 		return state.SignedState{}, fmt.Errorf("could not sign prefund %w", err)
 	}
-	ss := state.NewSignedState(setupState)
+	ss := state.NewSignedState(s)
 	err = ss.AddSignature(sig)
 	if err != nil {
 		panic("could not add own signature")

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -256,7 +256,7 @@ func (c Channel) signAndAddSetupState(preFund bool, sk *[]byte) (state.SignedSta
 	}
 	ok := c.AddSignedState(ss)
 	if !ok {
-		panic("could not add signed prefund to channel")
+		panic("could not add signed state to channel")
 	}
 	return ss, nil
 }

--- a/channel/state/signedstate.go
+++ b/channel/state/signedstate.go
@@ -20,7 +20,7 @@ func NewSignedState(s State) SignedState {
 	return SignedState{s, make(map[uint]Signature, len(s.Participants))}
 }
 
-// AddSignature adds a participant's signature for the
+// AddSignature adds a participant's signature to the SignedState.
 // An error is thrown if the signature is invalid.
 func (ss SignedState) AddSignature(sig Signature) error {
 	signer, err := ss.state.RecoverSigner(sig)


### PR DESCRIPTION
We currently rely on a relatively new method `signAndStore` on the `DirectFundObjective` type. This method has no documentation, has on unduly wide scope, and is not reusable by other protocols (such as `virtual-fund`). 

This PR solves all of these issues by pushing the functionality down into a new, documented method on the `Channel` type, which is already shared by all protocols. It narrows the scope of the function somewhat, to only handling setup states.


A slightly more controversial change is that it also replaces some errors with panics, along code paths that we should never hit (unless there is a bug). Most of those bugs would be considered severe, apart from one: In particular, we will panic if we have already signed the state. I think it is worth keeping this behaviour in place, as we should be careful enough when writing our protocols to not repeat the work of signing a state. 

This solution will be easier to maintain and audit, and will expose bugs more rapidly.

I have not added any unit tests for this method. They surely wouldn't hurt, and I can add them at the request of the reviewer. On the other hand, the replaced function was also not unit tested, and we probably have good coverage "from above" (from integration testing" and "from below" (the method simply wires up other, well unit-tested functions). 

---

## Checklist:

### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary

### Project management

- [x] I have assigned myself to this PR
- [ ] I have linked the appropriate github issue