### PR TITLE
Return early and log when objective is not found in `handleChainEvent`.

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -134,8 +134,12 @@ func (e *Engine) handleMessage(message protocols.Message) ObjectiveChangeEvent {
 // generates an updated objective and
 // attempts progress.
 func (e *Engine) handleChainEvent(chainEvent chainservice.Event) ObjectiveChangeEvent {
-
-	objective, _ := e.store.GetObjectiveByChannelId(chainEvent.ChannelId)
+	e.logger.Printf("handling chain event %v", chainEvent)
+	objective, ok := e.store.GetObjectiveByChannelId(chainEvent.ChannelId)
+	if !ok {
+		e.logger.Printf("handleChainEvent: No objective in store for channel with id %s", chainEvent.ChannelId)
+		return ObjectiveChangeEvent{}
+	}
 	event := protocols.ObjectiveEvent{Holdings: chainEvent.Holdings, AdjudicationStatus: chainEvent.AdjudicationStatus, ObjectiveId: objective.Id()}
 	updatedObjective, err := objective.Update(event)
 	if err != nil {


### PR DESCRIPTION
Currently, an "irrelevant" chain event can cause a panic in a client. It hears the event, tries to pull an objective from the store, ignores the `ok` boolean, and then tries to do stuff with this nil objective. 

Towards #217 .

This approach checks the `ok` boolean and returns early without trying to flog the proverbial dead horse 🐴 . We write to the logger for good measure. I don't think we need to treat this as an error.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary

#### Project management

- [x] I have assigned myself to this PR
- [ ] I have linked the appropriate github issue
