### PR TITLE
WIP: add JSONMarshaler interface to `Objective`

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -56,7 +56,7 @@ func (c *Client) CreateDirectChannel(counterparty types.Address, appDefinition t
 
 	// Pass in a fresh, dedicated go channel to communicate the response:
 	apiEvent := engine.APIEvent{
-		ObjectiveToSpawn: objective,
+		ObjectiveToSpawn: &objective,
 		Response:         make(chan engine.Response)}
 
 	// Send the event to the engine

--- a/client/engine/messageservice/test-messageservice_test.go
+++ b/client/engine/messageservice/test-messageservice_test.go
@@ -19,7 +19,7 @@ var aToB protocols.Message = protocols.Message{
 	To:          bobMS.address,
 	ObjectiveId: testId,
 	Sigs:        make(map[*state.State]state.Signature),
-	Proposal:    objective,
+	Proposal:    &objective,
 }
 
 func TestConnect(t *testing.T) {

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -10,7 +10,8 @@ import (
 )
 
 type MockStore struct {
-	objectives map[protocols.ObjectiveId]protocols.Objective
+	objectives map[protocols.ObjectiveId]string
+	channels   map[types.Destination]string
 
 	key     []byte        // the signing key of the store's engine
 	address types.Address // the (Ethereum) address associated to the signing key
@@ -31,7 +32,8 @@ func NewMockStore(key []byte) Store {
 	}
 	ms.address = crypto.PubkeyToAddress(*publicKeyECDSA)
 
-	ms.objectives = make(map[protocols.ObjectiveId]protocols.Objective)
+	ms.objectives = make(map[protocols.ObjectiveId]string)
+	ms.channels = make(map[types.Destination]string)
 
 	return &ms
 }

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -2,9 +2,11 @@ package store
 
 import (
 	"crypto/ecdsa"
+	"encoding/json"
 	"log"
 
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -58,15 +60,21 @@ func (ms MockStore) SetObjective(obj protocols.Objective) error {
 	return nil
 }
 
-func (ms MockStore) GetObjectiveByChannelId(channelId types.Destination) (protocols.Objective, bool) {
-	// todo: locking
-	for _, obj := range ms.objectives {
-		for _, ch := range obj.Channels() {
-			if ch == channelId {
-				return obj, true
-			}
-		}
+func (ms MockStore) setChannel(c channel.Channel) error {
+	bytes, err := json.Marshal(c)
+	if err != nil {
+		return err
 	}
+	ms.channels[c.Id] = string(bytes)
+	return nil
+}
+
+func (ms MockStore) getChannelById(id types.Destination) (channel.Channel, error) {
+	channelJSON := ms.channels[id]
+	var channel channel.Channel
+	err := json.Unmarshal([]byte(channelJSON), &channel)
+	return channel, err
+}
 
 	return nil, false
 }

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -53,6 +53,9 @@ func TestSetGetObjective(t *testing.T) {
 		}
 	}
 
+	// todo: test channel internals - IE, did the Objective's channels return
+	//       properly saturated with data?
+	// todo: test writing / reading of a VirtualGundObjective
 }
 
 func TestGetObjectiveByChannelId(t *testing.T) {

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -21,8 +21,8 @@ func TestSetGetObjective(t *testing.T) {
 	ms := NewMockStore(sk)
 
 	id := protocols.ObjectiveId("404")
-	got, ok := ms.GetObjectiveById(id)
-	if ok {
+	got, err := ms.GetObjectiveById(id)
+	if err == nil { // we expect an error here becuase the 404 is not set
 		t.Errorf("expected not to find the %s objective, but found %v", id, got)
 	}
 
@@ -34,18 +34,25 @@ func TestSetGetObjective(t *testing.T) {
 		ts.Participants[0],
 	)
 
-	if err := ms.SetObjective(testObj); err != nil {
-		t.Errorf("error setting objective %v: %s", testObj, err.Error())
+	if err := ms.SetObjective(&testObj); err != nil {
+		t.Errorf("error setting objective %v: %s", testObj, err)
 	}
 
-	got, ok = ms.GetObjectiveById(testObj.Id())
+	got, err = ms.GetObjectiveById(testObj.Id())
 
-	if !ok {
+	if err != nil {
 		t.Errorf("expected to find the inserted objective, but didn't")
 	}
 	if got.Id() != testObj.Id() {
 		t.Errorf("expected to retrieve same objective Id as was passed in, but didn't")
 	}
+	for i, ch := range got.Channels() {
+		if ch != testObj.Channels()[i] {
+			t.Errorf("expected to recover channel list %v, but recovered %v",
+				testObj.Channels(), got.Channels())
+		}
+	}
+
 }
 
 func TestGetObjectiveByChannelId(t *testing.T) {
@@ -61,7 +68,7 @@ func TestGetObjectiveByChannelId(t *testing.T) {
 		ts.Participants[0],
 	)
 
-	if err := ms.SetObjective(testObj); err != nil {
+	if err := ms.SetObjective(&testObj); err != nil {
 		t.Errorf("error setting objective %v: %s", testObj, err.Error())
 	}
 

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -11,7 +11,7 @@ type Store interface {
 	GetChannelSecretKey() *[]byte // Get a pointer to a secret key for signing channel updates
 	GetAddress() *types.Address   // Get the (Ethereum) address associated with the ChannelSecretKey
 
-	GetObjectiveById(protocols.ObjectiveId) (obj protocols.Objective, ok bool)    // Read an existing objective
+	GetObjectiveById(protocols.ObjectiveId) (protocols.Objective, error)          // Read an existing objective
 	GetObjectiveByChannelId(types.Destination) (obj protocols.Objective, ok bool) // Get the objective that currently owns the channel with the supplied ChannelId
 	SetObjective(protocols.Objective) error                                       // Write an objective
 

--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -1,6 +1,7 @@
 package directfund
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -99,6 +100,13 @@ func New(
 }
 
 // Public methods on the DirectFundingObjectiveState
+
+// MarshalJSON returns a JSON representation of the DirectFundObjective
+// with channel state replaced by a channel Id
+func (s DirectFundObjective) MarshalJSON() ([]byte, error) {
+	jsonDFO := JSONDirectFundObjective{s, s.C.Id}
+	return json.Marshal(jsonDFO)
+}
 
 func (s DirectFundObjective) Id() protocols.ObjectiveId {
 	return protocols.ObjectiveId("DirectFunding-" + s.C.Id.String())

--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -38,6 +38,13 @@ type DirectFundObjective struct {
 	fullyFundedThreshold     types.Funds // if the on chain holdings are equal
 }
 
+// JSONDirectFundObjective replaces the DirectFundObjective's channel pointer with the
+// channel's Id, making JSONVirtualFundObjective suitable for serialization
+type JSONDirectFundObjective struct {
+	DirectFundObjective
+	C types.Destination
+}
+
 // New initiates a DirectFundObjective with data calculated from
 // the supplied initialState and client address
 func New(

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -77,6 +77,7 @@ type Objective interface {
 
 	Crank(secretKey *[]byte) (Objective, SideEffects, WaitingFor, error) // does *not* accept an event, but *does* accept a pointer to a signing key; declare side effects; return an updated Objective
 	MarshalJSON() ([]byte, error)
+	UnmarshalJSON([]byte) error
 }
 
 // ObjectiveId is a unique identifier for an Objective.

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -76,6 +76,7 @@ type Objective interface {
 	Channels() []types.Destination
 
 	Crank(secretKey *[]byte) (Objective, SideEffects, WaitingFor, error) // does *not* accept an event, but *does* accept a pointer to a signing key; declare side effects; return an updated Objective
+	MarshalJSON() ([]byte, error)
 }
 
 // ObjectiveId is a unique identifier for an Objective.

--- a/protocols/virtual-fund/virtual-fund-single-hop_test.go
+++ b/protocols/virtual-fund/virtual-fund-single-hop_test.go
@@ -221,7 +221,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			}
 
 			// Approve the objective, so that the rest of the test cases can run.
-			o := s.Approve().(VirtualFundObjective)
+			o := s.Approve().(*VirtualFundObjective)
 			// To test the finite state progression, we are going to progressively mutate o
 			// And then crank it to see which "pause point" (WaitingFor) we end up at.
 
@@ -241,7 +241,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 			// Cranking should move us to the next waiting point, generate ledger requests as a side effect, and alter the extended state to reflect that
 			oObj, sideEffects, waitingFor, err := o.Crank(&my.privateKey)
-			o = oObj.(VirtualFundObjective)
+			o = oObj.(*VirtualFundObjective)
 			if err != nil {
 				t.Error(err)
 			}
@@ -264,7 +264,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			o.ToMyRight.Channel.OnChainFunding[types.Address{}] = l0state.Outcome[0].Allocations.Total() // Make this channel fully funded
 			// Cranking now should not generate side effects, because we already did that
 			oObj, _, waitingFor, err = o.Crank(&my.privateKey)
-			o = oObj.(VirtualFundObjective)
+			o = oObj.(*VirtualFundObjective)
 			if err != nil {
 				t.Error(err)
 			}
@@ -312,7 +312,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			prefundstate := s.V.PreFundState()
 			e.Sigs[&prefundstate] = correctSignatureByAliceOnVPreFund
 			updatedObj, err := s.Update(e)
-			updated := updatedObj.(VirtualFundObjective)
+			updated := updatedObj.(*VirtualFundObjective)
 			if err != nil {
 				t.Error(err)
 			}
@@ -327,7 +327,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			f.Sigs = make(map[*state.State]state.Signature)
 			f.Sigs[&l0updatedstate] = correctSignatureByAliceOnL_0updatedsate
 			updatedObj, err = s.Update(f)
-			updated = updatedObj.(VirtualFundObjective)
+			updated = updatedObj.(*VirtualFundObjective)
 			if err != nil {
 				t.Error(err)
 			}

--- a/protocols/virtual-fund/virtual-fund.go
+++ b/protocols/virtual-fund/virtual-fund.go
@@ -1,6 +1,7 @@
 package virtualfund
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -39,6 +40,23 @@ type AssetGuarantee struct {
 	guarantee outcome.Allocation
 }
 
+func (c Connection) MarshalJSON() ([]byte, error) {
+	guarantees := []AssetGuarantee{}
+	for asset, guarantee := range c.ExpectedGuarantees {
+		guarantees = append(guarantees, AssetGuarantee{
+			asset,
+			guarantee,
+		})
+	}
+	jsonConnection := JSONConnection{c.Channel.Id, guarantees}
+
+	bytes, err := json.Marshal(jsonConnection)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return bytes, err
+}
 
 // VirtualFundObjective is a cache of data computed by reading from the store. It stores (potentially) infinite data.
 type VirtualFundObjective struct {
@@ -150,6 +168,13 @@ func New(
 	}
 
 	return init, nil
+}
+
+// MarshalJSON returns a JSON representation of the VirtualFundObjective
+// with channel state replaced by a channel Id
+func (s VirtualFundObjective) MarshalJSON() ([]byte, error) {
+	jsonVFO := JSONVirtualFundObjective{s, s.V.Id}
+	return json.Marshal(jsonVFO)
 }
 
 // Id returns the objective id.

--- a/protocols/virtual-fund/virtual-fund.go
+++ b/protocols/virtual-fund/virtual-fund.go
@@ -103,11 +103,22 @@ type VirtualFundObjective struct {
 	requestedLedgerUpdates bool // records that the ledger update side effects were previously generated (they may not have been executed yet)
 }
 
-// JSONVirtualFundObjective replaces the VirtualFundObjective's channel pointer with the
-// channel's Id, making JSONVirtualFundObjective suitable for serialization
-type JSONVirtualFundObjective struct {
-	VirtualFundObjective
-	V types.Destination
+// jsonVirtualFundObjective is a replaces the VirtualFundObjective's channel pointers
+// with the channel's Id, making jsonVirtualFundObjective suitable for serialization
+type jsonVirtualFundObjective struct {
+	Status protocols.ObjectiveStatus
+	V      types.Destination
+
+	ToMyLeft  []byte
+	ToMyRight []byte
+
+	N      uint
+	MyRole uint
+
+	A0 types.Funds
+	B0 types.Funds
+
+	RequestedLedgerUpdates bool
 }
 
 ////////////////////////////////////////////////
@@ -199,10 +210,81 @@ func New(
 }
 
 // MarshalJSON returns a JSON representation of the VirtualFundObjective
-// with channel state replaced by a channel Id
+//
+// NOTE: Marshal -> Unmarshal is a lossy process. All channel data from
+//       the virtual and ledger channels (other than Ids) is discarded
 func (s VirtualFundObjective) MarshalJSON() ([]byte, error) {
-	jsonVFO := JSONVirtualFundObjective{s, s.V.Id}
+	var left []byte
+	var right []byte
+	var err error
+
+	if s.ToMyLeft == nil {
+		left = []byte("null")
+	} else {
+		left, err = s.ToMyLeft.MarshalJSON()
+
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling left channel of %v: %w", s, err)
+		}
+	}
+
+	if s.ToMyRight == nil {
+		right = []byte("null")
+	} else {
+		right, err = s.ToMyRight.MarshalJSON()
+
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling right channel of %v: %w", s, err)
+		}
+	}
+
+	jsonVFO := jsonVirtualFundObjective{
+		s.Status,
+		s.V.Id,
+		left,
+		right,
+		s.n,
+		s.MyRole,
+		s.a0,
+		s.b0,
+		s.requestedLedgerUpdates,
+	}
 	return json.Marshal(jsonVFO)
+}
+
+// UnmarshalJSON populates the calling VirtualFundObjective with the
+// json-encoded data
+//
+// NOTE: Marshal -> Unmarshal is a lossy process. All channel data from
+//       the virtual and ledger channels (other than Ids) is discarded
+func (vfo *VirtualFundObjective) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
+
+	var jsonVFO jsonVirtualFundObjective
+	err := json.Unmarshal(data, &jsonVFO)
+
+	if err != nil {
+		return err
+	}
+
+	vfo.V = &channel.Channel{}
+	vfo.V.Id = jsonVFO.V
+
+	vfo.ToMyLeft = &Connection{}
+	vfo.ToMyRight = &Connection{}
+	vfo.ToMyLeft.UnmarshalJSON(jsonVFO.ToMyLeft)
+	vfo.ToMyRight.UnmarshalJSON(jsonVFO.ToMyRight)
+
+	vfo.Status = jsonVFO.Status
+	vfo.n = jsonVFO.N
+	vfo.MyRole = jsonVFO.MyRole
+	vfo.a0 = jsonVFO.A0
+	vfo.b0 = jsonVFO.B0
+	vfo.requestedLedgerUpdates = jsonVFO.RequestedLedgerUpdates
+
+	return nil
 }
 
 // Id returns the objective id.

--- a/protocols/virtual-fund/virtual-fund.go
+++ b/protocols/virtual-fund/virtual-fund.go
@@ -29,33 +29,61 @@ type Connection struct {
 	Channel            channel.TwoPartyLedger
 	ExpectedGuarantees map[types.Address]outcome.Allocation
 }
-type JSONConnection struct {
+
+// jsonConnection is a serialization-friendly struct representation
+// of a Connection
+type jsonConnection struct {
 	Channel            types.Destination
-	ExpectedGuarantees []AssetGuarantee
+	ExpectedGuarantees []assetGuarantee
 }
-type AssetGuarantee struct {
-	// alternative: the map[types.Address]outcome.Allocation may be serialized
-	// directly if types.Address is made to implement encoding.TextMarshaler
-	asset     types.Address
-	guarantee outcome.Allocation
+
+// assetGuarantee is a serialization-friendly representation of
+// map[asset]Allocation
+type assetGuarantee struct {
+	Asset     types.Address
+	Guarantee outcome.Allocation
 }
 
 func (c Connection) MarshalJSON() ([]byte, error) {
-	guarantees := []AssetGuarantee{}
+	guarantees := []assetGuarantee{}
 	for asset, guarantee := range c.ExpectedGuarantees {
-		guarantees = append(guarantees, AssetGuarantee{
+		guarantees = append(guarantees, assetGuarantee{
 			asset,
 			guarantee,
 		})
 	}
-	jsonConnection := JSONConnection{c.Channel.Id, guarantees}
+	jsonC := jsonConnection{c.Channel.Id, guarantees}
+	bytes, err := json.Marshal(jsonC)
 
-	bytes, err := json.Marshal(jsonConnection)
 	if err != nil {
 		return []byte{}, err
 	}
 
 	return bytes, err
+}
+
+func (c *Connection) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
+
+	var jsonC jsonConnection
+	err := json.Unmarshal(data, &jsonC)
+
+	if err != nil {
+		return err
+	}
+
+	c.Channel = channel.TwoPartyLedger{}
+	c.Channel.Id = jsonC.Channel
+
+	c.ExpectedGuarantees = make(map[types.Address]outcome.Allocation)
+
+	for _, eg := range jsonC.ExpectedGuarantees {
+		c.ExpectedGuarantees[eg.Asset] = eg.Guarantee
+	}
+
+	return nil
 }
 
 // VirtualFundObjective is a cache of data computed by reading from the store. It stores (potentially) infinite data.

--- a/protocols/virtual-fund/virtual-fund.go
+++ b/protocols/virtual-fund/virtual-fund.go
@@ -28,6 +28,17 @@ type Connection struct {
 	Channel            channel.TwoPartyLedger
 	ExpectedGuarantees map[types.Address]outcome.Allocation
 }
+type JSONConnection struct {
+	Channel            types.Destination
+	ExpectedGuarantees []AssetGuarantee
+}
+type AssetGuarantee struct {
+	// alternative: the map[types.Address]outcome.Allocation may be serialized
+	// directly if types.Address is made to implement encoding.TextMarshaler
+	asset     types.Address
+	guarantee outcome.Allocation
+}
+
 
 // VirtualFundObjective is a cache of data computed by reading from the store. It stores (potentially) infinite data.
 type VirtualFundObjective struct {

--- a/protocols/virtual-fund/virtual-fund.go
+++ b/protocols/virtual-fund/virtual-fund.go
@@ -46,6 +46,13 @@ type VirtualFundObjective struct {
 	requestedLedgerUpdates bool // records that the ledger update side effects were previously generated (they may not have been executed yet)
 }
 
+// JSONVirtualFundObjective replaces the VirtualFundObjective's channel pointer with the
+// channel's Id, making JSONVirtualFundObjective suitable for serialization
+type JSONVirtualFundObjective struct {
+	VirtualFundObjective
+	V types.Destination
+}
+
 ////////////////////////////////////////////////
 // Public methods on the VirtualFundObjective //
 ////////////////////////////////////////////////

--- a/protocols/virtual-fund/virtualfund_test.go
+++ b/protocols/virtual-fund/virtualfund_test.go
@@ -1,0 +1,93 @@
+package virtualfund
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/statechannels/go-nitro/channel"
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/types"
+)
+
+func TestMarshalJSON(t *testing.T) {
+	// left, _ :=
+	ts := state.TestState
+	ts.TurnNum = channel.PreFundTurnNum
+
+	right, _ := channel.NewTwoPartyLedger(ts, 0)
+	vfo, err := New(
+		false,
+		ts,
+		types.Address{},
+		2,
+		0,
+		channel.TwoPartyLedger{},
+		right,
+	)
+
+	if err != nil {
+		err = fmt.Errorf("the test VirtualFundObjective was not initialized: %w", err)
+		t.Fatalf("%s", err)
+	}
+
+	encodedVfo, err := json.Marshal(vfo)
+
+	if err != nil {
+		t.Errorf("error encoding direct-fund objective %v", vfo)
+	}
+
+	got := VirtualFundObjective{}
+	got.UnmarshalJSON(encodedVfo)
+
+	if !(got.Status == vfo.Status) {
+		t.Errorf("expected Status %v but got %v", vfo.Status, got.Status)
+	}
+	if got.V.Id != vfo.V.Id {
+		t.Errorf("expected channel Id %s but got %s", vfo.V.Id, got.V.Id)
+	}
+
+	if vfo.ToMyLeft != nil {
+		if !reflect.DeepEqual(vfo.ToMyLeft.ExpectedGuarantees, got.ToMyLeft.ExpectedGuarantees) {
+			t.Errorf("expected left-channel guarantees %v, but found %v", vfo.ToMyLeft, got.ToMyLeft)
+		}
+
+		if got.ToMyLeft.Channel.Id != vfo.ToMyLeft.Channel.Id {
+			t.Errorf("expected left channel Id %s but got %s",
+				vfo.ToMyLeft.Channel.Id, got.ToMyLeft.Channel.Id)
+		}
+	} else if (got.ToMyLeft.Channel.Id != types.Destination{}) {
+		t.Errorf("recieved a non-blank channel Id where the connection was null")
+	}
+
+	if vfo.ToMyRight != nil {
+		if !reflect.DeepEqual(vfo.ToMyRight.ExpectedGuarantees, got.ToMyRight.ExpectedGuarantees) {
+			t.Errorf("expected right-channel %v, but found %v", vfo.ToMyRight, got.ToMyRight)
+		}
+
+		if got.ToMyRight.Channel.Id != vfo.ToMyRight.Channel.Id {
+			t.Errorf("expected left channel Id %s but got %s",
+				vfo.ToMyRight.Channel.Id, got.ToMyRight.Channel.Id)
+		}
+	} else if (got.ToMyRight.Channel.Id != types.Destination{}) {
+		t.Errorf("recieved a non-blank channel Id where the connection was null")
+	}
+
+	if got.n != vfo.n {
+		t.Errorf("expected %d channel participants but found %d", vfo.n, got.n)
+	}
+	if got.MyRole != vfo.MyRole {
+		t.Errorf("expected MyRole %d but found %d", vfo.MyRole, got.MyRole)
+	}
+	if !got.a0.Equal(vfo.a0) {
+		t.Errorf("expected alice initial balance of %v but found %v", vfo.a0, got.a0)
+	}
+	if !got.b0.Equal(vfo.b0) {
+		t.Errorf("expected bob initial balance of %v but found %v", vfo.b0, got.a0)
+	}
+	if got.requestedLedgerUpdates != vfo.requestedLedgerUpdates {
+		t.Errorf("expected requestedLedgerUpdates == %t, but found %t",
+			vfo.requestedLedgerUpdates, got.requestedLedgerUpdates)
+	}
+}


### PR DESCRIPTION
This is incremental work toward implementation of a store. See #191 

The CURRENT mockstore places in-memory objects into an in-memory map. This is not ideal because:

- it skips the serialization / deserialization steps that a production store will require (making it a less realistic mock)
- it (potentially) fails to share these in-memory 

The goal is to apply a real world serialization scheme to the data we're interested in storing: `Objective`s and `Channel`s. This is complicated by the following:

- in-memory `Objective`s contain references to `Channel`s, but we wish to store them separately in the store
- `Objective`s and `Channel`s contain a mix of public and private fields, all of which need to be serialized

**How Has This Been Tested?**

The existing test suite via `mockstore_test.go` relies on the correctness of these changes. They are currently failing!

**Current blocker**

https://go.dev/play/p/41si1Khs7xU - `MarshalJSON` implementations which act on structs that embed the receiver type seem to invoke an infinite loop. (stackoverflow error is not reported on the playground, but it's there). By comparison: [the same code](https://go.dev/play/p/mgaCCQLVDjq) with the `MarshalJSON` method removed works fine.

By my estimation, we need to implement a `MarshalJSON` in order to ensure that private fields are persisted, but doing this triggers the stackoverflow problem above.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [?] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
