### PR TITLE
Overhaul `Channel.Clone()`

### DIFF
--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -28,7 +28,7 @@ func TestChannel(t *testing.T) {
 
 	testClone := func(t *testing.T) {
 		r := c.Clone()
-		if diff := cmp.Diff(r, *c, cmp.Comparer(types.Equal)); diff != "" {
+		if diff := cmp.Diff(r, c, cmp.Comparer(types.Equal)); diff != "" {
 			t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
 		}
 
@@ -301,4 +301,57 @@ func TestChannel(t *testing.T) {
 	t.Run(`TestAddSignedStates`, testAddSignedStates)
 	t.Run(`TestAddSignedState`, testAddSignedState)
 
+}
+
+func TestTwoPartyLedger(t *testing.T) {
+	s := state.TestState.Clone()
+	s.TurnNum = 0
+	testClone := func(t *testing.T) {
+		r, err := NewTwoPartyLedger(s, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		c := r.Clone()
+		if diff := cmp.Diff(r, c, cmp.Comparer(types.Equal)); diff != "" {
+			t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+		}
+
+		r.latestSupportedStateTurnNum++
+		if r.Channel.Equal(c.Channel) {
+			t.Error("Clone: modifying the clone should not modify the original")
+		}
+
+		r.Participants[0] = common.HexToAddress("0x0000000000000000000000000000000000000001")
+		if r.Participants[0] == c.Participants[0] {
+			t.Error("Clone: modifying the clone should not modify the original")
+		}
+	}
+	t.Run(`TestClone`, testClone)
+}
+
+func TestSingleHopVirtualChannel(t *testing.T) {
+	s := state.TestState.Clone()
+	s.Participants = append(s.Participants, s.Participants[0]) // ensure three participants
+	s.TurnNum = 0
+	testClone := func(t *testing.T) {
+		r, err := NewSingleHopVirtualChannel(s, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		c := r.Clone()
+		if diff := cmp.Diff(r, c, cmp.Comparer(types.Equal)); diff != "" {
+			t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+		}
+
+		r.latestSupportedStateTurnNum++
+		if r.Channel.Equal(c.Channel) {
+			t.Error("Clone: modifying the clone should not modify the original")
+		}
+
+		r.Participants[0] = common.HexToAddress("0x0000000000000000000000000000000000000001")
+		if r.Participants[0] == c.Participants[0] {
+			t.Error("Clone: modifying the clone should not modify the original")
+		}
+	}
+	t.Run(`TestClone`, testClone)
 }

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -28,7 +28,7 @@ func TestChannel(t *testing.T) {
 
 	testClone := func(t *testing.T) {
 		r := c.Clone()
-		if diff := cmp.Diff(r, c, cmp.Comparer(types.Equal)); diff != "" {
+		if diff := cmp.Diff(*r, *c, cmp.Comparer(types.Equal)); diff != "" {
 			t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
 		}
 
@@ -312,7 +312,7 @@ func TestTwoPartyLedger(t *testing.T) {
 			t.Fatal(err)
 		}
 		c := r.Clone()
-		if diff := cmp.Diff(r, c, cmp.Comparer(types.Equal)); diff != "" {
+		if diff := cmp.Diff(*r, *c, cmp.Comparer(types.Equal)); diff != "" {
 			t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
 		}
 
@@ -339,7 +339,7 @@ func TestSingleHopVirtualChannel(t *testing.T) {
 			t.Fatal(err)
 		}
 		c := r.Clone()
-		if diff := cmp.Diff(r, c, cmp.Comparer(types.Equal)); diff != "" {
+		if diff := cmp.Diff(*r, *c, cmp.Comparer(types.Equal)); diff != "" {
 			t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
 		}
 

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -325,7 +325,15 @@ func TestTwoPartyLedger(t *testing.T) {
 		if r.Participants[0] == c.Participants[0] {
 			t.Error("Clone: modifying the clone should not modify the original")
 		}
+
+		var nilTwoPartyLedger *TwoPartyLedger
+		clone := nilTwoPartyLedger.Clone()
+		if clone != nil {
+			t.Fatal("Tried to clone a TwoPartyLedger via a nil pointer, but got something not nil")
+		}
+
 	}
+
 	t.Run(`TestClone`, testClone)
 }
 

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -263,7 +263,7 @@ func (s DirectFundObjective) clone() DirectFundObjective {
 	clone.Status = s.Status
 
 	cClone := s.C.Clone()
-	clone.C = &cClone
+	clone.C = cClone
 
 	clone.myDepositSafetyThreshold = s.myDepositSafetyThreshold.Clone()
 	clone.myDepositTarget = s.myDepositTarget.Clone()

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -332,7 +332,6 @@ func (s VirtualFundObjective) generateLedgerRequestSideEffects() protocols.SideE
 				ObjectiveId: s.Id(),
 				LedgerId:    s.ToMyLeft.Channel.Id,
 				Destination: s.V.Id,
-
 				Left:        s.ToMyLeft.Channel.TheirDestination(),
 				LeftAmount:  leftAmount,
 				Right:       s.ToMyLeft.Channel.MyDestination(),
@@ -359,12 +358,12 @@ func (s *VirtualFundObjective) clone() VirtualFundObjective {
 	clone := VirtualFundObjective{}
 	clone.Status = s.Status
 	vClone := s.V.Clone()
-	clone.V = &vClone
+	clone.V = vClone
 
 	if s.ToMyLeft != nil {
 		lClone := s.ToMyLeft.Channel.Clone()
 		clone.ToMyLeft = &Connection{
-			Channel:            &lClone,
+			Channel:            lClone,
 			ExpectedGuarantees: s.ToMyLeft.ExpectedGuarantees,
 		}
 	}
@@ -372,7 +371,7 @@ func (s *VirtualFundObjective) clone() VirtualFundObjective {
 	if s.ToMyRight != nil {
 		rClone := s.ToMyRight.Channel.Clone()
 		clone.ToMyRight = &Connection{
-			Channel:            &rClone,
+			Channel:            rClone,
 			ExpectedGuarantees: s.ToMyRight.ExpectedGuarantees,
 		}
 	}


### PR DESCRIPTION
There are several problems with our existing `Channel.Clone()` method, as well as the `SingleHopVirtualChannel.Clone()` and `TwoPartyLedger.Clone()` methods which depend on it. These methods are critically important because they lie at the heart of the "functional core" of `go-nitro`. 

Problem 1: 
`TwoPartyLedger.Clone()` returns a shallow clone. We need a deep clone. 

Problem 2: 
There are no unit tests for `SingleHopVirtualChannel.Clone()` or `TwoPartyLedger.Clone()`.

Problem 3:
The implementation of `Channel.Clone()` uses a value receiver. This was a bit strange, to me, and made it difficult to understand whether the implementation was correct. A pointer receiver seems more natural.

Problem 4:
`Channel.Clone()` returns a `Channel` instead of a `*Channel`. It is more natural to return the pointer, as we mostly work with pointers to channels. 

Problem 5:
If we tried to clone a nil channel, we could get a panic. In the virtual funding protocol, we use nil channels for Alice and Bob (who are at the ends of the chain of participants and have only a single ledger connection, instead of two). When testing this protocol, it is very useful to be able to simply clone a channel and have that work even if it is nil. 

This PR addresses all of the above problems. 

Towards #226 


---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [ ] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
