### PR TITLE
Handle multiple assets in handle request

### DIFF
--- a/protocols/ledger/ledger.go
+++ b/protocols/ledger/ledger.go
@@ -32,46 +32,50 @@ func (l *LedgerManager) HandleRequest(ledger *channel.TwoPartyLedger, request pr
 	if err != nil {
 		return protocols.SideEffects{}, fmt.Errorf("error finding a supported state: %w", err)
 	}
-
-	asset := types.Address{} // todo: loop over request.amount's assets
 	nextState := supported.Clone()
+	nextState.Outcome = outcome.Exit{}
+	// TODO: We should iterate over assets in RightAmount as well. For now we rely on the assumption that LeftAmount and RightAmount will have the same assets.
+	for asset := range request.LeftAmount {
 
-	// Get the current amounts from the ledger channel
-	currentLeftAmount := nextState.Outcome.TotalAllocatedFor(request.Left)[asset]
-	currentRightAmount := nextState.Outcome.TotalAllocatedFor(request.Right)[asset]
-	// Calculate the new amounts by subtracting the requested amounts from the current amounts
-	leftAmount := big.NewInt(0).Sub(currentLeftAmount, request.LeftAmount[asset])
-	rightAmount := big.NewInt(0).Sub(currentRightAmount, request.RightAmount[asset])
+		// Get the current amounts from the ledger channel
+		currentLeftAmount := nextState.Outcome.TotalAllocatedFor(request.Left)[asset]
+		currentRightAmount := nextState.Outcome.TotalAllocatedFor(request.Right)[asset]
+		// Calculate the new amounts by subtracting the requested amounts from the current amounts
+		leftAmount := big.NewInt(0).Sub(currentLeftAmount, request.LeftAmount[asset])
+		rightAmount := big.NewInt(0).Sub(currentRightAmount, request.RightAmount[asset])
 
-	// If any participant cannot afford the request amount, return an error
-	if types.Lt(leftAmount, big.NewInt(0)) {
-		return protocols.SideEffects{}, fmt.Errorf("Allocation for %x cannot afford the amount %d", request.Left, request.LeftAmount[asset])
+		// If any participant cannot afford the request amount, return an error
+		if types.Lt(leftAmount, big.NewInt(0)) {
+			return protocols.SideEffects{}, fmt.Errorf("Allocation for %x cannot afford the amount %d", request.Left, request.LeftAmount[asset])
+		}
+		if types.Lt(rightAmount, big.NewInt(0)) {
+			return protocols.SideEffects{}, fmt.Errorf("Allocation for %x cannot afford the amount %d", request.Right, request.RightAmount[asset])
+		}
+
+		// Calculate the total amount we need to allocate to the guarantee
+		total := big.NewInt(0).Add(request.LeftAmount[asset], request.RightAmount[asset])
+
+		newOutcome := outcome.SingleAssetExit{
+			Allocations: outcome.Allocations{
+				outcome.Allocation{
+					Destination: request.Left,
+					Amount:      leftAmount,
+				},
+				outcome.Allocation{
+					Destination: request.Right,
+					Amount:      rightAmount,
+				},
+				outcome.Allocation{
+					Destination:    request.Destination,
+					Amount:         total,
+					AllocationType: outcome.GuaranteeAllocationType,
+					Metadata:       guarantee,
+				},
+			},
+		}
+		nextState.Outcome = append(nextState.Outcome, newOutcome)
+
 	}
-	if types.Lt(rightAmount, big.NewInt(0)) {
-		return protocols.SideEffects{}, fmt.Errorf("Allocation for %x cannot afford the amount %d", request.Right, request.RightAmount[asset])
-	}
-
-	// Calculate the total amount we need to allocate to the guarantee
-	total := big.NewInt(0).Add(request.LeftAmount[asset], request.RightAmount[asset])
-
-	nextState.Outcome = outcome.Exit{outcome.SingleAssetExit{
-		Allocations: outcome.Allocations{
-			outcome.Allocation{
-				Destination: request.Left,
-				Amount:      leftAmount,
-			},
-			outcome.Allocation{
-				Destination: request.Right,
-				Amount:      rightAmount,
-			},
-			outcome.Allocation{
-				Destination:    request.Destination,
-				Amount:         total,
-				AllocationType: outcome.GuaranteeAllocationType,
-				Metadata:       guarantee,
-			},
-		},
-	}}
 
 	nextState.TurnNum = nextState.TurnNum + 1
 

--- a/protocols/ledger/ledger.go
+++ b/protocols/ledger/ledger.go
@@ -37,7 +37,7 @@ func (l *LedgerManager) HandleRequest(ledger *channel.TwoPartyLedger, request pr
 	for i, exit := range nextState.Outcome {
 		asset := exit.Asset
 		// If our request doesn't deal with this asset, skip it
-		if types.IsZero(request.LeftAmount[asset]) || types.IsZero(request.RightAmount[asset]) {
+		if types.IsZero(request.LeftAmount[asset]) && types.IsZero(request.RightAmount[asset]) {
 			continue
 		}
 		// Get the current amounts from the ledger channel

--- a/types/bigutils.go
+++ b/types/bigutils.go
@@ -19,3 +19,8 @@ func Lt(a *big.Int, b *big.Int) bool {
 func Equal(a *big.Int, b *big.Int) bool {
 	return a.Cmp(b) == 0
 }
+
+// Lt return true if a==0, false otherwise
+func IsZero(a *big.Int) bool {
+	return a.Cmp(big.NewInt(0)) == 0
+}


### PR DESCRIPTION
This updates the `handleRequest` method to iterate through multiple assets and create a `SingleAssetExit` for each asset as opposed to using a hardcoded asset.

The Ledger manager has been updated to call DivertToGuarantee which already handles the logic for updating an allocation with a guarantee.

The test has also been expanded to include handling a second ledger request on the same ledger channel. This makes sure that existing guarantees don't get removed (which @geoknee identified in https://github.com/statechannels/go-nitro/pull/250)