### PR TITLE
Add a single hop virtual channel

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -29,6 +29,60 @@ type Channel struct {
 	// Longer term, we should have a more efficient and smart mechanism to store states https://github.com/statechannels/go-nitro/issues/106
 }
 
+type SingleHopVirtualChannel struct {
+	Channel
+}
+
+func NewSingleHopVirtualChannel(s state.State, myIndex uint) (*SingleHopVirtualChannel, error) {
+	if myIndex > 2 {
+		return &SingleHopVirtualChannel{}, errors.New("myIndex in a single hope virtual channel must be 0 1,or 2")
+	}
+	if len(s.Participants) != 3 {
+		return &SingleHopVirtualChannel{}, errors.New("a single hop virtual channel must have exactly three participants")
+	}
+	for _, assetExit := range s.Outcome {
+		if len(assetExit.Allocations) != 2 {
+			return &SingleHopVirtualChannel{}, errors.New("a single hop virtual channels initial state should only have two allocations")
+		}
+	}
+	c, err := New(s, myIndex)
+
+	return &SingleHopVirtualChannel{*c}, err
+}
+
+func (v SingleHopVirtualChannel) amountAtIndex(index uint) types.Funds {
+	supported, err := v.LatestSupportedState()
+
+	// If there is no supported state we just return an empty amount
+	if err != nil {
+		return types.Funds{}
+	}
+
+	amount := types.Funds{}
+
+	for _, assetExit := range supported.Outcome {
+		asset := assetExit.Asset
+		allocations := assetExit.Allocations
+
+		if uint(len(allocations)) >= index {
+			amount[asset] = allocations[index].Amount
+		}
+	}
+	return amount
+}
+
+func (v SingleHopVirtualChannel) LeftAmount() types.Funds {
+	return v.amountAtIndex(0)
+}
+
+func (v SingleHopVirtualChannel) RightAmount() types.Funds {
+	return v.amountAtIndex(1)
+}
+
+func (v SingleHopVirtualChannel) Clone() SingleHopVirtualChannel {
+	return SingleHopVirtualChannel{v.Channel.Clone()}
+}
+
 type TwoPartyLedger struct {
 	Channel
 }

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -33,7 +33,7 @@ type Connection struct {
 // VirtualFundObjective is a cache of data computed by reading from the store. It stores (potentially) infinite data.
 type VirtualFundObjective struct {
 	Status protocols.ObjectiveStatus
-	V      *channel.Channel
+	V      *channel.SingleHopVirtualChannel
 
 	ToMyLeft  *Connection
 	ToMyRight *Connection
@@ -76,7 +76,7 @@ func New(
 	}
 
 	// Initialize virtual channel
-	v, err := channel.New(initialStateOfV, myRole)
+	v, err := channel.NewSingleHopVirtualChannel(initialStateOfV, myRole)
 	if err != nil {
 		return VirtualFundObjective{}, err
 	}
@@ -323,10 +323,8 @@ func (s VirtualFundObjective) generateLedgerRequestSideEffects() protocols.SideE
 	sideEffects := protocols.SideEffects{}
 	sideEffects.LedgerRequests = make([]protocols.LedgerRequest, 0)
 
-	leftAmount := s.V.PreFundState().Outcome.TotalAllocatedFor(s.V.MyDestination())
-	// TODO: This is hacky way of getting the second expected outcome.
-	other := s.V.PreFundState().Outcome[0].Allocations[1].Destination
-	rightAmount := s.V.PreFundState().Outcome.TotalAllocatedFor(other)
+	leftAmount := s.V.LeftAmount()
+	rightAmount := s.V.RightAmount()
 
 	if !s.isAlice() {
 		sideEffects.LedgerRequests = append(sideEffects.LedgerRequests,


### PR DESCRIPTION
While working on an `AsIrene` test I ran into bug with how we're calculating the left amount 
```
leftAmount := s.V.PreFundState().Outcome.TotalAllocatedFor(s.V.MyDestination())
```
As Irene there won't be an allocation for `s.V.MyDestination()`, what we actually want is the first allocation(for Alice).

Based on @geoknee [idea](https://github.com/statechannels/go-nitro/pull/245#discussion_r808856150) Ive added a new `SingleHopVirtualChannel` struct. 

`SingleHopVirtualChannel` checks that the channel has the correct amount of participants/allocations. There are also functions `LeftAmount` and `RightAmount` to get the amounts, so the virtual funding objective doesn't have to calculate them.