### PR TITLE
Switch channel Sign methods to use pointer receivers

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -221,7 +221,7 @@ func (c *Channel) AddSignedState(ss state.SignedState) bool {
 
 // AddSignedStates adds each signed state in the passed slice. It returns true if all signed states were added successfully, false otherwise.
 // If one or more signed states fails to be added, this does not prevent other signed states from being added.
-func (c Channel) AddSignedStates(sss []state.SignedState) bool {
+func (c *Channel) AddSignedStates(sss []state.SignedState) bool {
 	allOk := true
 	for _, ss := range sss {
 		ok := c.AddSignedState(ss)
@@ -233,17 +233,17 @@ func (c Channel) AddSignedStates(sss []state.SignedState) bool {
 }
 
 // SignAndAddPrefund signs and adds the prefund state for the channel, returning a state.SignedState suitable for sending to peers.
-func (c Channel) SignAndAddPrefund(sk *[]byte) (state.SignedState, error) {
+func (c *Channel) SignAndAddPrefund(sk *[]byte) (state.SignedState, error) {
 	return c.signAndAddState(c.PreFundState(), sk)
 }
 
 // SignAndAddPrefund signs and adds the postfund state for the channel, returning a state.SignedState suitable for sending to peers.
-func (c Channel) SignAndAddPostfund(sk *[]byte) (state.SignedState, error) {
+func (c *Channel) SignAndAddPostfund(sk *[]byte) (state.SignedState, error) {
 	return c.signAndAddState(c.PostFundState(), sk)
 }
 
 // signAndAddState signs and adds the state to the channel, returning a state.SignedState suitable for sending to peers.
-func (c Channel) signAndAddState(s state.State, sk *[]byte) (state.SignedState, error) {
+func (c *Channel) signAndAddState(s state.State, sk *[]byte) (state.SignedState, error) {
 
 	sig, err := s.Sign(*sk)
 	if err != nil {

--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -71,4 +72,8 @@ func joinSignature(signature Signature) (concatenatedSignature []byte) {
 	concatenatedSignature = append(concatenatedSignature, signature.S...)
 	concatenatedSignature = append(concatenatedSignature, signature.V)
 	return
+}
+
+func (s1 Signature) Equal(s2 Signature) bool {
+	return bytes.Equal(s1.S, s2.S) && bytes.Equal(s1.R, s2.R) && s1.V == s2.V
 }


### PR DESCRIPTION
Previously some of the sign functions on a `channel` were using [value receivers instead of pointer receivers.](https://medium.com/globant/go-method-receiver-pointer-vs-value-ffc5ab7acdb) This meant that we were using a copy of the channel and not modifying the actual channel. 

Since the `SignedStateForTurnNum` map acts like a [pointer](https://go.dev/doc/faq#:~:text=Map%20and%20slice%20values%20behave%20like,not%20the%20data%20it%20points%20to.) it was getting updated correctly with signatures and states. However setting `latestSupportedStateTurnNum` with a value receiver does not work (as it is modifying a copy of the structure) so we end up  with an incorrect `latestSupportedStateTurnNum`.

This PR:
- Implements a simple test for `AddSignedStates` to reproduce the failure.
- Updates all sign methods on channel to use a pointer receiver.
- Adds a Signature.Equal function to make comparing signatures easier.

