### PR TITLE
Implement deep Copying for Channel.Clone

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -97,7 +97,15 @@ func (lc TwoPartyLedger) TheirDestination() types.Destination {
 
 // Clone returns a deep copy of the receiver
 func (c Channel) Clone() Channel {
-	return c // no pointer members, so this is sufficient
+	clonedSignedStateForTurnNum := map[uint64]state.SignedState{}
+	for i, ss := range c.SignedStateForTurnNum {
+		clonedSignedStateForTurnNum[i] = ss.Clone()
+		// The fixed part contains pointer references so we update it to a cloned state
+		c.FixedPart = ss.Clone().State().FixedPart()
+	}
+	c.SignedStateForTurnNum = clonedSignedStateForTurnNum
+	c.OnChainFunding = c.OnChainFunding.Clone()
+	return c
 }
 
 // Equal returns true if the channel is deeply equal to the reciever, false otherwise

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -100,11 +100,10 @@ func (c Channel) Clone() Channel {
 	clonedSignedStateForTurnNum := map[uint64]state.SignedState{}
 	for i, ss := range c.SignedStateForTurnNum {
 		clonedSignedStateForTurnNum[i] = ss.Clone()
-		// The fixed part contains pointer references so we update it to a cloned state
-		c.FixedPart = ss.Clone().State().FixedPart()
 	}
 	c.SignedStateForTurnNum = clonedSignedStateForTurnNum
 	c.OnChainFunding = c.OnChainFunding.Clone()
+	c.FixedPart = c.FixedPart.Clone()
 	return c
 }
 

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -36,6 +36,11 @@ func TestChannel(t *testing.T) {
 		if r.Equal(c) {
 			t.Error("Clone: modifying the clone should not modify the original")
 		}
+
+		r.Participants[0] = common.HexToAddress("0x0000000000000000000000000000000000000001")
+		if r.Participants[0] == c.Participants[0] {
+			t.Error("Clone: modifying the clone should not modify the original")
+		}
 	}
 
 	testPreFund := func(t *testing.T) {

--- a/channel/state/signedstate.go
+++ b/channel/state/signedstate.go
@@ -90,6 +90,17 @@ func (ss SignedState) Merge(ss2 SignedState) error {
 	return nil
 }
 
+func (ss SignedState) Clone() SignedState {
+	clonedSigs := make(map[uint]Signature, len(ss.sigs))
+	for i, sig := range ss.sigs {
+		clonedSigs[i] = sig
+	}
+	return SignedState{
+		state: ss.state.Clone(),
+		sigs:  clonedSigs,
+	}
+}
+
 // Equal returns true if the passed SignedState is deeply equal in value to the receiver.
 func (ss SignedState) Equal(ss2 SignedState) bool {
 	if !ss.state.Equal(ss2.state) {

--- a/channel/state/state.go
+++ b/channel/state/state.go
@@ -176,16 +176,26 @@ func (s State) Equal(r State) bool {
 		s.IsFinal == r.IsFinal
 }
 
+func (f FixedPart) Clone() FixedPart {
+	clone := FixedPart{}
+	clone.ChainId = new(big.Int).Set(f.ChainId)
+	clone.Participants = append(clone.Participants, f.Participants...)
+	clone.ChannelNonce = new(big.Int).Set(f.ChannelNonce)
+	clone.AppDefinition = f.AppDefinition
+	clone.ChallengeDuration = new(big.Int).Set(f.ChallengeDuration)
+	return clone
+}
+
 // Clone returns a clone of the state
 func (s State) Clone() State {
 	clone := State{}
-
 	// Fixed part
-	clone.ChainId = new(big.Int).Set(s.ChainId)
-	clone.Participants = append(clone.Participants, s.Participants...)
-	clone.ChannelNonce = new(big.Int).Set(s.ChannelNonce)
-	clone.AppDefinition = s.AppDefinition
-	clone.ChallengeDuration = new(big.Int).Set(s.ChallengeDuration)
+	cloneFixedPart := s.FixedPart().Clone()
+	clone.ChainId = cloneFixedPart.ChainId
+	clone.Participants = cloneFixedPart.Participants
+	clone.ChannelNonce = cloneFixedPart.ChannelNonce
+	clone.AppDefinition = cloneFixedPart.AppDefinition
+	clone.ChallengeDuration = cloneFixedPart.ChallengeDuration
 
 	// Variable part
 	clone.AppData = make(types.Bytes, 0, len(s.AppData))

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -132,6 +132,7 @@ func (s DirectFundObjective) Update(event protocols.ObjectiveEvent) (protocols.O
 // Crank inspects the extended state and declares a list of Effects to be executed
 // It's like a state machine transition function where the finite / enumerable state is returned (computed from the extended state)
 // rather than being independent of the extended state; and where there is only one type of event ("the crank") with no data on it at all
+
 func (s DirectFundObjective) Crank(secretKey *[]byte) (protocols.Objective, protocols.SideEffects, protocols.WaitingFor, error) {
 	updated := s.clone()
 
@@ -143,7 +144,7 @@ func (s DirectFundObjective) Crank(secretKey *[]byte) (protocols.Objective, prot
 
 	// Prefunding
 	if !updated.C.PreFundSignedByMe() {
-		ss, err := s.C.SignAndAddPrefund(secretKey)
+		ss, err := updated.C.SignAndAddPrefund(secretKey)
 		if err != nil {
 			return updated, NoSideEffects, WaitingForCompletePrefund, fmt.Errorf("could not sign prefund %w", err)
 		}
@@ -179,7 +180,7 @@ func (s DirectFundObjective) Crank(secretKey *[]byte) (protocols.Objective, prot
 	// Postfunding
 	if !updated.C.PostFundSignedByMe() {
 
-		ss, err := s.C.SignAndAddPostfund(secretKey)
+		ss, err := updated.C.SignAndAddPostfund(secretKey)
 
 		if err != nil {
 			return updated, NoSideEffects, WaitingForCompletePostFund, fmt.Errorf("could not sign postfund %w", err)

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -81,12 +81,12 @@ func TestPreFundSideEffects(t *testing.T) {
 	// Construct various variables for use in the test.
 	var o, _ = New(true, testState, testState.Participants[0])
 
-	_, got, _, err := o.Crank(&alice.privateKey)
+	updated, got, _, err := o.Crank(&alice.privateKey)
 	if err != nil {
 		t.Error(err)
 	}
-
-	expectedMessage := protocols.Message{To: bob.address, ObjectiveId: o.Id(), SignedStates: []state.SignedState{o.C.SignedStateForTurnNum[0]}}
+	expectedState := updated.(DirectFundObjective).C.SignedStateForTurnNum[0]
+	expectedMessage := protocols.Message{To: bob.address, ObjectiveId: o.Id(), SignedStates: []state.SignedState{expectedState}}
 	want := protocols.SideEffects{MessagesToSend: []protocols.Message{expectedMessage}}
 
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -111,12 +111,13 @@ func TestPostFundSideEffects(t *testing.T) {
 	totalAmountAllocated := testState.Outcome[0].TotalAllocated()
 	o.C.OnChainFunding[testState.Outcome[0].Asset] = totalAmountAllocated
 
-	_, got, _, err := o.Crank(&alice.privateKey)
+	updated, got, _, err := o.Crank(&alice.privateKey)
 	if err != nil {
 		t.Error(err)
 	}
 
-	expectedMessage := protocols.Message{To: bob.address, ObjectiveId: o.Id(), SignedStates: []state.SignedState{o.C.SignedStateForTurnNum[1]}}
+	expectedState := updated.(DirectFundObjective).C.SignedStateForTurnNum[1]
+	expectedMessage := protocols.Message{To: bob.address, ObjectiveId: o.Id(), SignedStates: []state.SignedState{expectedState}}
 	want := protocols.SideEffects{MessagesToSend: []protocols.Message{expectedMessage}}
 
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -226,7 +226,8 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			// And then crank it to see which "pause point" (WaitingFor) we end up at.
 
 			// Initial Crank
-			_, got, waitingFor, err := o.Crank(&my.privateKey)
+			oObj, got, waitingFor, err := o.Crank(&my.privateKey)
+			o = oObj.(VirtualFundObjective)
 			if err != nil {
 				t.Error(err)
 			}
@@ -253,7 +254,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			o.V.AddStateWithSignature(vPreFund, correctSignatureByP_1OnVPreFund)
 
 			// Cranking should move us to the next waiting point, generate ledger requests as a side effect, and alter the extended state to reflect that
-			oObj, got, waitingFor, err := o.Crank(&my.privateKey)
+			oObj, got, waitingFor, err = o.Crank(&my.privateKey)
 			o = oObj.(VirtualFundObjective)
 			if err != nil {
 				t.Error(err)


### PR DESCRIPTION
Fixes #233 

Updates the `Channel.Clone` to return a deep copy by creating a copy of the underlying `SignedStateForTurnNum` map and  other reference types.

Previously we were returning a shallow copy meaning the `SignedStatesForTurnNum` map was being shared between multiple channels.

This PR:
- Adds a failing test to demonstrate the clone is returning a shallow copy
- Updates a clone to return a deep copy
- Fixes some code and tests that were not accessing the `Channel` off the latest objective.
