### PR TITLE
Update GH Action to always upload logs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,6 +21,7 @@ jobs:
         run: go test -v ./... -count=2 -shuffle=on
 
       - name: Archive logs
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: integration-test-logs


### PR DESCRIPTION
Previously a test failure would mean the action to upload the logs would not run. By adding `if: always()` the logs will always be uploaded even with a test failure.