### PR TITLE
Make as much progress as possible during protocol cranking

### DIFF
--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -143,7 +143,7 @@ func (s DirectFundObjective) Crank(secretKey *[]byte) (protocols.Objective, prot
 	if !updated.C.PreFundSignedByMe() {
 		ss, err := updated.C.SignAndAddPrefund(secretKey)
 		if err != nil {
-			return updated, sideEffects, WaitingForCompletePrefund, fmt.Errorf("could not sign prefund %w", err)
+			return updated, protocols.SideEffects{}, WaitingForCompletePrefund, fmt.Errorf("could not sign prefund %w", err)
 		}
 		messages := protocols.CreateSignedStateMessages(updated.Id(), ss, updated.C.MyIndex)
 		sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, messages...)
@@ -177,7 +177,7 @@ func (s DirectFundObjective) Crank(secretKey *[]byte) (protocols.Objective, prot
 		ss, err := updated.C.SignAndAddPostfund(secretKey)
 
 		if err != nil {
-			return updated, sideEffects, WaitingForCompletePostFund, fmt.Errorf("could not sign postfund %w", err)
+			return updated, protocols.SideEffects{}, WaitingForCompletePostFund, fmt.Errorf("could not sign postfund %w", err)
 		}
 		messages := protocols.CreateSignedStateMessages(updated.Id(), ss, updated.C.MyIndex)
 		sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, messages...)

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -24,8 +24,6 @@ func FundOnChainEffect(cId types.Destination, asset string, amount types.Funds) 
 	return "deposit" + amount.String() + "into" + cId.String()
 }
 
-var NoSideEffects = protocols.SideEffects{}
-
 // errors
 var ErrNotApproved = errors.New("objective not approved")
 
@@ -135,26 +133,24 @@ func (s DirectFundObjective) Update(event protocols.ObjectiveEvent) (protocols.O
 func (s DirectFundObjective) Crank(secretKey *[]byte) (protocols.Objective, protocols.SideEffects, protocols.WaitingFor, error) {
 	updated := s.clone()
 
-	se := NoSideEffects
+	sideEffects := protocols.SideEffects{}
 	// Input validation
 	if updated.Status != protocols.Approved {
-		return updated, NoSideEffects, WaitingForNothing, ErrNotApproved
+		return updated, sideEffects, WaitingForNothing, ErrNotApproved
 	}
 
 	// Prefunding
 	if !updated.C.PreFundSignedByMe() {
 		ss, err := updated.C.SignAndAddPrefund(secretKey)
 		if err != nil {
-			return updated, NoSideEffects, WaitingForCompletePrefund, fmt.Errorf("could not sign prefund %w", err)
+			return updated, sideEffects, WaitingForCompletePrefund, fmt.Errorf("could not sign prefund %w", err)
 		}
 		messages := protocols.CreateSignedStateMessages(updated.Id(), ss, updated.C.MyIndex)
-		se.MessagesToSend = append(se.MessagesToSend, messages...)
-
-		return updated, se, WaitingForCompletePrefund, nil
+		sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, messages...)
 	}
 
 	if !updated.C.PreFundComplete() {
-		return updated, NoSideEffects, WaitingForCompletePrefund, nil
+		return updated, sideEffects, WaitingForCompletePrefund, nil
 	}
 
 	// Funding
@@ -163,17 +159,16 @@ func (s DirectFundObjective) Crank(secretKey *[]byte) (protocols.Objective, prot
 	safeToDeposit := updated.safeToDeposit()
 
 	if !fundingComplete && !safeToDeposit {
-		return updated, NoSideEffects, WaitingForMyTurnToFund, nil
+		return updated, sideEffects, WaitingForMyTurnToFund, nil
 	}
 
 	if !fundingComplete && safeToDeposit && amountToDeposit.IsNonZero() {
 		deposit := protocols.ChainTransaction{ChannelId: updated.C.Id, Deposit: amountToDeposit}
-		se.TransactionsToSubmit = append(se.TransactionsToSubmit, deposit)
-		return updated, se, WaitingForCompleteFunding, nil
+		sideEffects.TransactionsToSubmit = append(sideEffects.TransactionsToSubmit, deposit)
 	}
 
 	if !fundingComplete {
-		return updated, NoSideEffects, WaitingForCompleteFunding, nil
+		return updated, sideEffects, WaitingForCompleteFunding, nil
 	}
 
 	// Postfunding
@@ -182,20 +177,18 @@ func (s DirectFundObjective) Crank(secretKey *[]byte) (protocols.Objective, prot
 		ss, err := updated.C.SignAndAddPostfund(secretKey)
 
 		if err != nil {
-			return updated, NoSideEffects, WaitingForCompletePostFund, fmt.Errorf("could not sign postfund %w", err)
+			return updated, sideEffects, WaitingForCompletePostFund, fmt.Errorf("could not sign postfund %w", err)
 		}
 		messages := protocols.CreateSignedStateMessages(updated.Id(), ss, updated.C.MyIndex)
-		se.MessagesToSend = append(se.MessagesToSend, messages...)
-
-		return updated, se, WaitingForCompletePostFund, nil
+		sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, messages...)
 	}
 
 	if !updated.C.PostFundComplete() {
-		return updated, NoSideEffects, WaitingForCompletePostFund, nil
+		return updated, sideEffects, WaitingForCompletePostFund, nil
 	}
 
 	// Completion
-	return updated, NoSideEffects, WaitingForNothing, nil
+	return updated, sideEffects, WaitingForNothing, nil
 }
 
 func (s DirectFundObjective) Channels() []types.Destination {

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -132,7 +132,6 @@ func (s DirectFundObjective) Update(event protocols.ObjectiveEvent) (protocols.O
 // Crank inspects the extended state and declares a list of Effects to be executed
 // It's like a state machine transition function where the finite / enumerable state is returned (computed from the extended state)
 // rather than being independent of the extended state; and where there is only one type of event ("the crank") with no data on it at all
-
 func (s DirectFundObjective) Crank(secretKey *[]byte) (protocols.Objective, protocols.SideEffects, protocols.WaitingFor, error) {
 	updated := s.clone()
 

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -237,7 +237,7 @@ func (s VirtualFundObjective) Crank(secretKey *[]byte) (protocols.Objective, pro
 	if !updated.V.PostFundSignedByMe() {
 		ss, err := updated.V.SignAndAddPostfund(secretKey)
 		if err != nil {
-			return s, sideEffects, WaitingForNothing, err
+			return s, protocols.SideEffects{}, WaitingForNothing, err
 		}
 		messages := protocols.CreateSignedStateMessages(s.Id(), ss, s.V.MyIndex)
 		sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, messages...)


### PR DESCRIPTION
Closes #276 . Please see the issue and commit messages for rationale. This fixes a bug which could cause protocol execution to stall, under the assumption that objectives are only cranked _once_ during a single run loop of the engine.

**Changes**

* Early returns are removed.
* `NoSideEffects` constant is deprecated / removed.
* new, empty `protocols.SideEffects` are returned when there is an error. 

**How Has This Been Tested?**
The existing tests. Ideally a unit test would be added which shows off the existing bug and also shows how this change fixes it. I didn't have the time to add that, yet. 

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
