### PR TITLE
Fix Safe to Deposit Check

### DIFF
--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -228,7 +228,8 @@ func (s DirectFundObjective) safeToDeposit() bool {
 		chainHolding, ok := s.C.OnChainFunding[asset]
 
 		if !ok {
-			return false
+			// If there are no holdings on chain we use 0 for our calculations
+			chainHolding = big.NewInt(0)
 		}
 
 		if types.Gt(safetyThreshold, chainHolding) {

--- a/protocols/direct-fund/direct-fund_test.go
+++ b/protocols/direct-fund/direct-fund_test.go
@@ -42,11 +42,11 @@ var testState = state.State{
 			Asset: types.Address{},
 			Allocations: outcome.Allocations{
 				outcome.Allocation{
-					Destination: alice.destination,
+					Destination: bob.destination, // Bob is first so we can easily test WaitingForMyTurnToFund
 					Amount:      big.NewInt(5),
 				},
 				outcome.Allocation{
-					Destination: bob.destination,
+					Destination: alice.destination,
 					Amount:      big.NewInt(5),
 				},
 			},
@@ -180,6 +180,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestCrank(t *testing.T) {
+
 	var s, _ = New(false, testState, testState.Participants[0])
 	var correctSignatureByAliceOnPreFund, _ = s.C.PreFundState().Sign(alice.privateKey)
 	var correctSignatureByBobOnPreFund, _ = s.C.PreFundState().Sign(bob.privateKey)


### PR DESCRIPTION
Previously if we couldn't find chain holdings for an `asset` the `safeToDeposit` check would always return false. 

This PR changes `safeToDeposit` so it uses a value of 0 if there are no chain holdings yet. This allows `safeToDeposit` to return true in the case where it is safe to deposit but there are no chain holdings yet.

Previously this behaviour meant that `safeToDeposit` would always return false until after the first deposit was triggered from the test, thus getting us to `WaitingForMyTurnToFund` for in the `TestCrank` test. However I believe this is incorrect behaviour as Alice was safe to deposit immediately since they came first in the allocation.

To get the test working correctly I've switched the initial outcome so bob is first in the allocations. This means Alice is only safe to deposit after Bob and let's us test the WaitingForMyTurnToFund condition.