### PR TITLE
Panic if encountering an error during `Channel.Clone()`

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -178,7 +178,12 @@ func (c *Channel) Clone() *Channel {
 	if c == nil {
 		return nil
 	}
-	d, _ := New(c.PreFundState().Clone(), c.MyIndex)
+	d, err := New(c.PreFundState().Clone(), c.MyIndex)
+	if err != nil {
+		// The constructor shouldn't error unless we have made a programming error
+		// (e.g. passed in a turnNum =/= 0 state)
+		panic(err)
+	}
 	d.latestSupportedStateTurnNum = c.latestSupportedStateTurnNum
 	for i, ss := range c.SignedStateForTurnNum {
 		d.SignedStateForTurnNum[i] = ss.Clone()


### PR DESCRIPTION
Closes #270 .

We are currently ignoring an error in this function, which is a bad practice and can result in hard-to-debug problems. 

We could considering passing an error back from `Clone`, but there are two downsides to this:
- we would have to bubble up that error passing in a lot of places 
- it seems like the wrong pattern, since there is no reason we would expect `Clone` to ever fail (unless we a programmer makes a mistake)

It is better to panic here, since the problem indicates the presence of a bug which we can't recover from.


---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
