### PR TITLE
Reserve "left/right" terms for guarantees (only)

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -207,7 +207,7 @@ func (e *Engine) attemptProgress(objective protocols.Objective) (outgoing Object
 	crankedObjective, sideEffects, waitingFor, ledgerRequests, _ := objective.Crank(secretKey) // TODO handle error
 	_ = e.store.SetObjective(crankedObjective)                                                 // TODO handle error
 
-	ledgerSideEffects, _ := e.handleLedgerRequests(ledgerRequests, crankedObjective) // TODO: handle error
+	ledgerSideEffects, _ := e.handleGuaranteeRequests(ledgerRequests, crankedObjective) // TODO: handle error
 	sideEffects.Merge(ledgerSideEffects)
 
 	e.executeSideEffects(sideEffects)
@@ -308,8 +308,8 @@ func (e *Engine) constructObjectiveFromMessage(message protocols.Message) (proto
 
 }
 
-// handleLedgerRequests handles a collection of ledger requests by submitting them to the ledger manager.
-func (e *Engine) handleLedgerRequests(ledgerRequests []protocols.LedgerRequest, objective protocols.Objective) (protocols.SideEffects, error) {
+// handleGuaranteeRequests handles a collection of ledger requests by submitting them to the ledger manager.
+func (e *Engine) handleGuaranteeRequests(ledgerRequests []protocols.GuaranteeRequest, objective protocols.Objective) (protocols.SideEffects, error) {
 	sideEffects := protocols.SideEffects{}
 	for _, req := range ledgerRequests {
 		e.logger.Printf("Handling ledger request  %+v", req)

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -13,8 +13,8 @@ type ChainTransaction struct {
 	// TODO support other transaction types (deposit, challenge, respond, conclude, withdraw)
 }
 
-// LedgerRequest is an object processed by the ledger cranker
-type LedgerRequest struct {
+// GuaranteeRequest is an object processed by the ledger cranker
+type GuaranteeRequest struct {
 	ObjectiveId ObjectiveId
 	LedgerId    types.Destination
 	Destination types.Destination
@@ -24,8 +24,8 @@ type LedgerRequest struct {
 	RightAmount types.Funds
 }
 
-// Equal checks for equality between the receiver and a second LedgerRequest
-func (l LedgerRequest) Equal(m LedgerRequest) bool {
+// Equal checks for equality between the receiver and a second GuaranteeRequest
+func (l GuaranteeRequest) Equal(m GuaranteeRequest) bool {
 	return l.ObjectiveId == m.ObjectiveId &&
 		l.LedgerId == m.LedgerId &&
 		l.Destination == m.Destination &&
@@ -75,7 +75,7 @@ type Objective interface {
 	Update(event ObjectiveEvent) (Objective, error) // returns an updated Objective (a copy, no mutation allowed), does not declare effects
 	Channels() []*channel.Channel
 
-	Crank(secretKey *[]byte) (Objective, SideEffects, WaitingFor, []LedgerRequest, error) // does *not* accept an event, but *does* accept a pointer to a signing key; declare side effects; return an updated Objective
+	Crank(secretKey *[]byte) (Objective, SideEffects, WaitingFor, []GuaranteeRequest, error) // does *not* accept an event, but *does* accept a pointer to a signing key; declare side effects; return an updated Objective
 }
 
 // ObjectiveId is a unique identifier for an Objective.

--- a/protocols/ledger/ledger.go
+++ b/protocols/ledger/ledger.go
@@ -21,7 +21,7 @@ func NewLedgerManager() *LedgerManager {
 
 // HandleRequest accepts a ledger request and updates the ledger channel based on the request.
 // It returns a signed state message that can be sent to other participants.
-func (l *LedgerManager) HandleRequest(ledger *channel.TwoPartyLedger, request protocols.LedgerRequest, secretKey *[]byte) (protocols.SideEffects, error) {
+func (l *LedgerManager) HandleRequest(ledger *channel.TwoPartyLedger, request protocols.GuaranteeRequest, secretKey *[]byte) (protocols.SideEffects, error) {
 
 	supported, err := ledger.Channel.LatestSupportedState()
 	if err != nil {

--- a/protocols/ledger/ledger.go
+++ b/protocols/ledger/ledger.go
@@ -76,8 +76,9 @@ func SignLatest(ledger *channel.TwoPartyLedger, secretKeys [][]byte) {
 	ledger.Channel.AddSignedState(toSign)
 }
 
-// CreateTestLedger creates a new two party ledger channel based on the provided left and right outcomes. The channel will appear to be fully-funded on chain.
-func CreateTestLedger(allocations []outcome.Allocation, secretKey *[]byte, myIndex uint, nonce *big.Int) (*channel.TwoPartyLedger, error) {
+// NewTestTwoPartyLedger creates a new two party ledger channel based on the provided allocations. The channel will appear to be fully-funded on chain.
+// ONLY FOR TESTING PURPOSES
+func NewTestTwoPartyLedger(allocations []outcome.Allocation, secretKey *[]byte, myIndex uint, nonce *big.Int) (*channel.TwoPartyLedger, error) {
 
 	initialState := state.State{
 		ChainId:           big.NewInt(9001),

--- a/protocols/ledger/ledger_test.go
+++ b/protocols/ledger/ledger_test.go
@@ -31,11 +31,8 @@ var bob = actor{
 }
 
 func TestCreateLedger(t *testing.T) {
-
-	left := outcome.Allocation{Destination: alice.destination, Amount: big.NewInt(3)}
-	right := outcome.Allocation{Destination: bob.destination, Amount: big.NewInt(2)}
-
-	ledger, err := CreateTestLedger(left, right, &alice.privateKey, 0, big.NewInt(0))
+	allocs := outcome.Allocations{{Destination: alice.destination, Amount: big.NewInt(3)}, {Destination: bob.destination, Amount: big.NewInt(2)}}
+	ledger, err := CreateTestLedger(allocs, &alice.privateKey, 0, big.NewInt(0))
 	if err != nil {
 		t.Error(err)
 	}
@@ -48,10 +45,9 @@ func TestCreateLedger(t *testing.T) {
 
 func TestHandleLedgerRequest(t *testing.T) {
 	ledgerManager := NewLedgerManager()
-	left := outcome.Allocation{Destination: alice.destination, Amount: big.NewInt(3)}
-	right := outcome.Allocation{Destination: bob.destination, Amount: big.NewInt(2)}
+	allocs := outcome.Allocations{{Destination: alice.destination, Amount: big.NewInt(3)}, {Destination: bob.destination, Amount: big.NewInt(2)}}
 
-	ledger, _ := CreateTestLedger(left, right, &alice.privateKey, 0, big.NewInt(0))
+	ledger, _ := CreateTestLedger(allocs, &alice.privateKey, 0, big.NewInt(0))
 
 	destination := types.AddressToDestination(common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`))
 
@@ -61,8 +57,8 @@ func TestHandleLedgerRequest(t *testing.T) {
 	validRequest := protocols.LedgerRequest{
 		ObjectiveId: oId,
 		LedgerId:    ledger.Id,
-		Left:        left.Destination,
-		Right:       right.Destination,
+		Left:        allocs[0].Destination,
+		Right:       allocs[1].Destination,
 		Destination: destination,
 		LeftAmount:  types.Funds{asset: big.NewInt(2)},
 		RightAmount: types.Funds{asset: big.NewInt(1)},
@@ -70,8 +66,8 @@ func TestHandleLedgerRequest(t *testing.T) {
 	invalidRequest := protocols.LedgerRequest{
 		ObjectiveId: oId,
 		LedgerId:    ledger.Id,
-		Left:        left.Destination,
-		Right:       right.Destination,
+		Left:        allocs[0].Destination,
+		Right:       allocs[1].Destination,
 		Destination: destination,
 		LeftAmount:  types.Funds{asset: big.NewInt(1000)},
 		RightAmount: types.Funds{asset: big.NewInt(1000)},
@@ -142,8 +138,8 @@ func TestHandleLedgerRequest(t *testing.T) {
 	secondRequest := protocols.LedgerRequest{
 		ObjectiveId: oId,
 		LedgerId:    ledger.Id,
-		Left:        left.Destination,
-		Right:       right.Destination,
+		Left:        allocs[0].Destination,
+		Right:       allocs[1].Destination,
 		Destination: anotherDestination,
 		LeftAmount:  types.Funds{asset: big.NewInt(0)},
 		RightAmount: types.Funds{asset: big.NewInt(1)},

--- a/protocols/ledger/ledger_test.go
+++ b/protocols/ledger/ledger_test.go
@@ -32,7 +32,7 @@ var bob = actor{
 
 func TestCreateLedger(t *testing.T) {
 	allocs := outcome.Allocations{{Destination: alice.destination, Amount: big.NewInt(3)}, {Destination: bob.destination, Amount: big.NewInt(2)}}
-	ledger, err := CreateTestLedger(allocs, &alice.privateKey, 0, big.NewInt(0))
+	ledger, err := NewTestTwoPartyLedger(allocs, &alice.privateKey, 0, big.NewInt(0))
 	if err != nil {
 		t.Error(err)
 	}
@@ -47,7 +47,7 @@ func TestHandleLedgerRequest(t *testing.T) {
 	ledgerManager := NewLedgerManager()
 	allocs := outcome.Allocations{{Destination: alice.destination, Amount: big.NewInt(3)}, {Destination: bob.destination, Amount: big.NewInt(2)}}
 
-	ledger, _ := CreateTestLedger(allocs, &alice.privateKey, 0, big.NewInt(0))
+	ledger, _ := NewTestTwoPartyLedger(allocs, &alice.privateKey, 0, big.NewInt(0))
 
 	destination := types.AddressToDestination(common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`))
 

--- a/protocols/ledger/ledger_test.go
+++ b/protocols/ledger/ledger_test.go
@@ -54,7 +54,7 @@ func TestHandleLedgerRequest(t *testing.T) {
 	asset := types.Address{}
 	oId := protocols.ObjectiveId("Test")
 
-	validRequest := protocols.LedgerRequest{
+	validRequest := protocols.GuaranteeRequest{
 		ObjectiveId: oId,
 		LedgerId:    ledger.Id,
 		Left:        allocs[0].Destination,
@@ -63,7 +63,7 @@ func TestHandleLedgerRequest(t *testing.T) {
 		LeftAmount:  types.Funds{asset: big.NewInt(2)},
 		RightAmount: types.Funds{asset: big.NewInt(1)},
 	}
-	invalidRequest := protocols.LedgerRequest{
+	invalidRequest := protocols.GuaranteeRequest{
 		ObjectiveId: oId,
 		LedgerId:    ledger.Id,
 		Left:        allocs[0].Destination,
@@ -135,7 +135,7 @@ func TestHandleLedgerRequest(t *testing.T) {
 
 	// Check that we can handle a second request
 	anotherDestination := types.AddressToDestination(common.HexToAddress(`0xb22679e1864BEd55497b5d499d1216c7D7F85cc4`))
-	secondRequest := protocols.LedgerRequest{
+	secondRequest := protocols.GuaranteeRequest{
 		ObjectiveId: oId,
 		LedgerId:    ledger.Id,
 		Left:        allocs[0].Destination,

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -135,7 +135,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			switch my.role {
 			case 0:
 				{
-					r, _ = ledger.CreateTestLedger(
+					r, _ = ledger.NewTestTwoPartyLedger(
 						outcome.Allocations{
 							{Destination: my.destination, Amount: big.NewInt(5)},
 							{Destination: p1.destination, Amount: big.NewInt(5)},
@@ -146,13 +146,13 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				}
 			case 1:
 				{
-					l, _ = ledger.CreateTestLedger(
+					l, _ = ledger.NewTestTwoPartyLedger(
 						outcome.Allocations{
 							{Destination: alice.destination, Amount: big.NewInt(5)},
 							{Destination: my.destination, Amount: big.NewInt(5)},
 						},
 						&alice.privateKey, 1, big.NewInt(0))
-					r, _ = ledger.CreateTestLedger(
+					r, _ = ledger.NewTestTwoPartyLedger(
 						outcome.Allocations{
 							{Destination: my.destination, Amount: big.NewInt(5)},
 							{Destination: bob.destination, Amount: big.NewInt(5)},
@@ -163,7 +163,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				}
 			case 2:
 				{
-					l, _ = ledger.CreateTestLedger(
+					l, _ = ledger.NewTestTwoPartyLedger(
 						outcome.Allocations{
 							{Destination: p1.destination, Amount: big.NewInt(5)},
 							{Destination: my.destination, Amount: big.NewInt(5)},

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -136,8 +136,10 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			case 0:
 				{
 					r, _ = ledger.CreateTestLedger(
-						outcome.Allocation{Destination: my.destination, Amount: big.NewInt(5)},
-						outcome.Allocation{Destination: p1.destination, Amount: big.NewInt(5)},
+						outcome.Allocations{
+							{Destination: my.destination, Amount: big.NewInt(5)},
+							{Destination: p1.destination, Amount: big.NewInt(5)},
+						},
 						&my.privateKey, 0, big.NewInt(0))
 					ledger.SignPreAndPostFundingStates(r, []*[]byte{&alice.privateKey, &p1.privateKey}) // TODO these steps could be absorbed into CreateTestLedger
 
@@ -145,12 +147,16 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			case 1:
 				{
 					l, _ = ledger.CreateTestLedger(
-						outcome.Allocation{Destination: alice.destination, Amount: big.NewInt(5)},
-						outcome.Allocation{Destination: my.destination, Amount: big.NewInt(5)},
+						outcome.Allocations{
+							{Destination: alice.destination, Amount: big.NewInt(5)},
+							{Destination: my.destination, Amount: big.NewInt(5)},
+						},
 						&alice.privateKey, 1, big.NewInt(0))
 					r, _ = ledger.CreateTestLedger(
-						outcome.Allocation{Destination: my.destination, Amount: big.NewInt(5)},
-						outcome.Allocation{Destination: bob.destination, Amount: big.NewInt(5)},
+						outcome.Allocations{
+							{Destination: my.destination, Amount: big.NewInt(5)},
+							{Destination: bob.destination, Amount: big.NewInt(5)},
+						},
 						&alice.privateKey, 0, big.NewInt(0))
 					ledger.SignPreAndPostFundingStates(l, []*[]byte{&alice.privateKey, &p1.privateKey})
 					ledger.SignPreAndPostFundingStates(r, []*[]byte{&p1.privateKey, &bob.privateKey})
@@ -158,8 +164,10 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			case 2:
 				{
 					l, _ = ledger.CreateTestLedger(
-						outcome.Allocation{Destination: p1.destination, Amount: big.NewInt(5)},
-						outcome.Allocation{Destination: my.destination, Amount: big.NewInt(5)},
+						outcome.Allocations{
+							{Destination: p1.destination, Amount: big.NewInt(5)},
+							{Destination: my.destination, Amount: big.NewInt(5)},
+						},
 						&alice.privateKey, 1, big.NewInt(0))
 					ledger.SignPreAndPostFundingStates(l, []*[]byte{&bob.privateKey, &p1.privateKey})
 				}

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -278,7 +278,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			collectPeerSignaturesOnSetupState(o.V, my.role, true)
 
 			// Cranking should move us to the next waiting point, generate ledger requests as a side effect, and alter the extended state to reflect that
-			var gotRequests []protocols.LedgerRequest
+			var gotRequests []protocols.GuaranteeRequest
 			oObj, _, waitingFor, gotRequests, err = o.Crank(&my.privateKey)
 			o = oObj.(Objective)
 			if err != nil {
@@ -291,11 +291,11 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				t.Error(`Expected ledger update idempotency flag to be raised, but it wasn't`)
 			}
 
-			wantRequests := []protocols.LedgerRequest{}
+			wantRequests := []protocols.GuaranteeRequest{}
 			switch my.role {
 			case 0:
 				{
-					wantRequests = append(wantRequests, protocols.LedgerRequest{
+					wantRequests = append(wantRequests, protocols.GuaranteeRequest{
 						ObjectiveId: o.Id(),
 						LedgerId:    ledgerChannelToMyRight.Id,
 						Destination: s.V.Id,
@@ -306,7 +306,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				}
 			case 1:
 				{
-					wantRequests = append(wantRequests, protocols.LedgerRequest{
+					wantRequests = append(wantRequests, protocols.GuaranteeRequest{
 						ObjectiveId: o.Id(),
 						LedgerId:    ledgerChannelToMyLeft.Id,
 						Destination: s.V.Id,
@@ -314,7 +314,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 						LeftAmount:  types.Funds{types.Address{}: big.NewInt(5)},
 						RightAmount: types.Funds{types.Address{}: big.NewInt(5)},
 					})
-					wantRequests = append(wantRequests, protocols.LedgerRequest{
+					wantRequests = append(wantRequests, protocols.GuaranteeRequest{
 						ObjectiveId: o.Id(),
 						LedgerId:    ledgerChannelToMyRight.Id,
 						Destination: s.V.Id,
@@ -325,7 +325,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				}
 			case 2:
 				{
-					wantRequests = append(wantRequests, protocols.LedgerRequest{
+					wantRequests = append(wantRequests, protocols.GuaranteeRequest{
 						ObjectiveId: o.Id(),
 						LedgerId:    ledgerChannelToMyLeft.Id,
 						Destination: s.V.Id,


### PR DESCRIPTION
We've come across a little confusion when transcribing data between ledger channels, requests for guarantees, and virtual channels. I think this may be exacerbated by the terms "left" and "right". This PR removes any doubt that these terms have a special meaning tied to guarantees and should not be used elsewhere. Closes #253.

**Changes** 

* remove left/right terms from ledger channels per se:
    - a test ledger channel no longer uses these words in its constructor
    - ledger requests do currently use left / right (and need to) so I renamed them "guarantee requests"
* test ledger channel constructor renamed to be more idiomatic. 

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
