### PR TITLE
Add AsIrene test

### DIFF
--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -556,12 +556,11 @@ func TestSingleHopVirtualFund(t *testing.T) {
 		p1Alloc := outcome.Allocation{Destination: p1.destination, Amount: big.NewInt(5)}
 		aliceAlloc := outcome.Allocation{Destination: alice.destination, Amount: big.NewInt(5)}
 		bobAlloc := outcome.Allocation{Destination: bob.destination, Amount: big.NewInt(5)}
-		myIndex := uint(1) // because Bob is in the "right" slot
 
 		//  P_1 has one ledger channel connecting her to alice
-		var ledgerChannelToMyLeft, _ = ledger.CreateTestLedger(aliceAlloc, p1Alloc, &bob.privateKey, myIndex, big.NewInt(0))
+		var ledgerChannelToMyLeft, _ = ledger.CreateTestLedger(aliceAlloc, p1Alloc, &bob.privateKey, 1, big.NewInt(0))
 		//  P_1 has one ledger channel connecting her to bob
-		var ledgerChannelToMyRight, _ = ledger.CreateTestLedger(p1Alloc, bobAlloc, &bob.privateKey, myIndex, big.NewInt(0))
+		var ledgerChannelToMyRight, _ = ledger.CreateTestLedger(p1Alloc, bobAlloc, &bob.privateKey, 0, big.NewInt(0))
 		// Ensure both channels are fully funded on chain
 		ledgerChannelToMyLeft.OnChainFunding = ledgerChannelToMyLeft.PreFundState().Outcome.TotalAllocated()
 		ledgerChannelToMyRight.OnChainFunding = ledgerChannelToMyRight.PreFundState().Outcome.TotalAllocated()

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -592,6 +592,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				t.Errorf("TestNew: expectedGuarantee mismatch (-want +got):\n%s", diff)
 			}
 
+			// For the second expected guarantee:
 			got = o.ToMyRight.ExpectedGuarantees[types.Address{}] // VState only has one (native) asset represented by the zero address
 			expectedGuaranteeMetadata = outcome.GuaranteeMetadata{Left: ledgerChannelToMyRight.MyDestination(), Right: ledgerChannelToMyRight.TheirDestination()}
 			expectedEncodedGuaranteeMetadata, _ = expectedGuaranteeMetadata.Encode()

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -631,8 +631,8 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			}
 
 			expectedSignedState := state.NewSignedState(o.V.PreFundState())
-			bobSig, _ := o.V.PreFundState().Sign(my.privateKey)
-			_ = expectedSignedState.AddSignature(bobSig)
+			mySig, _ := o.V.PreFundState().Sign(my.privateKey)
+			_ = expectedSignedState.AddSignature(mySig)
 
 			forAlice := protocols.Message{To: alice.address, ObjectiveId: o.Id(), SignedStates: []state.SignedState{expectedSignedState}}
 			forBob := protocols.Message{To: bob.address, ObjectiveId: o.Id(), SignedStates: []state.SignedState{expectedSignedState}}
@@ -648,7 +648,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			// Manually progress the extended state by collecting prefund signatures
 			aliceSig, _ := vPreFund.Sign(alice.privateKey)
 			o.V.AddStateWithSignature(vPreFund, aliceSig)
-			bobSig, _ = vPreFund.Sign(bob.privateKey)
+			bobSig, _ := vPreFund.Sign(bob.privateKey)
 			o.V.AddStateWithSignature(vPreFund, bobSig)
 
 			// Cranking should move us to the next waiting point, generate ledger requests as a side effect, and alter the extended state to reflect that

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -576,16 +576,32 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				t.Error(err)
 			}
 
+			// For the first expected guarantee:
 			got := o.ToMyLeft.ExpectedGuarantees[types.Address{}] // VState only has one (native) asset represented by the zero address
