### PR TITLE
Add GH action to auto assign to project

### DIFF
--- a/.github/workflows/assign_project.yml
+++ b/.github/workflows/assign_project.yml
@@ -1,0 +1,23 @@
+name: Auto Assign to Go Nitro Project
+
+on:
+  issues:
+    types: [opened, labeled]
+  pull_request_target:
+    types: [opened, labeled]
+  issue_comment:
+    types: [created]
+env:
+  MY_GITHUB_TOKEN: ${{ secrets.SC_GITHUB_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to One Project
+    steps:
+    - name: Assign NEW issues and NEW pull requests to the Go Nitro project
+      uses: srggrs/assign-one-project-github-action@1.3.1
+      if: github.event.action == 'opened'
+      with:
+        project: 'https://github.com/statechannels/go-nitro/projects/1'
+


### PR DESCRIPTION
Unfortunately I'm unsure of how to test this besides merging it into `main` and seeing if it works. It also only assigns the `Project` so the `Milestone` would still have to be a manual step.