### PR TITLE
Decouple objectives and channels in `mockstore`

### DIFF
--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -42,7 +42,7 @@ func (ms MockStore) GetObjectiveById(id protocols.ObjectiveId) (obj protocols.Ob
 	// todo: locking
 	obj, ok = ms.objectives[id]
 
-	// return immediately if no
+	// return immediately if no such objective exists
 	if !ok {
 		return nil, ok
 	}

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -48,8 +48,7 @@ func (ms MockStore) GetObjectiveById(id protocols.ObjectiveId) (obj protocols.Ob
 	}
 
 	// populate channel data
-	if directfund.IsDirectFundObjective(id) {
-		dfo := obj.(*directfund.Objective)
+	if dfo, isDirectFund := obj.(*directfund.Objective); isDirectFund {
 		ch, err := ms.getChannelById(dfo.C.Id)
 
 		if err != nil {
@@ -59,9 +58,7 @@ func (ms MockStore) GetObjectiveById(id protocols.ObjectiveId) (obj protocols.Ob
 		dfo.C = &ch
 
 		obj = dfo
-	} else if virtualfund.IsVirtualFundObjective(id) {
-		vfo := obj.(*virtualfund.Objective)
-
+	} else if vfo, isVirtualFund := obj.(*virtualfund.Objective); isVirtualFund {
 		v, err := ms.getChannelById(vfo.V.Id)
 		if err != nil {
 			return nil, false

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -65,25 +65,21 @@ func (ms MockStore) GetObjectiveById(id protocols.ObjectiveId) (obj protocols.Ob
 		}
 		vfo.V = &channel.SingleHopVirtualChannel{Channel: v}
 
-		// todo: clean these checks
-		if vfo.ToMyLeft != nil {
-			if vfo.ToMyLeft.Channel != nil {
-				left, err := ms.getChannelById(vfo.ToMyLeft.Channel.Id)
-				if err != nil {
-					return nil, false
-				}
-				vfo.ToMyLeft.Channel = &channel.TwoPartyLedger{Channel: left}
+		if vfo.ToMyLeft != nil && vfo.ToMyLeft.Channel != nil {
+			left, err := ms.getChannelById(vfo.ToMyLeft.Channel.Id)
+			if err != nil {
+				return nil, false
 			}
+			vfo.ToMyLeft.Channel = &channel.TwoPartyLedger{Channel: left}
 		}
 
-		if vfo.ToMyRight != nil {
-			if vfo.ToMyRight.Channel != nil {
-				right, err := ms.getChannelById(vfo.ToMyRight.Channel.Id)
-				if err != nil {
-					return nil, false
-				}
-				vfo.ToMyRight.Channel = &channel.TwoPartyLedger{Channel: right}
+		if vfo.ToMyRight != nil && vfo.ToMyRight.Channel != nil {
+			right, err := ms.getChannelById(vfo.ToMyRight.Channel.Id)
+			if err != nil {
+				return nil, false
 			}
+			vfo.ToMyRight.Channel = &channel.TwoPartyLedger{Channel: right}
+
 		}
 
 		obj = vfo

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -64,6 +64,16 @@ func (ms *MockStore) SetChannel(ch *channel.Channel) error {
 	return nil // temp - errors can exist / be reported when serde reintroduced
 }
 
+// getChannelById returns the stored channel
+func (ms *MockStore) getChannelById(id types.Destination) (channel.Channel, error) {
+	ch, ok := ms.channels[id]
+	if ok {
+		return ch, nil
+	} else {
+		return channel.Channel{}, fmt.Errorf("channel %s not found", id)
+	}
+}
+
 // GetTwoPartyLedger returns a ledger channel between the two parties if it exists.
 func (ms MockStore) GetTwoPartyLedger(firstParty types.Address, secondParty types.Address) (ledger *channel.TwoPartyLedger, ok bool) {
 	for _, obj := range ms.objectives {

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -1,13 +1,11 @@
 package store
 
 import (
-	"strings"
+	"fmt"
 
 	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/crypto"
 	"github.com/statechannels/go-nitro/protocols"
-	"github.com/statechannels/go-nitro/protocols/directfund"
-	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -46,7 +44,16 @@ func (ms MockStore) GetObjectiveById(id protocols.ObjectiveId) (obj protocols.Ob
 
 func (ms MockStore) SetObjective(obj protocols.Objective) error {
 	// todo: locking
+	// todo: strip channel data from stored objective (avoid duplicate data-storage) (on serde PR)
 	ms.objectives[obj.Id()] = obj
+
+	for _, ch := range obj.Channels() {
+		err := ms.SetChannel(ch)
+		if err != nil {
+			return fmt.Errorf("error setting channel %s from objective %s: %w", ch.Id, obj.Id(), err)
+		}
+	}
+
 	return nil
 }
 

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -52,48 +52,9 @@ func (ms MockStore) SetObjective(obj protocols.Objective) error {
 
 // SetChannel sets the channel in the store.
 func (ms *MockStore) SetChannel(ch *channel.Channel) error {
-	// TODO: This is a temporary implementation that is pretty clunky.
-	// This should be replaced in https://github.com/statechannels/go-nitro/pull/227
-	for _, obj := range ms.objectives {
-		if strings.HasPrefix(string(obj.Id()), "DirectFunding-") {
-			dfO := obj.(*directfund.Objective)
-			if dfO.C.Id == ch.Id {
-				dfO.C = ch
-				err := ms.SetObjective(dfO)
-				if err != nil {
-					return err
-				}
+	ms.channels[ch.Id] = *ch
 
-			}
-		} else if strings.HasPrefix(string(obj.Id()), "VirtualFund-") {
-			vfO := obj.(*virtualfund.Objective)
-			if vfO.V.Id == ch.Id {
-				vfO.V = &channel.SingleHopVirtualChannel{Channel: *ch}
-				err := ms.SetObjective(vfO)
-				if err != nil {
-					return err
-				}
-
-			}
-			if vfO.ToMyLeft != nil && vfO.ToMyLeft.Channel.Id == ch.Id {
-				vfO.ToMyLeft.Channel = &channel.TwoPartyLedger{Channel: *ch}
-				err := ms.SetObjective(vfO)
-				if err != nil {
-					return err
-				}
-
-			}
-			if vfO.ToMyRight != nil && vfO.ToMyRight.Channel.Id == ch.Id {
-				vfO.ToMyRight.Channel = &channel.TwoPartyLedger{Channel: *ch}
-				err := ms.SetObjective(vfO)
-				if err != nil {
-					return err
-				}
-
-			}
-		}
-	}
-	return nil
+	return nil // temp - errors can exist / be reported when serde reintroduced
 }
 
 // GetTwoPartyLedger returns a ledger channel between the two parties if it exists.

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -13,6 +13,7 @@ import (
 
 type MockStore struct {
 	objectives map[protocols.ObjectiveId]protocols.Objective
+	channels   map[types.Destination]channel.Channel
 
 	key     []byte        // the signing key of the store's engine
 	address types.Address // the (Ethereum) address associated to the signing key
@@ -24,6 +25,7 @@ func NewMockStore(key []byte) Store {
 	ms.address = crypto.GetAddressFromSecretKeyBytes(key)
 
 	ms.objectives = make(map[protocols.ObjectiveId]protocols.Objective)
+	ms.channels = make(map[types.Destination]channel.Channel)
 
 	return &ms
 }


### PR DESCRIPTION
This is incremental toward (re)instating json serialization. See #191 

Previously, `mockstore` stored entire `Objective` objects in memory, which included the channels they referenced. This is not a long term solution, because `channel -> objective` is a `1 -> many` relationship, particularly for ledger channels.

This PR is a minimal separation of `Objective` and `Channel` data.

**How Has This Been Tested?** [Optional]

Existing tests run and pass. This is a strong signal for the correctness of Objective persistence and recovery. No (public) functions were added - just implementation detail.

**Limitations**

Noteworthy: the `mockstore` is currently double-copying channel data. The `Objective` memstore map has the same hold of channel data that it had before, but these channels are overwritten by channel data recovered from the `Channel` memstore map.

This is to be followed with a PR which replaces the memstore map objects with json serde methods from #315.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] ~I have added tests that prove my fix is effective or that my feature works, if necessary~ (existing tests cover all edited code)
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
