### PR TITLE
set chain holdings when constructing a Channel

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -3,6 +3,7 @@ package channel
 import (
 	"errors"
 	"fmt"
+	"math/big"
 	"reflect"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -75,6 +76,11 @@ func New(s state.State, myIndex uint) (Channel, error) {
 	post := s.Clone()
 	post.TurnNum = PostFundTurnNum
 	c.SignedStateForTurnNum[PostFundTurnNum] = state.NewSignedState(post)
+
+	// Set on chain holdings to zero for each asset
+	for asset := range s.Outcome.TotalAllocated() {
+		c.OnChainFunding[asset] = big.NewInt(0)
+	}
 
 	return c, nil
 }

--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -224,7 +224,6 @@ func (s DirectFundObjective) fundingComplete() bool {
 
 // safeToDeposit returns true if the recorded OnChainHoldings are greater than or equal to the threshold for safety.
 func (s DirectFundObjective) safeToDeposit() bool {
-	fmt.Println(s.myDepositSafetyThreshold, s.C.OnChainFunding)
 	for asset, safetyThreshold := range s.myDepositSafetyThreshold {
 
 		chainHolding, ok := s.C.OnChainFunding[asset]

--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -87,6 +87,7 @@ func New(
 		types.AddressToDestination(myAddress),
 	)
 	init.myDepositTarget = init.myDepositSafetyThreshold.Add(myAllocatedAmount)
+
 	return init, nil
 }
 
@@ -223,12 +224,13 @@ func (s DirectFundObjective) fundingComplete() bool {
 
 // safeToDeposit returns true if the recorded OnChainHoldings are greater than or equal to the threshold for safety.
 func (s DirectFundObjective) safeToDeposit() bool {
+	fmt.Println(s.myDepositSafetyThreshold, s.C.OnChainFunding)
 	for asset, safetyThreshold := range s.myDepositSafetyThreshold {
+
 		chainHolding, ok := s.C.OnChainFunding[asset]
 
 		if !ok {
-			// If there are no holdings on chain we use 0 for our calculations
-			chainHolding = big.NewInt(0)
+			panic("nil chainHolding for asset in myDepositSafetyThreshold")
 		}
 
 		if types.Gt(safetyThreshold, chainHolding) {

--- a/protocols/direct-fund/direct-fund.go
+++ b/protocols/direct-fund/direct-fund.go
@@ -246,9 +246,9 @@ func (s DirectFundObjective) amountToDeposit() types.Funds {
 	deposits := make(types.Funds, len(s.C.OnChainFunding))
 
 	for asset, target := range s.myDepositTarget {
-		holding := s.C.OnChainFunding[asset]
-		if holding == nil {
-			holding = big.NewInt(0)
+		holding, ok := s.C.OnChainFunding[asset]
+		if !ok {
+			panic("nil chainHolding for asset in myDepositTarget")
 		}
 		deposits[asset] = big.NewInt(0).Sub(target, holding)
 	}


### PR DESCRIPTION
and panic if we try to read one we haven't set.

This is just an alternative suggestion to #215 . I'm not sure if it is more idiomatic or not. 

The underlying bug is a mismatch in two `types.Funds` mappings. One has been populated when the `Channel` was constructed, and one has not. When we come to compare the two mappings, the one which has not been populated will cause a panic unless we "catch" the problem and intervene

The solution here is simply to populate both mappings in the `Channel` constructor. Then, any other method that wants to work with those mappings need not have any special logic inside of it. 

It seems loosely connected to the go proverb about "making the zero value useful" https://go-proverbs.github.io/.  If we were just using `big.Ints`, an uninitialised value wouldn't pose a problem. But `maps` do cause a problem when they are not initialized, so it's hard to see a way to be true to the proverb. 

Solidity is actually "better" at this, I think. An uninitialised mapping would just return a 0 when read. 



