### PR TITLE
Add an `asBob` subtest to `virtualfund-single-hop_test.go`

### DIFF
--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -36,7 +36,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 		return ss
 	}
 
-	var n = uint(2) // number of ledger channels (num_hops + 1)
+	var n = uint(1) // number of intermediaries
 
 	// In general
 	// Alice = P_0 <=L_0=> P_1 <=L_1=> ... P_n <=L_n>= P_n+1 = Bob


### PR DESCRIPTION
Currently, we only test the virtual fund protocol over a single hop (3 participants in total), and never as "bob".  Thus there may be bugs in the code which are not surfaced yet. 

This approach adds such a test, and does so by:

- copy-pasting the "as Alice" test 
- making modifications so that it reflects Bob's situation
- ~fixing a bug in the `virtualfund` protocol where we used `n+1` instead of `n`~ this was cherry-picked off to #256 



This is a good approach because it solves the problem in a very verbose way that can be easily checked line-by-line. The downside is that the test is very repetitive and a little tiresome to read through. It is not easy to see the essential differences to the `asAlice` test.  I propose that we tackle refactoring the test (to DRY it out) in a future issue/PR. 

Additionally, I:
- Fixed a bug that confused `myRole` with `myIndex`. Easily done!
- tidied up some test types and functions that polluted the package

Towards #218.

As the change set is quite large, at the request of the reviewer I can split up the additions `TestNew`, `TestUpdate` and `TestCrank`. 

---

#### Code quality

- [x] I have written clear commit messages
- [ ] I have performed a self-review of my own code
- [ ] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary

#### Project management

- [x] I have assigned myself to this PR
- [ ] I have linked the appropriate github issue
