### PR TITLE
Archive logs during GH action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,6 +20,12 @@ jobs:
       - name: Test
         run: go test -v ./... -count=2 -shuffle=on
 
+      - name: Archive logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: integration-test-logs
+          path: ./**/*.log
+
       - name: Tidy
         run: go mod tidy
 


### PR DESCRIPTION
We have a flickering test #246 which is difficult to debug. Having access to the logs from that test will help. 

**How Has This Been Tested?**
If you click through to the action run on this branch (and then click "summary") https://github.com/statechannels/go-nitro/actions/runs/1892436562 you will see a link to download a zip of log files:
![Screenshot 2022-02-24 at 10 20 38](https://user-images.githubusercontent.com/1833419/155505632-6c5f9a20-6f59-4b96-9e1a-657aea8aef82.png)

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
