### PR TITLE
Client now sends Objective Requests to engine instead of Objectives

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -3,9 +3,7 @@ package client // import "github.com/statechannels/go-nitro/client"
 
 import (
 	"io"
-	"math/rand"
 
-	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client/engine"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
@@ -62,17 +60,8 @@ func (c *Client) CompletedObjectives() <-chan protocols.ObjectiveId {
 }
 
 // CreateVirtualChannel creates a virtual channel with the counterParty using ledger channels with the intermediary.
-func (c *Client) CreateVirtualChannel(counterParty types.Address, intermediary types.Address, appDefinition types.Address, appData types.Bytes, outcome outcome.Exit, challengeDuration *types.Uint256) protocols.ObjectiveId {
-	objectiveRequest := virtualfund.ObjectiveRequest{
-		MyAddress:         *c.Address,
-		CounterParty:      counterParty,
-		Intermediary:      intermediary,
-		AppDefinition:     appDefinition,
-		AppData:           appData,
-		Outcome:           outcome,
-		ChallengeDuration: challengeDuration,
-		Nonce:             rand.Int63(), // TODO: Proper nonce management!
-	}
+func (c *Client) CreateVirtualChannel(objectiveRequest virtualfund.ObjectiveRequest) protocols.ObjectiveId {
+
 	apiEvent := engine.APIEvent{
 		ObjectiveToSpawn: objectiveRequest,
 	}
@@ -83,17 +72,8 @@ func (c *Client) CreateVirtualChannel(counterParty types.Address, intermediary t
 }
 
 // CreateDirectChannel creates a directly funded channel with the given counterparty
-func (c *Client) CreateDirectChannel(counterparty types.Address, appDefinition types.Address, appData types.Bytes, outcome outcome.Exit, challengeDuration *types.Uint256) protocols.ObjectiveId {
-	// Convert the API call into an internal event.
-	objectiveRequest := directfund.ObjectiveRequest{
-		MyAddress:         *c.Address,
-		CounterParty:      counterparty,
-		AppDefinition:     appDefinition,
-		AppData:           appData,
-		Outcome:           outcome,
-		ChallengeDuration: challengeDuration,
-		Nonce:             rand.Int63(), // TODO: Proper nonce management!
-	}
+func (c *Client) CreateDirectChannel(objectiveRequest directfund.ObjectiveRequest) protocols.ObjectiveId {
+
 	apiEvent := engine.APIEvent{
 		ObjectiveToSpawn: objectiveRequest,
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -21,7 +21,6 @@ type Client struct {
 	engine              engine.Engine // The core business logic of the client
 	Address             *types.Address
 	completedObjectives chan protocols.ObjectiveId
-	store               *store.Store
 }
 
 // New is the constructor for a Client. It accepts a messaging service, a chain service, and a store as injected dependencies.
@@ -30,7 +29,7 @@ func New(messageService messageservice.MessageService, chainservice chainservice
 	c.Address = store.GetAddress()
 	c.engine = engine.New(messageService, chainservice, store, logDestination)
 	c.completedObjectives = make(chan protocols.ObjectiveId, 100)
-	c.store = &store
+
 	// Start the engine in a go routine
 	go c.engine.Run()
 

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -166,19 +166,24 @@ func (e *Engine) handleAPIEvent(apiEvent APIEvent) ObjectiveChangeEvent {
 		case virtualfund.ObjectiveRequest:
 			vfo, err := virtualfund.SpawnObjective(request, e.store.GetTwoPartyLedger)
 			if err != nil {
-				panic(err)
+				e.logger.Printf("handleAPIEvent: Could not create objective for  %+v", request)
+				return ObjectiveChangeEvent{}
 			}
 			return e.attemptProgress(&vfo)
 
 		case directfund.ObjectiveRequest:
 			dfo, err := directfund.SpawnObjective(request)
 			if err != nil {
-				panic(err)
+				e.logger.Printf("handleAPIEvent: Could not create objective for  %+v", request)
+				return ObjectiveChangeEvent{}
 			}
 			return e.attemptProgress(&dfo)
 
 		default:
-			panic(fmt.Errorf("Unknown objective type %T", request))
+
+			e.logger.Printf("handleAPIEvent: Unknown objective type %T", request)
+			return ObjectiveChangeEvent{}
+
 		}
 
 	}

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -29,11 +29,16 @@ func TestSetGetObjective(t *testing.T) {
 
 	ts := state.TestState
 	ts.TurnNum = 0
-
-	testObj, _ := directfund.NewObjective(false,
-		ts,
-		ts.Participants[0],
-	)
+	request := directfund.ObjectiveRequest{
+		MyAddress:         ts.Participants[0],
+		CounterParty:      ts.Participants[1],
+		AppData:           ts.AppData,
+		AppDefinition:     ts.AppDefinition,
+		ChallengeDuration: ts.ChallengeDuration,
+		Nonce:             ts.ChannelNonce.Int64(),
+		Outcome:           ts.Outcome,
+	}
+	testObj, _ := directfund.NewObjective(request, false)
 
 	if err := ms.SetObjective(&testObj); err != nil {
 		t.Errorf("error setting objective %v: %s", testObj, err.Error())
@@ -57,11 +62,16 @@ func TestGetObjectiveByChannelId(t *testing.T) {
 
 	ts := state.TestState
 	ts.TurnNum = 0
-
-	testObj, _ := directfund.NewObjective(false,
-		ts,
-		ts.Participants[0],
-	)
+	request := directfund.ObjectiveRequest{
+		MyAddress:         ts.Participants[0],
+		CounterParty:      ts.Participants[1],
+		AppData:           ts.AppData,
+		AppDefinition:     ts.AppDefinition,
+		ChallengeDuration: ts.ChallengeDuration,
+		Nonce:             ts.ChannelNonce.Int64(),
+		Outcome:           ts.Outcome,
+	}
+	testObj, _ := directfund.NewObjective(request, false)
 
 	if err := ms.SetObjective(&testObj); err != nil {
 		t.Errorf("error setting objective %v: %s", testObj, err.Error())

--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -3,12 +3,14 @@ package client_test // import "github.com/statechannels/go-nitro/client_test"
 
 import (
 	"math/big"
+	"math/rand"
 	"testing"
 
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
+	"github.com/statechannels/go-nitro/protocols/directfund"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -26,7 +28,16 @@ func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.C
 			},
 		},
 	}}
-	id := alpha.CreateDirectChannel(*beta.Address, types.Address{}, types.Bytes{}, outcome, big.NewInt(0))
+	request := directfund.ObjectiveRequest{
+		MyAddress:         *alpha.Address,
+		CounterParty:      *beta.Address,
+		Outcome:           outcome,
+		AppDefinition:     types.Address{},
+		AppData:           types.Bytes{},
+		ChallengeDuration: big.NewInt(0),
+		Nonce:             rand.Int63(),
+	}
+	id := alpha.CreateDirectChannel(request)
 	waitTimeForCompletedObjectiveIds(t, &alpha, defaultTimeout, id)
 	waitTimeForCompletedObjectiveIds(t, &beta, defaultTimeout, id)
 }

--- a/client_test/virtualfund_integration_test.go
+++ b/client_test/virtualfund_integration_test.go
@@ -2,10 +2,12 @@ package client_test
 
 import (
 	"math/big"
+	"math/rand"
 	"testing"
 
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
+	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -26,8 +28,17 @@ func TestVirtualFundIntegration(t *testing.T) {
 	directlyFundALedgerChannel(t, clientI, clientB)
 
 	outcome := createVirtualOutcome(alice, bob)
-
-	id := clientA.CreateVirtualChannel(bob, irene, types.Address{}, types.Bytes{}, outcome, big.NewInt(0))
+	request := virtualfund.ObjectiveRequest{
+		MyAddress:         alice,
+		CounterParty:      bob,
+		Intermediary:      irene,
+		Outcome:           outcome,
+		AppDefinition:     types.Address{},
+		AppData:           types.Bytes{},
+		ChallengeDuration: big.NewInt(0),
+		Nonce:             rand.Int63(),
+	}
+	id := clientA.CreateVirtualChannel(request)
 
 	waitTimeForCompletedObjectiveIds(t, &clientA, defaultTimeout, id)
 	waitTimeForCompletedObjectiveIds(t, &clientB, defaultTimeout, id)

--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -2,10 +2,12 @@ package client_test
 
 import (
 	"math/big"
+	"math/rand"
 	"testing"
 
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
+	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -26,9 +28,28 @@ func TestMultiPartyVirtualFundIntegration(t *testing.T) {
 	directlyFundALedgerChannel(t, clientAlice, clientIrene)
 	directlyFundALedgerChannel(t, clientIrene, clientBob)
 	directlyFundALedgerChannel(t, clientIrene, clientBrian)
-
-	id := clientAlice.CreateVirtualChannel(bob, irene, types.Address{}, types.Bytes{}, createVirtualOutcome(alice, bob), big.NewInt(0))
-	id2 := clientAlice.CreateVirtualChannel(brian, irene, types.Address{}, types.Bytes{}, createVirtualOutcome(alice, brian), big.NewInt(0))
+	withBobRequest := virtualfund.ObjectiveRequest{
+		MyAddress:         alice,
+		CounterParty:      bob,
+		Intermediary:      irene,
+		Outcome:           createVirtualOutcome(alice, bob),
+		AppDefinition:     types.Address{},
+		AppData:           types.Bytes{},
+		ChallengeDuration: big.NewInt(0),
+		Nonce:             rand.Int63(),
+	}
+	withBrianRequest := virtualfund.ObjectiveRequest{
+		MyAddress:         alice,
+		CounterParty:      brian,
+		Intermediary:      irene,
+		Outcome:           createVirtualOutcome(alice, bob),
+		AppDefinition:     types.Address{},
+		AppData:           types.Bytes{},
+		ChallengeDuration: big.NewInt(0),
+		Nonce:             rand.Int63(),
+	}
+	id := clientAlice.CreateVirtualChannel(withBobRequest)
+	id2 := clientAlice.CreateVirtualChannel(withBrianRequest)
 
 	waitTimeForCompletedObjectiveIds(t, &clientBob, defaultTimeout, id)
 	waitTimeForCompletedObjectiveIds(t, &clientBrian, defaultTimeout, id2)

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -60,7 +60,7 @@ var testState = state.State{
 // TestNew tests the constructor using a TestState fixture
 func TestNew(t *testing.T) {
 	// Assert that valid constructor args do not result in error
-	if _, err := NewObjective(false, testState, testState.Participants[0]); err != nil {
+	if _, err := constructFromState(false, testState, testState.Participants[0]); err != nil {
 		t.Error(err)
 	}
 
@@ -68,19 +68,38 @@ func TestNew(t *testing.T) {
 	finalState := testState.Clone()
 	finalState.IsFinal = true
 
-	if _, err := NewObjective(false, finalState, testState.Participants[0]); err == nil {
+	if _, err := constructFromState(false, finalState, testState.Participants[0]); err == nil {
 		t.Error("expected an error when constructing with an intial state marked final, but got nil")
 	}
 
 	nonParticipant := common.HexToAddress("0x5b53f71453aeCb03D837bfe170570d40aE736CB4")
-	if _, err := NewObjective(false, testState, nonParticipant); err == nil {
+	if _, err := constructFromState(false, testState, nonParticipant); err == nil {
 		t.Error("expected an error when constructing with a participant not in the channel, but got nil")
 	}
 }
 
+func TestConstructFromState(t *testing.T) {
+	// Assert that valid constructor args do not result in error
+	if _, err := constructFromState(false, testState, testState.Participants[0]); err != nil {
+		t.Error(err)
+	}
+
+	// Construct a final state
+	finalState := testState.Clone()
+	finalState.IsFinal = true
+
+	if _, err := constructFromState(false, finalState, testState.Participants[0]); err == nil {
+		t.Error("expected an error when constructing with an intial state marked final, but got nil")
+	}
+
+	nonParticipant := common.HexToAddress("0x5b53f71453aeCb03D837bfe170570d40aE736CB4")
+	if _, err := constructFromState(false, testState, nonParticipant); err == nil {
+		t.Error("expected an error when constructing with a participant not in the channel, but got nil")
+	}
+}
 func TestUpdate(t *testing.T) {
 	// Construct various variables for use in TestUpdate
-	var s, _ = NewObjective(false, testState, testState.Participants[0])
+	var s, _ = constructFromState(false, testState, testState.Participants[0])
 
 	var stateToSign state.State = s.C.PreFundState()
 	var correctSignatureByParticipant, _ = stateToSign.Sign(alice.privateKey)
@@ -135,7 +154,7 @@ func TestUpdate(t *testing.T) {
 func TestCrank(t *testing.T) {
 
 	// BEGIN test data preparation
-	var s, _ = NewObjective(false, testState, testState.Participants[0])
+	var s, _ = constructFromState(false, testState, testState.Participants[0])
 	var correctSignatureByAliceOnPreFund, _ = s.C.PreFundState().Sign(alice.privateKey)
 	var correctSignatureByBobOnPreFund, _ = s.C.PreFundState().Sign(bob.privateKey)
 
@@ -261,7 +280,7 @@ func TestCrank(t *testing.T) {
 }
 
 func TestClone(t *testing.T) {
-	var s, _ = NewObjective(false, testState, testState.Participants[0])
+	var s, _ = constructFromState(false, testState, testState.Participants[0])
 
 	clone := s.clone()
 
@@ -271,7 +290,7 @@ func TestClone(t *testing.T) {
 }
 
 func TestMarshalJSON(t *testing.T) {
-	dfo, _ := NewObjective(false, testState, testState.Participants[0])
+	dfo, _ := constructFromState(false, testState, testState.Participants[0])
 
 	encodedDfo, err := json.Marshal(dfo)
 

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -68,3 +68,8 @@ const (
 	Approved
 	Rejected
 )
+
+// ObjectiveRequest is a request to create a new objective.
+type ObjectiveRequest interface {
+	Id() ObjectiveId
+}

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -286,7 +286,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 		testNew := func(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
 			// Assert that a valid set of constructor args does not result in an error
-			o, err := NewObjective(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			o, err := constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
 			if err != nil {
 				t.Error(err)
 			}
@@ -340,7 +340,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 		testclone := func(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
 
-			o, _ := NewObjective(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			o, _ := constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
 
 			clone := o.clone()
 
@@ -351,7 +351,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 		testCrank := func(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
-			var s, _ = NewObjective(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			var s, _ = constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
 			// Assert that cranking an unapproved objective returns an error
 			if _, _, _, err := s.Crank(&my.privateKey); err == nil {
 				t.Error(`Expected error when cranking unapproved objective, but got nil`)
@@ -486,7 +486,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 		testUpdate := func(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
-			var s, _ = NewObjective(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			var s, _ = constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
 			// Prepare an event with a mismatched objectiveId
 			e := protocols.ObjectiveEvent{
 				ObjectiveId: "some-other-id",

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -163,8 +163,38 @@ type jsonObjective struct {
 	B0 types.Funds
 }
 
-// NewObjective initiates an Objective.
-func NewObjective(
+// NewObjective creates a new virtual funding objective from a given request.
+func NewObjective(request ObjectiveRequest, getTwoPartyLedger GetTwoPartyLedgerFunction) (Objective, error) {
+	right, ok := getTwoPartyLedger(request.MyAddress, request.Intermediary)
+
+	if !ok {
+		return Objective{}, fmt.Errorf("could not find ledger for %s and %s", request.MyAddress, request.Intermediary)
+
+	}
+	var left *channel.TwoPartyLedger
+
+	objective, err := constructFromState(true,
+		state.State{
+			ChainId:           big.NewInt(0), // TODO
+			Participants:      []types.Address{request.MyAddress, request.Intermediary, request.CounterParty},
+			ChannelNonce:      big.NewInt(request.Nonce),
+			ChallengeDuration: request.ChallengeDuration,
+			AppData:           request.AppData,
+			Outcome:           request.Outcome,
+			TurnNum:           0,
+			IsFinal:           false,
+		},
+		request.MyAddress,
+		left, right)
+	if err != nil {
+		return Objective{}, fmt.Errorf("error creating objective: %w", err)
+	}
+	return objective, nil
+
+}
+
+// constructFromState initiates an Objective from an initial state and set of ledgers.
+func constructFromState(
 	preApprove bool,
 	initialStateOfV state.State,
 	myAddress types.Address,
@@ -647,7 +677,7 @@ func ConstructObjectiveFromMessage(m protocols.Message, myAddress types.Address,
 		}
 	}
 
-	return NewObjective(
+	return constructFromState(
 		true, // TODO ensure objective in only approved if the application has given permission somehow
 		initialState,
 		myAddress,
@@ -808,34 +838,4 @@ func (r ObjectiveRequest) Id() protocols.ObjectiveId {
 
 	channelId, _ := fixedPart.ChannelId()
 	return protocols.ObjectiveId(ObjectivePrefix + channelId.String())
-}
-
-// SpawnObjective creates a new virtual funding objective from a given request.
-func SpawnObjective(request ObjectiveRequest, getTwoPartyLedger GetTwoPartyLedgerFunction) (Objective, error) {
-	right, ok := getTwoPartyLedger(request.MyAddress, request.Intermediary)
-
-	if !ok {
-		return Objective{}, fmt.Errorf("could not find ledger for %s and %s", request.MyAddress, request.Intermediary)
-
-	}
-	var left *channel.TwoPartyLedger
-
-	objective, err := NewObjective(true,
-		state.State{
-			ChainId:           big.NewInt(0), // TODO
-			Participants:      []types.Address{request.MyAddress, request.Intermediary, request.CounterParty},
-			ChannelNonce:      big.NewInt(request.Nonce),
-			ChallengeDuration: request.ChallengeDuration,
-			AppData:           request.AppData,
-			Outcome:           request.Outcome,
-			TurnNum:           0,
-			IsFinal:           false,
-		},
-		request.MyAddress,
-		left, right)
-	if err != nil {
-		return Objective{}, fmt.Errorf("error creating objective: %w", err)
-	}
-	return objective, nil
-
 }

--- a/protocols/virtualfund/virtualfund_test.go
+++ b/protocols/virtualfund/virtualfund_test.go
@@ -71,7 +71,7 @@ func TestMarshalJSON(t *testing.T) {
 	ts.TurnNum = channel.PreFundTurnNum
 
 	right, _ := channel.NewTwoPartyLedger(ts, 0)
-	vfo, err := NewObjective(
+	vfo, err := constructFromState(
 		false,
 		vPreFund,
 		alice.address,


### PR DESCRIPTION
The client now sends an `ObjectiveRequest` struct to the engine. The engine is responsible for constructing an `Objective` for this `ObjectiveRequest`.

This removes the need for the `client` to lookup ledger channels in the store and to construct a proper Objective. The `client` now just needs to prepare a simple `ObjectiveRequest` that the engine will handle. The engine can then create the objective using the most recent store data when it's ready to process that request. This fixes #338 as we construct the objective only when the engine is ready to process it.

The protocols now have a `SpawnObjective` function that takes an `ObjectiveRequest` and returns an objective. The engine calls `SpawnObjective` to transform an `ObjectiveRequest` to an `Objective`.

The `ObjectiveRequest` interface has an `Id` function, so the client can easily get the objective Id and return that, without having to construct a full Objective. This also means that the `client` is still responsible for nonce management, since  we need to know the nonce to generate the objective id. For now I think this is ok?

**Note:**  One change is that is easy to miss is the change to use random nonces instead of 0. This allows us to create multiple channels with the same participants.

---

#### Code quality

- [x] I have written clear commit messages
- [ ] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
