### PR TITLE
Add `Exit.DivertToGuarantee` method

### DIFF
--- a/channel/state/outcome/allocation.go
+++ b/channel/state/outcome/allocation.go
@@ -127,8 +127,8 @@ var allocationsTy = abi.ArgumentMarshaling{
 }
 
 // DivertToGuarantee returns a new Allocations, identical to the reciever but with
-// the leftDebtee's amount reduced by leftDebit,
-// the rightDebtee's amount reduced by rightDebit,
+// the leftDestination's amount reduced by leftAmount,
+// the rightDestination's amount reduced by rightAmount,
 // and a Guarantee appended for the guaranteeDestination
 func (a Allocations) DivertToGuarantee(
 	leftDestination types.Destination,

--- a/channel/state/outcome/allocation_test.go
+++ b/channel/state/outcome/allocation_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/google/go-cmp/cmp"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -63,62 +62,4 @@ func TestAffords(t *testing.T) {
 
 	}
 
-}
-
-func TestDivertToGuarantee(t *testing.T) {
-
-	aliceDestination := types.Destination(common.HexToHash("0x0a"))
-	bobDestination := types.Destination(common.HexToHash("0x0b"))
-
-	targetChannel := types.Destination(common.HexToHash("0xabc"))
-
-	a := Allocations{
-		{
-			Destination:    aliceDestination,
-			Amount:         big.NewInt(243),
-			AllocationType: 0,
-			Metadata:       make(types.Bytes, 0),
-		},
-		{
-			Destination:    bobDestination,
-			Amount:         big.NewInt(309),
-			AllocationType: 0,
-			Metadata:       make(types.Bytes, 0),
-		},
-	}
-
-	got, err := a.DivertToGuarantee(aliceDestination, bobDestination, big.NewInt(5), big.NewInt(5), targetChannel)
-
-	if err != nil {
-		t.Error(err)
-	}
-
-	want := Allocations{
-		{
-			Destination:    aliceDestination,
-			Amount:         big.NewInt(238),
-			AllocationType: 0,
-			Metadata:       make(types.Bytes, 0),
-		},
-		{
-			Destination:    bobDestination,
-			Amount:         big.NewInt(304),
-			AllocationType: 0,
-			Metadata:       make(types.Bytes, 0),
-		},
-		{
-			Destination:    targetChannel,
-			Amount:         big.NewInt(10),
-			AllocationType: 1,
-			Metadata:       append(aliceDestination.Bytes(), bobDestination.Bytes()...),
-		},
-	}
-
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("TestDivertToGuarantee: expectedGuarantee mismatch (-want +got):\n%s", diff)
-	}
-
-	if a[0].Amount.Cmp(big.NewInt(243)) != 0 {
-		t.Errorf("TestDivertToGuarantee: input arguments mutated")
-	}
 }

--- a/channel/state/outcome/exit.go
+++ b/channel/state/outcome/exit.go
@@ -192,7 +192,7 @@ func (e Exit) Affords(
 
 }
 
-// DivertToGuarantee returns a new Exit, identical to the reciever but with
+// DivertToGuarantee returns a new Exit, identical to the receiver but with
 // (for each asset of the Exit)
 // the leftDestination's amount reduced by leftFunds[asset],
 // the rightDestination's amount reduced by rightAmount[asset],

--- a/channel/state/outcome/exit.go
+++ b/channel/state/outcome/exit.go
@@ -193,10 +193,11 @@ func (e Exit) Affords(
 }
 
 // DivertToGuarantee returns a new Exit, identical to the reciever but with
-// (for each asset of the Exit present in both leftFunds and rightFunds)
+// (for each asset of the Exit)
 // the leftDestination's amount reduced by leftFunds[asset],
 // the rightDestination's amount reduced by rightAmount[asset],
 // and a Guarantee appended for the guaranteeDestination.
