### PR TITLE
Introduce `waitTimeForCompletedObjectiveIds`

### DIFF
--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-func directlyFundALedgerChannel(alpha client.Client, beta client.Client) {
+func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.Client) {
 	// Set up an outcome that requires both participants to deposit
 	outcome := outcome.Exit{outcome.SingleAssetExit{
 		Allocations: outcome.Allocations{
@@ -28,7 +28,7 @@ func directlyFundALedgerChannel(alpha client.Client, beta client.Client) {
 		},
 	}}
 	id := alpha.CreateDirectChannel(*beta.Address, types.Address{}, types.Bytes{}, outcome, big.NewInt(0))
-	waitForCompletedObjectiveIds(&alpha, id)
+	waitTimeForCompletedObjectiveIds(t, &alpha, defaultTimeout, id)
 	waitForCompletedObjectiveIds(&beta, id)
 }
 func TestDirectFundIntegration(t *testing.T) {
@@ -52,6 +52,6 @@ func TestDirectFundIntegration(t *testing.T) {
 
 	connectMessageServices(messageserviceA, messageserviceB)
 
-	directlyFundALedgerChannel(clientA, clientB)
+	directlyFundALedgerChannel(t, clientA, clientB)
 
 }

--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -29,7 +29,7 @@ func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.C
 	}}
 	id := alpha.CreateDirectChannel(*beta.Address, types.Address{}, types.Bytes{}, outcome, big.NewInt(0))
 	waitTimeForCompletedObjectiveIds(t, &alpha, defaultTimeout, id)
-	waitForCompletedObjectiveIds(&beta, id)
+	waitTimeForCompletedObjectiveIds(t, &beta, defaultTimeout, id)
 }
 func TestDirectFundIntegration(t *testing.T) {
 

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -19,7 +19,7 @@ import (
 const defaultTimeout = time.Second
 
 // waitWithTimeoutForCompletedObjectiveIds waits up to the given timeout for completed objectives and returns when the all objective ids provided have been completed.
-// If the timeout lapses adnd the objectives have not all completed, the parent test will be failed.
+// If the timeout lapses and the objectives have not all completed, the parent test will be failed.
 func waitTimeForCompletedObjectiveIds(t *testing.T, client *client.Client, timeout time.Duration, ids ...protocols.ObjectiveId) {
 	waitAndSendOn := func(allDone chan interface{}) {
 		waitForCompletedObjectiveIds(client, ids...)

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -3,6 +3,8 @@ package client_test
 import (
 	"io"
 	"math/big"
+	"testing"
+	"time"
 
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client"
@@ -13,6 +15,27 @@ import (
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
+
+const defaultTimeout = time.Second
+
+// waitWithTimeoutForCompletedObjectiveIds waits up to the given timeout for completed objectives and returns when the all objective ids provided have been completed.
+// If the timeout lapses adnd the objectives have not all completed, the parent test will be failed.
+func waitTimeForCompletedObjectiveIds(t *testing.T, client *client.Client, timeout time.Duration, ids ...protocols.ObjectiveId) {
+	waitAndSendOn := func(allDone chan interface{}) {
+		waitForCompletedObjectiveIds(client, ids...)
+		allDone <- struct{}{}
+	}
+	allDone := make(chan interface{})
+	go waitAndSendOn(allDone)
+
+	select {
+	case <-time.After(timeout):
+		t.Fatalf("Objective ids %s failed to complete in one second on client %s", ids, client.Address)
+	case <-allDone:
+		return
+	}
+
+}
 
 // waitForCompletedObjectiveIds waits for completed objectives and returns when the all objective ids provided have been completed.
 func waitForCompletedObjectiveIds(client *client.Client, ids ...protocols.ObjectiveId) {

--- a/client_test/virtualfund_integration_test.go
+++ b/client_test/virtualfund_integration_test.go
@@ -32,15 +32,15 @@ func TestVirtualFundIntegration(t *testing.T) {
 
 	connectMessageServices(messageserviceA, messageserviceB, messageserviceI)
 
-	directlyFundALedgerChannel(clientA, clientI)
-	directlyFundALedgerChannel(clientI, clientB)
+	directlyFundALedgerChannel(t, clientA, clientI)
+	directlyFundALedgerChannel(t, clientI, clientB)
 
 	outcome := createVirtualOutcome(alice, bob)
 
 	id := clientA.CreateVirtualChannel(bob, irene, types.Address{}, types.Bytes{}, outcome, big.NewInt(0))
 
-	waitForCompletedObjectiveIds(&clientA, id)
-	waitForCompletedObjectiveIds(&clientB, id)
-	waitForCompletedObjectiveIds(&clientI, id)
+	waitTimeForCompletedObjectiveIds(t, &clientA, defaultTimeout, id)
+	waitTimeForCompletedObjectiveIds(t, &clientB, defaultTimeout, id)
+	waitTimeForCompletedObjectiveIds(t, &clientI, defaultTimeout, id)
 
 }

--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -35,17 +35,17 @@ func TestMultiPartyVirtualFundIntegration(t *testing.T) {
 
 	connectMessageServices(aliceMS, bobMS, ireneMS, brianMS)
 
-	directlyFundALedgerChannel(clientAlice, clientIrene)
-	directlyFundALedgerChannel(clientIrene, clientBob)
-	directlyFundALedgerChannel(clientIrene, clientBrian)
+	directlyFundALedgerChannel(t, clientAlice, clientIrene)
+	directlyFundALedgerChannel(t, clientIrene, clientBob)
+	directlyFundALedgerChannel(t, clientIrene, clientBrian)
 
 	id := clientAlice.CreateVirtualChannel(bob, irene, types.Address{}, types.Bytes{}, createVirtualOutcome(alice, bob), big.NewInt(0))
 	id2 := clientAlice.CreateVirtualChannel(brian, irene, types.Address{}, types.Bytes{}, createVirtualOutcome(alice, brian), big.NewInt(0))
 
-	waitForCompletedObjectiveIds(&clientBob, id)
-	waitForCompletedObjectiveIds(&clientBrian, id)
+	waitTimeForCompletedObjectiveIds(t, &clientBob, defaultTimeout, id)
+	waitTimeForCompletedObjectiveIds(t, &clientBrian, defaultTimeout, id)
 
-	waitForCompletedObjectiveIds(&clientAlice, id, id2)
-	waitForCompletedObjectiveIds(&clientIrene, id, id2)
+	waitTimeForCompletedObjectiveIds(t, &clientAlice, defaultTimeout, id, id2)
+	waitTimeForCompletedObjectiveIds(t, &clientIrene, defaultTimeout, id, id2)
 
 }


### PR DESCRIPTION
Currently, our integration tests will just hang in the case of a deadlock between clients. This change allows us to adjust timeouts inside our tests, and detects deadlocks by failing a test if expectations are not met within those timeouts.

Towards #217.
Relevant issue: #280 

⚠️ stacked on #309.


**How Has This Been Tested?** 
Manually unskipping a test that currently just hangs, we get a quick failure with: 

```
    helpers_test.go:33: Objective ids [VirtualFund-0xe25bb77c1b36b618f553c1fab4b473c53c2a67a1c63591bdc2a72b244e039fd6] failed to complete in one second on client 0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01
```

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [ ] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
