### PR TITLE
Ensure all `.Clone()` methods are documented and unit tested

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -83,6 +83,11 @@ func (v SingleHopVirtualChannel) RightAmount() types.Funds {
 	return v.amountAtIndex(1)
 }
 
+// Equal returns true if the supplied TwoPartyLedger is deeply equal to the receiver, false otherwise.
+func (v *SingleHopVirtualChannel) Equal(w *SingleHopVirtualChannel) bool {
+	return v.Channel.Equal(w.Channel)
+}
+
 // Clone returns a pointer to a new, deep copy of the receiver, or a nil pointer if the receiver is nil.
 func (v *SingleHopVirtualChannel) Clone() *SingleHopVirtualChannel {
 	if v == nil {
@@ -107,6 +112,11 @@ func NewTwoPartyLedger(s state.State, myIndex uint) (*TwoPartyLedger, error) {
 	c, err := New(s, myIndex)
 
 	return &TwoPartyLedger{*c}, err
+}
+
+// Equal returns true if the supplied TwoPartyLedger is deeply equal to the receiver, false otherwise.
+func (lc *TwoPartyLedger) Equal(lc2 *TwoPartyLedger) bool {
+	return lc.Channel.Equal(lc2.Channel)
 }
 
 // Clone returns a pointer to a new, deep copy of the receiver, or a nil pointer if the receiver is nil.

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -83,6 +83,7 @@ func (v SingleHopVirtualChannel) RightAmount() types.Funds {
 	return v.amountAtIndex(1)
 }
 
+// Clone returns a pointer to a new, deep copy of the receiver, or a nil pointer if the receiver is nil.
 func (v *SingleHopVirtualChannel) Clone() *SingleHopVirtualChannel {
 	if v == nil {
 		return nil
@@ -108,6 +109,7 @@ func NewTwoPartyLedger(s state.State, myIndex uint) (*TwoPartyLedger, error) {
 	return &TwoPartyLedger{*c}, err
 }
 
+// Clone returns a pointer to a new, deep copy of the receiver, or a nil pointer if the receiver is nil.
 func (lc *TwoPartyLedger) Clone() *TwoPartyLedger {
 	if lc == nil {
 		return nil
@@ -161,7 +163,7 @@ func (lc TwoPartyLedger) TheirDestination() types.Destination {
 	return types.AddressToDestination(lc.Participants[(lc.MyIndex+1)%2])
 }
 
-// Clone returns a deep copy of the receiver
+// Clone returns a pointer to a new, deep copy of the receiver, or a nil pointer if the receiver is nil.
 func (c *Channel) Clone() *Channel {
 	if c == nil {
 		return nil

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -83,7 +83,7 @@ func (v SingleHopVirtualChannel) RightAmount() types.Funds {
 	return v.amountAtIndex(1)
 }
 
-// Equal returns true if the supplied TwoPartyLedger is deeply equal to the receiver, false otherwise.
+// Equal returns true if the supplied SingleHopVirtualChannel is deeply equal to the receiver, false otherwise.
 func (v *SingleHopVirtualChannel) Equal(w *SingleHopVirtualChannel) bool {
 	return v.Channel.Equal(w.Channel)
 }

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -41,6 +41,12 @@ func TestChannel(t *testing.T) {
 		if r.Participants[0] == c.Participants[0] {
 			t.Error("Clone: modifying the clone should not modify the original")
 		}
+
+		var nilChannel *Channel
+		clone := nilChannel.Clone()
+		if clone != nil {
+			t.Fatal("Tried to clone a Channel via a nil pointer, but got something not nil")
+		}
 	}
 
 	testPreFund := func(t *testing.T) {

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -366,6 +366,13 @@ func TestSingleHopVirtualChannel(t *testing.T) {
 		if r.Participants[0] == c.Participants[0] {
 			t.Error("Clone: modifying the clone should not modify the original")
 		}
+
+		var nilChannel *SingleHopVirtualChannel
+		clone := nilChannel.Clone()
+		if clone != nil {
+			t.Fatal("Tried to clone a Channel via a nil pointer, but got something not nil")
+		}
+
 	}
 	t.Run(`TestClone`, testClone)
 }

--- a/channel/state/outcome/allocation_test.go
+++ b/channel/state/outcome/allocation_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/google/go-cmp/cmp"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -62,4 +63,39 @@ func TestAffords(t *testing.T) {
 
 	}
 
+}
+
+func TestAllocationClone(t *testing.T) {
+
+	var a = Allocation{ // [{Alice: 2}]
+		Destination:    types.Destination(common.HexToHash("0x0a")),
+		Amount:         big.NewInt(2),
+		AllocationType: 0,
+		Metadata:       make(types.Bytes, 0)}
+
+	clone := a.Clone()
+
+	if diff := cmp.Diff(a, clone); diff != "" {
+		t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestAllocationsClone(t *testing.T) {
+
+	var as = Allocations{{ // [{Alice: 2}]
+		Destination:    types.Destination(common.HexToHash("0x0a")),
+		Amount:         big.NewInt(2),
+		AllocationType: 0,
+		Metadata:       make(types.Bytes, 0)},
+		{ // [{Bob: 3}]
+			Destination:    types.Destination(common.HexToHash("0x0b")),
+			Amount:         big.NewInt(3),
+			AllocationType: 0,
+			Metadata:       make(types.Bytes, 0)}}
+
+	clone := as.Clone()
+
+	if diff := cmp.Diff(as, clone); diff != "" {
+		t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+	}
 }

--- a/channel/state/outcome/exit_test.go
+++ b/channel/state/outcome/exit_test.go
@@ -300,3 +300,90 @@ func TestExitDivertToGuarantee(t *testing.T) {
 	}
 
 }
+
+func TestSingleAssetExitClone(t *testing.T) {
+
+	aliceDestination := types.Destination(common.HexToHash("0x0a"))
+	bobDestination := types.Destination(common.HexToHash("0x0b"))
+	targetChannel := types.Destination(common.HexToHash("0xabc"))
+
+	var sae = SingleAssetExit{
+		Asset: types.Address{0},
+		Allocations: Allocations{
+			{
+				Destination:    aliceDestination,
+				Amount:         big.NewInt(238),
+				AllocationType: 0,
+				Metadata:       make(types.Bytes, 0),
+			},
+			{
+				Destination:    bobDestination,
+				Amount:         big.NewInt(309),
+				AllocationType: 0,
+				Metadata:       make(types.Bytes, 0),
+			},
+			{
+				Destination:    targetChannel,
+				Amount:         big.NewInt(5),
+				AllocationType: 1,
+				Metadata:       append(aliceDestination.Bytes(), bobDestination.Bytes()...),
+			},
+		},
+	}
+
+	clone := sae.Clone()
+
+	if diff := cmp.Diff(sae, clone); diff != "" {
+		t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestClone(t *testing.T) {
+
+	aliceDestination := types.Destination(common.HexToHash("0x0a"))
+	bobDestination := types.Destination(common.HexToHash("0x0b"))
+	targetChannel := types.Destination(common.HexToHash("0xabc"))
+
+	var e = Exit{
+		SingleAssetExit{
+			Asset: types.Address{0},
+			Allocations: Allocations{
+				{
+					Destination:    aliceDestination,
+					Amount:         big.NewInt(238),
+					AllocationType: 0,
+					Metadata:       make(types.Bytes, 0),
+				},
+				{
+					Destination:    bobDestination,
+					Amount:         big.NewInt(309),
+					AllocationType: 0,
+					Metadata:       make(types.Bytes, 0),
+				},
+				{
+					Destination:    targetChannel,
+					Amount:         big.NewInt(5),
+					AllocationType: 1,
+					Metadata:       append(aliceDestination.Bytes(), bobDestination.Bytes()...),
+				},
+			},
+		},
+		SingleAssetExit{
+			Asset: types.Address{0},
+			Allocations: Allocations{
+				{
+					Destination:    aliceDestination,
+					Amount:         big.NewInt(438),
+					AllocationType: 0,
+					Metadata:       make(types.Bytes, 0),
+				},
+			},
+		},
+	}
+
+	clone := e.Clone()
+
+	if diff := cmp.Diff(e, clone); diff != "" {
+		t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/channel/state/signedstate.go
+++ b/channel/state/signedstate.go
@@ -110,6 +110,7 @@ func (ss SignedState) Merge(ss2 SignedState) error {
 	return nil
 }
 
+// Clone returns a deep copy of the receiver.
 func (ss SignedState) Clone() SignedState {
 	clonedSigs := make(map[uint]Signature, len(ss.sigs))
 	for i, sig := range ss.sigs {

--- a/channel/state/signedstate_test.go
+++ b/channel/state/signedstate_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestSignedStateEqual(t *testing.T) {
@@ -112,5 +113,18 @@ func TestJSON(t *testing.T) {
 			t.Errorf(`incorrect UnmarshalJSON, got %v, wanted %v`, got, want)
 		}
 	})
+
+}
+
+func TestSignedStateClone(t *testing.T) {
+	ss1 := NewSignedState(TestState)
+	sigA, _ := TestState.Sign(common.Hex2Bytes(`caab404f975b4620747174a75f08d98b4e5a7053b691b41bcfc0d839d48b7634`))
+	_ = ss1.AddSignature(sigA)
+
+	clone := ss1.Clone()
+
+	if diff := cmp.Diff(ss1, clone); diff != "" {
+		t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+	}
 
 }

--- a/channel/state/state.go
+++ b/channel/state/state.go
@@ -176,6 +176,7 @@ func (s State) Equal(r State) bool {
 		s.IsFinal == r.IsFinal
 }
 
+// Clone returns a deep copy of the receiver.
 func (f FixedPart) Clone() FixedPart {
 	clone := FixedPart{}
 	clone.ChainId = new(big.Int).Set(f.ChainId)
@@ -186,7 +187,7 @@ func (f FixedPart) Clone() FixedPart {
 	return clone
 }
 
-// Clone returns a clone of the state
+// Clone returns a deep copy of the receiver.
 func (s State) Clone() State {
 	clone := State{}
 	// Fixed part

--- a/channel/state/state_test.go
+++ b/channel/state/state_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/google/go-cmp/cmp"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -104,8 +105,8 @@ func TestClone(t *testing.T) {
 
 	clone := TestState.Clone()
 
-	if !clone.Equal(TestState) {
-		t.Errorf(`expected %v to equal %v, but it did not`, clone, TestState)
+	if diff := cmp.Diff(TestState, clone); diff != "" {
+		t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
 	}
 
 	clone.ChannelNonce.Add(clone.ChannelNonce, big.NewInt(1))

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -37,7 +37,7 @@ type Objective struct {
 	fullyFundedThreshold     types.Funds // if the on chain holdings are equal
 }
 
-// NewObjective initiates a DirectFundObjective with data calculated from
+// NewObjective initiates a Objective with data calculated from
 // the supplied initialState and client address
 func NewObjective(
 	preApprove bool,
@@ -249,7 +249,16 @@ func (s Objective) amountToDeposit() types.Funds {
 	return deposits
 }
 
-// Clone returns a deep copy of the receiver
+// Equal returns true if the supplied Objective is deeply equal to the receiver.
+func (s Objective) Equal(r Objective) bool {
+	return s.Status == r.Status &&
+		s.C.Equal(*r.C) &&
+		s.myDepositSafetyThreshold.Equal(r.myDepositSafetyThreshold) &&
+		s.myDepositTarget.Equal((r.myDepositTarget)) &&
+		s.fullyFundedThreshold.Equal(r.fullyFundedThreshold)
+}
+
+// clone returns a deep copy of the receiver.
 func (s Objective) clone() Objective {
 	clone := Objective{}
 	clone.Status = s.Status

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -258,3 +258,13 @@ func TestCrank(t *testing.T) {
 		t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForNothing, waitingFor)
 	}
 }
+
+func TestClone(t *testing.T) {
+	var s, _ = New(false, testState, testState.Participants[0])
+
+	clone := s.clone()
+
+	if diff := cmp.Diff(s, clone); diff != "" {
+		t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -260,7 +260,7 @@ func TestCrank(t *testing.T) {
 }
 
 func TestClone(t *testing.T) {
-	var s, _ = New(false, testState, testState.Participants[0])
+	var s, _ = NewObjective(false, testState, testState.Participants[0])
 
 	clone := s.clone()
 

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -226,6 +226,18 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 		}
 
+		testclone := func(t *testing.T) {
+			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
+
+			o, _ := New(false, vPreFund, my.address, n, my.role, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+
+			clone := o.clone()
+
+			if diff := cmp.Diff(o, clone); diff != "" {
+				t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+			}
+		}
+
 		testCrank := func(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
 			var s, _ = NewObjective(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
@@ -503,6 +515,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 		}
 		t.Run(`New`, testNew)
+		t.Run(`clone`, testclone)
 		t.Run(`Crank`, testCrank)
 		t.Run(`Update`, testUpdate)
 

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -229,7 +229,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 		testclone := func(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
 
-			o, _ := New(false, vPreFund, my.address, n, my.role, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			o, _ := NewObjective(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
 
 			clone := o.clone()
 

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"reflect"
 
 	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/state"
@@ -27,6 +28,21 @@ var ErrNotApproved = errors.New("objective not approved")
 type Connection struct {
 	Channel            *channel.TwoPartyLedger
 	ExpectedGuarantees map[types.Address]outcome.Allocation
+}
+
+// Equal returns true if the Connection pointed to by the supplied pointer is deeply equal to the receiver.
+func (c *Connection) Equal(d *Connection) bool {
+	if c == nil && d == nil {
+		return true
+	}
+	if !c.Channel.Equal(d.Channel) {
+		return false
+	}
+	if !reflect.DeepEqual(c.ExpectedGuarantees, d.ExpectedGuarantees) {
+		return false
+	}
+	return true
+
 }
 
 // Objective is a cache of data computed by reading from the store. It stores (potentially) infinite data.
@@ -358,7 +374,20 @@ func (s Objective) generateLedgerRequestSideEffects() []protocols.LedgerRequest 
 	return requests
 }
 
-// Clone returns a deep copy of the receiver
+// Equal returns true if the supplied DirectFundObjective is deeply equal to the receiver.
+func (s Objective) Equal(r Objective) bool {
+	return s.Status == r.Status &&
+		s.V.Equal(r.V) &&
+		s.ToMyLeft.Equal(r.ToMyLeft) &&
+		s.ToMyRight.Equal(r.ToMyRight) &&
+		s.n == r.n &&
+		s.MyRole == r.MyRole &&
+		s.a0.Equal(r.a0) &&
+		s.b0.Equal(r.b0) &&
+		s.requestedLedgerUpdates == r.requestedLedgerUpdates
+}
+
+// Clone returns a deep copy of the receiver.
 func (s *Objective) clone() Objective {
 	clone := Objective{}
 	clone.Status = s.Status

--- a/types/funds.go
+++ b/types/funds.go
@@ -80,7 +80,7 @@ func (f Funds) canAfford(g Funds) bool {
 	return true
 }
 
-// Clone returns a deep copy of the receiver
+// Clone returns a deep copy of the receiver.
 func (f Funds) Clone() Funds {
 	return Sum(f, Funds{})
 }

--- a/types/funds_test.go
+++ b/types/funds_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/google/go-cmp/cmp"
 )
 
 var testData map[string]Funds = map[string]Funds{
@@ -197,4 +198,14 @@ func TestEqual(t *testing.T) {
 type fundsPair struct {
 	a Funds
 	b Funds
+}
+
+func TestFundsClone(t *testing.T) {
+	f := testData["a"]
+	clone := f.Clone()
+
+	if diff := cmp.Diff(f, clone); diff != "" {
+		t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+	}
+
 }


### PR DESCRIPTION
We have 13 such methods (some are private). I audited them all, and have ensured they all have at least a rudimentary unit test using `cmp.Diff`. This approach relies on there being `.Equal()` methods for all involved types, so I have added those were necessary. 

Closes #166 


---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