+// Where an asset is missing from leftFunds or rightFunds, it is treated as if the corresponding amount is zero.
 func (e Exit) DivertToGuarantee(
 	leftDestination types.Destination,
 	rightDestination types.Destination,
@@ -213,9 +214,12 @@ func (e Exit) DivertToGuarantee(
 		// either of leftFunds or rightFunds does not have it, OR
 		// leftFunds and rightFunds have a zero amount for this asset
 		leftAmount, leftOk := leftFunds[asset]
+		if !leftOk {
+			leftAmount = big.NewInt(0)
+		}
 		rightAmount, rightOk := rightFunds[asset]
-		if !leftOk || !rightOk || types.IsZero(leftAmount) && types.IsZero(rightAmount) {
-			continue
+		if !rightOk {
+			rightAmount = big.NewInt(0)
 		}
 
 		newAllocations, err := sae.Allocations.DivertToGuarantee(leftDestination, rightDestination, leftAmount, rightAmount, guaranteeDestination)

--- a/channel/state/outcome/exit.go
+++ b/channel/state/outcome/exit.go
@@ -208,14 +208,17 @@ func (e Exit) DivertToGuarantee(
 
 	f := e.Clone()
 
+	leftFundsClone := leftFunds.Clone()
+	rightFundsClone := rightFunds.Clone()
+
 	for i, sae := range f {
 		asset := sae.Asset
 
-		leftAmount, leftOk := leftFunds.Clone()[asset]
+		leftAmount, leftOk := leftFundsClone[asset]
 		if !leftOk {
 			leftAmount = big.NewInt(0)
 		}
-		rightAmount, rightOk := rightFunds.Clone()[asset]
+		rightAmount, rightOk := rightFundsClone[asset]
 		if !rightOk {
 			rightAmount = big.NewInt(0)
 		}

--- a/channel/state/outcome/exit.go
+++ b/channel/state/outcome/exit.go
@@ -210,14 +210,12 @@ func (e Exit) DivertToGuarantee(
 
 	for i, sae := range f {
 		asset := sae.Asset
-		// Skip this asset if:
-		// either of leftFunds or rightFunds does not have it, OR
-		// leftFunds and rightFunds have a zero amount for this asset
-		leftAmount, leftOk := leftFunds[asset]
+
+		leftAmount, leftOk := leftFunds.Clone()[asset]
 		if !leftOk {
 			leftAmount = big.NewInt(0)
 		}
-		rightAmount, rightOk := rightFunds[asset]
+		rightAmount, rightOk := rightFunds.Clone()[asset]
 		if !rightOk {
 			rightAmount = big.NewInt(0)
 		}

--- a/channel/state/outcome/exit.go
+++ b/channel/state/outcome/exit.go
@@ -209,7 +209,9 @@ func (e Exit) DivertToGuarantee(
 
 	for i, sae := range f {
 		asset := sae.Asset
-		// If our request doesn't deal with this asset, skip it
+		// Skip this asset if:
+		// either of leftFunds or rightFunds does not have it, OR
+		// leftFunds and rightFunds have a zero amount for this asset
 		leftAmount, leftOk := leftFunds[asset]
 		rightAmount, rightOk := rightFunds[asset]
 		if !leftOk || !rightOk || types.IsZero(leftAmount) && types.IsZero(rightAmount) {

--- a/protocols/ledger/ledger.go
+++ b/protocols/ledger/ledger.go
@@ -35,20 +35,6 @@ func (l *LedgerManager) HandleRequest(ledger *channel.TwoPartyLedger, request pr
 		if types.IsZero(request.LeftAmount[asset]) && types.IsZero(request.RightAmount[asset]) {
 			continue
 		}
-		// Get the current amounts from the ledger channel
-		currentLeftAmount := nextState.Outcome.TotalAllocatedFor(request.Left)[asset]
-		currentRightAmount := nextState.Outcome.TotalAllocatedFor(request.Right)[asset]
-		// Calculate the new amounts by subtracting the requested amounts from the current amounts
-		leftAmount := big.NewInt(0).Sub(currentLeftAmount, request.LeftAmount[asset])
-		rightAmount := big.NewInt(0).Sub(currentRightAmount, request.RightAmount[asset])
-
-		// If any participant cannot afford the request amount, return an error
-		if types.Lt(leftAmount, big.NewInt(0)) {
-			return protocols.SideEffects{}, fmt.Errorf("Allocation for %x cannot afford the amount %d", request.Left, request.LeftAmount[asset])
-		}
-		if types.Lt(rightAmount, big.NewInt(0)) {
-			return protocols.SideEffects{}, fmt.Errorf("Allocation for %x cannot afford the amount %d", request.Right, request.RightAmount[asset])
-		}
 
 		// Get an updated allocation with the guarantee
 		newAlloc, err := nextState.Outcome[i].Allocations.DivertToGuarantee(request.Left, request.Right, request.LeftAmount[asset], request.RightAmount[asset], request.Destination)


### PR DESCRIPTION
We currently have an `Allocations.DivertToGuarantee` method which applies to a single asset. In the ledger protocol, we loop over assets and call into this method. It would fit existing patterns better, and lead to greater encapsulation /  abstraction and readability if we had a method on the `Exit` type which was responsible for that looping behaviour. 


**Changes**

- Move logic to `outcome` package
- fix bug where a "missing" asset would result in a panic
- Add a unit test for this


---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary

#### Project management

- [x] I have assigned myself to this PR
- [ ] I have linked the appropriate github issue
