### PR TITLE
Implement basic Ledger Manager

### DIFF
--- a/channel/state/signedstate.go
+++ b/channel/state/signedstate.go
@@ -20,6 +20,18 @@ func NewSignedState(s State) SignedState {
 	return SignedState{s, make(map[uint]Signature, len(s.Participants))}
 }
 
+func (ss SignedState) SignAndAdd(secretKey *[]byte) error {
+	sig, err := ss.state.Sign(*secretKey)
+	if err != nil {
+		return fmt.Errorf("SignAndAdd failed to sign the state %w", err)
+	}
+	err = ss.AddSignature(sig)
+	if err != nil {
+		return fmt.Errorf("SignAndAdd failed to sign the state %w", err)
+	}
+	return nil
+}
+
 // AddSignature adds a participant's signature to the SignedState.
 // An error is thrown if the signature is invalid.
 func (ss SignedState) AddSignature(sig Signature) error {

--- a/channel/state/signedstate.go
+++ b/channel/state/signedstate.go
@@ -23,11 +23,11 @@ func NewSignedState(s State) SignedState {
 func (ss SignedState) SignAndAdd(secretKey *[]byte) error {
 	sig, err := ss.state.Sign(*secretKey)
 	if err != nil {
-		return fmt.Errorf("SignAndAdd failed to sign the state %w", err)
+		return fmt.Errorf("SignAndAdd failed to sign the state: %w", err)
 	}
 	err = ss.AddSignature(sig)
 	if err != nil {
-		return fmt.Errorf("SignAndAdd failed to sign the state %w", err)
+		return fmt.Errorf("SignAndAdd failed to sign the state: %w", err)
 	}
 	return nil
 }

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -24,7 +24,11 @@ type LedgerRequest struct {
 
 // Equal checks for equality between the receiver and a second LedgerRequest
 func (l LedgerRequest) Equal(m LedgerRequest) bool {
-	return l.LedgerId == m.LedgerId && l.Amount.Equal(m.Amount) && l.Left == m.Left && l.Right == m.Right && l.ObjectiveId == m.ObjectiveId
+	return l.LedgerId == m.LedgerId &&
+		l.Amount.Equal(m.Amount) &&
+		l.Left == m.Left &&
+		l.Right == m.Right &&
+		l.ObjectiveId == m.ObjectiveId
 }
 
 // SideEffects are effects to be executed by an imperative shell

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -14,6 +14,7 @@ type ChainTransaction struct {
 
 // LedgerRequest is an object processed by the ledger cranker
 type LedgerRequest struct {
+	ObjectiveId ObjectiveId
 	LedgerId    types.Destination
 	Destination types.Destination
 	Amount      types.Funds
@@ -23,7 +24,7 @@ type LedgerRequest struct {
 
 // Equal checks for equality between the receiver and a second LedgerRequest
 func (l LedgerRequest) Equal(m LedgerRequest) bool {
-	return l.LedgerId == m.LedgerId && l.Amount.Equal(m.Amount) && l.Left == m.Left && l.Right == m.Right
+	return l.LedgerId == m.LedgerId && l.Amount.Equal(m.Amount) && l.Left == m.Left && l.Right == m.Right && l.ObjectiveId == m.ObjectiveId
 }
 
 // SideEffects are effects to be executed by an imperative shell

--- a/protocols/ledger/ledger.go
+++ b/protocols/ledger/ledger.go
@@ -30,6 +30,7 @@ func (l *LedgerCranker) Update(ledger *channel.TwoPartyLedger) {
 	l.ledgers[ledger.Id] = ledger
 }
 
+// CreateLedger creates a new  two party ledger channel based on the provided left and right outcomes.
 func (l *LedgerCranker) CreateLedger(left outcome.Allocation, right outcome.Allocation, secretKey *[]byte, myIndex uint) *channel.TwoPartyLedger {
 
 	leftAddress, _ := left.Destination.ToAddress()
@@ -54,10 +55,13 @@ func (l *LedgerCranker) CreateLedger(left outcome.Allocation, right outcome.Allo
 	}
 
 	l.ledgers[ledger.Id] = ledger
+	// Update the nonce by 1
+	l.nonce = big.NewInt(0).Add(l.nonce, big.NewInt(1))
 	return ledger
 }
 
 // HandleRequest accepts a ledger request and updates the ledger channel based on the request.
+// It returns a signed state message that can be sent to other participants.
 func (l *LedgerCranker) HandleRequest(request protocols.LedgerRequest, oId protocols.ObjectiveId, secretKey *[]byte) (protocols.SideEffects, error) {
 
 	ledger := l.GetLedger(request.LedgerId)

--- a/protocols/ledger/ledger.go
+++ b/protocols/ledger/ledger.go
@@ -53,7 +53,7 @@ func (l *LedgerCranker) CreateLedger(left outcome.Allocation, right outcome.Allo
 
 // HandleRequest accepts a ledger request and updates the ledger channel based on the request.
 // It returns a signed state message that can be sent to other participants.
-func (l *LedgerCranker) HandleRequest(ledger *channel.TwoPartyLedger, request protocols.LedgerRequest, oId protocols.ObjectiveId, secretKey *[]byte) (protocols.SideEffects, error) {
+func (l *LedgerCranker) HandleRequest(ledger *channel.TwoPartyLedger, request protocols.LedgerRequest, secretKey *[]byte) (protocols.SideEffects, error) {
 
 	guarantee, _ := outcome.GuaranteeMetadata{
 		Left:  request.Left,
@@ -109,7 +109,7 @@ func (l *LedgerCranker) HandleRequest(ledger *channel.TwoPartyLedger, request pr
 		return protocols.SideEffects{}, errors.New("Could not add signed state to channel")
 	}
 
-	messages := protocols.CreateSignedStateMessages(oId, ss, ledger.MyIndex)
+	messages := protocols.CreateSignedStateMessages(request.ObjectiveId, ss, ledger.MyIndex)
 	return protocols.SideEffects{MessagesToSend: messages}, nil
 
 }

--- a/protocols/ledger/ledger.go
+++ b/protocols/ledger/ledger.go
@@ -13,41 +13,10 @@ import (
 )
 
 type LedgerManager struct {
-	nonce *big.Int
 }
 
 func NewLedgerManager() LedgerManager {
-	return LedgerManager{
-		nonce: big.NewInt(0),
-	}
-}
-
-// CreateTestLedger creates a new  two party ledger channel based on the provided left and right outcomes.
-func (l *LedgerManager) CreateTestLedger(left outcome.Allocation, right outcome.Allocation, secretKey *[]byte, myIndex uint) (*channel.TwoPartyLedger, error) {
-
-	leftAddress, _ := left.Destination.ToAddress()
-	rightAddress, _ := right.Destination.ToAddress()
-	initialState := state.State{
-		ChainId:           big.NewInt(9001),
-		Participants:      []types.Address{leftAddress, rightAddress},
-		ChannelNonce:      l.nonce,
-		AppDefinition:     types.Address{},
-		ChallengeDuration: big.NewInt(45),
-		AppData:           []byte{},
-		Outcome: outcome.Exit{outcome.SingleAssetExit{
-			Allocations: outcome.Allocations{left, right},
-		}},
-		TurnNum: 0,
-		IsFinal: false,
-	}
-
-	ledger, lErr := channel.NewTwoPartyLedger(initialState, myIndex)
-	if lErr != nil {
-		return ledger, fmt.Errorf("error creating ledger: %w", lErr)
-	}
-	// Update the nonce by 1
-	l.nonce = big.NewInt(0).Add(l.nonce, big.NewInt(1))
-	return ledger, nil
+	return LedgerManager{}
 }
 
 // HandleRequest accepts a ledger request and updates the ledger channel based on the request.
@@ -139,4 +108,31 @@ func SignLatest(ledger *channel.TwoPartyLedger, secretKeys [][]byte) {
 		_ = toSign.SignAndAdd(&secretKey)
 	}
 	ledger.Channel.AddSignedState(toSign)
+}
+
+// CreateTestLedger creates a new  two party ledger channel based on the provided left and right outcomes.
+func CreateTestLedger(left outcome.Allocation, right outcome.Allocation, secretKey *[]byte, myIndex uint, nonce *big.Int) (*channel.TwoPartyLedger, error) {
+
+	leftAddress, _ := left.Destination.ToAddress()
+	rightAddress, _ := right.Destination.ToAddress()
+	initialState := state.State{
+		ChainId:           big.NewInt(9001),
+		Participants:      []types.Address{leftAddress, rightAddress},
+		ChannelNonce:      nonce,
+		AppDefinition:     types.Address{},
+		ChallengeDuration: big.NewInt(45),
+		AppData:           []byte{},
+		Outcome: outcome.Exit{outcome.SingleAssetExit{
+			Allocations: outcome.Allocations{left, right},
+		}},
+		TurnNum: 0,
+		IsFinal: false,
+	}
+
+	ledger, lErr := channel.NewTwoPartyLedger(initialState, myIndex)
+	if lErr != nil {
+		return ledger, fmt.Errorf("error creating ledger: %w", lErr)
+	}
+
+	return ledger, nil
 }

--- a/protocols/ledger/ledger.go
+++ b/protocols/ledger/ledger.go
@@ -1,0 +1,131 @@
+package ledger
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/statechannels/go-nitro/channel"
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/types"
+)
+
+// DirectFundObjective is a cache of data computed by reading from the store. It stores (potentially) infinite data
+type LedgerRequestHandler interface {
+	HandleRequest(request protocols.LedgerRequest, secretKey *[]byte) protocols.SideEffects
+}
+
+type LedgerCranker struct {
+	ledgers map[types.Destination]*channel.TwoPartyLedger
+	nonce   *big.Int
+}
+
+func NewLedgerCranker() LedgerCranker {
+	return LedgerCranker{
+		ledgers: make(map[types.Destination]*channel.TwoPartyLedger),
+		nonce:   big.NewInt(0),
+	}
+}
+func (l *LedgerCranker) Update(ledger *channel.TwoPartyLedger) {
+	l.ledgers[ledger.Id] = ledger
+}
+func (l *LedgerCranker) CreateLedger(left outcome.Allocation, right outcome.Allocation, secretKey *[]byte, myIndex uint) *channel.TwoPartyLedger {
+
+	leftAddress, _ := left.Destination.ToAddress()
+	rightAddress, _ := right.Destination.ToAddress()
+	initialState := state.State{
+		ChainId:           big.NewInt(9001),
+		Participants:      []types.Address{leftAddress, rightAddress},
+		ChannelNonce:      l.nonce,
+		AppDefinition:     types.Address{},
+		ChallengeDuration: big.NewInt(45),
+		AppData:           []byte{},
+		Outcome: outcome.Exit{outcome.SingleAssetExit{
+			Allocations: outcome.Allocations{left, right},
+		}},
+		TurnNum: 0, // Start at post fund
+		IsFinal: false,
+	}
+
+	ledger, lErr := channel.NewTwoPartyLedger(initialState, myIndex)
+	if lErr != nil {
+		panic(lErr)
+	}
+
+	l.ledgers[ledger.Id] = ledger
+	return ledger
+}
+
+func (l *LedgerCranker) CompleteFunding(ledgerId types.Destination, secretKeys []*[]byte) {
+	ledger, ok := l.ledgers[ledgerId]
+	if !ok {
+		panic(fmt.Sprintf("Ledger %s not found", ledgerId))
+	}
+	for _, sk := range secretKeys {
+		_, _ = ledger.SignAndAddPrefund(sk)
+
+	}
+	for _, sk := range secretKeys {
+		_, _ = ledger.Channel.SignAndAddPostfund(sk)
+
+	}
+	l.ledgers[ledgerId] = ledger
+
+}
+
+func (l *LedgerCranker) Sign(ledgerId types.Destination, turnNum uint64, secretKeys [][]byte) {
+	ledger, ok := l.ledgers[ledgerId]
+	if !ok {
+		panic(fmt.Sprintf("Ledger %s not found", ledgerId))
+	}
+	toSign := ledger.SignedStateForTurnNum[turnNum]
+	for _, secretKey := range secretKeys {
+		_ = toSign.SignAndAdd(&secretKey)
+	}
+	ledger.Channel.AddSignedState(toSign)
+}
+
+func (l *LedgerCranker) HandleRequest(request protocols.LedgerRequest, oId protocols.ObjectiveId, secretKey *[]byte) protocols.SideEffects {
+	ledger := l.ledgers[request.LedgerId]
+	guarantee, _ := outcome.GuaranteeMetadata{
+		Left:  request.Left,
+		Right: request.Right,
+	}.Encode()
+	supported, err := ledger.Channel.LatestSupportedState()
+	if err != nil {
+		panic(err)
+	}
+	nextState := supported.Clone()
+	nextState.Outcome = outcome.Exit{outcome.SingleAssetExit{
+		Allocations: outcome.Allocations{
+			outcome.Allocation{
+				Destination: request.Left,
+				Amount:      big.NewInt(0),
+			},
+			outcome.Allocation{
+				Destination: request.Right,
+				Amount:      big.NewInt(0),
+			},
+			outcome.Allocation{
+				Destination:    request.Destination,
+				Amount:         request.Amount[types.Address{}],
+				AllocationType: outcome.GuaranteeAllocationType,
+				Metadata:       guarantee,
+			},
+		},
+	}}
+	nextState.TurnNum = nextState.TurnNum + 1
+	ss := state.NewSignedState(nextState)
+	err = ss.SignAndAdd(secretKey)
+	if err != nil {
+		panic(err)
+	}
+	if ok := ledger.Channel.AddSignedState(ss); !ok {
+		panic("could not add state")
+	}
+
+	messages := protocols.CreateSignedStateMessages(oId, ss, ledger.MyIndex)
+	return protocols.SideEffects{MessagesToSend: messages}
+
+}

--- a/protocols/ledger/ledger.go
+++ b/protocols/ledger/ledger.go
@@ -12,18 +12,18 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-type LedgerCranker struct {
+type LedgerManager struct {
 	nonce *big.Int
 }
 
-func NewLedgerCranker() LedgerCranker {
-	return LedgerCranker{
+func NewLedgerManager() LedgerManager {
+	return LedgerManager{
 		nonce: big.NewInt(0),
 	}
 }
 
 // CreateLedger creates a new  two party ledger channel based on the provided left and right outcomes.
-func (l *LedgerCranker) CreateLedger(left outcome.Allocation, right outcome.Allocation, secretKey *[]byte, myIndex uint) *channel.TwoPartyLedger {
+func (l *LedgerManager) CreateLedger(left outcome.Allocation, right outcome.Allocation, secretKey *[]byte, myIndex uint) *channel.TwoPartyLedger {
 
 	leftAddress, _ := left.Destination.ToAddress()
 	rightAddress, _ := right.Destination.ToAddress()
@@ -53,7 +53,7 @@ func (l *LedgerCranker) CreateLedger(left outcome.Allocation, right outcome.Allo
 
 // HandleRequest accepts a ledger request and updates the ledger channel based on the request.
 // It returns a signed state message that can be sent to other participants.
-func (l *LedgerCranker) HandleRequest(ledger *channel.TwoPartyLedger, request protocols.LedgerRequest, secretKey *[]byte) (protocols.SideEffects, error) {
+func (l *LedgerManager) HandleRequest(ledger *channel.TwoPartyLedger, request protocols.LedgerRequest, secretKey *[]byte) (protocols.SideEffects, error) {
 
 	guarantee, _ := outcome.GuaranteeMetadata{
 		Left:  request.Left,

--- a/protocols/ledger/ledger.go
+++ b/protocols/ledger/ledger.go
@@ -22,8 +22,8 @@ func NewLedgerManager() LedgerManager {
 	}
 }
 
-// CreateLedger creates a new  two party ledger channel based on the provided left and right outcomes.
-func (l *LedgerManager) CreateLedger(left outcome.Allocation, right outcome.Allocation, secretKey *[]byte, myIndex uint) *channel.TwoPartyLedger {
+// CreateTestLedger creates a new  two party ledger channel based on the provided left and right outcomes.
+func (l *LedgerManager) CreateTestLedger(left outcome.Allocation, right outcome.Allocation, secretKey *[]byte, myIndex uint) *channel.TwoPartyLedger {
 
 	leftAddress, _ := left.Destination.ToAddress()
 	rightAddress, _ := right.Destination.ToAddress()

--- a/protocols/ledger/ledger.go
+++ b/protocols/ledger/ledger.go
@@ -23,7 +23,7 @@ func NewLedgerManager() LedgerManager {
 }
 
 // CreateTestLedger creates a new  two party ledger channel based on the provided left and right outcomes.
-func (l *LedgerManager) CreateTestLedger(left outcome.Allocation, right outcome.Allocation, secretKey *[]byte, myIndex uint) *channel.TwoPartyLedger {
+func (l *LedgerManager) CreateTestLedger(left outcome.Allocation, right outcome.Allocation, secretKey *[]byte, myIndex uint) (*channel.TwoPartyLedger, error) {
 
 	leftAddress, _ := left.Destination.ToAddress()
 	rightAddress, _ := right.Destination.ToAddress()
@@ -43,12 +43,11 @@ func (l *LedgerManager) CreateTestLedger(left outcome.Allocation, right outcome.
 
 	ledger, lErr := channel.NewTwoPartyLedger(initialState, myIndex)
 	if lErr != nil {
-		panic(lErr)
+		return ledger, fmt.Errorf("error creating ledger: %w", lErr)
 	}
-
 	// Update the nonce by 1
 	l.nonce = big.NewInt(0).Add(l.nonce, big.NewInt(1))
-	return ledger
+	return ledger, nil
 }
 
 // HandleRequest accepts a ledger request and updates the ledger channel based on the request.

--- a/protocols/ledger/ledger.go
+++ b/protocols/ledger/ledger.go
@@ -62,10 +62,10 @@ func (l *LedgerManager) HandleRequest(ledger *channel.TwoPartyLedger, request pr
 
 	supported, err := ledger.Channel.LatestSupportedState()
 	if err != nil {
-		return protocols.SideEffects{}, fmt.Errorf("Could not find a supported state %w", err)
+		return protocols.SideEffects{}, fmt.Errorf("error finding a supported state: %w", err)
 	}
 
-	asset := types.Address{}
+	asset := types.Address{} // todo: loop over request.amount's assets
 	nextState := supported.Clone()
 
 	// Calculate the amounts
@@ -91,7 +91,7 @@ func (l *LedgerManager) HandleRequest(ledger *channel.TwoPartyLedger, request pr
 			},
 			outcome.Allocation{
 				Destination:    request.Destination,
-				Amount:         request.Amount[types.Address{}],
+				Amount:         request.Amount[asset],
 				AllocationType: outcome.GuaranteeAllocationType,
 				Metadata:       guarantee,
 			},
@@ -114,15 +114,17 @@ func (l *LedgerManager) HandleRequest(ledger *channel.TwoPartyLedger, request pr
 
 }
 
+// SignPreAndPostFundingStates is a test utility function which applies signatures from
+// multiple participants to pre and post fund states
 func SignPreAndPostFundingStates(ledger *channel.TwoPartyLedger, secretKeys []*[]byte) {
 	for _, sk := range secretKeys {
 		_, _ = ledger.SignAndAddPrefund(sk)
-	}
-	for _, sk := range secretKeys {
-		_, _ = ledger.Channel.SignAndAddPostfund(sk)
+		_, _ = ledger.SignAndAddPostfund(sk)
 	}
 }
 
+// Signlatest is a test utility function which applies signatures from
+// multiple participants to the latest recorded state
 func SignLatest(ledger *channel.TwoPartyLedger, secretKeys [][]byte) {
 
 	// Find the largest turn num and therefore the latest state

--- a/protocols/ledger/ledger.go
+++ b/protocols/ledger/ledger.go
@@ -1,6 +1,7 @@
 package ledger
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -67,7 +68,7 @@ func (l *LedgerCranker) HandleRequest(request protocols.LedgerRequest, oId proto
 
 	supported, err := ledger.Channel.LatestSupportedState()
 	if err != nil {
-		panic(err)
+		return protocols.SideEffects{}, fmt.Errorf("Could not find a supported state %w", err)
 	}
 
 	asset := types.Address{}
@@ -108,10 +109,10 @@ func (l *LedgerCranker) HandleRequest(request protocols.LedgerRequest, oId proto
 	ss := state.NewSignedState(nextState)
 	err = ss.SignAndAdd(secretKey)
 	if err != nil {
-		panic(err)
+		return protocols.SideEffects{}, fmt.Errorf("Could not sign state: %w", err)
 	}
 	if ok := ledger.Channel.AddSignedState(ss); !ok {
-		panic("could not add state")
+		return protocols.SideEffects{}, errors.New("Could not add signed state to channel")
 	}
 
 	messages := protocols.CreateSignedStateMessages(oId, ss, ledger.MyIndex)

--- a/protocols/ledger/ledger_test.go
+++ b/protocols/ledger/ledger_test.go
@@ -1,0 +1,127 @@
+package ledger
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/google/go-cmp/cmp"
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/types"
+)
+
+type actor struct {
+	address     types.Address
+	destination types.Destination
+	privateKey  []byte
+}
+
+var alice = actor{
+	address:     common.HexToAddress(`0xF5A1BB5607C9D079E46d1B3Dc33f257d937b43BD`),
+	destination: types.AddressToDestination(common.HexToAddress(`0xF5A1BB5607C9D079E46d1B3Dc33f257d937b43BD`)),
+	privateKey:  common.Hex2Bytes(`caab404f975b4620747174a75f08d98b4e5a7053b691b41bcfc0d839d48b7634`),
+}
+
+var bob = actor{
+	address:     common.HexToAddress(`0x760bf27cd45036a6C486802D30B5D90CfFBE31FE`),
+	destination: types.AddressToDestination(common.HexToAddress(`0x760bf27cd45036a6C486802D30B5D90CfFBE31FE`)),
+	privateKey:  common.Hex2Bytes(`62ecd49c4ccb41a70ad46532aed63cf815de15864bc415c87d507afd6a5e8da2`),
+}
+
+func TestCreateLedger(t *testing.T) {
+	cranker := NewLedgerCranker()
+	left := outcome.Allocation{Destination: alice.destination, Amount: big.NewInt(3)}
+	right := outcome.Allocation{Destination: bob.destination, Amount: big.NewInt(2)}
+
+	ledger := cranker.CreateLedger(left, right, &alice.privateKey, 0)
+
+	expectedState := state.State{
+		ChainId:           big.NewInt(9001),
+		Participants:      []types.Address{alice.address, bob.address},
+		ChannelNonce:      big.NewInt(0),
+		AppDefinition:     types.Address{},
+		ChallengeDuration: big.NewInt(45),
+		AppData:           []byte{},
+		Outcome: outcome.Exit{outcome.SingleAssetExit{
+			Allocations: outcome.Allocations{left, right},
+		}},
+		TurnNum: 0,
+		IsFinal: false,
+	}
+
+	gotState := ledger.SignedStateForTurnNum[0].State()
+	if diff := cmp.Diff(expectedState, gotState); diff != "" {
+		t.Errorf("TestCreateLedger: ledger state mismatch (-want +got):\n%s", diff)
+	}
+
+}
+
+func TestHandleLedgerRequest(t *testing.T) {
+	cranker := NewLedgerCranker()
+	left := outcome.Allocation{Destination: alice.destination, Amount: big.NewInt(3)}
+	right := outcome.Allocation{Destination: bob.destination, Amount: big.NewInt(2)}
+
+	ledger := cranker.CreateLedger(left, right, &alice.privateKey, 0)
+
+	SignPreAndPostFundingStates(ledger, []*[]byte{&alice.privateKey, &bob.privateKey})
+
+	destination := types.AddressToDestination(common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`))
+	asset := types.Address{}
+	oId := protocols.ObjectiveId("Test")
+	invalidRequest := protocols.LedgerRequest{LedgerId: ledger.Id, Left: left.Destination, Right: right.Destination, Destination: destination, Amount: types.Funds{asset: big.NewInt(10)}}
+	_, err := cranker.HandleRequest(invalidRequest, oId, &alice.privateKey)
+	if err == nil {
+		t.Errorf("TestHandleLedgerRequest: expected request to be fail as the ledger does not have enough funds")
+	}
+
+	validRequest := protocols.LedgerRequest{LedgerId: ledger.Id, Left: left.Destination, Right: right.Destination, Destination: destination, Amount: types.Funds{asset: big.NewInt(4)}}
+	sideEffects, err := cranker.HandleRequest(validRequest, oId, &alice.privateKey)
+	if err != nil {
+		t.Error(err)
+	}
+	guarantee, _ := outcome.GuaranteeMetadata{
+		Left:  alice.destination,
+		Right: bob.destination,
+	}.Encode()
+
+	expectedState := state.State{
+		ChainId:           big.NewInt(9001),
+		Participants:      []types.Address{alice.address, bob.address},
+		ChannelNonce:      big.NewInt(0),
+		AppDefinition:     types.Address{},
+		ChallengeDuration: big.NewInt(45),
+		AppData:           []byte{},
+		Outcome: outcome.Exit{outcome.SingleAssetExit{
+			Allocations: outcome.Allocations{
+				outcome.Allocation{
+					Destination: alice.destination,
+					Amount:      big.NewInt(1),
+				},
+				outcome.Allocation{
+					Destination: bob.destination,
+					Amount:      big.NewInt(0),
+				},
+				outcome.Allocation{
+					Destination:    destination,
+					Amount:         big.NewInt(4),
+					AllocationType: outcome.GuaranteeAllocationType,
+					Metadata:       guarantee,
+				},
+			}}},
+		TurnNum: 2,
+		IsFinal: false}
+
+	expectedSigned := state.NewSignedState(expectedState)
+	err = expectedSigned.SignAndAdd(&alice.privateKey)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedMessage := protocols.Message{To: bob.address, ObjectiveId: oId, SignedStates: []state.SignedState{expectedSigned}}
+
+	if diff := cmp.Diff(sideEffects.MessagesToSend[0], expectedMessage); diff != "" {
+		t.Errorf("TestHandleRequest: ledger message mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/protocols/ledger/ledger_test.go
+++ b/protocols/ledger/ledger_test.go
@@ -35,7 +35,10 @@ func TestCreateLedger(t *testing.T) {
 	left := outcome.Allocation{Destination: alice.destination, Amount: big.NewInt(3)}
 	right := outcome.Allocation{Destination: bob.destination, Amount: big.NewInt(2)}
 
-	ledger := ledgerManager.CreateTestLedger(left, right, &alice.privateKey, 0)
+	ledger, err := ledgerManager.CreateTestLedger(left, right, &alice.privateKey, 0)
+	if err != nil {
+		t.Error(err)
+	}
 
 	expectedState := state.State{
 		ChainId:           big.NewInt(9001),
@@ -56,7 +59,7 @@ func TestCreateLedger(t *testing.T) {
 		t.Errorf("TestCreateLedger: ledger state mismatch (-want +got):\n%s", diff)
 	}
 
-	ledger2 := ledgerManager.CreateTestLedger(left, right, &alice.privateKey, 0)
+	ledger2, _ := ledgerManager.CreateTestLedger(left, right, &alice.privateKey, 0)
 	if ledger2.ChannelNonce.Cmp(big.NewInt(1)) != 0 {
 		t.Error("TestCreateLedger: ledger channel should use the next nonce")
 	}
@@ -68,7 +71,7 @@ func TestHandleLedgerRequest(t *testing.T) {
 	left := outcome.Allocation{Destination: alice.destination, Amount: big.NewInt(3)}
 	right := outcome.Allocation{Destination: bob.destination, Amount: big.NewInt(2)}
 
-	ledger := ledgerManager.CreateTestLedger(left, right, &alice.privateKey, 0)
+	ledger, _ := ledgerManager.CreateTestLedger(left, right, &alice.privateKey, 0)
 
 	destination := types.AddressToDestination(common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`))
 	asset := types.Address{}

--- a/protocols/ledger/ledger_test.go
+++ b/protocols/ledger/ledger_test.go
@@ -35,7 +35,7 @@ func TestCreateLedger(t *testing.T) {
 	left := outcome.Allocation{Destination: alice.destination, Amount: big.NewInt(3)}
 	right := outcome.Allocation{Destination: bob.destination, Amount: big.NewInt(2)}
 
-	ledger := ledgerManager.CreateLedger(left, right, &alice.privateKey, 0)
+	ledger := ledgerManager.CreateTestLedger(left, right, &alice.privateKey, 0)
 
 	expectedState := state.State{
 		ChainId:           big.NewInt(9001),
@@ -56,7 +56,7 @@ func TestCreateLedger(t *testing.T) {
 		t.Errorf("TestCreateLedger: ledger state mismatch (-want +got):\n%s", diff)
 	}
 
-	ledger2 := ledgerManager.CreateLedger(left, right, &alice.privateKey, 0)
+	ledger2 := ledgerManager.CreateTestLedger(left, right, &alice.privateKey, 0)
 	if ledger2.ChannelNonce.Cmp(big.NewInt(1)) != 0 {
 		t.Error("TestCreateLedger: ledger channel should use the next nonce")
 	}
@@ -68,7 +68,7 @@ func TestHandleLedgerRequest(t *testing.T) {
 	left := outcome.Allocation{Destination: alice.destination, Amount: big.NewInt(3)}
 	right := outcome.Allocation{Destination: bob.destination, Amount: big.NewInt(2)}
 
-	ledger := ledgerManager.CreateLedger(left, right, &alice.privateKey, 0)
+	ledger := ledgerManager.CreateTestLedger(left, right, &alice.privateKey, 0)
 
 	destination := types.AddressToDestination(common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`))
 	asset := types.Address{}

--- a/protocols/ledger/ledger_test.go
+++ b/protocols/ledger/ledger_test.go
@@ -62,12 +62,26 @@ func TestHandleLedgerRequest(t *testing.T) {
 	asset := types.Address{}
 	oId := protocols.ObjectiveId("Test")
 
-	validRequest := protocols.LedgerRequest{ObjectiveId: oId, LedgerId: ledger.Id, Left: left.Destination, Right: right.Destination, Destination: destination, Amount: types.Funds{asset: big.NewInt(4)}}
-	invalidRequest := protocols.LedgerRequest{ObjectiveId: oId, LedgerId: ledger.Id, Left: left.Destination, Right: right.Destination, Destination: destination, Amount: types.Funds{asset: big.NewInt(10)}}
+	validRequest := protocols.LedgerRequest{
+		ObjectiveId: oId,
+		LedgerId:    ledger.Id,
+		Left:        left.Destination,
+		Right:       right.Destination,
+		Destination: destination,
+		Amount:      types.Funds{asset: big.NewInt(4)},
+	}
+	invalidRequest := protocols.LedgerRequest{
+		ObjectiveId: oId,
+		LedgerId:    ledger.Id,
+		Left:        left.Destination,
+		Right:       right.Destination,
+		Destination: destination,
+		Amount:      types.Funds{asset: big.NewInt(10)},
+	}
 
 	_, err := ledgerManager.HandleRequest(ledger, validRequest, &alice.privateKey)
 	if err == nil {
-		t.Errorf("TestHandleLedgerRequest: expected request to be fail as there is no supported state")
+		t.Errorf("TestHandleLedgerRequest: expected request to fail as there is no supported state")
 	}
 
 	SignPreAndPostFundingStates(ledger, []*[]byte{&alice.privateKey, &bob.privateKey})

--- a/protocols/ledger/ledger_test.go
+++ b/protocols/ledger/ledger_test.go
@@ -74,7 +74,7 @@ func TestHandleLedgerRequest(t *testing.T) {
 
 	_, err = ledgerManager.HandleRequest(ledger, invalidRequest, &alice.privateKey)
 	if err == nil {
-		t.Errorf("TestHandleLedgerRequest: expected request to  fail as the ledger does not have enough funds")
+		t.Errorf("TestHandleLedgerRequest: expected request to fail as the ledger does not have enough funds")
 	}
 
 	sideEffects, err := ledgerManager.HandleRequest(ledger, validRequest, &alice.privateKey)

--- a/protocols/ledger/ledger_test.go
+++ b/protocols/ledger/ledger_test.go
@@ -74,22 +74,22 @@ func TestHandleLedgerRequest(t *testing.T) {
 	asset := types.Address{}
 	oId := protocols.ObjectiveId("Test")
 
-	validRequest := protocols.LedgerRequest{LedgerId: ledger.Id, Left: left.Destination, Right: right.Destination, Destination: destination, Amount: types.Funds{asset: big.NewInt(4)}}
-	invalidRequest := protocols.LedgerRequest{LedgerId: ledger.Id, Left: left.Destination, Right: right.Destination, Destination: destination, Amount: types.Funds{asset: big.NewInt(10)}}
+	validRequest := protocols.LedgerRequest{ObjectiveId: oId, LedgerId: ledger.Id, Left: left.Destination, Right: right.Destination, Destination: destination, Amount: types.Funds{asset: big.NewInt(4)}}
+	invalidRequest := protocols.LedgerRequest{ObjectiveId: oId, LedgerId: ledger.Id, Left: left.Destination, Right: right.Destination, Destination: destination, Amount: types.Funds{asset: big.NewInt(10)}}
 
-	_, err := cranker.HandleRequest(ledger, validRequest, oId, &alice.privateKey)
+	_, err := cranker.HandleRequest(ledger, validRequest, &alice.privateKey)
 	if err == nil {
 		t.Errorf("TestHandleLedgerRequest: expected request to be fail as there is no supported state")
 	}
 
 	SignPreAndPostFundingStates(ledger, []*[]byte{&alice.privateKey, &bob.privateKey})
 
-	_, err = cranker.HandleRequest(ledger, invalidRequest, oId, &alice.privateKey)
+	_, err = cranker.HandleRequest(ledger, invalidRequest, &alice.privateKey)
 	if err == nil {
 		t.Errorf("TestHandleLedgerRequest: expected request to  fail as the ledger does not have enough funds")
 	}
 
-	sideEffects, err := cranker.HandleRequest(ledger, validRequest, oId, &alice.privateKey)
+	sideEffects, err := cranker.HandleRequest(ledger, validRequest, &alice.privateKey)
 	if err != nil {
 		t.Error(err)
 	}

--- a/protocols/ledger/ledger_test.go
+++ b/protocols/ledger/ledger_test.go
@@ -40,23 +40,8 @@ func TestCreateLedger(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedState := state.State{
-		ChainId:           big.NewInt(9001),
-		Participants:      []types.Address{alice.address, bob.address},
-		ChannelNonce:      big.NewInt(0),
-		AppDefinition:     types.Address{},
-		ChallengeDuration: big.NewInt(45),
-		AppData:           []byte{},
-		Outcome: outcome.Exit{outcome.SingleAssetExit{
-			Allocations: outcome.Allocations{left, right},
-		}},
-		TurnNum: 0,
-		IsFinal: false,
-	}
-
-	gotState := ledger.SignedStateForTurnNum[0].State()
-	if diff := cmp.Diff(expectedState, gotState); diff != "" {
-		t.Errorf("TestCreateLedger: ledger state mismatch (-want +got):\n%s", diff)
+	if ledger.ChannelNonce.Cmp(big.NewInt(0)) != 0 {
+		t.Error("TestCreateLedger: initial ledger channel should use the 0 nonce")
 	}
 
 	ledger2, _ := ledgerManager.CreateTestLedger(left, right, &alice.privateKey, 0)

--- a/protocols/ledger/ledger_test.go
+++ b/protocols/ledger/ledger_test.go
@@ -31,22 +31,17 @@ var bob = actor{
 }
 
 func TestCreateLedger(t *testing.T) {
-	ledgerManager := NewLedgerManager()
+
 	left := outcome.Allocation{Destination: alice.destination, Amount: big.NewInt(3)}
 	right := outcome.Allocation{Destination: bob.destination, Amount: big.NewInt(2)}
 
-	ledger, err := ledgerManager.CreateTestLedger(left, right, &alice.privateKey, 0)
+	ledger, err := CreateTestLedger(left, right, &alice.privateKey, 0, big.NewInt(0))
 	if err != nil {
 		t.Error(err)
 	}
 
 	if ledger.ChannelNonce.Cmp(big.NewInt(0)) != 0 {
 		t.Error("TestCreateLedger: initial ledger channel should use the 0 nonce")
-	}
-
-	ledger2, _ := ledgerManager.CreateTestLedger(left, right, &alice.privateKey, 0)
-	if ledger2.ChannelNonce.Cmp(big.NewInt(1)) != 0 {
-		t.Error("TestCreateLedger: ledger channel should use the next nonce")
 	}
 
 }
@@ -56,7 +51,7 @@ func TestHandleLedgerRequest(t *testing.T) {
 	left := outcome.Allocation{Destination: alice.destination, Amount: big.NewInt(3)}
 	right := outcome.Allocation{Destination: bob.destination, Amount: big.NewInt(2)}
 
-	ledger, _ := ledgerManager.CreateTestLedger(left, right, &alice.privateKey, 0)
+	ledger, _ := CreateTestLedger(left, right, &alice.privateKey, 0, big.NewInt(0))
 
 	destination := types.AddressToDestination(common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`))
 	asset := types.Address{}

--- a/protocols/ledger/ledger_test.go
+++ b/protocols/ledger/ledger_test.go
@@ -77,19 +77,19 @@ func TestHandleLedgerRequest(t *testing.T) {
 	validRequest := protocols.LedgerRequest{LedgerId: ledger.Id, Left: left.Destination, Right: right.Destination, Destination: destination, Amount: types.Funds{asset: big.NewInt(4)}}
 	invalidRequest := protocols.LedgerRequest{LedgerId: ledger.Id, Left: left.Destination, Right: right.Destination, Destination: destination, Amount: types.Funds{asset: big.NewInt(10)}}
 
-	_, err := cranker.HandleRequest(validRequest, oId, &alice.privateKey)
+	_, err := cranker.HandleRequest(ledger, validRequest, oId, &alice.privateKey)
 	if err == nil {
 		t.Errorf("TestHandleLedgerRequest: expected request to be fail as there is no supported state")
 	}
 
 	SignPreAndPostFundingStates(ledger, []*[]byte{&alice.privateKey, &bob.privateKey})
 
-	_, err = cranker.HandleRequest(invalidRequest, oId, &alice.privateKey)
+	_, err = cranker.HandleRequest(ledger, invalidRequest, oId, &alice.privateKey)
 	if err == nil {
 		t.Errorf("TestHandleLedgerRequest: expected request to  fail as the ledger does not have enough funds")
 	}
 
-	sideEffects, err := cranker.HandleRequest(validRequest, oId, &alice.privateKey)
+	sideEffects, err := cranker.HandleRequest(ledger, validRequest, oId, &alice.privateKey)
 	if err != nil {
 		t.Error(err)
 	}

--- a/protocols/ledger/ledger_test.go
+++ b/protocols/ledger/ledger_test.go
@@ -56,6 +56,11 @@ func TestCreateLedger(t *testing.T) {
 		t.Errorf("TestCreateLedger: ledger state mismatch (-want +got):\n%s", diff)
 	}
 
+	ledger2 := cranker.CreateLedger(left, right, &alice.privateKey, 0)
+	if ledger2.ChannelNonce.Cmp(big.NewInt(1)) != 0 {
+		t.Error("TestCreateLedger: ledger channel should use the next nonce")
+	}
+
 }
 
 func TestHandleLedgerRequest(t *testing.T) {

--- a/protocols/ledger/ledger_test.go
+++ b/protocols/ledger/ledger_test.go
@@ -65,18 +65,25 @@ func TestHandleLedgerRequest(t *testing.T) {
 
 	ledger := cranker.CreateLedger(left, right, &alice.privateKey, 0)
 
-	SignPreAndPostFundingStates(ledger, []*[]byte{&alice.privateKey, &bob.privateKey})
-
 	destination := types.AddressToDestination(common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`))
 	asset := types.Address{}
 	oId := protocols.ObjectiveId("Test")
-	invalidRequest := protocols.LedgerRequest{LedgerId: ledger.Id, Left: left.Destination, Right: right.Destination, Destination: destination, Amount: types.Funds{asset: big.NewInt(10)}}
-	_, err := cranker.HandleRequest(invalidRequest, oId, &alice.privateKey)
-	if err == nil {
-		t.Errorf("TestHandleLedgerRequest: expected request to be fail as the ledger does not have enough funds")
-	}
 
 	validRequest := protocols.LedgerRequest{LedgerId: ledger.Id, Left: left.Destination, Right: right.Destination, Destination: destination, Amount: types.Funds{asset: big.NewInt(4)}}
+	invalidRequest := protocols.LedgerRequest{LedgerId: ledger.Id, Left: left.Destination, Right: right.Destination, Destination: destination, Amount: types.Funds{asset: big.NewInt(10)}}
+
+	_, err := cranker.HandleRequest(validRequest, oId, &alice.privateKey)
+	if err == nil {
+		t.Errorf("TestHandleLedgerRequest: expected request to be fail as there is no supported state")
+	}
+
+	SignPreAndPostFundingStates(ledger, []*[]byte{&alice.privateKey, &bob.privateKey})
+
+	_, err = cranker.HandleRequest(invalidRequest, oId, &alice.privateKey)
+	if err == nil {
+		t.Errorf("TestHandleLedgerRequest: expected request to  fail as the ledger does not have enough funds")
+	}
+
 	sideEffects, err := cranker.HandleRequest(validRequest, oId, &alice.privateKey)
 	if err != nil {
 		t.Error(err)

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -113,7 +113,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 		right := outcome.Allocation{Destination: p1.destination, Amount: big.NewInt(5)}
 
 		// She has a single ledger channel L_0 connecting her to P_1
-		var ledgerChannelToMyRight = ledgerManager.CreateLedger(left, right, &alice.privateKey, alice.role)
+		var ledgerChannelToMyRight = ledgerManager.CreateTestLedger(left, right, &alice.privateKey, alice.role)
 		// Ensure this channel is fully funded on chain
 		ledgerChannelToMyRight.OnChainFunding = ledgerChannelToMyRight.PreFundState().Outcome.TotalAllocated()
 
@@ -296,7 +296,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			}
 			f.SignedStates = make([]state.SignedState, 0)
 			manager := ledger.NewLedgerManager()
-			ledger := manager.CreateLedger(left, right, &alice.privateKey, 0)
+			ledger := manager.CreateTestLedger(left, right, &alice.privateKey, 0)
 			ss := signState(ledger.PreFundState(), alice)
 
 			f.SignedStates = append(f.SignedStates, ss)

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -113,7 +113,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 		right := outcome.Allocation{Destination: p1.destination, Amount: big.NewInt(5)}
 
 		// She has a single ledger channel L_0 connecting her to P_1
-		var ledgerChannelToMyRight, _ = ledgerManager.CreateTestLedger(left, right, &alice.privateKey, alice.role)
+		var ledgerChannelToMyRight, _ = ledger.CreateTestLedger(left, right, &alice.privateKey, alice.role, big.NewInt(0))
 		// Ensure this channel is fully funded on chain
 		ledgerChannelToMyRight.OnChainFunding = ledgerChannelToMyRight.PreFundState().Outcome.TotalAllocated()
 
@@ -295,8 +295,8 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				ObjectiveId: s.Id(),
 			}
 			f.SignedStates = make([]state.SignedState, 0)
-			manager := ledger.NewLedgerManager()
-			ledger, _ := manager.CreateTestLedger(left, right, &alice.privateKey, 0)
+
+			ledger, _ := ledger.CreateTestLedger(left, right, &alice.privateKey, 0, big.NewInt(0))
 			ss := signState(ledger.PreFundState(), alice)
 
 			f.SignedStates = append(f.SignedStates, ss)

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -113,7 +113,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 		right := outcome.Allocation{Destination: p1.destination, Amount: big.NewInt(5)}
 
 		// She has a single ledger channel L_0 connecting her to P_1
-		var ledgerChannelToMyRight = ledgerManager.CreateTestLedger(left, right, &alice.privateKey, alice.role)
+		var ledgerChannelToMyRight, _ = ledgerManager.CreateTestLedger(left, right, &alice.privateKey, alice.role)
 		// Ensure this channel is fully funded on chain
 		ledgerChannelToMyRight.OnChainFunding = ledgerChannelToMyRight.PreFundState().Outcome.TotalAllocated()
 
@@ -296,7 +296,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			}
 			f.SignedStates = make([]state.SignedState, 0)
 			manager := ledger.NewLedgerManager()
-			ledger := manager.CreateTestLedger(left, right, &alice.privateKey, 0)
+			ledger, _ := manager.CreateTestLedger(left, right, &alice.privateKey, 0)
 			ss := signState(ledger.PreFundState(), alice)
 
 			f.SignedStates = append(f.SignedStates, ss)

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -214,10 +214,9 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				t.Errorf("TestCrank: side effects mismatch (-want +got):\n%s", diff)
 			}
 
-			ledgerCranker.Update(o.ToMyRight.Channel)
-
 			ledger.SignPreAndPostFundingStates(o.ToMyRight.Channel, []*[]byte{&alice.privateKey, &p1.privateKey})
-			_, _ = ledgerCranker.HandleRequest(got.LedgerRequests[0], o.Id(), &alice.privateKey)
+
+			_, _ = ledgerCranker.HandleRequest(o.ToMyRight.Channel, got.LedgerRequests[0], o.Id(), &alice.privateKey)
 			ledger.SignLatest(o.ToMyRight.Channel, [][]byte{p1.privateKey})
 			// Cranking now should not generate side effects, because we already did that
 			oObj, got, waitingFor, err = o.Crank(&my.privateKey)

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -289,9 +289,9 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 			ledgerCranker.Update(o.ToMyRight.Channel)
 
-			ledgerCranker.SignPreAndPostFundingStates(got.LedgerRequests[0].LedgerId, []*[]byte{&alice.privateKey, &p1.privateKey})
+			ledger.SignPreAndPostFundingStates(o.ToMyRight.Channel, []*[]byte{&alice.privateKey, &p1.privateKey})
 			ledgerCranker.HandleRequest(got.LedgerRequests[0], o.Id(), &alice.privateKey)
-			ledgerCranker.SignLatest(got.LedgerRequests[0].LedgerId, [][]byte{p1.privateKey})
+			ledger.SignLatest(o.ToMyRight.Channel, [][]byte{p1.privateKey})
 			// Cranking now should not generate side effects, because we already did that
 			oObj, got, waitingFor, err = o.Crank(&my.privateKey)
 			o = oObj.(VirtualFundObjective)

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -108,12 +108,12 @@ func TestSingleHopVirtualFund(t *testing.T) {
 		// Alice plays role 0 so has no ledger channel on her left
 		var ledgerChannelToMyLeft *channel.TwoPartyLedger
 
-		ledgerCranker := ledger.NewLedgerCranker()
+		ledgerManager := ledger.NewLedgerManager()
 		left := outcome.Allocation{Destination: alice.destination, Amount: big.NewInt(5)}
 		right := outcome.Allocation{Destination: p1.destination, Amount: big.NewInt(5)}
 
 		// She has a single ledger channel L_0 connecting her to P_1
-		var ledgerChannelToMyRight = ledgerCranker.CreateLedger(left, right, &alice.privateKey, alice.role)
+		var ledgerChannelToMyRight = ledgerManager.CreateLedger(left, right, &alice.privateKey, alice.role)
 		// Ensure this channel is fully funded on chain
 		ledgerChannelToMyRight.OnChainFunding = ledgerChannelToMyRight.PreFundState().Outcome.TotalAllocated()
 
@@ -217,7 +217,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 			ledger.SignPreAndPostFundingStates(o.ToMyRight.Channel, []*[]byte{&alice.privateKey, &p1.privateKey})
 
-			_, _ = ledgerCranker.HandleRequest(o.ToMyRight.Channel, got.LedgerRequests[0], &alice.privateKey)
+			_, _ = ledgerManager.HandleRequest(o.ToMyRight.Channel, got.LedgerRequests[0], &alice.privateKey)
 			ledger.SignLatest(o.ToMyRight.Channel, [][]byte{p1.privateKey})
 			// Cranking now should not generate side effects, because we already did that
 			oObj, got, waitingFor, err = o.Crank(&my.privateKey)
@@ -295,8 +295,8 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				ObjectiveId: s.Id(),
 			}
 			f.SignedStates = make([]state.SignedState, 0)
-			cranker := ledger.NewLedgerCranker()
-			ledger := cranker.CreateLedger(left, right, &alice.privateKey, 0)
+			manager := ledger.NewLedgerManager()
+			ledger := manager.CreateLedger(left, right, &alice.privateKey, 0)
 			ss := signState(ledger.PreFundState(), alice)
 
 			f.SignedStates = append(f.SignedStates, ss)

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -289,9 +289,9 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 			ledgerCranker.Update(o.ToMyRight.Channel)
 
-			ledgerCranker.CompleteFunding(got.LedgerRequests[0].LedgerId, []*[]byte{&alice.privateKey, &p1.privateKey})
+			ledgerCranker.SignPreAndPostFundingStates(got.LedgerRequests[0].LedgerId, []*[]byte{&alice.privateKey, &p1.privateKey})
 			ledgerCranker.HandleRequest(got.LedgerRequests[0], o.Id(), &alice.privateKey)
-			ledgerCranker.Sign(got.LedgerRequests[0].LedgerId, 2, [][]byte{p1.privateKey})
+			ledgerCranker.SignLatest(got.LedgerRequests[0].LedgerId, [][]byte{p1.privateKey})
 			// Cranking now should not generate side effects, because we already did that
 			oObj, got, waitingFor, err = o.Crank(&my.privateKey)
 			o = oObj.(VirtualFundObjective)

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -203,6 +203,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				t.Error(`Expected ledger update idempotency flag to be raised, but it wasn't`)
 			}
 			var expectedLedgerRequests = []protocols.LedgerRequest{{
+				ObjectiveId: o.Id(),
 				LedgerId:    ledgerChannelToMyRight.Id,
 				Destination: s.V.Id,
 				Amount:      types.Funds{types.Address{}: s.V.PreFundState().VariablePart().Outcome[0].Allocations.Total()},
@@ -210,13 +211,13 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			}}
 			want = protocols.SideEffects{LedgerRequests: expectedLedgerRequests}
 
-			if diff := cmp.Diff(want, got); diff != "" {
+			if diff := cmp.Diff(want, got, cmp.Comparer(types.Equal)); diff != "" {
 				t.Errorf("TestCrank: side effects mismatch (-want +got):\n%s", diff)
 			}
 
 			ledger.SignPreAndPostFundingStates(o.ToMyRight.Channel, []*[]byte{&alice.privateKey, &p1.privateKey})
 
-			_, _ = ledgerCranker.HandleRequest(o.ToMyRight.Channel, got.LedgerRequests[0], o.Id(), &alice.privateKey)
+			_, _ = ledgerCranker.HandleRequest(o.ToMyRight.Channel, got.LedgerRequests[0], &alice.privateKey)
 			ledger.SignLatest(o.ToMyRight.Channel, [][]byte{p1.privateKey})
 			// Cranking now should not generate side effects, because we already did that
 			oObj, got, waitingFor, err = o.Crank(&my.privateKey)

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -329,6 +329,7 @@ func (s VirtualFundObjective) generateLedgerRequestSideEffects() protocols.SideE
 	if s.MyRole > 0 { // Not Alice
 		sideEffects.LedgerRequests = append(sideEffects.LedgerRequests,
 			protocols.LedgerRequest{
+				ObjectiveId: s.Id(),
 				LedgerId:    s.ToMyLeft.Channel.Id,
 				Destination: s.V.Id,
 				Amount:      s.V.Total(),
@@ -340,6 +341,7 @@ func (s VirtualFundObjective) generateLedgerRequestSideEffects() protocols.SideE
 	if s.MyRole < n { // Not Bob
 		sideEffects.LedgerRequests = append(sideEffects.LedgerRequests,
 			protocols.LedgerRequest{
+				ObjectiveId: s.Id(),
 				LedgerId:    s.ToMyRight.Channel.Id,
 				Destination: s.V.Id,
 				Amount:      s.V.Total(),


### PR DESCRIPTION
Fixes #223 

This PR adds a new `LedgerManager` that handles a ledger request by updating the ledger channel and generating a message with the signed ledger state. The current logic is not a full ledger protocol, but should be enough for now to work towards #217 

The virtual funding tests have been updated to use the `LedgerManager` which has removed a lot of manually created ledger data.

Eventually this `LedgerManager` [will be used in the engine to handle ](https://github.com/statechannels/go-nitro/issues/240)`LedgerRequests` and get us closer to #217.