### PR TITLE
refactor: in <--> out

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -62,12 +62,12 @@ func New(msg messageservice.MessageService, chain chainservice.ChainService, sto
 	// bind to inbound chans
 	e.FromAPI = make(chan APIEvent)
 	e.fromChain = chain.Out()
-	e.fromMsg = msg.Out()
+	e.fromMsg = msg.Inbox()
 
 	e.toApi = make(chan ObjectiveChangeEvent, 100)
 	// bind to outbound chans
 	e.toChain = chain.In()
-	e.toMsg = msg.In()
+	e.toMsg = msg.Outbox()
 
 	// initialize a Logger
 	logPrefix := e.store.GetAddress().String()[0:8] + ": "

--- a/client/engine/messageservice/messageservice.go
+++ b/client/engine/messageservice/messageservice.go
@@ -4,8 +4,8 @@ package messageservice // import "github.com/statechannels/go-nitro/client/messa
 import "github.com/statechannels/go-nitro/protocols"
 
 type MessageService interface {
-	// Out returns a chan for recieving messages from the message service
-	Out() <-chan protocols.Message
-	// In returns a chan for sending messages to the message service
-	In() chan<- protocols.Message
+	// Inbox returns a chan for recieving messages from the message service
+	Inbox() <-chan protocols.Message
+	// Outbox returns a chan for sending messages to the message service
+	Outbox() chan<- protocols.Message
 }

--- a/client/engine/messageservice/test-messageservice.go
+++ b/client/engine/messageservice/test-messageservice.go
@@ -20,8 +20,8 @@ type TestMessageService struct {
 	address types.Address
 
 	// connection to Engine:
-	in  chan protocols.Message // for recieving messages from engine
-	out chan protocols.Message // for sending message to engine
+	outbox chan protocols.Message // for recieving messages from engine
+	inbox  chan protocols.Message // for sending message to engine
 }
 
 type Broker struct {
@@ -40,26 +40,26 @@ func NewBroker() Broker {
 func NewTestMessageService(address types.Address, broker Broker) TestMessageService {
 	tms := TestMessageService{
 		address: address,
-		in:      make(chan protocols.Message, 5),
-		out:     make(chan protocols.Message, 5),
+		outbox:  make(chan protocols.Message, 5),
+		inbox:   make(chan protocols.Message, 5),
 	}
 
 	tms.Connect(broker)
 	return tms
 }
 
-func (t TestMessageService) Out() <-chan protocols.Message {
-	return t.out
+func (t TestMessageService) Inbox() <-chan protocols.Message {
+	return t.inbox
 }
 
-func (t TestMessageService) In() chan<- protocols.Message {
-	return t.in
+func (t TestMessageService) Outbox() chan<- protocols.Message {
+	return t.outbox
 }
 
 // Connect creates a gochan for message service to send messages to the given peer.
 func (t TestMessageService) Connect(b Broker) {
 	go func() {
-		for message := range t.in {
+		for message := range t.outbox {
 			peerChan, ok := b.services[message.To]
 			if ok {
 				msg, err := message.Serialize()
@@ -70,7 +70,7 @@ func (t TestMessageService) Connect(b Broker) {
 				if err != nil {
 					panic(`could not deserialize message`)
 				}
-				peerChan.out <- m
+				peerChan.inbox <- m
 			} else {
 				panic(fmt.Sprintf("client %v has no connection to client %v",
 					t.address, message.To))

--- a/client/engine/messageservice/test-messageservice_test.go
+++ b/client/engine/messageservice/test-messageservice_test.go
@@ -21,11 +21,11 @@ var aToB protocols.Message = protocols.Message{
 }
 
 func TestConnect(t *testing.T) {
-	bobOut := bobMS.Out()
+	bobIn := bobMS.Inbox()
 
-	aliceMS.in <- aToB
+	aliceMS.outbox <- aToB
 
-	got := <-bobOut
+	got := <-bobIn
 
 	if got.ObjectiveId != testId {
 		t.Errorf("expected bob to recieve ObjectiveId %v, but recieved %v",


### PR DESCRIPTION
Note how this is now consistent with "bind to inbound/outbound chans" in engine.go