### PR TITLE
Handle duplicate signatures in SignedState.Merge

### DIFF
--- a/channel/state/signedstate.go
+++ b/channel/state/signedstate.go
@@ -81,10 +81,17 @@ func (ss SignedState) Merge(ss2 SignedState) error {
 	if !ss.state.Equal(ss2.state) {
 		return errors.New(`cannot merge signed states with distinct state hashes`)
 	}
-	for _, sig := range ss2.sigs {
-		err := ss.AddSignature(sig)
-		if err != nil {
-			return err
+	for i, sig := range ss2.sigs {
+		existing, found := ss.sigs[uint(i)]
+		if found { // if the signature is already present, check that it is the same
+			if !existing.Equal(sig) {
+				return errors.New(`cannot merge signed states with conflicting signatures`)
+			}
+		} else { // otherwise add the signature
+			err := ss.AddSignature(sig)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/channel/state/signedstate_test.go
+++ b/channel/state/signedstate_test.go
@@ -19,7 +19,38 @@ func TestSignedStateEqual(t *testing.T) {
 		t.Errorf(`expected %v to Equal %v, but it did not`, ss1, ss2)
 	}
 }
+func TestMergeWithDuplicateSignatures(t *testing.T) {
+	// ss1 has only alice's signature
+	ss1 := NewSignedState(TestState)
+	sigA, _ := TestState.Sign(common.Hex2Bytes(`caab404f975b4620747174a75f08d98b4e5a7053b691b41bcfc0d839d48b7634`))
+	_ = ss1.AddSignature(sigA)
 
+	// ss2 has alice and bob's signatures
+	sigB, _ := TestState.Sign(common.Hex2Bytes(`62ecd49c4ccb41a70ad46532aed63cf815de15864bc415c87d507afd6a5e8da2`))
+	ss2 := NewSignedState(TestState)
+	_ = ss2.AddSignature(sigA)
+	_ = ss2.AddSignature(sigB)
+
+	err := ss1.Merge(ss2)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	got := ss1
+	want := SignedState{
+		TestState,
+		map[uint]Signature{
+			0: sigA,
+			1: sigB,
+		},
+	}
+
+	if !got.Equal(want) {
+		t.Errorf(`incorrect merge, got %v, wanted %v`, got, want)
+	}
+
+}
 func TestMerge(t *testing.T) {
 
 	ss1 := NewSignedState(TestState)


### PR DESCRIPTION
Previously Merge would fail if there were any duplicate signatures between the two signed states. This limits the usefulness of Merge as you could only merge signed states with completely different signature sets.

This PR:
- Adds a small test to reproduce the error.
- Modifies Merge so that we only attempt to add signatures if they don't already exist


