### PR TITLE
Remove protocol name from Objective struct

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -77,7 +77,7 @@ func (c *Client) CreateVirtualChannel(counterParty types.Address, intermediary t
 	var left *channel.TwoPartyLedger
 
 	// Convert the API call into an internal event.
-	objective, _ := virtualfund.New(true,
+	objective, _ := virtualfund.NewObjective(true,
 		state.State{
 			ChainId:           big.NewInt(0), // TODO
 			Participants:      []types.Address{*c.Address, intermediary, counterParty},
@@ -104,7 +104,7 @@ func (c *Client) CreateVirtualChannel(counterParty types.Address, intermediary t
 // CreateDirectChannel creates a directly funded channel with the given counterparty
 func (c *Client) CreateDirectChannel(counterparty types.Address, appDefinition types.Address, appData types.Bytes, outcome outcome.Exit, challengeDuration *types.Uint256) protocols.ObjectiveId {
 	// Convert the API call into an internal event.
-	objective, _ := directfund.New(true,
+	objective, _ := directfund.NewObjective(true,
 		state.State{
 			ChainId:           big.NewInt(0), // TODO
 			Participants:      []types.Address{*c.Address, counterparty},

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -254,9 +254,9 @@ func (e *Engine) constructObjectiveFromMessage(message protocols.Message) (proto
 	case strings.Contains(string(message.ObjectiveId), `DirectFund`):
 
 		if initialState.TurnNum != 0 {
-			return directfund.DirectFundObjective{}, errors.New("cannot construct direct fund objective without prefund state")
+			return directfund.Objective{}, errors.New("cannot construct direct fund objective without prefund state")
 		}
-		return directfund.New(
+		return directfund.NewObjective(
 			true, // TODO ensure objective in only approved if the application has given permission somehow
 			initialState,
 			*e.store.GetAddress(),
@@ -276,26 +276,26 @@ func (e *Engine) constructObjectiveFromMessage(message protocols.Message) (proto
 		if alice == myAddress {
 			right, ok = e.store.GetTwoPartyLedger(intermediary, bob)
 			if !ok {
-				return virtualfund.VirtualFundObjective{}, fmt.Errorf("could not find a right ledger channel between %v and %v", intermediary, bob)
+				return virtualfund.Objective{}, fmt.Errorf("could not find a right ledger channel between %v and %v", intermediary, bob)
 			}
 		} else if bob == myAddress {
 			left, ok = e.store.GetTwoPartyLedger(intermediary, bob)
 			if !ok {
-				return virtualfund.VirtualFundObjective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", alice, intermediary)
+				return virtualfund.Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", alice, intermediary)
 			}
 		}
 		if intermediary == myAddress {
 			left, ok = e.store.GetTwoPartyLedger(alice, intermediary)
 			if !ok {
-				return virtualfund.VirtualFundObjective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", alice, intermediary)
+				return virtualfund.Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", alice, intermediary)
 			}
 			right, ok = e.store.GetTwoPartyLedger(intermediary, bob)
 			if !ok {
-				return virtualfund.VirtualFundObjective{}, fmt.Errorf("could not find a right ledger channel between %v and %v", intermediary, bob)
+				return virtualfund.Objective{}, fmt.Errorf("could not find a right ledger channel between %v and %v", intermediary, bob)
 			}
 		}
 
-		return virtualfund.New(
+		return virtualfund.NewObjective(
 			true, // TODO ensure objective in only approved if the application has given permission somehow
 			initialState,
 			*e.store.GetAddress(),
@@ -303,7 +303,7 @@ func (e *Engine) constructObjectiveFromMessage(message protocols.Message) (proto
 			right,
 		)
 	default:
-		return virtualfund.VirtualFundObjective{}, errors.New("cannot handle unimplemented objective type")
+		return directfund.Objective{}, errors.New("cannot handle unimplemented objective type")
 	}
 
 }

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -66,7 +66,7 @@ func (ms *MockStore) SetChannel(ch *channel.Channel) error {
 	// This should be replaced in https://github.com/statechannels/go-nitro/pull/227
 	for _, obj := range ms.objectives {
 		if strings.HasPrefix(string(obj.Id()), "DirectFunding-") {
-			dfO := obj.(directfund.DirectFundObjective)
+			dfO := obj.(directfund.Objective)
 			if dfO.C.Id == ch.Id {
 				dfO.C = ch
 				err := ms.SetObjective(dfO)
@@ -76,7 +76,7 @@ func (ms *MockStore) SetChannel(ch *channel.Channel) error {
 
 			}
 		} else if strings.HasPrefix(string(obj.Id()), "VirtualFund-") {
-			vfO := obj.(virtualfund.VirtualFundObjective)
+			vfO := obj.(virtualfund.Objective)
 			if vfO.V.Id == ch.Id {
 				vfO.V = &channel.SingleHopVirtualChannel{Channel: *ch}
 				err := ms.SetObjective(vfO)

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -29,7 +29,7 @@ func TestSetGetObjective(t *testing.T) {
 	ts := state.TestState
 	ts.TurnNum = 0
 
-	testObj, _ := directfund.New(false,
+	testObj, _ := directfund.NewObjective(false,
 		ts,
 		ts.Participants[0],
 	)
@@ -56,7 +56,7 @@ func TestGetObjectiveByChannelId(t *testing.T) {
 	ts := state.TestState
 	ts.TurnNum = 0
 
-	testObj, _ := directfund.New(false,
+	testObj, _ := directfund.NewObjective(false,
 		ts,
 		ts.Participants[0],
 	)

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -59,7 +59,7 @@ var testState = state.State{
 // TestNew tests the constructor using a TestState fixture
 func TestNew(t *testing.T) {
 	// Assert that valid constructor args do not result in error
-	if _, err := New(false, testState, testState.Participants[0]); err != nil {
+	if _, err := NewObjective(false, testState, testState.Participants[0]); err != nil {
 		t.Error(err)
 	}
 
@@ -67,19 +67,19 @@ func TestNew(t *testing.T) {
 	finalState := testState.Clone()
 	finalState.IsFinal = true
 
-	if _, err := New(false, finalState, testState.Participants[0]); err == nil {
+	if _, err := NewObjective(false, finalState, testState.Participants[0]); err == nil {
 		t.Error("expected an error when constructing with an intial state marked final, but got nil")
 	}
 
 	nonParticipant := common.HexToAddress("0x5b53f71453aeCb03D837bfe170570d40aE736CB4")
-	if _, err := New(false, testState, nonParticipant); err == nil {
+	if _, err := NewObjective(false, testState, nonParticipant); err == nil {
 		t.Error("expected an error when constructing with a participant not in the channel, but got nil")
 	}
 }
 
 func TestUpdate(t *testing.T) {
 	// Construct various variables for use in TestUpdate
-	var s, _ = New(false, testState, testState.Participants[0])
+	var s, _ = NewObjective(false, testState, testState.Participants[0])
 
 	var stateToSign state.State = s.C.PreFundState()
 	var correctSignatureByParticipant, _ = stateToSign.Sign(alice.privateKey)
@@ -111,7 +111,7 @@ func TestUpdate(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	updated := updatedObjective.(DirectFundObjective)
+	updated := updatedObjective.(Objective)
 	if updated.C.PreFundSignedByMe() != true {
 		t.Error(`Objective data not updated as expected`)
 	}
@@ -124,7 +124,7 @@ func TestUpdate(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	updated = updatedObjective.(DirectFundObjective)
+	updated = updatedObjective.(Objective)
 	if !updated.C.OnChainFunding.Equal(e.Holdings) {
 		t.Error(`Objective data not updated as expected`, updated.C.OnChainFunding, e.Holdings)
 	}
@@ -134,7 +134,7 @@ func TestUpdate(t *testing.T) {
 func TestCrank(t *testing.T) {
 
 	// BEGIN test data preparation
-	var s, _ = New(false, testState, testState.Participants[0])
+	var s, _ = NewObjective(false, testState, testState.Participants[0])
 	var correctSignatureByAliceOnPreFund, _ = s.C.PreFundState().Sign(alice.privateKey)
 	var correctSignatureByBobOnPreFund, _ = s.C.PreFundState().Sign(bob.privateKey)
 
@@ -183,7 +183,7 @@ func TestCrank(t *testing.T) {
 	}
 
 	// Approve the objective, so that the rest of the test cases can run.
-	o := s.Approve().(DirectFundObjective)
+	o := s.Approve().(Objective)
 
 	// To test the finite state progression, we are going to progressively mutate o
 	// And then crank it to see

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -175,7 +175,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 		testNew := func(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
 			// Assert that a valid set of constructor args does not result in an error
-			o, err := New(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			o, err := NewObjective(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
 			if err != nil {
 				t.Error(err)
 			}
@@ -228,20 +228,20 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 		testCrank := func(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
-			var s, _ = New(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			var s, _ = NewObjective(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
 			// Assert that cranking an unapproved objective returns an error
 			if _, _, _, _, err := s.Crank(&my.privateKey); err == nil {
 				t.Error(`Expected error when cranking unapproved objective, but got nil`)
 			}
 
 			// Approve the objective, so that the rest of the test cases can run.
-			o := s.Approve().(VirtualFundObjective)
+			o := s.Approve().(Objective)
 			// To test the finite state progression, we are going to progressively mutate o
 			// And then crank it to see which "pause point" (WaitingFor) we end up at.
 
 			// Initial Crank
 			oObj, got, waitingFor, _, err := o.Crank(&my.privateKey)
-			o = oObj.(VirtualFundObjective)
+			o = oObj.(Objective)
 			if err != nil {
 				t.Error(err)
 			}
@@ -260,7 +260,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			// Cranking should move us to the next waiting point, generate ledger requests as a side effect, and alter the extended state to reflect that
 			var gotRequests []protocols.LedgerRequest
 			oObj, _, waitingFor, gotRequests, err = o.Crank(&my.privateKey)
-			o = oObj.(VirtualFundObjective)
+			o = oObj.(Objective)
 			if err != nil {
 				t.Error(err)
 			}
@@ -345,7 +345,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 			// Cranking now should not generate side effects, because we already did that
 			oObj, got, waitingFor, _, err = o.Crank(&my.privateKey)
-			o = oObj.(VirtualFundObjective)
+			o = oObj.(Objective)
 			if err != nil {
 				t.Error(err)
 			}
@@ -373,7 +373,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 		testUpdate := func(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
-			var s, _ = New(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			var s, _ = NewObjective(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
 			// Prepare an event with a mismatched objectiveId
 			e := protocols.ObjectiveEvent{
 				ObjectiveId: "some-other-id",
@@ -417,7 +417,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			e.SignedStates = append(e.SignedStates, ss)
 
 			updatedObj, err := s.Update(e)
-			updated := updatedObj.(VirtualFundObjective)
+			updated := updatedObj.(Objective)
 			if err != nil {
 				t.Error(err)
 			}
@@ -475,7 +475,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			f.SignedStates = append(f.SignedStates, ss)
 
 			updatedObj, err = s.Update(f)
-			updated = updatedObj.(VirtualFundObjective)
+			updated = updatedObj.(Objective)
 			if err != nil {
 				t.Error(err)
 			}


### PR DESCRIPTION
...and change `New` to `NewObjective`.

The package namespace already serves the purpose of specifying which protocol we are dealing with.

See https://gist.github.com/adamveld12/c0d9f0d5f0e1fba1e551#package-names and
https://go.dev/blog/package-names?utm_source=dlvr.it&utm_medium=twitter

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
