### PR TITLE
Update Ledger Request to have amount for left and right

### DIFF
--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -17,15 +17,17 @@ type LedgerRequest struct {
 	ObjectiveId ObjectiveId
 	LedgerId    types.Destination
 	Destination types.Destination
-	Amount      types.Funds
 	Left        types.Destination
+	LeftAmount  types.Funds
 	Right       types.Destination
+	RightAmount types.Funds
 }
 
 // Equal checks for equality between the receiver and a second LedgerRequest
 func (l LedgerRequest) Equal(m LedgerRequest) bool {
 	return l.LedgerId == m.LedgerId &&
-		l.Amount.Equal(m.Amount) &&
+		l.LeftAmount.Equal(m.LeftAmount) &&
+		l.RightAmount.Equal(m.RightAmount) &&
 		l.Left == m.Left &&
 		l.Right == m.Right &&
 		l.ObjectiveId == m.ObjectiveId

--- a/protocols/ledger/ledger.go
+++ b/protocols/ledger/ledger.go
@@ -37,14 +37,13 @@ func (l *LedgerManager) HandleRequest(ledger *channel.TwoPartyLedger, request pr
 	nextState := supported.Clone()
 
 	// Calculate the amounts
-
 	leftAmount := big.NewInt(0).Sub(nextState.Outcome.TotalAllocatedFor(request.Left)[asset], request.LeftAmount[asset])
 	rightAmount := big.NewInt(0).Sub(nextState.Outcome.TotalAllocatedFor(request.Right)[asset], request.RightAmount[asset])
 	total := big.NewInt(0).Add(request.LeftAmount[asset], request.RightAmount[asset])
-	if leftAmount.Cmp(big.NewInt(0)) < 0 {
+	if types.Lt(leftAmount, big.NewInt(0)) {
 		return protocols.SideEffects{}, fmt.Errorf("Allocation for %x cannot afford the amount %d", request.Left, request.LeftAmount[asset])
 	}
-	if rightAmount.Cmp(big.NewInt(0)) < 0 {
+	if types.Lt(rightAmount, big.NewInt(0)) {
 		return protocols.SideEffects{}, fmt.Errorf("Allocation for %x cannot afford the amount %d", request.Right, request.RightAmount[asset])
 	}
 

--- a/protocols/ledger/ledger_test.go
+++ b/protocols/ledger/ledger_test.go
@@ -63,7 +63,8 @@ func TestHandleLedgerRequest(t *testing.T) {
 		Left:        left.Destination,
 		Right:       right.Destination,
 		Destination: destination,
-		Amount:      types.Funds{asset: big.NewInt(4)},
+		LeftAmount:  types.Funds{asset: big.NewInt(2)},
+		RightAmount: types.Funds{asset: big.NewInt(2)},
 	}
 	invalidRequest := protocols.LedgerRequest{
 		ObjectiveId: oId,
@@ -71,7 +72,8 @@ func TestHandleLedgerRequest(t *testing.T) {
 		Left:        left.Destination,
 		Right:       right.Destination,
 		Destination: destination,
-		Amount:      types.Funds{asset: big.NewInt(10)},
+		LeftAmount:  types.Funds{asset: big.NewInt(5)},
+		RightAmount: types.Funds{asset: big.NewInt(5)},
 	}
 
 	_, err := ledgerManager.HandleRequest(ledger, validRequest, &alice.privateKey)

--- a/protocols/ledger/ledger_test.go
+++ b/protocols/ledger/ledger_test.go
@@ -64,7 +64,7 @@ func TestHandleLedgerRequest(t *testing.T) {
 		Right:       right.Destination,
 		Destination: destination,
 		LeftAmount:  types.Funds{asset: big.NewInt(2)},
-		RightAmount: types.Funds{asset: big.NewInt(2)},
+		RightAmount: types.Funds{asset: big.NewInt(1)},
 	}
 	invalidRequest := protocols.LedgerRequest{
 		ObjectiveId: oId,
@@ -72,8 +72,8 @@ func TestHandleLedgerRequest(t *testing.T) {
 		Left:        left.Destination,
 		Right:       right.Destination,
 		Destination: destination,
-		LeftAmount:  types.Funds{asset: big.NewInt(5)},
-		RightAmount: types.Funds{asset: big.NewInt(5)},
+		LeftAmount:  types.Funds{asset: big.NewInt(1000)},
+		RightAmount: types.Funds{asset: big.NewInt(1000)},
 	}
 
 	_, err := ledgerManager.HandleRequest(ledger, validRequest, &alice.privateKey)
@@ -112,11 +112,11 @@ func TestHandleLedgerRequest(t *testing.T) {
 				},
 				outcome.Allocation{
 					Destination: bob.destination,
-					Amount:      big.NewInt(0),
+					Amount:      big.NewInt(1),
 				},
 				outcome.Allocation{
 					Destination:    destination,
-					Amount:         big.NewInt(4),
+					Amount:         big.NewInt(3),
 					AllocationType: outcome.GuaranteeAllocationType,
 					Metadata:       guarantee,
 				},

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -206,8 +206,10 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				ObjectiveId: o.Id(),
 				LedgerId:    ledgerChannelToMyRight.Id,
 				Destination: s.V.Id,
-				Amount:      types.Funds{types.Address{}: s.V.PreFundState().VariablePart().Outcome[0].Allocations.Total()},
-				Left:        ledgerChannelToMyRight.MyDestination(), Right: ledgerChannelToMyRight.TheirDestination(),
+
+				Left: ledgerChannelToMyRight.MyDestination(), Right: ledgerChannelToMyRight.TheirDestination(),
+				LeftAmount:  types.Funds{types.Address{}: big.NewInt(5)},
+				RightAmount: types.Funds{types.Address{}: big.NewInt(5)},
 			}}
 			want = protocols.SideEffects{LedgerRequests: expectedLedgerRequests}
 

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -326,15 +326,24 @@ func (connection *Connection) ledgerChannelAffordsExpectedGuarantees() bool {
 func (s VirtualFundObjective) generateLedgerRequestSideEffects() protocols.SideEffects {
 	sideEffects := protocols.SideEffects{}
 	sideEffects.LedgerRequests = make([]protocols.LedgerRequest, 0)
+
+	leftAmount := s.V.PreFundState().Outcome.TotalAllocatedFor(s.V.MyDestination())
+	// TODO: This is hacky way of getting the second expected outcome.
+	other := s.V.PreFundState().Outcome[0].Allocations[1].Destination
+	rightAmount := s.V.PreFundState().Outcome.TotalAllocatedFor(other)
+
 	if s.MyRole > 0 { // Not Alice
+
 		sideEffects.LedgerRequests = append(sideEffects.LedgerRequests,
 			protocols.LedgerRequest{
 				ObjectiveId: s.Id(),
 				LedgerId:    s.ToMyLeft.Channel.Id,
 				Destination: s.V.Id,
-				Amount:      s.V.Total(),
+
 				Left:        s.ToMyLeft.Channel.TheirDestination(),
+				LeftAmount:  leftAmount,
 				Right:       s.ToMyLeft.Channel.MyDestination(),
+				RightAmount: rightAmount,
 			})
 	}
 	n := s.n
@@ -344,9 +353,10 @@ func (s VirtualFundObjective) generateLedgerRequestSideEffects() protocols.SideE
 				ObjectiveId: s.Id(),
 				LedgerId:    s.ToMyRight.Channel.Id,
 				Destination: s.V.Id,
-				Amount:      s.V.Total(),
 				Left:        s.ToMyRight.Channel.MyDestination(),
+				LeftAmount:  leftAmount,
 				Right:       s.ToMyRight.Channel.TheirDestination(),
+				RightAmount: rightAmount,
 			})
 	}
 	return sideEffects

--- a/types/bigutils.go
+++ b/types/bigutils.go
@@ -11,6 +11,11 @@ func Gt(a *big.Int, b *big.Int) bool {
 	return a.Cmp(b) > 0
 }
 
+// Lt return true if a < b, false otherwise
+func Lt(a *big.Int, b *big.Int) bool {
+	return a.Cmp(b) < 0
+}
+
 func Equal(a *big.Int, b *big.Int) bool {
 	return a.Cmp(b) == 0
 }


### PR DESCRIPTION
Fixes #244 

Previously the ledger request only contained a single `Amount`. This meant when handling the request we didn't know how much should be paid by `left` and how much should be paid by `right`.

The ledger request has been updated  to have a `leftAmount` and `rightAmount`.  These get set based on the virtual channel's outcome. IE: `leftAmount=V.Allocations[0]`  `rightAmount=V.Allocations[1]`  

This means that the `LedgerManager` can properly adjust the ledger outcome and construct the guarantee.

