### PR TITLE
`virtualfund`: Use participants in `V` as source of truth when constructing expected guarantees and ledger requests.

### DIFF
--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -116,8 +116,8 @@ func New(
 			init.a0,
 			init.b0,
 			init.V.Id,
-			types.AddressToDestination(init.ToMyLeft.Channel.Participants[0]),
-			types.AddressToDestination(init.ToMyLeft.Channel.Participants[1]),
+			types.AddressToDestination(init.V.Participants[init.MyRole-1]),
+			types.AddressToDestination(init.V.Participants[init.MyRole]),
 		)
 		if err != nil {
 			return VirtualFundObjective{}, err
@@ -131,8 +131,8 @@ func New(
 			init.a0,
 			init.b0,
 			init.V.Id,
-			types.AddressToDestination(init.ToMyRight.Channel.Participants[0]),
-			types.AddressToDestination(init.ToMyRight.Channel.Participants[1]),
+			types.AddressToDestination(init.V.Participants[init.MyRole]),
+			types.AddressToDestination(init.V.Participants[init.MyRole+1]),
 		)
 		if err != nil {
 			return VirtualFundObjective{}, err
@@ -341,9 +341,9 @@ func (s VirtualFundObjective) generateLedgerRequestSideEffects() []protocols.Led
 				ObjectiveId: s.Id(),
 				LedgerId:    s.ToMyLeft.Channel.Id,
 				Destination: s.V.Id,
-				Left:        types.AddressToDestination(s.ToMyLeft.Channel.Participants[0]),
+				Left:        types.AddressToDestination(s.V.Participants[s.MyRole-1]),
 				LeftAmount:  leftAmount,
-				Right:       types.AddressToDestination(s.ToMyLeft.Channel.Participants[1]),
+				Right:       types.AddressToDestination(s.V.Participants[s.MyRole]),
 				RightAmount: rightAmount,
 			})
 	}
@@ -353,9 +353,9 @@ func (s VirtualFundObjective) generateLedgerRequestSideEffects() []protocols.Led
 				ObjectiveId: s.Id(),
 				LedgerId:    s.ToMyRight.Channel.Id,
 				Destination: s.V.Id,
-				Left:        types.AddressToDestination(s.ToMyRight.Channel.Participants[0]),
+				Left:        types.AddressToDestination(s.V.Participants[s.MyRole]),
 				LeftAmount:  leftAmount,
-				Right:       types.AddressToDestination(s.ToMyRight.Channel.Participants[1]),
+				Right:       types.AddressToDestination(s.V.Participants[s.MyRole+1]),
 				RightAmount: rightAmount,
 			})
 	}


### PR DESCRIPTION
Currently, the expected guarantees as well as the ledger request side effects crafted by the `virtualfund` protocol are not always correct. This is because they are crafted using a relative "me/them" approach, by inspecting the _ledger_ channel. As per the SATP paper (which is the specification for this protocol), the guarantees need to be crafted in absolute terms, depending on the index (here called myRole) of each client in the participant list of the virtual channel.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
