### PR TITLE
rename and document `ss.SignAndAdd` => `ss.Sign`

### DIFF
--- a/channel/state/signedstate.go
+++ b/channel/state/signedstate.go
@@ -20,7 +20,8 @@ func NewSignedState(s State) SignedState {
 	return SignedState{s, make(map[uint]Signature, len(s.Participants))}
 }
 
-func (ss SignedState) SignAndAdd(secretKey *[]byte) error {
+// Sign generates a signature on the receiver's state with the supplied key, and adds that signature.
+func (ss SignedState) Sign(secretKey *[]byte) error {
 	sig, err := ss.state.Sign(*secretKey)
 	if err != nil {
 		return fmt.Errorf("SignAndAdd failed to sign the state: %w", err)

--- a/protocols/ledger/ledger.go
+++ b/protocols/ledger/ledger.go
@@ -69,7 +69,7 @@ func (l *LedgerManager) HandleRequest(ledger *channel.TwoPartyLedger, request pr
 	nextState.TurnNum = nextState.TurnNum + 1
 
 	ss := state.NewSignedState(nextState)
-	err = ss.SignAndAdd(secretKey)
+	err = ss.Sign(secretKey)
 	if err != nil {
 		return protocols.SideEffects{}, fmt.Errorf("Could not sign state: %w", err)
 	}
@@ -105,7 +105,7 @@ func SignLatest(ledger *channel.TwoPartyLedger, secretKeys [][]byte) {
 	// Sign it
 	toSign := ledger.SignedStateForTurnNum[turnNum]
 	for _, secretKey := range secretKeys {
-		_ = toSign.SignAndAdd(&secretKey)
+		_ = toSign.Sign(&secretKey)
 	}
 	ledger.Channel.AddSignedState(toSign)
 }

--- a/protocols/ledger/ledger_test.go
+++ b/protocols/ledger/ledger_test.go
@@ -123,7 +123,7 @@ func TestHandleLedgerRequest(t *testing.T) {
 		IsFinal: false}
 
 	expectedSigned := state.NewSignedState(expectedState)
-	err = expectedSigned.SignAndAdd(&alice.privateKey)
+	err = expectedSigned.Sign(&alice.privateKey)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
This is a pretty minor rename, which makes a little more sense to me. It might be subjective, though!

The issue with "Sign and add" to me is that it is slightly ambiguous _what_ is being added (is it a state or signature). Coupled with the lack of documentation, we have to read through the source code to understand it.