### PR TITLE
add vscode config for golangci-lint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-  "go.formatTool": "gofmt"
+  "go.formatTool": "gofmt",
+  "go.lintTool": "golangci-lint",
+  "go.lintOnSave": "workspace",
 }


### PR DESCRIPTION
This is an incremental improvement in terms of aligning the on-machine CI checks with github's CI checks.

Previously, I was manually running `golangci-lint run` (and often forgetting to) before making pushes.