### PR TITLE
test: MockChain implements a Subscribe() method

### DIFF
--- a/client/engine/chainservice/mockchain.go
+++ b/client/engine/chainservice/mockchain.go
@@ -27,20 +27,20 @@ func (mc MockChain) In() chan<- protocols.ChainTransaction {
 }
 
 // NewMockChain returns a new MockChain with an out chan initialized for each of the addresses passed in.
-func NewMockChain(addresses []types.Address) MockChain {
+func NewMockChain() MockChain {
 
 	mc := MockChain{}
 	mc.out = make(map[types.Address]chan Event)
 	mc.in = make(chan protocols.ChainTransaction)
 	mc.holdings = make(map[types.Destination]types.Funds)
 
-	for _, a := range addresses {
-		// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
-		mc.out[a] = make(chan Event, 10)
-	}
-
 	go mc.Run()
 	return mc
+}
+
+func (mc *MockChain) Subscribe(a types.Address) {
+	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
+	mc.out[a] = make(chan Event, 10)
 }
 
 // Run starts a listener for transactions on the MockChain's in chan.

--- a/client/engine/chainservice/mockchain_test.go
+++ b/client/engine/chainservice/mockchain_test.go
@@ -18,7 +18,9 @@ func TestDeposit(t *testing.T) {
 
 	// Construct MockChain and tell it the addresses of the SimpleChainServices which will subscribe to it.
 	// This is not super elegant but gets around data races -- the constructor will make channels and then run a listener which will send on them.
-	var chain = NewMockChain([]types.Address{a, b})
+	var chain = NewMockChain()
+	chain.Subscribe(a)
+	chain.Subscribe(b)
 
 	// Construct SimpleChainServices
 	mcsA := NewSimpleChainService(chain, a)

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -70,7 +70,8 @@ func New(msg messageservice.MessageService, chain chainservice.ChainService, sto
 	e.toMsg = msg.In()
 
 	// initialize a Logger
-	e.logger = log.New(logDestination, e.store.GetAddress().String()+": ", log.Ldate|log.Ltime|log.Lshortfile)
+	logPrefix := e.store.GetAddress().String()[0:8] + ": "
+	e.logger = log.New(logDestination, logPrefix, log.Ldate|log.Ltime|log.Lshortfile)
 
 	e.logger.Println("Constructed Engine")
 

--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -33,7 +33,7 @@ func TestDirectFundIntegration(t *testing.T) {
 	logFile := "directfund_client_test.log"
 	truncateLog(logFile)
 
-	chain := chainservice.NewMockChain([]types.Address{alice, bob})
+	chain := chainservice.NewMockChain()
 
 	clientA, messageserviceA := setupClient(aliceKey, chain, logFile)
 	clientB, messageserviceB := setupClient(bobKey, chain, logFile)

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -75,6 +75,7 @@ func connectMessageServices(services ...messageservice.TestMessageService) {
 // setupClient is a helper function that contructs a client and returns the new client and message service.
 func setupClient(pk []byte, chain chainservice.MockChain, logFilename string) (client.Client, messageservice.TestMessageService) {
 	myAddress := crypto.GetAddressFromSecretKeyBytes(pk)
+	chain.Subscribe(myAddress)
 	chainservice := chainservice.NewSimpleChainService(chain, myAddress)
 	messageservice := messageservice.NewTestMessageService(myAddress)
 	storeA := store.NewMockStore(pk)

--- a/client_test/virtualfund_integration_test.go
+++ b/client_test/virtualfund_integration_test.go
@@ -14,7 +14,7 @@ func TestVirtualFundIntegration(t *testing.T) {
 	logFile := "virtualfund_client_test.log"
 	truncateLog(logFile)
 
-	chain := chainservice.NewMockChain([]types.Address{alice, bob, irene})
+	chain := chainservice.NewMockChain()
 
 	clientA, messageserviceA := setupClient(aliceKey, chain, logFile)
 	clientB, messageserviceB := setupClient(bobKey, chain, logFile)

--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -14,7 +14,7 @@ func TestMultiPartyVirtualFundIntegration(t *testing.T) {
 	logFile := "virtualfund_multiparty_client_test.log"
 	truncateLog(logFile)
 
-	chain := chainservice.NewMockChain([]types.Address{alice, bob, irene, brian})
+	chain := chainservice.NewMockChain()
 
 	clientAlice, aliceMS := setupClient(aliceKey, chain, logFile)
 	clientBob, bobMS := setupClient(bobKey, chain, logFile)


### PR DESCRIPTION
This enables setupClient to be responsible for "subscribing" to the mock chain service's events, which facilitates more dynamic test setup.

(Also, the logger uses the prefix of an address as the log prefix, which makes the logs easier for humans to read)