### PR TITLE
`virtualfund`: clarify that `n=num_hops` (not `num_hops+1`)

### DIFF
--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -33,8 +33,8 @@ func signState(s state.State, a actor) state.SignedState {
 	}
 	return ss
 }
-
 func TestSingleHopVirtualFund(t *testing.T) {
+	var n = uint(1) // number of intermediaries
 
 	// In general
 	// Alice = P_0 <=L_0=> P_1 <=L_1=> ... P_n <=L_n>= P_n+1 = Bob
@@ -117,9 +117,6 @@ func TestSingleHopVirtualFund(t *testing.T) {
 		// Ensure this channel is fully funded on chain
 		ledgerChannelToMyRight.OnChainFunding = ledgerChannelToMyRight.PreFundState().Outcome.TotalAllocated()
 
-		// Objective
-		var n = uint(2) // number of ledger channels (num_hops + 1)
-
 		///////////////////
 		// END test data //
 		///////////////////
@@ -127,7 +124,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 		testNew := func(t *testing.T) {
 
 			// Assert that a valid set of constructor args does not result in an error
-			o, err := New(false, vPreFund, my.address, 2, my.role, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			o, err := New(false, vPreFund, my.address, n, my.role, ledgerChannelToMyLeft, ledgerChannelToMyRight)
 			if err != nil {
 				t.Error(err)
 			}

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -395,7 +395,7 @@ func (s *VirtualFundObjective) isAlice() bool {
 	return s.MyRole == 0
 }
 
-// isAlice returns true if the reciever represents participant n+1 in the virtualfund protocol.
+// isBob returns true if the reciever represents participant n+1 in the virtualfund protocol.
 func (s *VirtualFundObjective) isBob() bool {
 	return s.MyRole == s.n+1
 }


### PR DESCRIPTION
In the virtual fund protocol in the SATP paper, the ledger channels run from `0,...,n` so there are `n+1` of them. Currently, the `virtualfund` implementation has comments that imply there are only `n` ledger channels. Confusion ensues in the rest of the code!

There aren't actually any serious bugs as a consequence. Only:
1. An incorrect error message
2. An incorrect test parameter in our unit tests, which is inconsequential until we tackle #218.

