### PR TITLE
Update channel arguments to pointers

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -33,17 +33,17 @@ type TwoPartyLedger struct {
 	Channel
 }
 
-func NewTwoPartyLedger(s state.State, myIndex uint) (TwoPartyLedger, error) {
+func NewTwoPartyLedger(s state.State, myIndex uint) (*TwoPartyLedger, error) {
 	if myIndex > 1 {
-		return TwoPartyLedger{}, errors.New("myIndex in a two party ledger channel must be 0 or 1")
+		return &TwoPartyLedger{}, errors.New("myIndex in a two party ledger channel must be 0 or 1")
 	}
 	if len(s.Participants) != 2 {
-		return TwoPartyLedger{}, errors.New("two party ledger channels must have exactly two participants")
+		return &TwoPartyLedger{}, errors.New("two party ledger channels must have exactly two participants")
 	}
 
 	c, err := New(s, myIndex)
 
-	return TwoPartyLedger{c}, err
+	return &TwoPartyLedger{*c}, err
 }
 
 func (lc TwoPartyLedger) Clone() TwoPartyLedger {
@@ -51,16 +51,16 @@ func (lc TwoPartyLedger) Clone() TwoPartyLedger {
 }
 
 // New constructs a new Channel from the supplied state.
-func New(s state.State, myIndex uint) (Channel, error) {
+func New(s state.State, myIndex uint) (*Channel, error) {
 	c := Channel{}
 	if s.TurnNum != PreFundTurnNum {
-		return c, errors.New(`objective must be constructed with TurnNum=0 state`)
+		return &c, errors.New(`objective must be constructed with TurnNum=0 state`)
 	}
 
 	var err error
 	c.Id, err = s.ChannelId()
 	if err != nil {
-		return c, err
+		return &c, err
 	}
 	c.MyIndex = myIndex
 	c.OnChainFunding = make(types.Funds)
@@ -82,7 +82,7 @@ func New(s state.State, myIndex uint) (Channel, error) {
 		c.OnChainFunding[asset] = big.NewInt(0)
 	}
 
-	return c, nil
+	return &c, nil
 }
 
 // MyDestination returns the client's destination

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -28,12 +28,12 @@ func TestChannel(t *testing.T) {
 
 	testClone := func(t *testing.T) {
 		r := c.Clone()
-		if diff := cmp.Diff(r, c, cmp.Comparer(types.Equal)); diff != "" {
+		if diff := cmp.Diff(r, *c, cmp.Comparer(types.Equal)); diff != "" {
 			t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
 		}
 
 		r.latestSupportedStateTurnNum++
-		if r.Equal(c) {
+		if r.Equal(*c) {
 			t.Error("Clone: modifying the clone should not modify the original")
 		}
 	}

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -73,7 +73,7 @@ func New(
 	}
 
 	init.C = &channel.Channel{}
-	*init.C, err = channel.New(initialState, myIndex)
+	init.C, err = channel.New(initialState, myIndex)
 
 	if err != nil {
 		return DirectFundObjective{}, fmt.Errorf("failed to initialize channel for direct-fund objective: %w", err)

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -154,7 +154,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 		my := alice
 
 		// Alice plays role 0 so has no ledger channel on her left
-		var ledgerChannelToMyLeft channel.TwoPartyLedger
+		var ledgerChannelToMyLeft *channel.TwoPartyLedger
 
 		// She has a single ledger channel L_0 connecting her to P_1
 		var ledgerChannelToMyRight, _ = channel.NewTwoPartyLedger(
@@ -167,7 +167,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 		// Objective
 		var n = uint(2) // number of ledger channels (num_hops + 1)
-		var s, _ = New(false, vPreFund, my.address, n, my.role, &ledgerChannelToMyLeft, ledgerChannelToMyRight)
+		var s, _ = New(false, vPreFund, my.address, n, my.role, ledgerChannelToMyLeft, ledgerChannelToMyRight)
 		var expectedGuaranteeMetadata = outcome.GuaranteeMetadata{Left: ledgerChannelToMyRight.MyDestination(), Right: ledgerChannelToMyRight.TheirDestination()}
 		var expectedEncodedGuaranteeMetadata, _ = expectedGuaranteeMetadata.Encode()
 		var expectedGuarantee outcome.Allocation = outcome.Allocation{
@@ -200,7 +200,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 		testNew := func(t *testing.T) {
 			// Assert that a valid set of constructor args does not result in an error
-			o, err := New(false, vPreFund, my.address, 2, my.role, &ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			o, err := New(false, vPreFund, my.address, 2, my.role, ledgerChannelToMyLeft, ledgerChannelToMyRight)
 			if err != nil {
 				t.Error(err)
 			}

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -167,7 +167,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 		// Objective
 		var n = uint(2) // number of ledger channels (num_hops + 1)
-		var s, _ = New(false, vPreFund, my.address, n, my.role, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+		var s, _ = New(false, vPreFund, my.address, n, my.role, &ledgerChannelToMyLeft, ledgerChannelToMyRight)
 		var expectedGuaranteeMetadata = outcome.GuaranteeMetadata{Left: ledgerChannelToMyRight.MyDestination(), Right: ledgerChannelToMyRight.TheirDestination()}
 		var expectedEncodedGuaranteeMetadata, _ = expectedGuaranteeMetadata.Encode()
 		var expectedGuarantee outcome.Allocation = outcome.Allocation{
@@ -200,7 +200,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 		testNew := func(t *testing.T) {
 			// Assert that a valid set of constructor args does not result in an error
-			o, err := New(false, vPreFund, my.address, 2, my.role, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			o, err := New(false, vPreFund, my.address, 2, my.role, &ledgerChannelToMyLeft, ledgerChannelToMyRight)
 			if err != nil {
 				t.Error(err)
 			}

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -26,7 +26,7 @@ var NoSideEffects = protocols.SideEffects{}
 var ErrNotApproved = errors.New("objective not approved")
 
 type Connection struct {
-	Channel            channel.TwoPartyLedger
+	Channel            *channel.TwoPartyLedger
 	ExpectedGuarantees map[types.Address]outcome.Allocation
 }
 
@@ -58,8 +58,8 @@ func New(
 	myAddress types.Address,
 	n uint, // number of ledger channels (num_hops + 1)
 	myRole uint,
-	ledgerChannelToMyLeft channel.TwoPartyLedger,
-	ledgerChannelToMyRight channel.TwoPartyLedger,
+	ledgerChannelToMyLeft *channel.TwoPartyLedger,
+	ledgerChannelToMyRight *channel.TwoPartyLedger,
 ) (VirtualFundObjective, error) {
 	// role and ledger-channel checks
 	if myRole > n+1 {
@@ -81,7 +81,7 @@ func New(
 		return VirtualFundObjective{}, err
 	}
 
-	init.V = &v
+	init.V = v
 	init.n = n
 	init.MyRole = myRole
 	init.a0 = make(map[types.Address]*big.Int)
@@ -358,15 +358,17 @@ func (s *VirtualFundObjective) clone() VirtualFundObjective {
 	clone.V = &vClone
 
 	if s.ToMyLeft != nil {
+		lClone := s.ToMyLeft.Channel.Clone()
 		clone.ToMyLeft = &Connection{
-			Channel:            s.ToMyLeft.Channel.Clone(),
+			Channel:            &lClone,
 			ExpectedGuarantees: s.ToMyLeft.ExpectedGuarantees,
 		}
 	}
 
 	if s.ToMyRight != nil {
+		rClone := s.ToMyRight.Channel.Clone()
 		clone.ToMyRight = &Connection{
-			Channel:            s.ToMyRight.Channel.Clone(),
+			Channel:            &rClone,
 			ExpectedGuarantees: s.ToMyRight.ExpectedGuarantees,
 		}
 	}


### PR DESCRIPTION
Fixes #232 

Two main changes in this PR:
## Channel constructor methods now return a pointer
Channel constructor methods now return a pointer to a channel struct instead of a channel struct. Generally we want to pass a channel around by a pointer since passing by value results in a a shallow copied channel. Switching the constructors to return pointers helps reinforce that.

## VirtualFundObjective.New accepts channel pointers instead of a channel struct
  Previously the channels structs were directly being passed into the  `New` function. This meant that `New` would get a shallow copy of the channel. The shallow copy would still reference the same map/slice data  as the original, causing problems.

By accepting a pointer we are now making explicit that we're modifying the same channel as the caller. If we want to create a copy of that we should explicitly call `Clone`