### PR TITLE
Tidy up log files

### DIFF
--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -2,9 +2,7 @@
 package client_test // import "github.com/statechannels/go-nitro/client_test"
 
 import (
-	"log"
 	"math/big"
-	"os"
 	"testing"
 
 	"github.com/statechannels/go-nitro/channel/state/outcome"
@@ -32,23 +30,13 @@ func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.C
 	waitTimeForCompletedObjectiveIds(t, &beta, defaultTimeout, id)
 }
 func TestDirectFundIntegration(t *testing.T) {
-
-	// Set up logging
-	logDestination, err := os.OpenFile("directfund_client_test.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Reset log destination file
-	err = logDestination.Truncate(0)
-	if err != nil {
-		log.Fatal(err)
-	}
+	logFile := "directfund_client_test.log"
+	truncateLog(logFile)
 
 	chain := chainservice.NewMockChain([]types.Address{alice, bob})
 
-	clientA, messageserviceA := setupClient(aliceKey, chain, logDestination)
-	clientB, messageserviceB := setupClient(bobKey, chain, logDestination)
+	clientA, messageserviceA := setupClient(aliceKey, chain, logFile)
+	clientB, messageserviceB := setupClient(bobKey, chain, logFile)
 
 	connectMessageServices(messageserviceA, messageserviceB)
 

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"math/big"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -108,7 +109,13 @@ func truncateLog(logFile string) {
 }
 
 func newLogWriter(logFile string) *os.File {
-	logDestination, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	err := os.MkdirAll("../artifacts", os.ModePerm)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	filename := filepath.Join("../artifacts", logFile)
+	logDestination, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
 
 	if err != nil {
 		log.Fatal(err)

--- a/client_test/virtualfund_integration_test.go
+++ b/client_test/virtualfund_integration_test.go
@@ -1,9 +1,7 @@
 package client_test
 
 import (
-	"log"
 	"math/big"
-	"os"
 	"testing"
 
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
@@ -13,22 +11,14 @@ import (
 func TestVirtualFundIntegration(t *testing.T) {
 
 	// Set up logging
-	logDestination, err := os.OpenFile("virtualfund_client_test.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Reset log destination file
-	err = logDestination.Truncate(0)
-	if err != nil {
-		log.Fatal(err)
-	}
+	logFile := "virtualfund_client_test.log"
+	truncateLog(logFile)
 
 	chain := chainservice.NewMockChain([]types.Address{alice, bob, irene})
 
-	clientA, messageserviceA := setupClient(aliceKey, chain, logDestination)
-	clientB, messageserviceB := setupClient(bobKey, chain, logDestination)
-	clientI, messageserviceI := setupClient(ireneKey, chain, logDestination)
+	clientA, messageserviceA := setupClient(aliceKey, chain, logFile)
+	clientB, messageserviceB := setupClient(bobKey, chain, logFile)
+	clientI, messageserviceI := setupClient(ireneKey, chain, logFile)
 
 	connectMessageServices(messageserviceA, messageserviceB, messageserviceI)
 

--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -1,9 +1,7 @@
 package client_test
 
 import (
-	"log"
 	"math/big"
-	"os"
 	"testing"
 
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
@@ -13,24 +11,15 @@ import (
 // TestMultiPartyVirtualFundIntegration tests the scenario where Alice creates virtual channels with Bob and Brian using Irene as the intermediary.
 func TestMultiPartyVirtualFundIntegration(t *testing.T) {
 
-	// Set up logging
-	logDestination, err := os.OpenFile("virtualfund_multiparty_client_test.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Reset log destination file
-	err = logDestination.Truncate(0)
-	if err != nil {
-		log.Fatal(err)
-	}
+	logFile := "virtualfund_multiparty_client_test.log"
+	truncateLog(logFile)
 
 	chain := chainservice.NewMockChain([]types.Address{alice, bob, irene, brian})
 
-	clientAlice, aliceMS := setupClient(aliceKey, chain, logDestination)
-	clientBob, bobMS := setupClient(bobKey, chain, logDestination)
-	clientBrian, brianMS := setupClient(brianKey, chain, logDestination)
-	clientIrene, ireneMS := setupClient(ireneKey, chain, logDestination)
+	clientAlice, aliceMS := setupClient(aliceKey, chain, logFile)
+	clientBob, bobMS := setupClient(bobKey, chain, logFile)
+	clientBrian, brianMS := setupClient(brianKey, chain, logFile)
+	clientIrene, ireneMS := setupClient(ireneKey, chain, logFile)
 
 	connectMessageServices(aliceMS, bobMS, ireneMS, brianMS)
 


### PR DESCRIPTION
Currently, log files are written next to source files. This is a little bothersome!

This PR:
- refactors common code used to construct log files, defining two helper functions `truncateLog` and `newLogWriter`
- updates these helper functions to write to a `artifacts` folder

Fixes #329 

**How Has This Been Tested?** [Optional]

I checked the artifacts generated by the GH actions to make sure they're consistent with what's on `main`.