### PR TITLE
Wire Up Ledger Manager to Engine

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -266,7 +266,7 @@ func (e *Engine) handleLedgerRequests(ledgerRequests []protocols.LedgerRequest) 
 
 		se, err := e.ledgerManager.HandleRequest(ledger, req, e.store.GetChannelSecretKey())
 		if err != nil {
-			return se, fmt.Errorf("could not handle ledger request: %s", err)
+			return se, fmt.Errorf("could not handle ledger request: %w", err)
 		}
 		sideEffects.Merge(se)
 	}

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -196,8 +196,8 @@ func (e *Engine) executeSideEffects(sideEffects protocols.SideEffects) {
 // 	5. It updates progress metadata in the store
 func (e *Engine) attemptProgress(objective protocols.Objective) (outgoing ObjectiveChangeEvent) {
 	secretKey := e.store.GetChannelSecretKey()
-	crankedObjective, sideEffects, waitingFor, _ := objective.Crank(secretKey) // TODO handle error
-	_ = e.store.SetObjective(crankedObjective)                                 // TODO handle error
+	crankedObjective, sideEffects, waitingFor, _, _ := objective.Crank(secretKey) // TODO handle error
+	_ = e.store.SetObjective(crankedObjective)                                    // TODO handle error
 	e.executeSideEffects(sideEffects)
 	e.logger.Printf("Objective %s is %s", objective.Id(), waitingFor)
 	e.store.UpdateProgressLastMadeAt(objective.Id(), waitingFor)

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -32,7 +32,7 @@ type Engine struct {
 
 	store store.Store // A Store for persisting and restoring important data
 
-	ledgerManager *ledger.LedgerManager
+	ledgerManager *ledger.LedgerManager // A LedgerManager for handling ledger requests.
 	logger        *log.Logger
 }
 

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -56,11 +57,23 @@ func (ms MockStore) SetObjective(obj protocols.Objective) error {
 	return nil
 }
 
+func (ms MockStore) GetChannel(channelId types.Destination) (*channel.Channel, bool) {
+	// todo: locking
+	for _, obj := range ms.objectives {
+		for _, ch := range obj.Channels() {
+			if ch.Id == channelId {
+				return ch, true
+			}
+		}
+	}
+	return nil, false
+}
+
 func (ms MockStore) GetObjectiveByChannelId(channelId types.Destination) (protocols.Objective, bool) {
 	// todo: locking
 	for _, obj := range ms.objectives {
 		for _, ch := range obj.Channels() {
-			if ch == channelId {
+			if ch.Id == channelId {
 				return obj, true
 			}
 		}

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -2,6 +2,7 @@
 package store // import "github.com/statechannels/go-nitro/client/engine/store"
 
 import (
+	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -14,6 +15,6 @@ type Store interface {
 	GetObjectiveById(protocols.ObjectiveId) (obj protocols.Objective, ok bool)    // Read an existing objective
 	GetObjectiveByChannelId(types.Destination) (obj protocols.Objective, ok bool) // Get the objective that currently owns the channel with the supplied ChannelId
 	SetObjective(protocols.Objective) error                                       // Write an objective
-
+	GetChannel(types.Destination) (channel *channel.Channel, ok bool)
 	UpdateProgressLastMadeAt(protocols.ObjectiveId, protocols.WaitingFor) // updates progressLastMadeAt information for an objective
 }

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -191,9 +191,9 @@ func (s DirectFundObjective) Crank(secretKey *[]byte) (protocols.Objective, prot
 	return updated, sideEffects, WaitingForNothing, nil
 }
 
-func (s DirectFundObjective) Channels() []types.Destination {
-	ret := make([]types.Destination, 0, 1)
-	ret = append(ret, s.C.Id)
+func (s DirectFundObjective) Channels() []*channel.Channel {
+	ret := make([]*channel.Channel, 0, 1)
+	ret = append(ret, s.C)
 	return ret
 }
 

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -130,27 +130,27 @@ func (s DirectFundObjective) Update(event protocols.ObjectiveEvent) (protocols.O
 // Crank inspects the extended state and declares a list of Effects to be executed
 // It's like a state machine transition function where the finite / enumerable state is returned (computed from the extended state)
 // rather than being independent of the extended state; and where there is only one type of event ("the crank") with no data on it at all
-func (s DirectFundObjective) Crank(secretKey *[]byte) (protocols.Objective, protocols.SideEffects, protocols.WaitingFor, error) {
+func (s DirectFundObjective) Crank(secretKey *[]byte) (protocols.Objective, protocols.SideEffects, protocols.WaitingFor, []protocols.LedgerRequest, error) {
 	updated := s.clone()
 
 	sideEffects := protocols.SideEffects{}
 	// Input validation
 	if updated.Status != protocols.Approved {
-		return updated, sideEffects, WaitingForNothing, ErrNotApproved
+		return updated, protocols.SideEffects{}, WaitingForNothing, []protocols.LedgerRequest{}, ErrNotApproved
 	}
 
 	// Prefunding
 	if !updated.C.PreFundSignedByMe() {
 		ss, err := updated.C.SignAndAddPrefund(secretKey)
 		if err != nil {
-			return updated, protocols.SideEffects{}, WaitingForCompletePrefund, fmt.Errorf("could not sign prefund %w", err)
+			return updated, protocols.SideEffects{}, WaitingForCompletePrefund, []protocols.LedgerRequest{}, fmt.Errorf("could not sign prefund %w", err)
 		}
 		messages := protocols.CreateSignedStateMessages(updated.Id(), ss, updated.C.MyIndex)
 		sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, messages...)
 	}
 
 	if !updated.C.PreFundComplete() {
-		return updated, sideEffects, WaitingForCompletePrefund, nil
+		return updated, sideEffects, WaitingForCompletePrefund, []protocols.LedgerRequest{}, nil
 	}
 
 	// Funding
@@ -159,7 +159,7 @@ func (s DirectFundObjective) Crank(secretKey *[]byte) (protocols.Objective, prot
 	safeToDeposit := updated.safeToDeposit()
 
 	if !fundingComplete && !safeToDeposit {
-		return updated, sideEffects, WaitingForMyTurnToFund, nil
+		return updated, sideEffects, WaitingForMyTurnToFund, []protocols.LedgerRequest{}, nil
 	}
 
 	if !fundingComplete && safeToDeposit && amountToDeposit.IsNonZero() {
@@ -168,7 +168,7 @@ func (s DirectFundObjective) Crank(secretKey *[]byte) (protocols.Objective, prot
 	}
 
 	if !fundingComplete {
-		return updated, sideEffects, WaitingForCompleteFunding, nil
+		return updated, sideEffects, WaitingForCompleteFunding, []protocols.LedgerRequest{}, nil
 	}
 
 	// Postfunding
@@ -177,18 +177,18 @@ func (s DirectFundObjective) Crank(secretKey *[]byte) (protocols.Objective, prot
 		ss, err := updated.C.SignAndAddPostfund(secretKey)
 
 		if err != nil {
-			return updated, protocols.SideEffects{}, WaitingForCompletePostFund, fmt.Errorf("could not sign postfund %w", err)
+			return updated, protocols.SideEffects{}, WaitingForCompletePostFund, []protocols.LedgerRequest{}, fmt.Errorf("could not sign postfund %w", err)
 		}
 		messages := protocols.CreateSignedStateMessages(updated.Id(), ss, updated.C.MyIndex)
 		sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, messages...)
 	}
 
 	if !updated.C.PostFundComplete() {
-		return updated, sideEffects, WaitingForCompletePostFund, nil
+		return updated, sideEffects, WaitingForCompletePostFund, []protocols.LedgerRequest{}, nil
 	}
 
 	// Completion
-	return updated, sideEffects, WaitingForNothing, nil
+	return updated, sideEffects, WaitingForNothing, []protocols.LedgerRequest{}, nil
 }
 
 func (s DirectFundObjective) Channels() []*channel.Channel {

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -178,7 +178,7 @@ func TestCrank(t *testing.T) {
 	// END test data preparation
 
 	// Assert that cranking an unapproved objective returns an error
-	if _, _, _, err := s.Crank(&alice.privateKey); err == nil {
+	if _, _, _, _, err := s.Crank(&alice.privateKey); err == nil {
 		t.Error(`Expected error when cranking unapproved objective, but got nil`)
 	}
 
@@ -191,7 +191,7 @@ func TestCrank(t *testing.T) {
 	// - what side effects are declared.
 
 	// Initial Crank
-	_, sideEffects, waitingFor, err := o.Crank(&alice.privateKey)
+	_, sideEffects, waitingFor, _, err := o.Crank(&alice.privateKey)
 	if err != nil {
 		t.Error(err)
 	}
@@ -208,7 +208,7 @@ func TestCrank(t *testing.T) {
 	o.C.AddStateWithSignature(o.C.PreFundState(), correctSignatureByBobOnPreFund)
 
 	// Cranking should move us to the next waiting point
-	_, _, waitingFor, err = o.Crank(&alice.privateKey)
+	_, _, waitingFor, _, err = o.Crank(&alice.privateKey)
 	if err != nil {
 		t.Error(err)
 	}
@@ -218,7 +218,7 @@ func TestCrank(t *testing.T) {
 
 	// Manually make the first "deposit"
 	o.C.OnChainFunding[testState.Outcome[0].Asset] = testState.Outcome[0].Allocations[0].Amount
-	_, sideEffects, waitingFor, err = o.Crank(&alice.privateKey)
+	_, sideEffects, waitingFor, _, err = o.Crank(&alice.privateKey)
 	if err != nil {
 		t.Error(err)
 	}
@@ -233,7 +233,7 @@ func TestCrank(t *testing.T) {
 	// Manually make the second "deposit"
 	totalAmountAllocated := testState.Outcome[0].TotalAllocated()
 	o.C.OnChainFunding[testState.Outcome[0].Asset] = totalAmountAllocated
-	_, sideEffects, waitingFor, err = o.Crank(&alice.privateKey)
+	_, sideEffects, waitingFor, _, err = o.Crank(&alice.privateKey)
 	if err != nil {
 		t.Error(err)
 	}
@@ -250,7 +250,7 @@ func TestCrank(t *testing.T) {
 
 	// This should be the final crank
 	o.C.OnChainFunding[testState.Outcome[0].Asset] = totalAmountAllocated
-	_, _, waitingFor, err = o.Crank(&alice.privateKey)
+	_, _, waitingFor, _, err = o.Crank(&alice.privateKey)
 	if err != nil {
 		t.Error(err)
 	}

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -39,7 +39,6 @@ func (l LedgerRequest) Equal(m LedgerRequest) bool {
 type SideEffects struct {
 	MessagesToSend       []Message
 	TransactionsToSubmit []ChainTransaction
-	LedgerRequests       []LedgerRequest
 }
 
 // WaitingFor is an enumerable "pause-point" computed from an Objective. It describes how the objective is blocked on actions by third parties (i.e. co-participants or the blockchain).
@@ -76,7 +75,7 @@ type Objective interface {
 	Update(event ObjectiveEvent) (Objective, error) // returns an updated Objective (a copy, no mutation allowed), does not declare effects
 	Channels() []*channel.Channel
 
-	Crank(secretKey *[]byte) (Objective, SideEffects, WaitingFor, error) // does *not* accept an event, but *does* accept a pointer to a signing key; declare side effects; return an updated Objective
+	Crank(secretKey *[]byte) (Objective, SideEffects, WaitingFor, []LedgerRequest, error) // does *not* accept an event, but *does* accept a pointer to a signing key; declare side effects; return an updated Objective
 }
 
 // ObjectiveId is a unique identifier for an Objective.

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -1,6 +1,7 @@
 package protocols
 
 import (
+	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -73,7 +74,7 @@ type Objective interface {
 	Approve() Objective                             // returns an updated Objective (a copy, no mutation allowed), does not declare effects
 	Reject() Objective                              // returns an updated Objective (a copy, no mutation allowed), does not declare effects
 	Update(event ObjectiveEvent) (Objective, error) // returns an updated Objective (a copy, no mutation allowed), does not declare effects
-	Channels() []types.Destination
+	Channels() []*channel.Channel
 
 	Crank(secretKey *[]byte) (Objective, SideEffects, WaitingFor, error) // does *not* accept an event, but *does* accept a pointer to a signing key; declare side effects; return an updated Objective
 }

--- a/protocols/ledger/ledger.go
+++ b/protocols/ledger/ledger.go
@@ -15,8 +15,8 @@ import (
 type LedgerManager struct {
 }
 
-func NewLedgerManager() LedgerManager {
-	return LedgerManager{}
+func NewLedgerManager() *LedgerManager {
+	return &LedgerManager{}
 }
 
 // HandleRequest accepts a ledger request and updates the ledger channel based on the request.

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -64,3 +64,11 @@ func CreateSignedStateMessages(id ObjectiveId, ss state.SignedState, myIndex uin
 	}
 	return messages
 }
+
+// Merge accepts a SideEffects struct that is merged into the the existing SideEffects.
+func (se *SideEffects) Merge(other SideEffects) {
+
+	se.MessagesToSend = append(se.MessagesToSend, other.MessagesToSend...)
+	se.TransactionsToSubmit = append(se.TransactionsToSubmit, other.TransactionsToSubmit...)
+
+}

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -306,7 +306,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(wantRequests, gotRequests, cmp.Comparer(types.Equal)); diff != "" {
-				t.Errorf("TestCrank: side effects mismatch (-want +got):\n%s", diff)
+				t.Errorf("TestCrank: ledger requests mismatch (-want +got):\n%s", diff)
 			}
 
 			ledgerManager := ledger.NewLedgerManager()

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -219,7 +219,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
 			var s, _ = New(false, vPreFund, my.address, n, my.role, ledgerChannelToMyLeft, ledgerChannelToMyRight)
 			// Assert that cranking an unapproved objective returns an error
-			if _, _, _, err := s.Crank(&my.privateKey); err == nil {
+			if _, _, _, _, err := s.Crank(&my.privateKey); err == nil {
 				t.Error(`Expected error when cranking unapproved objective, but got nil`)
 			}
 
@@ -229,7 +229,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			// And then crank it to see which "pause point" (WaitingFor) we end up at.
 
 			// Initial Crank
-			oObj, got, waitingFor, err := o.Crank(&my.privateKey)
+			oObj, got, waitingFor, _, err := o.Crank(&my.privateKey)
 			o = oObj.(VirtualFundObjective)
 			if err != nil {
 				t.Error(err)
@@ -247,7 +247,8 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			collectPeerSignaturesOnSetupState(o.V, my.role, true)
 
 			// Cranking should move us to the next waiting point, generate ledger requests as a side effect, and alter the extended state to reflect that
-			oObj, got, waitingFor, err = o.Crank(&my.privateKey)
+			var gotRequests []protocols.LedgerRequest
+			oObj, _, waitingFor, gotRequests, err = o.Crank(&my.privateKey)
 			o = oObj.(VirtualFundObjective)
 			if err != nil {
 				t.Error(err)
@@ -259,11 +260,11 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				t.Error(`Expected ledger update idempotency flag to be raised, but it wasn't`)
 			}
 
-			want := protocols.SideEffects{LedgerRequests: []protocols.LedgerRequest{}}
+			wantRequests := []protocols.LedgerRequest{}
 			switch my.role {
 			case 0:
 				{
-					want.LedgerRequests = append(want.LedgerRequests, protocols.LedgerRequest{
+					wantRequests = append(wantRequests, protocols.LedgerRequest{
 						ObjectiveId: o.Id(),
 						LedgerId:    ledgerChannelToMyRight.Id,
 						Destination: s.V.Id,
@@ -274,7 +275,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				}
 			case 1:
 				{
-					want.LedgerRequests = append(want.LedgerRequests, protocols.LedgerRequest{
+					wantRequests = append(wantRequests, protocols.LedgerRequest{
 						ObjectiveId: o.Id(),
 						LedgerId:    ledgerChannelToMyLeft.Id,
 						Destination: s.V.Id,
@@ -282,7 +283,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 						LeftAmount:  types.Funds{types.Address{}: big.NewInt(5)},
 						RightAmount: types.Funds{types.Address{}: big.NewInt(5)},
 					})
-					want.LedgerRequests = append(want.LedgerRequests, protocols.LedgerRequest{
+					wantRequests = append(wantRequests, protocols.LedgerRequest{
 						ObjectiveId: o.Id(),
 						LedgerId:    ledgerChannelToMyRight.Id,
 						Destination: s.V.Id,
@@ -293,7 +294,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				}
 			case 2:
 				{
-					want.LedgerRequests = append(want.LedgerRequests, protocols.LedgerRequest{
+					wantRequests = append(wantRequests, protocols.LedgerRequest{
 						ObjectiveId: o.Id(),
 						LedgerId:    ledgerChannelToMyLeft.Id,
 						Destination: s.V.Id,
@@ -304,7 +305,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				}
 			}
 
-			if diff := cmp.Diff(want, got, cmp.Comparer(types.Equal)); diff != "" {
+			if diff := cmp.Diff(wantRequests, gotRequests, cmp.Comparer(types.Equal)); diff != "" {
 				t.Errorf("TestCrank: side effects mismatch (-want +got):\n%s", diff)
 			}
 
@@ -312,27 +313,27 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			switch my.role {
 			case 0:
 				{
-					_, _ = ledgerManager.HandleRequest(o.ToMyRight.Channel, got.LedgerRequests[0], &my.privateKey)
+					_, _ = ledgerManager.HandleRequest(o.ToMyRight.Channel, gotRequests[0], &my.privateKey)
 					ledger.SignLatest(o.ToMyRight.Channel, [][]byte{p1.privateKey})
 				}
 			case 1:
 				{
-					_, _ = ledgerManager.HandleRequest(o.ToMyLeft.Channel, got.LedgerRequests[0], &my.privateKey)
+					_, _ = ledgerManager.HandleRequest(o.ToMyLeft.Channel, gotRequests[0], &my.privateKey)
 					ledger.SignLatest(o.ToMyLeft.Channel, [][]byte{alice.privateKey})
-					_, _ = ledgerManager.HandleRequest(o.ToMyRight.Channel, got.LedgerRequests[1], &my.privateKey)
+					_, _ = ledgerManager.HandleRequest(o.ToMyRight.Channel, gotRequests[1], &my.privateKey)
 					ledger.SignLatest(o.ToMyRight.Channel, [][]byte{bob.privateKey})
 
 				}
 			case 2:
 				{
-					_, _ = ledgerManager.HandleRequest(o.ToMyLeft.Channel, got.LedgerRequests[0], &my.privateKey)
+					_, _ = ledgerManager.HandleRequest(o.ToMyLeft.Channel, gotRequests[0], &my.privateKey)
 					ledger.SignLatest(o.ToMyLeft.Channel, [][]byte{p1.privateKey})
 
 				}
 			}
 
 			// Cranking now should not generate side effects, because we already did that
-			oObj, got, waitingFor, err = o.Crank(&my.privateKey)
+			oObj, got, waitingFor, _, err = o.Crank(&my.privateKey)
 			o = oObj.(VirtualFundObjective)
 			if err != nil {
 				t.Error(err)
@@ -349,7 +350,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			collectPeerSignaturesOnSetupState(o.V, my.role, false)
 
 			// This should be the final crank...
-			_, _, waitingFor, err = o.Crank(&my.privateKey)
+			_, _, waitingFor, _, err = o.Crank(&my.privateKey)
 			if err != nil {
 				t.Error(err)
 			}

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -251,14 +251,14 @@ func (s VirtualFundObjective) Crank(secretKey *[]byte) (protocols.Objective, pro
 	return updated, sideEffects, WaitingForNothing, nil
 }
 
-func (s VirtualFundObjective) Channels() []types.Destination {
-	ret := make([]types.Destination, 0, 3)
-	ret = append(ret, s.V.Id)
+func (s VirtualFundObjective) Channels() []*channel.Channel {
+	ret := make([]*channel.Channel, 0, 3)
+	ret = append(ret, &s.V.Channel)
 	if !s.isAlice() {
-		ret = append(ret, s.ToMyLeft.Channel.Id)
+		ret = append(ret, &s.ToMyLeft.Channel.Channel)
 	}
 	if !s.isBob() {
-		ret = append(ret, s.ToMyRight.Channel.Id)
+		ret = append(ret, &s.ToMyRight.Channel.Channel)
 	}
 	return ret
 }

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -197,14 +197,14 @@ func (s VirtualFundObjective) Update(event protocols.ObjectiveEvent) (protocols.
 // Crank inspects the extended state and declares a list of Effects to be executed
 // It's like a state machine transition function where the finite / enumerable state is returned (computed from the extended state)
 // rather than being independent of the extended state; and where there is only one type of event ("the crank") with no data on it at all.
-func (s VirtualFundObjective) Crank(secretKey *[]byte) (protocols.Objective, protocols.SideEffects, protocols.WaitingFor, error) {
+func (s VirtualFundObjective) Crank(secretKey *[]byte) (protocols.Objective, protocols.SideEffects, protocols.WaitingFor, []protocols.LedgerRequest, error) {
 	updated := s.clone()
 
 	sideEffects := protocols.SideEffects{}
-
+	ledgerRequests := []protocols.LedgerRequest{}
 	// Input validation
 	if updated.Status != protocols.Approved {
-		return updated, sideEffects, WaitingForNothing, ErrNotApproved
+		return updated, sideEffects, WaitingForNothing, []protocols.LedgerRequest{}, ErrNotApproved
 	}
 
 	// Prefunding
@@ -212,43 +212,43 @@ func (s VirtualFundObjective) Crank(secretKey *[]byte) (protocols.Objective, pro
 	if !updated.V.PreFundSignedByMe() {
 		ss, err := updated.V.SignAndAddPrefund(secretKey)
 		if err != nil {
-			return s, protocols.SideEffects{}, WaitingForNothing, err
+			return s, protocols.SideEffects{}, WaitingForNothing, []protocols.LedgerRequest{}, err
 		}
 		messages := protocols.CreateSignedStateMessages(s.Id(), ss, s.V.MyIndex)
 		sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, messages...)
 	}
 
 	if !updated.V.PreFundComplete() {
-		return updated, sideEffects, WaitingForCompletePrefund, nil
+		return updated, sideEffects, WaitingForCompletePrefund, ledgerRequests, nil
 	}
 
 	// Funding
 
 	if !updated.requestedLedgerUpdates {
 		updated.requestedLedgerUpdates = true
-		sideEffects.LedgerRequests = append(sideEffects.LedgerRequests, s.generateLedgerRequestSideEffects().LedgerRequests...)
+		ledgerRequests = append(ledgerRequests, s.generateLedgerRequestSideEffects()...)
 	}
 
 	if !updated.fundingComplete() {
-		return updated, sideEffects, WaitingForCompleteFunding, nil
+		return updated, sideEffects, WaitingForCompleteFunding, ledgerRequests, nil
 	}
 
 	// Postfunding
 	if !updated.V.PostFundSignedByMe() {
 		ss, err := updated.V.SignAndAddPostfund(secretKey)
 		if err != nil {
-			return s, protocols.SideEffects{}, WaitingForNothing, err
+			return s, protocols.SideEffects{}, WaitingForNothing, []protocols.LedgerRequest{}, err
 		}
 		messages := protocols.CreateSignedStateMessages(s.Id(), ss, s.V.MyIndex)
 		sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, messages...)
 	}
 
 	if !updated.V.PostFundComplete() {
-		return updated, sideEffects, WaitingForCompletePostFund, nil
+		return updated, sideEffects, WaitingForCompletePostFund, ledgerRequests, nil
 	}
 
 	// Completion
-	return updated, sideEffects, WaitingForNothing, nil
+	return updated, sideEffects, WaitingForNothing, ledgerRequests, nil
 }
 
 func (s VirtualFundObjective) Channels() []*channel.Channel {
@@ -319,15 +319,15 @@ func (connection *Connection) ledgerChannelAffordsExpectedGuarantees() bool {
 }
 
 // generateLedgerRequestSideEffects generates the appropriate side effects, which (when executed and countersigned) will update 1 or 2 ledger channels to guarantee the joint channel.
-func (s VirtualFundObjective) generateLedgerRequestSideEffects() protocols.SideEffects {
-	sideEffects := protocols.SideEffects{}
-	sideEffects.LedgerRequests = make([]protocols.LedgerRequest, 0)
+func (s VirtualFundObjective) generateLedgerRequestSideEffects() []protocols.LedgerRequest {
+
+	requests := make([]protocols.LedgerRequest, 0)
 
 	leftAmount := s.V.LeftAmount()
 	rightAmount := s.V.RightAmount()
 
 	if !s.isAlice() {
-		sideEffects.LedgerRequests = append(sideEffects.LedgerRequests,
+		requests = append(requests,
 			protocols.LedgerRequest{
 				ObjectiveId: s.Id(),
 				LedgerId:    s.ToMyLeft.Channel.Id,
@@ -339,7 +339,7 @@ func (s VirtualFundObjective) generateLedgerRequestSideEffects() protocols.SideE
 			})
 	}
 	if !s.isBob() {
-		sideEffects.LedgerRequests = append(sideEffects.LedgerRequests,
+		requests = append(requests,
 			protocols.LedgerRequest{
 				ObjectiveId: s.Id(),
 				LedgerId:    s.ToMyRight.Channel.Id,
@@ -350,7 +350,7 @@ func (s VirtualFundObjective) generateLedgerRequestSideEffects() protocols.SideE
 				RightAmount: rightAmount,
 			})
 	}
-	return sideEffects
+	return requests
 }
 
 // Clone returns a deep copy of the receiver


### PR DESCRIPTION
Fixes #240 
This PR has two main changes:
- Remove LedgerRequests from SideEffects 
- Connect the LedgerManager up to the engine

Based on this [discussion](https://www.notion.so/statechannels/Ledger-protocol-planning-007a7fc95ac74846a2cec1ed035330d5) `LedgerRequest`s are no longer a part of the `SideEffects` struct. Instead they are returned as a return param on `Objective.Crank`. 

The engine has been updated to call `ledgerManager.handleRequest` when `Crank` returns ledger requests. The messages generated by these requests are included in the `SideEffects` passed into `executeSideEffects`.

A `GetChannel` function has been added to the `Store` so the engine can get the necessary ledger channel to handle a request.