### PR TITLE
`Objetive` implements json.Marshaler, json.Unarshaler

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -93,7 +93,7 @@ func (c *Client) CreateVirtualChannel(counterParty types.Address, intermediary t
 		left, right)
 
 	apiEvent := engine.APIEvent{
-		ObjectiveToSpawn: objective,
+		ObjectiveToSpawn: &objective,
 	}
 	// Send the event to the engine
 	c.engine.FromAPI <- apiEvent
@@ -120,7 +120,7 @@ func (c *Client) CreateDirectChannel(counterparty types.Address, appDefinition t
 	)
 
 	apiEvent := engine.APIEvent{
-		ObjectiveToSpawn: objective,
+		ObjectiveToSpawn: &objective,
 	}
 	// Send the event to the engine
 	c.engine.FromAPI <- apiEvent

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -250,21 +250,21 @@ func (e *Engine) constructObjectiveFromMessage(message protocols.Message) (proto
 
 	switch {
 	case directfund.IsDirectFundObjective(message.ObjectiveId):
-
-		return directfund.NewObjective(
+		dfo, err := directfund.NewObjective(
 			true, // TODO ensure objective in only approved if the application has given permission somehow
 			initialState,
 			*e.store.GetAddress(),
 		)
+		return &dfo, err
 	case virtualfund.IsVirtualFundObjective(message.ObjectiveId):
 		vfo, err := virtualfund.ConstructObjectiveFromMessage(message, *e.store.GetAddress(), e.store.GetTwoPartyLedger)
 		if err != nil {
-			return virtualfund.Objective{}, fmt.Errorf("could not create virtual fund objective from message: %w", err)
+			return &virtualfund.Objective{}, fmt.Errorf("could not create virtual fund objective from message: %w", err)
 		}
-		return vfo, nil
+		return &vfo, nil
 
 	default:
-		return directfund.Objective{}, errors.New("cannot handle unimplemented objective type")
+		return &directfund.Objective{}, errors.New("cannot handle unimplemented objective type")
 	}
 
 }

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -54,7 +54,7 @@ func (ms *MockStore) SetChannel(ch *channel.Channel) error {
 	// This should be replaced in https://github.com/statechannels/go-nitro/pull/227
 	for _, obj := range ms.objectives {
 		if strings.HasPrefix(string(obj.Id()), "DirectFunding-") {
-			dfO := obj.(directfund.Objective)
+			dfO := obj.(*directfund.Objective)
 			if dfO.C.Id == ch.Id {
 				dfO.C = ch
 				err := ms.SetObjective(dfO)
@@ -64,7 +64,7 @@ func (ms *MockStore) SetChannel(ch *channel.Channel) error {
 
 			}
 		} else if strings.HasPrefix(string(obj.Id()), "VirtualFund-") {
-			vfO := obj.(virtualfund.Objective)
+			vfO := obj.(*virtualfund.Objective)
 			if vfO.V.Id == ch.Id {
 				vfO.V = &channel.SingleHopVirtualChannel{Channel: *ch}
 				err := ms.SetObjective(vfO)

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -34,7 +34,7 @@ func TestSetGetObjective(t *testing.T) {
 		ts.Participants[0],
 	)
 
-	if err := ms.SetObjective(testObj); err != nil {
+	if err := ms.SetObjective(&testObj); err != nil {
 		t.Errorf("error setting objective %v: %s", testObj, err.Error())
 	}
 
@@ -61,7 +61,7 @@ func TestGetObjectiveByChannelId(t *testing.T) {
 		ts.Participants[0],
 	)
 
-	if err := ms.SetObjective(testObj); err != nil {
+	if err := ms.SetObjective(&testObj); err != nil {
 		t.Errorf("error setting objective %v: %s", testObj, err.Error())
 	}
 

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -119,20 +119,20 @@ func (o Objective) Approve() protocols.Objective {
 	// todo: consider case of s.Status == Rejected
 	updated.Status = protocols.Approved
 
-	return updated
+	return &updated
 }
 
 func (o Objective) Reject() protocols.Objective {
 	updated := o.clone()
 	updated.Status = protocols.Rejected
-	return updated
+	return &updated
 }
 
 // Update receives an ObjectiveEvent, applies all applicable event data to the DirectFundingObjectiveState,
 // and returns the updated state
 func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, error) {
 	if o.Id() != event.ObjectiveId {
-		return o, fmt.Errorf("event and objective Ids do not match: %s and %s respectively", string(event.ObjectiveId), string(o.Id()))
+		return &o, fmt.Errorf("event and objective Ids do not match: %s and %s respectively", string(event.ObjectiveId), string(o.Id()))
 	}
 
 	updated := o.clone()
@@ -142,7 +142,7 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 		updated.C.OnChainFunding = event.Holdings
 	}
 
-	return updated, nil
+	return &updated, nil
 }
 
 // Crank inspects the extended state and declares a list of Effects to be executed
@@ -154,21 +154,21 @@ func (o Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Side
 	sideEffects := protocols.SideEffects{}
 	// Input validation
 	if updated.Status != protocols.Approved {
-		return updated, protocols.SideEffects{}, WaitingForNothing, []protocols.GuaranteeRequest{}, ErrNotApproved
+		return &updated, protocols.SideEffects{}, WaitingForNothing, []protocols.GuaranteeRequest{}, ErrNotApproved
 	}
 
 	// Prefunding
 	if !updated.C.PreFundSignedByMe() {
 		ss, err := updated.C.SignAndAddPrefund(secretKey)
 		if err != nil {
-			return updated, protocols.SideEffects{}, WaitingForCompletePrefund, []protocols.GuaranteeRequest{}, fmt.Errorf("could not sign prefund %w", err)
+			return &updated, protocols.SideEffects{}, WaitingForCompletePrefund, []protocols.GuaranteeRequest{}, fmt.Errorf("could not sign prefund %w", err)
 		}
 		messages := protocols.CreateSignedStateMessages(updated.Id(), ss, updated.C.MyIndex)
 		sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, messages...)
 	}
 
 	if !updated.C.PreFundComplete() {
-		return updated, sideEffects, WaitingForCompletePrefund, []protocols.GuaranteeRequest{}, nil
+		return &updated, sideEffects, WaitingForCompletePrefund, []protocols.GuaranteeRequest{}, nil
 	}
 
 	// Funding
@@ -177,7 +177,7 @@ func (o Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Side
 	safeToDeposit := updated.safeToDeposit()
 
 	if !fundingComplete && !safeToDeposit {
-		return updated, sideEffects, WaitingForMyTurnToFund, []protocols.GuaranteeRequest{}, nil
+		return &updated, sideEffects, WaitingForMyTurnToFund, []protocols.GuaranteeRequest{}, nil
 	}
 
 	if !fundingComplete && safeToDeposit && amountToDeposit.IsNonZero() {
@@ -186,7 +186,7 @@ func (o Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Side
 	}
 
 	if !fundingComplete {
-		return updated, sideEffects, WaitingForCompleteFunding, []protocols.GuaranteeRequest{}, nil
+		return &updated, sideEffects, WaitingForCompleteFunding, []protocols.GuaranteeRequest{}, nil
 	}
 
 	// Postfunding
@@ -195,18 +195,18 @@ func (o Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Side
 		ss, err := updated.C.SignAndAddPostfund(secretKey)
 
 		if err != nil {
-			return updated, protocols.SideEffects{}, WaitingForCompletePostFund, []protocols.GuaranteeRequest{}, fmt.Errorf("could not sign postfund %w", err)
+			return &updated, protocols.SideEffects{}, WaitingForCompletePostFund, []protocols.GuaranteeRequest{}, fmt.Errorf("could not sign postfund %w", err)
 		}
 		messages := protocols.CreateSignedStateMessages(updated.Id(), ss, updated.C.MyIndex)
 		sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, messages...)
 	}
 
 	if !updated.C.PostFundComplete() {
-		return updated, sideEffects, WaitingForCompletePostFund, []protocols.GuaranteeRequest{}, nil
+		return &updated, sideEffects, WaitingForCompletePostFund, []protocols.GuaranteeRequest{}, nil
 	}
 
 	// Completion
-	return updated, sideEffects, WaitingForNothing, []protocols.GuaranteeRequest{}, nil
+	return &updated, sideEffects, WaitingForNothing, []protocols.GuaranteeRequest{}, nil
 }
 
 func (o Objective) Channels() []*channel.Channel {

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -40,6 +40,17 @@ type Objective struct {
 	fullyFundedThreshold     types.Funds // if the on chain holdings are equal
 }
 
+// jsonObjective replaces the directfund.Objective's channel pointer with the
+// channel's ID, making jsonObjective suitable for serialization
+type jsonObjective struct {
+	Status protocols.ObjectiveStatus
+	C      types.Destination
+
+	MyDepositSafetyThreshold types.Funds
+	MyDepositTarget          types.Funds
+	FullyFundedThreshold     types.Funds
+}
+
 // NewObjective initiates a Objective with data calculated from
 // the supplied initialState and client address
 func NewObjective(

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -2,6 +2,7 @@
 package directfund // import "github.com/statechannels/go-nitro/directfund"
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -212,6 +213,49 @@ func (o Objective) Channels() []*channel.Channel {
 	ret := make([]*channel.Channel, 0, 1)
 	ret = append(ret, o.C)
 	return ret
+}
+
+// MarshalJSON returns a JSON representation of the DirectFundObjective
+//
+// NOTE: Marshal -> Unmarshal is a lossy process. All channel data
+//       (other than Id) from the field C is discarded
+func (o Objective) MarshalJSON() ([]byte, error) {
+	jsonDFO := jsonObjective{
+		o.Status,
+		o.C.Id,
+		o.myDepositSafetyThreshold,
+		o.myDepositTarget,
+		o.fullyFundedThreshold,
+	}
+	return json.Marshal(jsonDFO)
+}
+
+// UnmarshalJSON populates the calling DirectFundObjective with the
+// json-encoded data
+//
+// NOTE: Marshal -> Unmarshal is a lossy process. All channel data
+//       (other than Id) from the field C is discarded
+func (o *Objective) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
+
+	var jsonDFO jsonObjective
+	err := json.Unmarshal(data, &jsonDFO)
+
+	if err != nil {
+		return err
+	}
+
+	o.C = &channel.Channel{}
+	o.C.Id = jsonDFO.C
+
+	o.Status = jsonDFO.Status
+	o.fullyFundedThreshold = jsonDFO.FullyFundedThreshold
+	o.myDepositTarget = jsonDFO.MyDepositTarget
+	o.myDepositSafetyThreshold = jsonDFO.MyDepositSafetyThreshold
+
+	return nil
 }
 
 //  Private methods on the DirectFundingObjectiveState

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -1,6 +1,7 @@
 package directfund
 
 import (
+	"encoding/json"
 	"math/big"
 	"testing"
 
@@ -266,5 +267,39 @@ func TestClone(t *testing.T) {
 
 	if diff := cmp.Diff(s, clone); diff != "" {
 		t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMarshalJSON(t *testing.T) {
+	dfo, _ := NewObjective(false, testState, testState.Participants[0])
+
+	encodedDfo, err := json.Marshal(dfo)
+
+	if err != nil {
+		t.Errorf("error encoding direct-fund objective %v", dfo)
+	}
+
+	got := Objective{}
+	if err := got.UnmarshalJSON(encodedDfo); err != nil {
+		t.Errorf("error unmarshaling test direct fund objective: %s", err.Error())
+	}
+
+	if !got.myDepositSafetyThreshold.Equal(dfo.myDepositSafetyThreshold) {
+		t.Errorf("expected myDepositSafetyThreshhold %v but got %v",
+			dfo.myDepositSafetyThreshold, got.myDepositSafetyThreshold)
+	}
+	if !got.myDepositTarget.Equal(dfo.myDepositTarget) {
+		t.Errorf("expected myDepositTarget %v but got %v",
+			dfo.myDepositTarget, got.myDepositTarget)
+	}
+	if !got.fullyFundedThreshold.Equal(dfo.fullyFundedThreshold) {
+		t.Errorf("expected fullyFundedThreshold %v but got %v",
+			dfo.fullyFundedThreshold, got.fullyFundedThreshold)
+	}
+	if !(got.Status == dfo.Status) {
+		t.Errorf("expected Status %v but got %v", dfo.Status, got.Status)
+	}
+	if got.C.Id != dfo.C.Id {
+		t.Errorf("expected channel Id %s but got %s", dfo.C.Id, got.C.Id)
 	}
 }

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -111,7 +111,7 @@ func TestUpdate(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	updated := updatedObjective.(Objective)
+	updated := updatedObjective.(*Objective)
 	if updated.C.PreFundSignedByMe() != true {
 		t.Error(`Objective data not updated as expected`)
 	}
@@ -124,7 +124,7 @@ func TestUpdate(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	updated = updatedObjective.(Objective)
+	updated = updatedObjective.(*Objective)
 	if !updated.C.OnChainFunding.Equal(e.Holdings) {
 		t.Error(`Objective data not updated as expected`, updated.C.OnChainFunding, e.Holdings)
 	}
@@ -183,7 +183,7 @@ func TestCrank(t *testing.T) {
 	}
 
 	// Approve the objective, so that the rest of the test cases can run.
-	o := s.Approve().(Objective)
+	o := s.Approve().(*Objective)
 
 	// To test the finite state progression, we are going to progressively mutate o
 	// And then crank it to see

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -76,6 +76,9 @@ type Objective interface {
 	Channels() []*channel.Channel
 
 	Crank(secretKey *[]byte) (Objective, SideEffects, WaitingFor, []GuaranteeRequest, error) // does *not* accept an event, but *does* accept a pointer to a signing key; declare side effects; return an updated Objective
+
+	MarshalJSON() ([]byte, error)
+	UnmarshalJSON([]byte) error
 }
 
 // ObjectiveId is a unique identifier for an Objective.

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -255,13 +255,13 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			}
 
 			// Approve the objective, so that the rest of the test cases can run.
-			o := s.Approve().(Objective)
+			o := s.Approve().(*Objective)
 			// To test the finite state progression, we are going to progressively mutate o
 			// And then crank it to see which "pause point" (WaitingFor) we end up at.
 
 			// Initial Crank
 			oObj, got, waitingFor, _, err := o.Crank(&my.privateKey)
-			o = oObj.(Objective)
+			o = oObj.(*Objective)
 			if err != nil {
 				t.Error(err)
 			}
@@ -280,7 +280,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			// Cranking should move us to the next waiting point, generate ledger requests as a side effect, and alter the extended state to reflect that
 			var gotRequests []protocols.GuaranteeRequest
 			oObj, _, waitingFor, gotRequests, err = o.Crank(&my.privateKey)
-			o = oObj.(Objective)
+			o = oObj.(*Objective)
 			if err != nil {
 				t.Error(err)
 			}
@@ -365,7 +365,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 			// Cranking now should not generate side effects, because we already did that
 			oObj, got, waitingFor, _, err = o.Crank(&my.privateKey)
-			o = oObj.(Objective)
+			o = oObj.(*Objective)
 			if err != nil {
 				t.Error(err)
 			}
@@ -437,7 +437,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			e.SignedStates = append(e.SignedStates, ss)
 
 			updatedObj, err := s.Update(e)
-			updated := updatedObj.(Objective)
+			updated := updatedObj.(*Objective)
 			if err != nil {
 				t.Error(err)
 			}
@@ -495,7 +495,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			f.SignedStates = append(f.SignedStates, ss)
 
 			updatedObj, err = s.Update(f)
-			updated = updatedObj.(Objective)
+			updated = updatedObj.(*Objective)
 			if err != nil {
 				t.Error(err)
 			}

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -49,6 +49,20 @@ func (c *Connection) Equal(d *Connection) bool {
 
 }
 
+// jsonConnection is a serialization-friendly struct representation
+// of a Connection
+type jsonConnection struct {
+	Channel            types.Destination
+	ExpectedGuarantees []assetGuarantee
+}
+
+// assetGuarantee is a serialization-friendly representation of
+// map[asset]Allocation
+type assetGuarantee struct {
+	Asset     types.Address
+	Guarantee outcome.Allocation
+}
+
 // Objective is a cache of data computed by reading from the store. It stores (potentially) infinite data.
 type Objective struct {
 	Status protocols.ObjectiveStatus
@@ -64,6 +78,24 @@ type Objective struct {
 	b0 types.Funds // Initial balance for Bob
 
 	requestedLedgerUpdates bool // records that the ledger update side effects were previously generated (they may not have been executed yet)
+}
+
+// jsonObjective replaces the virtualfund Objective's channel pointers
+// with the channel's respective IDs, making jsonObjective suitable for serialization
+type jsonObjective struct {
+	Status protocols.ObjectiveStatus
+	V      types.Destination
+
+	ToMyLeft  []byte
+	ToMyRight []byte
+
+	N      uint
+	MyRole uint
+
+	A0 types.Funds
+	B0 types.Funds
+
+	RequestedLedgerUpdates bool
 }
 
 // NewObjective initiates an Objective.

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -76,7 +76,12 @@ func (c Connection) MarshalJSON() ([]byte, error) {
 }
 
 func (c *Connection) UnmarshalJSON(data []byte) error {
+	c.Channel = &channel.TwoPartyLedger{}
+	c.ExpectedGuarantees = make(map[types.Address]outcome.Allocation)
+
 	if string(data) == "null" {
+		// populate a well-formed but blank-addressed Connection
+		c.Channel.Id = types.Destination{}
 		return nil
 	}
 
@@ -87,10 +92,7 @@ func (c *Connection) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	c.Channel = &channel.TwoPartyLedger{}
 	c.Channel.Id = jsonC.Channel
-
-	c.ExpectedGuarantees = make(map[types.Address]outcome.Allocation)
 
 	for _, eg := range jsonC.ExpectedGuarantees {
 		c.ExpectedGuarantees[eg.Asset] = eg.Guarantee

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -57,6 +57,10 @@ type jsonConnection struct {
 	ExpectedGuarantees []assetGuarantee
 }
 
+// MarshalJSON returns a JSON representation of the Connection
+//
+// NOTE: Marshal -> Unmarshal is a lossy process. All channel data
+//       other than the ID is dropped
 func (c Connection) MarshalJSON() ([]byte, error) {
 	guarantees := []assetGuarantee{}
 	for asset, guarantee := range c.ExpectedGuarantees {
@@ -75,6 +79,11 @@ func (c Connection) MarshalJSON() ([]byte, error) {
 	return bytes, err
 }
 
+// UnmarshalJSON populates the calling Connection with the
+// json-encoded data
+//
+// NOTE: Marshal -> Unmarshal is a lossy process. All channel data from
+//       (other than Id) is discarded
 func (c *Connection) UnmarshalJSON(data []byte) error {
 	c.Channel = &channel.TwoPartyLedger{}
 	c.ExpectedGuarantees = make(map[types.Address]outcome.Allocation)

--- a/protocols/virtualfund/virtualfund_test.go
+++ b/protocols/virtualfund/virtualfund_test.go
@@ -67,7 +67,6 @@ func TestMarshalJSON(t *testing.T) {
 		IsFinal: false,
 	}
 
-	// left, _ :=
 	ts := state.TestState
 	ts.TurnNum = channel.PreFundTurnNum
 

--- a/protocols/virtualfund/virtualfund_test.go
+++ b/protocols/virtualfund/virtualfund_test.go
@@ -1,0 +1,151 @@
+package virtualfund
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/channel"
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/types"
+)
+
+func TestMarshalJSON(t *testing.T) {
+
+	type actor struct {
+		address     types.Address
+		destination types.Destination
+		privateKey  []byte
+		role        uint
+	}
+
+	alice := actor{
+		address:     common.HexToAddress(`0xD9995BAE12FEe327256FFec1e3184d492bD94C31`),
+		destination: types.AddressToDestination(common.HexToAddress(`0xD9995BAE12FEe327256FFec1e3184d492bD94C31`)),
+		privateKey:  common.Hex2Bytes(`7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8`),
+		role:        0,
+	}
+
+	p1 := actor{ // Aliases: The Hub, Irene
+		address:     common.HexToAddress(`0xd4Fa489Eacc52BA59438993f37Be9fcC20090E39`),
+		destination: types.AddressToDestination(common.HexToAddress(`0xd4Fa489Eacc52BA59438993f37Be9fcC20090E39`)),
+		privateKey:  common.Hex2Bytes(`2030b463177db2da82908ef90fa55ddfcef56e8183caf60db464bc398e736e6f`),
+		role:        1,
+	}
+
+	bob := actor{
+		address:     common.HexToAddress(`0x760bf27cd45036a6C486802D30B5D90CfFBE31FE`),
+		destination: types.AddressToDestination(common.HexToAddress(`0x760bf27cd45036a6C486802D30B5D90CfFBE31FE`)),
+		privateKey:  common.Hex2Bytes(`62ecd49c4ccb41a70ad46532aed63cf815de15864bc415c87d507afd6a5e8da2`),
+		role:        2,
+	}
+
+	vPreFund := state.State{
+		ChainId:           big.NewInt(9001),
+		Participants:      []types.Address{alice.address, p1.address, bob.address}, // A single hop virtual channel
+		ChannelNonce:      big.NewInt(0),
+		AppDefinition:     types.Address{},
+		ChallengeDuration: big.NewInt(45),
+		AppData:           []byte{},
+		Outcome: outcome.Exit{outcome.SingleAssetExit{
+			Allocations: outcome.Allocations{
+				outcome.Allocation{
+					Destination: alice.destination,
+					Amount:      big.NewInt(5),
+				},
+				outcome.Allocation{
+					Destination: bob.destination,
+					Amount:      big.NewInt(5),
+				},
+			},
+		}},
+		TurnNum: 0,
+		IsFinal: false,
+	}
+
+	// left, _ :=
+	ts := state.TestState
+	ts.TurnNum = channel.PreFundTurnNum
+
+	right, _ := channel.NewTwoPartyLedger(ts, 0)
+	vfo, err := NewObjective(
+		false,
+		vPreFund,
+		alice.address,
+		&channel.TwoPartyLedger{},
+		right,
+	)
+
+	if err != nil {
+		err = fmt.Errorf("the test VirtualFundObjective was not initialized: %w", err)
+		t.Fatalf("%s", err)
+	}
+
+	encodedVfo, err := json.Marshal(vfo)
+
+	if err != nil {
+		t.Errorf("error encoding direct-fund objective %v", vfo)
+	}
+
+	got := Objective{}
+	if err := got.UnmarshalJSON(encodedVfo); err != nil {
+		t.Fatalf("the test VirtualFundObjective did not deserialize correctly: %s", err.Error())
+	}
+
+	if !(got.Status == vfo.Status) {
+		t.Errorf("expected Status %v but got %v", vfo.Status, got.Status)
+	}
+
+	// only checking channel ID rather than whole channel because
+	// marshal / unmarshal loses channel data
+	if got.V.Id != vfo.V.Id {
+		t.Errorf("expected channel Id %s but got %s", vfo.V.Id, got.V.Id)
+	}
+
+	if vfo.ToMyLeft != nil {
+		if !reflect.DeepEqual(vfo.ToMyLeft.ExpectedGuarantees, got.ToMyLeft.ExpectedGuarantees) {
+			t.Errorf("expected left-channel guarantees %v, but found %v", vfo.ToMyLeft, got.ToMyLeft)
+		}
+
+		if got.ToMyLeft.Channel.Id != vfo.ToMyLeft.Channel.Id {
+			t.Errorf("expected left channel Id %s but got %s",
+				vfo.ToMyLeft.Channel.Id, got.ToMyLeft.Channel.Id)
+		}
+	} else if (got.ToMyLeft.Channel.Id != types.Destination{}) {
+		t.Errorf("recieved a non-blank channel Id where the connection was null")
+	}
+
+	if vfo.ToMyRight != nil {
+		if !reflect.DeepEqual(vfo.ToMyRight.ExpectedGuarantees, got.ToMyRight.ExpectedGuarantees) {
+			t.Errorf("expected right-channel %v, but found %v", vfo.ToMyRight, got.ToMyRight)
+		}
+
+		if got.ToMyRight.Channel.Id != vfo.ToMyRight.Channel.Id {
+			t.Errorf("expected left channel Id %s but got %s",
+				vfo.ToMyRight.Channel.Id, got.ToMyRight.Channel.Id)
+		}
+	} else if (got.ToMyRight.Channel.Id != types.Destination{}) {
+		t.Errorf("recieved a non-blank channel Id where the connection was null")
+	}
+
+	if got.n != vfo.n {
+		t.Errorf("expected %d channel participants but found %d", vfo.n, got.n)
+	}
+	if got.MyRole != vfo.MyRole {
+		t.Errorf("expected MyRole %d but found %d", vfo.MyRole, got.MyRole)
+	}
+	if !got.a0.Equal(vfo.a0) {
+		t.Errorf("expected alice initial balance of %v but found %v", vfo.a0, got.a0)
+	}
+	if !got.b0.Equal(vfo.b0) {
+		t.Errorf("expected bob initial balance of %v but found %v", vfo.b0, got.a0)
+	}
+	if got.requestedLedgerUpdates != vfo.requestedLedgerUpdates {
+		t.Errorf("expected requestedLedgerUpdates == %t, but found %t",
+			vfo.requestedLedgerUpdates, got.requestedLedgerUpdates)
+	}
+}


### PR DESCRIPTION
This is incremental work toward:
1. a serialization scheme for the store
2. the mockstore (& store) having a mechanism for splitting and recombining in-memory Objectives (which contain channels) into separate Objective and Channel

See #191, + discussion in #227

This PR splits previous work which had added these methods and integrated them with the existing `mockstore` implementation. `mockstore` will pick these methods up in a follow-up PR after this goes in.

## Shortcomings

- adding the `Unmarshal` interface requires a pointer-receiver method, which forces objectives to be passed around as pointers. (It's unclear if this is a problem, but it is at least a nuisance).
- the test for `virtualfund`'s encode / decode contains a heap of duplicated code from the single-hop virualfund test (init data for a virtualfund Objective)

**Changes**

This PR adds the json.Marshal and json.Unmarshal interface methods to the `Objective` interface, and adds implementations with tests to `directfund` and `virtualfund`.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
