### PR TITLE
Get multi party virtual integration test passing

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -202,6 +202,17 @@ func (e *Engine) attemptProgress(objective protocols.Objective) (outgoing Object
 	crankedObjective, sideEffects, waitingFor, _ := objective.Crank(secretKey) // TODO handle error
 	_ = e.store.SetObjective(crankedObjective)                                 // TODO handle error
 
+	// TODO: This is hack to get around the fact that currently each objective in the store has it's own set of channels.
+	vfo, isVirtual := crankedObjective.(*virtualfund.Objective)
+	if isVirtual {
+		if vfo.ToMyLeft != nil {
+			_ = e.store.SetChannel(&vfo.ToMyLeft.Channel.Channel)
+		}
+		if vfo.ToMyRight != nil {
+			_ = e.store.SetChannel(&vfo.ToMyRight.Channel.Channel)
+		}
+	}
+
 	e.executeSideEffects(sideEffects)
 	e.logger.Printf("Objective %s is %s", objective.Id(), waitingFor)
 

--- a/client/engine/messageservice/test-messageservice.go
+++ b/client/engine/messageservice/test-messageservice.go
@@ -31,8 +31,8 @@ func NewTestMessageService(address types.Address) TestMessageService {
 	tms := TestMessageService{
 		address: address,
 		toPeers: make(map[types.Address]chan<- string),
-		in:      make(chan protocols.Message),
-		out:     make(chan protocols.Message),
+		in:      make(chan protocols.Message, 5),
+		out:     make(chan protocols.Message, 5),
 	}
 	tms.run()
 	return tms

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -87,11 +87,11 @@ func createVirtualOutcome(first types.Address, second types.Address) outcome.Exi
 		Allocations: outcome.Allocations{
 			outcome.Allocation{
 				Destination: types.AddressToDestination(first),
-				Amount:      big.NewInt(5),
+				Amount:      big.NewInt(1),
 			},
 			outcome.Allocation{
 				Destination: types.AddressToDestination(second),
-				Amount:      big.NewInt(5),
+				Amount:      big.NewInt(1),
 			},
 		},
 	}}

--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -12,7 +12,6 @@ import (
 
 // TestMultiPartyVirtualFundIntegration tests the scenario where Alice creates virtual channels with Bob and Brian using Irene as the intermediary.
 func TestMultiPartyVirtualFundIntegration(t *testing.T) {
-	t.Skip()
 
 	// Set up logging
 	logDestination, err := os.OpenFile("virtualfund_multiparty_client_test.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)

--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -43,7 +43,7 @@ func TestMultiPartyVirtualFundIntegration(t *testing.T) {
 	id2 := clientAlice.CreateVirtualChannel(brian, irene, types.Address{}, types.Bytes{}, createVirtualOutcome(alice, brian), big.NewInt(0))
 
 	waitTimeForCompletedObjectiveIds(t, &clientBob, defaultTimeout, id)
-	waitTimeForCompletedObjectiveIds(t, &clientBrian, defaultTimeout, id)
+	waitTimeForCompletedObjectiveIds(t, &clientBrian, defaultTimeout, id2)
 
 	waitTimeForCompletedObjectiveIds(t, &clientAlice, defaultTimeout, id, id2)
 	waitTimeForCompletedObjectiveIds(t, &clientIrene, defaultTimeout, id, id2)

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -677,7 +677,9 @@ func (o *Objective) proposeLedgerUpdate(connection Connection, sk *[]byte) (prot
 	} else {
 		nextState = supported.Clone()
 	}
-
+	if nextState.Outcome.Affords(connection.ExpectedGuarantees, ledger.OnChainFunding) {
+		return protocols.SideEffects{}, nil
+	}
 	nextState.TurnNum = nextState.TurnNum + 1
 	// Update the outcome with the guarantee.
 	nextState.Outcome, err = nextState.Outcome.DivertToGuarantee(left, right, leftAmount, rightAmount, o.V.Id)

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -667,8 +667,17 @@ func (o *Objective) proposeLedgerUpdate(connection Connection, sk *[]byte) (prot
 		return protocols.SideEffects{}, fmt.Errorf("error finding a supported state: %w", err)
 	}
 
+	proposed, proposedFound := ledger.Proposed()
+
 	// Clone the state and update the turn to the next turn.
-	nextState := supported.Clone()
+	// We want to use the most recent proposal if it exists, otherwise we use the support.
+	var nextState state.State
+	if proposedFound {
+		nextState = proposed.Clone()
+	} else {
+		nextState = supported.Clone()
+	}
+
 	nextState.TurnNum = nextState.TurnNum + 1
 	// Update the outcome with the guarantee.
 	nextState.Outcome, err = nextState.Outcome.DivertToGuarantee(left, right, leftAmount, rightAmount, o.V.Id)


### PR DESCRIPTION
Fixes #313 

This a collection of changes to get the current multi party integration test passing.

This PR **does not implement any locking**. Since this test passes without locking, I've created #322 to implement a failing test and #323 to implement a locking solution to resolve the test.

## Changes
- [7bd6315](https://github.com/statechannels/go-nitro/pull/321/commits/7bd631559a7df821813131ca66384911f920c42b) Fixed an incorrect test assertion that was waiting for Brian on the wrong virtual funding objective
- [455b7b5](https://github.com/statechannels/go-nitro/pull/321/commits/455b7b535b7bce47e4210784217402deae40afb5) lowered the amounts on the virtual channel so the ledger channel can afford multiple virtual channels
- [d84913f](https://github.com/statechannels/go-nitro/pull/321/commits/d84913f5d27e6380a6b518b54b0374e194440103) if a proposal already exists we use the `turnNum` after that instead of always using the `turnNum` after the supported state
- [a3a2c63](https://github.com/statechannels/go-nitro/pull/321/commits/a3a2c639fadb2dac3894c7a9bd3111554ee29778) only create a new proposal if we haven't created proposal already. This allows us to crank multiple times without generating a new proposal every time.
- [a738f11](https://github.com/statechannels/go-nitro/pull/321/commits/a738f11967d42975e25b05d43d14080bd60968e3) This is a workaround for the current store implementation. `SetObjective` only updates the channels on the specific objective, so by manually calling `SetChannel` we know that all objectives will have the latest channel.
- [fbe9bd4](https://github.com/statechannels/go-nitro/pull/321/commits/fbe9bd4207d7e3d371d6ba498684839e5bf54d84) Instead of outputting the whole message to the log just output a very basic summary. The summary is pretty basic at the moment but we can expand it as needed.
- [e7da061](https://github.com/statechannels/go-nitro/pull/321/commits/e7da061b21257b3aebd7b4919445dd498b24c576) Allow the message service channels to buffer incoming and outgoing messages. Previous to this change the engine would get blocked trying to send out messages. I haven't thought too much about this change but it seems to make sense and gets things passing.
---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
