### PR TITLE
Add time limit for tests on CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,6 +19,7 @@ jobs:
 
       - name: Test
         run: go test -v ./... -count=2 -shuffle=on
+        timeout-minutes: 1
 
       - name: Archive logs
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Our tests normally complete rather [quickly](https://github.com/statechannels/go-nitro/runs/5324748727?check_suite_focus=true). However if our integration test "fail" we can be waiting up to 10 minutes for the CI action to complete.

This PR just adds a 1 minute limit on our tests so we don't have to wait 10 minutes for an integration test failure.