### PR TITLE
Move objective construction logic into objectives

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -128,6 +128,24 @@ func (lc *TwoPartyLedger) Clone() *TwoPartyLedger {
 	return &w
 }
 
+// Proposed returns the
+func (lc *TwoPartyLedger) Proposed() (state.State, bool) {
+
+	highestSignedByProposer := uint64(0)
+
+	for turnNum, signedState := range lc.SignedStateForTurnNum {
+		if signedByProposer := signedState.HasSignatureForParticipant(0); signedByProposer && turnNum > highestSignedByProposer {
+			highestSignedByProposer = turnNum
+		}
+	}
+
+	if highestSignedByProposer == lc.latestSupportedStateTurnNum {
+		return state.State{}, false
+	} else {
+		return lc.SignedStateForTurnNum[highestSignedByProposer].State(), true
+	}
+}
+
 // New constructs a new Channel from the supplied state.
 func New(s state.State, myIndex uint) (*Channel, error) {
 	c := Channel{}

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -253,55 +253,18 @@ func (e *Engine) constructObjectiveFromMessage(message protocols.Message) (proto
 	switch {
 	case strings.Contains(string(message.ObjectiveId), `DirectFund`):
 
-		if initialState.TurnNum != 0 {
-			return directfund.Objective{}, errors.New("cannot construct direct fund objective without prefund state")
-		}
 		return directfund.NewObjective(
 			true, // TODO ensure objective in only approved if the application has given permission somehow
 			initialState,
 			*e.store.GetAddress(),
 		)
 	case strings.Contains(string(message.ObjectiveId), "Virtual"):
-		// TODO: This logic belongs in the virtual fund protocol
-		// Once it is moved there it can be cleaned up to use myRole and isAlice/isBob
-		participants := message.SignedStates[0].State().Participants
-		alice := participants[0]
-		intermediary := participants[1]
-		bob := participants[2]
-		myAddress := *e.store.GetAddress()
-
-		var left *channel.TwoPartyLedger
-		var right *channel.TwoPartyLedger
-		var ok bool
-		if alice == myAddress {
-			right, ok = e.store.GetTwoPartyLedger(intermediary, bob)
-			if !ok {
-				return virtualfund.Objective{}, fmt.Errorf("could not find a right ledger channel between %v and %v", intermediary, bob)
-			}
-		} else if bob == myAddress {
-			left, ok = e.store.GetTwoPartyLedger(intermediary, bob)
-			if !ok {
-				return virtualfund.Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", alice, intermediary)
-			}
+		vfo, err := virtualfund.ConstructObjectiveFromMessage(message, *e.store.GetAddress(), e.store.GetTwoPartyLedger)
+		if err != nil {
+			return virtualfund.Objective{}, fmt.Errorf("could not create virtual fund objective from message: %w", err)
 		}
-		if intermediary == myAddress {
-			left, ok = e.store.GetTwoPartyLedger(alice, intermediary)
-			if !ok {
-				return virtualfund.Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", alice, intermediary)
-			}
-			right, ok = e.store.GetTwoPartyLedger(intermediary, bob)
-			if !ok {
-				return virtualfund.Objective{}, fmt.Errorf("could not find a right ledger channel between %v and %v", intermediary, bob)
-			}
-		}
+		return vfo, nil
 
-		return virtualfund.NewObjective(
-			true, // TODO ensure objective in only approved if the application has given permission somehow
-			initialState,
-			*e.store.GetAddress(),
-			left,
-			right,
-		)
 	default:
 		return directfund.Objective{}, errors.New("cannot handle unimplemented objective type")
 	}

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"strings"
 
 	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
@@ -251,14 +250,14 @@ func (e *Engine) constructObjectiveFromMessage(message protocols.Message) (proto
 	initialState := message.SignedStates[0].State()
 
 	switch {
-	case strings.Contains(string(message.ObjectiveId), `DirectFund`):
+	case directfund.IsDirectFundObjective(message.ObjectiveId):
 
 		return directfund.NewObjective(
 			true, // TODO ensure objective in only approved if the application has given permission somehow
 			initialState,
 			*e.store.GetAddress(),
 		)
-	case strings.Contains(string(message.ObjectiveId), "Virtual"):
+	case virtualfund.IsVirtualFundObjective(message.ObjectiveId):
 		vfo, err := virtualfund.ConstructObjectiveFromMessage(message, *e.store.GetAddress(), e.store.GetTwoPartyLedger)
 		if err != nil {
 			return virtualfund.Objective{}, fmt.Errorf("could not create virtual fund objective from message: %w", err)

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -44,6 +44,9 @@ func NewObjective(
 	initialState state.State,
 	myAddress types.Address,
 ) (Objective, error) {
+	if initialState.TurnNum != 0 {
+		return Objective{}, errors.New("cannot construct direct fund objective without prefund state")
+	}
 	if initialState.IsFinal {
 		return Objective{}, errors.New("attempted to initiate new direct-funding objective with IsFinal == true")
 	}

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -284,6 +284,25 @@ func IsDirectFundObjective(id protocols.ObjectiveId) bool {
 	return strings.HasPrefix(string(id), ObjectivePrefix)
 }
 
+// ConstructObjectiveFromMessage takes in a message and constructs a direct funding objective from it.
+func ConstructObjectiveFromMessage(m protocols.Message, myAddress types.Address) (Objective, error) {
+
+	if len(m.SignedStates) == 0 {
+		return Objective{}, errors.New("expected at least one signed state in the message")
+	}
+	initialState := m.SignedStates[0].State()
+
+	objective, err := NewObjective(
+		true, // TODO ensure objective in only approved if the application has given permission somehow
+		initialState,
+		myAddress,
+	)
+	if err != nil {
+		return Objective{}, fmt.Errorf("could not create new objective: %w", err)
+	}
+	return objective, nil
+}
+
 // mermaid diagram
 // key:
 // - effect!

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 
 	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/state"
@@ -19,6 +20,8 @@ const (
 	WaitingForCompletePostFund protocols.WaitingFor = "WaitingForCompletePostFund"
 	WaitingForNothing          protocols.WaitingFor = "WaitingForNothing" // Finished
 )
+
+const ObjectivePrefix = "DirectFunding-"
 
 func FundOnChainEffect(cId types.Destination, asset string, amount types.Funds) string {
 	return "deposit" + amount.String() + "into" + cId.String()
@@ -96,7 +99,7 @@ func NewObjective(
 // Public methods on the DirectFundingObjectiveState
 
 func (o Objective) Id() protocols.ObjectiveId {
-	return protocols.ObjectiveId("DirectFunding-" + o.C.Id.String())
+	return protocols.ObjectiveId(ObjectivePrefix + o.C.Id.String())
 }
 
 func (o Objective) Approve() protocols.Objective {
@@ -274,6 +277,11 @@ func (o Objective) clone() Objective {
 	clone.fullyFundedThreshold = o.fullyFundedThreshold.Clone()
 
 	return clone
+}
+
+// IsDirectFundObjective inspects a objective id and returns true if the objective id is for a direct fund objective.
+func IsDirectFundObjective(id protocols.ObjectiveId) bool {
+	return strings.HasPrefix(string(id), ObjectivePrefix)
 }
 
 // mermaid diagram

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"strings"
 
 	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/state"
@@ -22,6 +23,8 @@ const (
 	WaitingForCompletePostFund protocols.WaitingFor = "WaitingForCompletePostFund" // Round 3
 	WaitingForNothing          protocols.WaitingFor = "WaitingForNothing"          // Finished
 )
+
+const ObjectivePrefix = "VirtualFund-"
 
 // errors
 var ErrNotApproved = errors.New("objective not approved")
@@ -157,7 +160,7 @@ func NewObjective(
 
 // Id returns the objective id.
 func (o Objective) Id() protocols.ObjectiveId {
-	return protocols.ObjectiveId("VirtualFund-" + o.V.Id.String())
+	return protocols.ObjectiveId(ObjectivePrefix + o.V.Id.String())
 }
 
 // Approve returns an approved copy of the objective.
@@ -482,4 +485,9 @@ func ConstructObjectiveFromMessage(m protocols.Message, myAddress types.Address,
 		left,
 		right,
 	)
+}
+
+// IsVirtualFundObjective inspects a objective id and returns true if the objective id is for a virtual fund objective.
+func IsVirtualFundObjective(id protocols.ObjectiveId) bool {
+	return strings.HasPrefix(string(id), ObjectivePrefix)
 }


### PR DESCRIPTION
Fixes #293 

Previously the `engine` was responsible for constructing the objectives from messages. However the logic to construct objectives was deeply coupled to the protocol implementations, meaning that the `engine` contained a bunch of logic specific for virtual funding.

This PR moves that logic from the `Engine` into a `ConstructObjectiveFromMessage` in the virtual funding protocol. It also adds a `IsVirtualFundObjective/IsDirectFundObjective` functions so the `engine` doesn't have to directly inspect the objective id string.

To prevent a circular reference to the `Store` package `ConstructObjectiveFromMessage` just accepts a `getTwoPartyLedger` function instead of a whole store. This also has the benefit of preventing `ConstructObjectiveFromMessage` writing to the store accidentally.