### PR TITLE
Get Virtual Funding Integration Test Passing

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -21,6 +21,7 @@ type Client struct {
 	engine              engine.Engine // The core business logic of the client
 	Address             *types.Address
 	completedObjectives chan protocols.ObjectiveId
+	store               *store.Store
 }
 
 // New is the constructor for a Client. It accepts a messaging service, a chain service, and a store as injected dependencies.
@@ -29,7 +30,7 @@ func New(messageService messageservice.MessageService, chainservice chainservice
 	c.Address = store.GetAddress()
 	c.engine = engine.New(messageService, chainservice, store, logDestination)
 	c.completedObjectives = make(chan protocols.ObjectiveId, 100)
-
+	c.store = &store
 	// Start the engine in a go routine
 	go c.engine.Run()
 

--- a/client/client.go
+++ b/client/client.go
@@ -93,7 +93,6 @@ func (c *Client) CreateVirtualChannel(counterParty types.Address, intermediary t
 		0, // We always play the role of alice if we initiate the channel
 		left, right)
 
-	// Pass in a fresh, dedicated go channel to communicate the response:
 	apiEvent := engine.APIEvent{
 		ObjectiveToSpawn: objective,
 	}
@@ -121,7 +120,6 @@ func (c *Client) CreateDirectChannel(counterparty types.Address, appDefinition t
 		*c.Address,
 	)
 
-	// Pass in a fresh, dedicated go channel to communicate the response:
 	apiEvent := engine.APIEvent{
 		ObjectiveToSpawn: objective,
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -65,6 +65,7 @@ func (c *Client) CompletedObjectives() <-chan protocols.ObjectiveId {
 	return c.completedObjectives
 }
 
+// CreateVirtualChannel creates a virtual channel with the counterParty using ledger channels with the intermediary.
 func (c *Client) CreateVirtualChannel(counterParty types.Address, intermediary types.Address, appDefinition types.Address, appData types.Bytes, outcome outcome.Exit, challengeDuration *types.Uint256) protocols.ObjectiveId {
 	right, ok := (*c.store).GetTwoPartyLedger(*c.Address, intermediary)
 

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -341,7 +341,7 @@ func (e *Engine) handleLedgerRequests(ledgerRequests []protocols.LedgerRequest, 
 		if err != nil {
 			return se, fmt.Errorf("could not handle ledger request: %w", err)
 		}
-		err = e.store.SetObjective(objective)
+		err = e.store.SetChannel(&ledger.Channel)
 
 		if err != nil {
 			return se, fmt.Errorf("could not set channel: %w", err)

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -130,11 +130,7 @@ func (e *Engine) handleMessage(message protocols.Message) ObjectiveChangeEvent {
 		e.logger.Print(err)
 		return ObjectiveChangeEvent{}
 	}
-	err = e.store.SetObjective(updatedObjective)
-	if err != nil {
-		e.logger.Print(err)
-		return ObjectiveChangeEvent{}
-	}
+
 	return e.attemptProgress(updatedObjective)
 
 }

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -3,10 +3,13 @@ package store
 import (
 	"crypto/ecdsa"
 	"log"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/protocols/directfund"
+	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -54,6 +57,52 @@ func (ms MockStore) GetObjectiveById(id protocols.ObjectiveId) (obj protocols.Ob
 func (ms MockStore) SetObjective(obj protocols.Objective) error {
 	// todo: locking
 	ms.objectives[obj.Id()] = obj
+	return nil
+}
+
+// SetChannel sets the channel in the store.
+func (ms *MockStore) SetChannel(ch *channel.Channel) error {
+	// TODO: This is a temporary implementation that is pretty clunky.
+	// This should be replaced in https://github.com/statechannels/go-nitro/pull/227
+	for _, obj := range ms.objectives {
+		if strings.HasPrefix(string(obj.Id()), "DirectFunding-") {
+			dfO := obj.(directfund.DirectFundObjective)
+			if dfO.C.Id == ch.Id {
+				dfO.C = ch
+				err := ms.SetObjective(dfO)
+				if err != nil {
+					return err
+				}
+
+			}
+		} else if strings.HasPrefix(string(obj.Id()), "VirtualFund-") {
+			vfO := obj.(virtualfund.VirtualFundObjective)
+			if vfO.V.Id == ch.Id {
+				vfO.V = &channel.SingleHopVirtualChannel{Channel: *ch}
+				err := ms.SetObjective(vfO)
+				if err != nil {
+					return err
+				}
+
+			}
+			if vfO.ToMyLeft != nil && vfO.ToMyLeft.Channel.Id == ch.Id {
+				vfO.ToMyLeft.Channel = &channel.TwoPartyLedger{Channel: *ch}
+				err := ms.SetObjective(vfO)
+				if err != nil {
+					return err
+				}
+
+			}
+			if vfO.ToMyRight != nil && vfO.ToMyRight.Channel.Id == ch.Id {
+				vfO.ToMyRight.Channel = &channel.TwoPartyLedger{Channel: *ch}
+				err := ms.SetObjective(vfO)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+	}
 	return nil
 }
 

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -106,18 +106,6 @@ func (ms *MockStore) SetChannel(ch *channel.Channel) error {
 	return nil
 }
 
-func (ms MockStore) GetChannel(channelId types.Destination) (*channel.Channel, bool) {
-	// todo: locking
-	for _, obj := range ms.objectives {
-		for _, ch := range obj.Channels() {
-			if ch.Id == channelId {
-				return ch, true
-			}
-		}
-	}
-	return nil, false
-}
-
 func (ms MockStore) GetTwoPartyLedger(firstParty types.Address, secondParty types.Address) (ledger *channel.TwoPartyLedger, ok bool) {
 	for _, obj := range ms.objectives {
 		for _, ch := range obj.Channels() {

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -106,6 +106,7 @@ func (ms *MockStore) SetChannel(ch *channel.Channel) error {
 	return nil
 }
 
+// GetTwoPartyLedger returns a ledger channel between the two parties if it exists.
 func (ms MockStore) GetTwoPartyLedger(firstParty types.Address, secondParty types.Address) (ledger *channel.TwoPartyLedger, ok bool) {
 	for _, obj := range ms.objectives {
 		for _, ch := range obj.Channels() {

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -69,6 +69,20 @@ func (ms MockStore) GetChannel(channelId types.Destination) (*channel.Channel, b
 	return nil, false
 }
 
+func (ms MockStore) GetTwoPartyLedger(firstParty types.Address, secondParty types.Address) (ledger *channel.TwoPartyLedger, ok bool) {
+	for _, obj := range ms.objectives {
+		for _, ch := range obj.Channels() {
+			if len(ch.Participants) == 2 {
+				// TODO: Should order matter?
+				if ch.Participants[0] == firstParty && ch.Participants[1] == secondParty {
+					return &channel.TwoPartyLedger{Channel: *ch}, true
+				}
+			}
+		}
+	}
+	return nil, false
+}
+
 func (ms MockStore) GetObjectiveByChannelId(channelId types.Destination) (protocols.Objective, bool) {
 	// todo: locking
 	for _, obj := range ms.objectives {

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -16,5 +16,6 @@ type Store interface {
 	GetObjectiveByChannelId(types.Destination) (obj protocols.Objective, ok bool) // Get the objective that currently owns the channel with the supplied ChannelId
 	SetObjective(protocols.Objective) error                                       // Write an objective
 	GetChannel(types.Destination) (channel *channel.Channel, ok bool)
+	GetTwoPartyLedger(firstParty types.Address, secondParty types.Address) (channel *channel.TwoPartyLedger, ok bool)
 	UpdateProgressLastMadeAt(protocols.ObjectiveId, protocols.WaitingFor) // updates progressLastMadeAt information for an objective
 }

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -17,5 +17,6 @@ type Store interface {
 	SetObjective(protocols.Objective) error                                       // Write an objective
 	GetChannel(types.Destination) (channel *channel.Channel, ok bool)
 	GetTwoPartyLedger(firstParty types.Address, secondParty types.Address) (channel *channel.TwoPartyLedger, ok bool)
+	SetChannel(*channel.Channel) error
 	UpdateProgressLastMadeAt(protocols.ObjectiveId, protocols.WaitingFor) // updates progressLastMadeAt information for an objective
 }

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -15,7 +15,6 @@ type Store interface {
 	GetObjectiveById(protocols.ObjectiveId) (obj protocols.Objective, ok bool)    // Read an existing objective
 	GetObjectiveByChannelId(types.Destination) (obj protocols.Objective, ok bool) // Get the objective that currently owns the channel with the supplied ChannelId
 	SetObjective(protocols.Objective) error                                       // Write an objective
-	GetChannel(types.Destination) (channel *channel.Channel, ok bool)
 	GetTwoPartyLedger(firstParty types.Address, secondParty types.Address) (channel *channel.TwoPartyLedger, ok bool)
 	SetChannel(*channel.Channel) error
 	UpdateProgressLastMadeAt(protocols.ObjectiveId, protocols.WaitingFor) // updates progressLastMadeAt information for an objective

--- a/client/virtualfund_integration_test.go
+++ b/client/virtualfund_integration_test.go
@@ -14,6 +14,12 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
+// TestVirtualFundIntegration is a work in progress:
+// It should:
+// [x] spin up three clients with connected test services
+// [x] directly fund a pair of ledger channels
+// [ ] call an API method such as clientA.CreateVirtualChannel
+// [ ] assert on an appropriate objective completing in all clients
 func TestVirtualFundIntegration(t *testing.T) {
 
 	// Set up logging

--- a/client/virtualfund_integration_test.go
+++ b/client/virtualfund_integration_test.go
@@ -1,0 +1,95 @@
+package client
+
+import (
+	"log"
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/client/engine/chainservice"
+	"github.com/statechannels/go-nitro/client/engine/messageservice"
+	"github.com/statechannels/go-nitro/client/engine/store"
+	"github.com/statechannels/go-nitro/types"
+)
+
+func TestVirtualFundIntegration(t *testing.T) {
+
+	// Set up logging
+	logDestination, err := os.OpenFile("virtualfund_integration_test.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Reset log destination file
+	err = logDestination.Truncate(0)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	aKey := common.Hex2Bytes(`2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d`)
+	a := common.HexToAddress(`0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE`)
+
+	bKey := common.Hex2Bytes(`0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4`)
+	b := common.HexToAddress(`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`)
+
+	iKey := common.Hex2Bytes(`febb3b74b0b52d0976f6571d555f4ac8b91c308dfa25c7b58d1e6a7c3f50c781`)
+	i := common.HexToAddress(`0x111A00868581f73AB42FEEF67D235Ca09ca1E8db`)
+
+	chain := chainservice.NewMockChain([]types.Address{a, b, i})
+
+	chainservA := chainservice.NewSimpleChainService(chain, a)
+	messageserviceA := messageservice.NewTestMessageService(a)
+	storeA := store.NewMockStore(aKey)
+	clientA := New(messageserviceA, chainservA, storeA, logDestination)
+
+	chainservB := chainservice.NewSimpleChainService(chain, b)
+	messageserviceB := messageservice.NewTestMessageService(b)
+	storeB := store.NewMockStore(bKey)
+	clientB := New(messageserviceB, chainservB, storeB, logDestination)
+
+	chainservI := chainservice.NewSimpleChainService(chain, i)
+	messageserviceI := messageservice.NewTestMessageService(i)
+	storeI := store.NewMockStore(iKey)
+	clientI := New(messageserviceI, chainservI, storeI, logDestination)
+
+	messageserviceA.Connect(messageserviceB)
+	messageserviceA.Connect(messageserviceI)
+	messageserviceB.Connect(messageserviceA)
+	messageserviceB.Connect(messageserviceI)
+	messageserviceI.Connect(messageserviceA)
+	messageserviceI.Connect(messageserviceB)
+
+	directlyFundALedgerChannel := func(i Client, j Client) {
+		// Set up an outcome that requires both participants to deposit
+		outcome := outcome.Exit{outcome.SingleAssetExit{
+			Allocations: outcome.Allocations{
+				outcome.Allocation{
+					Destination: types.AddressToDestination(*i.Address),
+					Amount:      big.NewInt(5),
+				},
+				outcome.Allocation{
+					Destination: types.AddressToDestination(*j.Address),
+					Amount:      big.NewInt(5),
+				},
+			},
+		}}
+		id := i.CreateDirectChannel(b, types.Address{}, types.Bytes{}, outcome, big.NewInt(0))
+		got := <-i.CompletedObjectives()
+
+		if got != id {
+			t.Errorf("expected completed objective with id %v, but got %v", id, got)
+		}
+
+		gotFromJ := <-j.CompletedObjectives()
+
+		if gotFromJ != id {
+			t.Errorf("expected completed objective with id %v, but got %v", id, gotFromJ)
+		}
+	}
+
+	directlyFundALedgerChannel(clientA, clientI)
+	directlyFundALedgerChannel(clientI, clientB)
+
+}

--- a/client/virtualfund_integration_test.go
+++ b/client/virtualfund_integration_test.go
@@ -117,7 +117,17 @@ func TestVirtualFundIntegration(t *testing.T) {
 	got := <-clientA.CompletedObjectives()
 
 	if got != id {
-		t.Errorf("expected completed objective with id %v, but got %v", id, got)
+		t.Errorf("expected completed objective from a with id %v, but got %v", id, got)
+	}
+
+	gotFromB := <-clientB.CompletedObjectives()
+	if gotFromB != id {
+		t.Errorf("expected completed objective from b with id %v, but got %v", id, gotFromB)
+	}
+
+	gotFromI := <-clientI.CompletedObjectives()
+	if gotFromI != id {
+		t.Errorf("expected completed objective from i with id %v, but got %v", id, gotFromI)
 	}
 
 }

--- a/client/virtualfund_integration_test.go
+++ b/client/virtualfund_integration_test.go
@@ -19,8 +19,8 @@ import (
 // It should:
 // [x] spin up three clients with connected test services
 // [x] directly fund a pair of ledger channels
-// [ ] call an API method such as clientA.CreateVirtualChannel
-// [ ] assert on an appropriate objective completing in all clients
+// [x] call an API method such as clientA.CreateVirtualChannel
+// [x] assert on an appropriate objective completing in all clients
 func TestVirtualFundIntegration(t *testing.T) {
 
 	// Set up logging

--- a/client/virtualfund_integration_test.go
+++ b/client/virtualfund_integration_test.go
@@ -56,33 +56,35 @@ func TestVirtualFundIntegration(t *testing.T) {
 
 	messageserviceA.Connect(messageserviceB)
 	messageserviceA.Connect(messageserviceI)
+
 	messageserviceB.Connect(messageserviceA)
 	messageserviceB.Connect(messageserviceI)
+
 	messageserviceI.Connect(messageserviceA)
 	messageserviceI.Connect(messageserviceB)
 
-	directlyFundALedgerChannel := func(i Client, j Client) {
+	directlyFundALedgerChannel := func(alpha Client, beta Client) {
 		// Set up an outcome that requires both participants to deposit
 		outcome := outcome.Exit{outcome.SingleAssetExit{
 			Allocations: outcome.Allocations{
 				outcome.Allocation{
-					Destination: types.AddressToDestination(*i.Address),
+					Destination: types.AddressToDestination(*alpha.Address),
 					Amount:      big.NewInt(5),
 				},
 				outcome.Allocation{
-					Destination: types.AddressToDestination(*j.Address),
+					Destination: types.AddressToDestination(*beta.Address),
 					Amount:      big.NewInt(5),
 				},
 			},
 		}}
-		id := i.CreateDirectChannel(b, types.Address{}, types.Bytes{}, outcome, big.NewInt(0))
-		got := <-i.CompletedObjectives()
+		id := alpha.CreateDirectChannel(*beta.Address, types.Address{}, types.Bytes{}, outcome, big.NewInt(0))
+		got := <-alpha.CompletedObjectives()
 
 		if got != id {
 			t.Errorf("expected completed objective with id %v, but got %v", id, got)
 		}
 
-		gotFromJ := <-j.CompletedObjectives()
+		gotFromJ := <-beta.CompletedObjectives()
 
 		if gotFromJ != id {
 			t.Errorf("expected completed objective with id %v, but got %v", id, gotFromJ)

--- a/client/virtualfund_integration_test.go
+++ b/client/virtualfund_integration_test.go
@@ -95,9 +95,29 @@ func TestVirtualFundIntegration(t *testing.T) {
 		if gotFromJ != id {
 			t.Errorf("expected completed objective with id %v, but got %v", id, gotFromJ)
 		}
+
 	}
 
 	directlyFundALedgerChannel(clientA, clientI)
 	directlyFundALedgerChannel(clientI, clientB)
+
+	outcome := outcome.Exit{outcome.SingleAssetExit{
+		Allocations: outcome.Allocations{
+			outcome.Allocation{
+				Destination: types.AddressToDestination(a),
+				Amount:      big.NewInt(5),
+			},
+			outcome.Allocation{
+				Destination: types.AddressToDestination(i),
+				Amount:      big.NewInt(5),
+			},
+		},
+	}}
+	id := clientA.CreateVirtualChannel(b, i, types.Address{}, types.Bytes{}, outcome, big.NewInt(0))
+	got := <-clientA.CompletedObjectives()
+
+	if got != id {
+		t.Errorf("expected completed objective with id %v, but got %v", id, got)
+	}
 
 }

--- a/client/virtualfund_integration_test.go
+++ b/client/virtualfund_integration_test.go
@@ -100,7 +100,7 @@ func TestVirtualFundIntegration(t *testing.T) {
 				Amount:      big.NewInt(5),
 			},
 			outcome.Allocation{
-				Destination: types.AddressToDestination(i),
+				Destination: types.AddressToDestination(b),
 				Amount:      big.NewInt(5),
 			},
 		},

--- a/client/virtualfund_integration_test.go
+++ b/client/virtualfund_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	"github.com/statechannels/go-nitro/client/engine/store"
+	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -84,17 +85,8 @@ func TestVirtualFundIntegration(t *testing.T) {
 			},
 		}}
 		id := alpha.CreateDirectChannel(*beta.Address, types.Address{}, types.Bytes{}, outcome, big.NewInt(0))
-		got := <-alpha.CompletedObjectives()
-
-		if got != id {
-			t.Errorf("expected completed objective with id %v, but got %v", id, got)
-		}
-
-		gotFromJ := <-beta.CompletedObjectives()
-
-		if gotFromJ != id {
-			t.Errorf("expected completed objective with id %v, but got %v", id, gotFromJ)
-		}
+		waitForCompletedObjectiveId(id, &alpha)
+		waitForCompletedObjectiveId(id, &beta)
 
 	}
 
@@ -114,20 +106,16 @@ func TestVirtualFundIntegration(t *testing.T) {
 		},
 	}}
 	id := clientA.CreateVirtualChannel(b, i, types.Address{}, types.Bytes{}, outcome, big.NewInt(0))
-	got := <-clientA.CompletedObjectives()
+	waitForCompletedObjectiveId(id, &clientA)
+	waitForCompletedObjectiveId(id, &clientB)
+	waitForCompletedObjectiveId(id, &clientI)
 
-	if got != id {
-		t.Errorf("expected completed objective from a with id %v, but got %v", id, got)
+}
+
+// waitForCompletedObjectiveId waits for completed objectives and returns when the completed objective id matchs the id waitForCompletedObjectiveId has been given
+func waitForCompletedObjectiveId(id protocols.ObjectiveId, client *Client) {
+	got := <-client.completedObjectives
+	for got != id {
+		got = <-client.completedObjectives
 	}
-
-	gotFromB := <-clientB.CompletedObjectives()
-	if gotFromB != id {
-		t.Errorf("expected completed objective from b with id %v, but got %v", id, gotFromB)
-	}
-
-	gotFromI := <-clientI.CompletedObjectives()
-	if gotFromI != id {
-		t.Errorf("expected completed objective from i with id %v, but got %v", id, gotFromI)
-	}
-
 }

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -108,8 +108,9 @@ func New(
 			init.a0,
 			init.b0,
 			init.V.Id,
-			init.ToMyLeft.Channel.TheirDestination(),
-			init.ToMyLeft.Channel.MyDestination())
+			types.AddressToDestination(init.ToMyLeft.Channel.Participants[0]),
+			types.AddressToDestination(init.ToMyLeft.Channel.Participants[1]),
+		)
 		if err != nil {
 			return VirtualFundObjective{}, err
 		}
@@ -122,9 +123,9 @@ func New(
 			init.a0,
 			init.b0,
 			init.V.Id,
-			init.ToMyRight.Channel.MyDestination(),
-			init.ToMyRight.Channel.TheirDestination())
-
+			types.AddressToDestination(init.ToMyRight.Channel.Participants[0]),
+			types.AddressToDestination(init.ToMyRight.Channel.Participants[1]),
+		)
 		if err != nil {
 			return VirtualFundObjective{}, err
 		}

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -332,9 +332,9 @@ func (s VirtualFundObjective) generateLedgerRequestSideEffects() []protocols.Led
 				ObjectiveId: s.Id(),
 				LedgerId:    s.ToMyLeft.Channel.Id,
 				Destination: s.V.Id,
-				Left:        s.ToMyLeft.Channel.TheirDestination(),
+				Left:        types.AddressToDestination(s.ToMyLeft.Channel.Participants[0]),
 				LeftAmount:  leftAmount,
-				Right:       s.ToMyLeft.Channel.MyDestination(),
+				Right:       types.AddressToDestination(s.ToMyLeft.Channel.Participants[1]),
 				RightAmount: rightAmount,
 			})
 	}
@@ -344,9 +344,9 @@ func (s VirtualFundObjective) generateLedgerRequestSideEffects() []protocols.Led
 				ObjectiveId: s.Id(),
 				LedgerId:    s.ToMyRight.Channel.Id,
 				Destination: s.V.Id,
-				Left:        s.ToMyRight.Channel.MyDestination(),
+				Left:        types.AddressToDestination(s.ToMyRight.Channel.Participants[0]),
 				LeftAmount:  leftAmount,
-				Right:       s.ToMyRight.Channel.TheirDestination(),
+				Right:       types.AddressToDestination(s.ToMyRight.Channel.Participants[1]),
 				RightAmount: rightAmount,
 			})
 	}


### PR DESCRIPTION
Fixes #217 

This includes the changes from #280 and #281 

This PR introduces a virtual funding integration test and contains a collection of changes to get the test working.

The integration test is now passing on CI 🎉 :
```
.....
0x111A00868581f73AB42FEEF67D235Ca09ca1E8db: 2022/02/25 00:37:40 engine.go:219: Objective VirtualFund-0xe25bb77c1b36b618f553c1fab4b473c53c2a67a1c63591bdc2a72b244e039fd6 is WaitingForNothing
0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94: 2022/02/25 00:37:40 engine.go:219: Objective VirtualFund-0xe25bb77c1b36b618f553c1fab4b473c53c2a67a1c63591bdc2a72b244e039fd6 is WaitingForCompletePostFund
0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94: 2022/02/25 00:37:40 engine.go:121: Handling inbound message {0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 VirtualFund-0xe25bb77c1b36b618f553c1fab4b473c53c2a67a1c63591bdc2a72b244e039fd6 [{{0xc000271880 [[170 166 98 142 196 74 138 116 41 135 239 58 17 77 223 226 212 247 173 206] [17 26 0 134 133 129 247 58 180 47 238 246 125 35 92 160 156 161 232 219] [187 182 118 249 207 248 210 66 233 234 195 157 6 56 72 128 125 61 29 148]] 0xc0002718a0 [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] 0xc0002718c0 [] [{[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] [] [{[0 0 0 0 0 0 0 0 0 0 0 0 170 166 98 142 196 74 138 116 41 135 239 58 17 77 223 226 212 247 173 206] 0xc0002718e0 0 []} {[0 0 0 0 0 0 0 0 0 0 0 0 17 26 0 134 133 129 247 58 180 47 238 246 125 35 92 160 156 161 232 219] 0xc000271900 0 []}]}] 1 false} map[1:{[104 206 53 50 126 77 245 91 175 69 182 194 226 7 171 22 208 134 29 244 98 142 2 102 239 227 219 42 236 92 19 78] [80 128 163 91 255 207 160 38 246 136 106 152 228 28 194 186 160 34 62 148 3 10 87 71 38 90 245 79 0 189 111 142] 1}]}]}
0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE: 2022/02/25 00:37:40 engine.go:219: Objective VirtualFund-0xe25bb77c1b36b618f553c1fab4b473c53c2a67a1c63591bdc2a72b244e039fd6 is WaitingForNothing
0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94: 2022/02/25 00:37:40 engine.go:219: Objective VirtualFund-0xe25bb77c1b36b618f553c1fab4b473c53c2a67a1c63591bdc2a72b244e039fd6 is WaitingForNothing
```

# Changes

This is a list of various supporting changes made to get the virtual funding integration passing.

- [360e88d](https://github.com/statechannels/go-nitro/pull/274/commits/360e88d14c3e301520e8c4bb9f8ef4c01136e573): Add a basic `CreateVirtualChannel` API function so we can call it from the integration test.
- [b034820](https://github.com/statechannels/go-nitro/pull/274/commits/b034820464177e3823b237d70ac85d04f6f75699): Fix #275 by constructing a virtual funding objective from a message
- [467a27c](https://github.com/statechannels/go-nitro/pull/274/commits/467a27cf1ea7949e1ddd752b598da762c8fd347f): Add a `SetChannel` function so we can update the store after handling ledger requests. 
- [8401cb3](https://github.com/statechannels/go-nitro/pull/274/commits/8401cb316015f616e2f7698b874c47bef63b830d): Make sure we consistently call `SetObjective` whenever we mutate data
- [9b5d134](https://github.com/statechannels/go-nitro/pull/274/commits/9b5d134a0ff2be97ace54f181b7b00c4a19c6808) & [162fdf5](https://github.com/statechannels/go-nitro/pull/274/commits/162fdf5b50483b08e38b3b52a75741bec1c36cee): Make sure that Irene generates the exact same `LedgerRequest`s as Bob and Alice, so all ledger states match exactly. Previously we were using `MyDestination/TheirDestination` for `Left` and `Right` so Irene would generate a different request than Alice/Bob.
- [9e9f7ed](https://github.com/statechannels/go-nitro/pull/274/commits/9e9f7edda71b27334c9247ca245b5a6b1b7c3d4a): Remove `GetChannel`. Right now multiple objectives can have the same channel. However when we call `SetObjective` we only update one objective. This means that the channels on objectives can get out of sync. This should get fixed in https://github.com/statechannels/go-nitro/pull/227 but for now I just removed `GetChannel` and rely on `GetObjectiveById`
- [033bf82](https://github.com/statechannels/go-nitro/pull/274/commits/033bf82c2f0dfe41c065526edac70dcbb85a513a): Call SetChannel in HandleLedgerRequests. Previously we were mutating the ledger channel but not setting it in the store correctly