-			var expectedGuaranteeMetadata = outcome.GuaranteeMetadata{Left: ledgerChannelToMyLeft.TheirDestination(), Right: ledgerChannelToMyLeft.MyDestination()}
-			var expectedEncodedGuaranteeMetadata, _ = expectedGuaranteeMetadata.Encode()
-			var expectedGuarantee outcome.Allocation = outcome.Allocation{
+			expectedGuaranteeMetadata := outcome.GuaranteeMetadata{Left: ledgerChannelToMyLeft.TheirDestination(), Right: ledgerChannelToMyLeft.MyDestination()}
+			expectedEncodedGuaranteeMetadata, _ := expectedGuaranteeMetadata.Encode()
+			expectedGuarantee := outcome.Allocation{
 				Destination:    o.V.Id,
 				Amount:         big.NewInt(0).Set(vPreFund.VariablePart().Outcome[0].TotalAllocated()),
 				AllocationType: outcome.GuaranteeAllocationType,
 				Metadata:       expectedEncodedGuaranteeMetadata,
 			}
 			want := expectedGuarantee
+
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("TestNew: expectedGuarantee mismatch (-want +got):\n%s", diff)
+			}
+
+			got = o.ToMyRight.ExpectedGuarantees[types.Address{}] // VState only has one (native) asset represented by the zero address
+			expectedGuaranteeMetadata = outcome.GuaranteeMetadata{Left: ledgerChannelToMyRight.MyDestination(), Right: ledgerChannelToMyRight.TheirDestination()}
+			expectedEncodedGuaranteeMetadata, _ = expectedGuaranteeMetadata.Encode()
+			expectedGuarantee = outcome.Allocation{
+				Destination:    o.V.Id,
+				Amount:         big.NewInt(0).Set(vPreFund.VariablePart().Outcome[0].TotalAllocated()),
+				AllocationType: outcome.GuaranteeAllocationType,
+				Metadata:       expectedEncodedGuaranteeMetadata,
+			}
+			want = expectedGuarantee
 
 			if diff := cmp.Diff(want, got); diff != "" {
 				t.Errorf("TestNew: expectedGuarantee mismatch (-want +got):\n%s", diff)

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -543,8 +543,242 @@ func TestSingleHopVirtualFund(t *testing.T) {
 		t.Run(`Crank`, testCrank)
 
 	}
+	var AsP1 = func(t *testing.T) {
 
+		/////////////////////
+		// BEGIN test data //
+		/////////////////////
+
+		// In this test, we play P_1
+		my := p1
+
+		ledgerManager := ledger.NewLedgerManager()
+		p1Alloc := outcome.Allocation{Destination: p1.destination, Amount: big.NewInt(5)}
+		aliceAlloc := outcome.Allocation{Destination: alice.destination, Amount: big.NewInt(5)}
+		bobAlloc := outcome.Allocation{Destination: bob.destination, Amount: big.NewInt(5)}
+		myIndex := uint(1) // because Bob is in the "right" slot
+
+		//  P_1 has one ledger channel connecting her to alice
+		var ledgerChannelToMyLeft, _ = ledger.CreateTestLedger(aliceAlloc, p1Alloc, &bob.privateKey, myIndex, big.NewInt(0))
+		//  P_1 has one ledger channel connecting her to bob
+		var ledgerChannelToMyRight, _ = ledger.CreateTestLedger(p1Alloc, bobAlloc, &bob.privateKey, myIndex, big.NewInt(0))
+		// Ensure both channels are fully funded on chain
+		ledgerChannelToMyLeft.OnChainFunding = ledgerChannelToMyLeft.PreFundState().Outcome.TotalAllocated()
+		ledgerChannelToMyRight.OnChainFunding = ledgerChannelToMyRight.PreFundState().Outcome.TotalAllocated()
+		///////////////////
+		// END test data //
+		///////////////////
+
+		testNew := func(t *testing.T) {
+
+			// Assert that a valid set of constructor args does not result in an error
+			o, err := New(false, vPreFund, my.address, n, my.role, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			if err != nil {
+				t.Error(err)
+			}
+
+			got := o.ToMyLeft.ExpectedGuarantees[types.Address{}] // VState only has one (native) asset represented by the zero address
+			var expectedGuaranteeMetadata = outcome.GuaranteeMetadata{Left: ledgerChannelToMyLeft.TheirDestination(), Right: ledgerChannelToMyLeft.MyDestination()}
+			var expectedEncodedGuaranteeMetadata, _ = expectedGuaranteeMetadata.Encode()
+			var expectedGuarantee outcome.Allocation = outcome.Allocation{
+				Destination:    o.V.Id,
+				Amount:         big.NewInt(0).Set(vPreFund.VariablePart().Outcome[0].TotalAllocated()),
+				AllocationType: outcome.GuaranteeAllocationType,
+				Metadata:       expectedEncodedGuaranteeMetadata,
+			}
+			want := expectedGuarantee
+
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("TestNew: expectedGuarantee mismatch (-want +got):\n%s", diff)
+			}
+		}
+
+		testCrank := func(t *testing.T) {
+			var s, _ = New(false, vPreFund, my.address, n, my.role, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			// Assert that cranking an unapproved objective returns an error
+			if _, _, _, err := s.Crank(&my.privateKey); err == nil {
+				t.Error(`Expected error when cranking unapproved objective, but got nil`)
+			}
+
+			// Approve the objective, so that the rest of the test cases can run.
+			o := s.Approve().(VirtualFundObjective)
+			// To test the finite state progression, we are going to progressively mutate o
+			// And then crank it to see which "pause point" (WaitingFor) we end up at.
+
+			// Initial Crank
+			oObj, got, waitingFor, err := o.Crank(&my.privateKey)
+			o = oObj.(VirtualFundObjective)
+			if err != nil {
+				t.Error(err)
+			}
+			if waitingFor != WaitingForCompletePrefund {
+				t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForCompletePrefund, waitingFor)
+			}
+
+			expectedSignedState := state.NewSignedState(o.V.PreFundState())
+			bobSig, _ := o.V.PreFundState().Sign(my.privateKey)
+			_ = expectedSignedState.AddSignature(bobSig)
+
+			forAlice := protocols.Message{To: alice.address, ObjectiveId: o.Id(), SignedStates: []state.SignedState{expectedSignedState}}
+			forBob := protocols.Message{To: bob.address, ObjectiveId: o.Id(), SignedStates: []state.SignedState{expectedSignedState}}
+			want := protocols.SideEffects{MessagesToSend: []protocols.Message{forAlice, forBob}}
+			// TODO ^^^ The test is currently sensitive to the order of the messages. It should not be.
+
+			if diff := cmp.Diff(want, got); diff != "" {
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("TestCrank: side effects mismatch (-want +got):\n%s", diff)
+				}
+
+			}
+			// Manually progress the extended state by collecting prefund signatures
+			aliceSig, _ := vPreFund.Sign(alice.privateKey)
+			o.V.AddStateWithSignature(vPreFund, aliceSig)
+			bobSig, _ = vPreFund.Sign(bob.privateKey)
+			o.V.AddStateWithSignature(vPreFund, bobSig)
+
+			// Cranking should move us to the next waiting point, generate ledger requests as a side effect, and alter the extended state to reflect that
+			oObj, got, waitingFor, err = o.Crank(&my.privateKey)
+			o = oObj.(VirtualFundObjective)
+			if err != nil {
+				t.Error(err)
+			}
+			if waitingFor != WaitingForCompleteFunding {
+				t.Fatalf(`WaitingFor: expected %v, got %v`, WaitingForCompleteFunding, waitingFor)
+			}
+			if o.requestedLedgerUpdates != true {
+				t.Error(`Expected ledger update idempotency flag to be raised, but it wasn't`)
+			}
+			var expectedLedgerRequests = []protocols.LedgerRequest{{
+				ObjectiveId: o.Id(),
+				LedgerId:    ledgerChannelToMyLeft.Id,
+				Destination: s.V.Id,
+				LeftAmount:  types.Funds{types.Address{}: big.NewInt(5)},
+				RightAmount: types.Funds{types.Address{}: big.NewInt(5)},
+				Left:        ledgerChannelToMyLeft.TheirDestination(), Right: ledgerChannelToMyLeft.MyDestination(),
+			}, {
+				ObjectiveId: o.Id(),
+				LedgerId:    ledgerChannelToMyRight.Id,
+				Destination: s.V.Id,
+				LeftAmount:  types.Funds{types.Address{}: big.NewInt(5)},
+				RightAmount: types.Funds{types.Address{}: big.NewInt(5)},
+				Left:        ledgerChannelToMyRight.MyDestination(), Right: ledgerChannelToMyRight.TheirDestination(),
+			}}
+			want = protocols.SideEffects{LedgerRequests: expectedLedgerRequests}
+
+			if diff := cmp.Diff(want, got, cmp.Comparer(types.Equal)); diff != "" {
+				t.Errorf("TestCrank: side effects mismatch (-want +got):\n%s", diff)
+			}
+
+			ledger.SignPreAndPostFundingStates(o.ToMyLeft.Channel, []*[]byte{&alice.privateKey, &p1.privateKey})
+			_, _ = ledgerManager.HandleRequest(o.ToMyLeft.Channel, got.LedgerRequests[0], &p1.privateKey)
+			ledger.SignLatest(o.ToMyLeft.Channel, [][]byte{alice.privateKey})
+
+			ledger.SignPreAndPostFundingStates(o.ToMyRight.Channel, []*[]byte{&p1.privateKey, &bob.privateKey})
+			_, _ = ledgerManager.HandleRequest(o.ToMyRight.Channel, got.LedgerRequests[1], &p1.privateKey)
+			ledger.SignLatest(o.ToMyRight.Channel, [][]byte{bob.privateKey})
+
+			// Cranking now should not generate side effects, because we already did that
+			oObj, got, waitingFor, err = o.Crank(&my.privateKey)
+			o = oObj.(VirtualFundObjective)
+			if err != nil {
+				t.Error(err)
+			}
+			if waitingFor != WaitingForCompletePostFund {
+				t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForCompletePostFund, waitingFor)
+			}
+
+			expectedSignedState = signState(o.V.PostFundState(), my)
+
+			forAlice = protocols.Message{To: alice.address, ObjectiveId: o.Id(), SignedStates: []state.SignedState{expectedSignedState}}
+			forBob = protocols.Message{To: bob.address, ObjectiveId: o.Id(), SignedStates: []state.SignedState{expectedSignedState}}
+			want = protocols.SideEffects{MessagesToSend: []protocols.Message{forAlice, forBob}}
+			// TODO ^^^ The test is currently sensitive to the order of the messages. It should not be.
+
+			if diff := cmp.Diff(want, got); diff != "" {
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("TestCrank: side effects mismatch (-want +got):\n%s", diff)
+				}
+
+			}
+
+			// Manually progress the extended state by collecting postfund signatures
+			alicePost := signState(o.V.PostFundState(), alice)
+			bobPost := signState(o.V.PostFundState(), bob)
+			o.V.AddSignedStates([]state.SignedState{alicePost, bobPost})
+
+			// This should be the final crank...
+			_, _, waitingFor, err = o.Crank(&my.privateKey)
+			if err != nil {
+				t.Error(err)
+			}
+			if waitingFor != WaitingForNothing {
+				t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForNothing, waitingFor)
+			}
+
+		}
+
+		testUpdate := func(t *testing.T) {
+			var s, _ = New(false, vPreFund, my.address, n, my.role, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			// Prepare an event with a mismatched objectiveId
+			e := protocols.ObjectiveEvent{
+				ObjectiveId: "some-other-id",
+			}
+			// Assert that Updating the objective with such an event returns an error
+			// TODO is this the behaviour we want? Below with the signatures, we prefer a log + NOOP (no error)
+			if _, err := s.Update(e); err == nil {
+				t.Error(`Objective ID mismatch -- expected an error but did not get one`)
+			}
+
+			// Now modify the event to give it the "correct" channelId (matching the objective),
+			// and make a new Sigs map.
+			// This prepares us for the rest of the test. We will reuse the same event multiple times
+			e.ObjectiveId = s.Id()
+			e.SignedStates = make([]state.SignedState, 0)
+
+			// Next, attempt to update the objective with correct signature by a participant on a relevant state
+			// Assert that this results in an appropriate change in the extended state of the objective
+			// Part 1: a signature on a state in channel V
+			prefundsignedstate := signState(s.V.PreFundState(), alice)
+			e.SignedStates = append(e.SignedStates, prefundsignedstate)
+
+			updatedObj, err := s.Update(e)
+			updated := updatedObj.(VirtualFundObjective)
+			if err != nil {
+				t.Error(err)
+			}
+			if updated.V.SignedStateForTurnNum[0].HasSignatureForParticipant(alice.role) != true {
+				t.Error(`Objective data not updated as expected`)
+			}
+
+			// Part 2: a signature on Bob's ledger channel (on his left)
+			f := protocols.ObjectiveEvent{
+				ObjectiveId: s.Id(),
+			}
+			f.SignedStates = make([]state.SignedState, 0)
+
+			ledger, _ := ledger.CreateTestLedger(aliceAlloc, p1Alloc, &p1.privateKey, 0, big.NewInt(0))
+			ss := signState(ledger.PreFundState(), alice)
+
+			f.SignedStates = append(f.SignedStates, ss)
+
+			updatedObj, err = s.Update(f)
+			updated = updatedObj.(VirtualFundObjective)
+			if err != nil {
+				t.Error(err)
+			}
+			if !updated.ToMyLeft.ledgerChannelAffordsExpectedGuarantees() != true {
+				t.Error(`Objective data not updated as expected`)
+			}
+
+		}
+
+		t.Run(`New`, testNew)
+		t.Run(`Update`, testUpdate)
+		t.Run(`Crank`, testCrank)
+
+	}
 	t.Run(`AsAlice`, AsAlice)
 	t.Run(`AsBob`, AsBob)
+	t.Run(`AsP1`, AsP1)
 
 }

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -765,7 +765,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				t.Error(`Objective data not updated as expected`)
 			}
 
-			// Part 2: a signature on Bob's ledger channel (on his left)
+			// Part 2: a signature on P1's ledger channel (on her left)
 			f := protocols.ObjectiveEvent{
 				ObjectiveId: s.Id(),
 			}


### PR DESCRIPTION
⚠️ Based on #260 

Adds a test to the virtual funding test for the intermediary role. To keep it consistent with current naming in the file I've called it `AsP1` instead of `AsIrene`. I've followed a similar approach to #255 and just copied an existing test and tailored it to Irene.

The only fix required to get the test working was [a change to how we calculate left/right amounts.](https://github.com/statechannels/go-nitro/commit/ce913d57c466b82e5f440ecdb86c3846aa56bab1)

#### Code quality

- [x] I have written clear commit messages
- [ ] I have performed a self-review of my own code
- [ ] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary

#### Project management

- [x] I have assigned myself to this PR
- [ ] I have linked the appropriate github issue
