### PR TITLE
TestMessageService: remove pairwise connections

### DIFF
--- a/client/engine/messageservice/messageservice.go
+++ b/client/engine/messageservice/messageservice.go
@@ -8,5 +8,4 @@ type MessageService interface {
 	Out() <-chan protocols.Message
 	// In returns a chan for sending messages to the message service
 	In() chan<- protocols.Message
-	Send(message protocols.Message)
 }

--- a/client/engine/messageservice/test-messageservice.go
+++ b/client/engine/messageservice/test-messageservice.go
@@ -50,10 +50,6 @@ func (t TestMessageService) In() chan<- protocols.Message {
 	return t.in
 }
 
-func (t TestMessageService) Send(message protocols.Message) {
-	t.in <- message
-}
-
 // Connect creates a gochan for message service to send messages to the given peer.
 func (t TestMessageService) Connect(peer TestMessageService) {
 	toPeer := make(chan string)

--- a/client/engine/messageservice/test-messageservice.go
+++ b/client/engine/messageservice/test-messageservice.go
@@ -24,6 +24,9 @@ type TestMessageService struct {
 	out chan protocols.Message // for sending message to engine
 }
 
+// A Broker manages a mapping from identifying address to a TestMessageService,
+// allowing messages sent from one message service to be directed to the intended
+// recipient
 type Broker struct {
 	services map[types.Address]TestMessageService
 }
@@ -62,15 +65,18 @@ func (t TestMessageService) Connect(b Broker) {
 		for message := range t.in {
 			peerChan, ok := b.services[message.To]
 			if ok {
-				msg, err := message.Serialize()
+				// To mimic a proper message service, we serialize and then
+				// deserialize the message
+
+				serializedMsg, err := message.Serialize()
 				if err != nil {
 					panic(`could not serialize message`)
 				}
-				m, err := protocols.DeserializeMessage(msg)
+				deserializedMsg, err := protocols.DeserializeMessage(serializedMsg)
 				if err != nil {
 					panic(`could not deserialize message`)
 				}
-				peerChan.out <- m
+				peerChan.out <- deserializedMsg
 			} else {
 				panic(fmt.Sprintf("client %v has no connection to client %v",
 					t.address, message.To))

--- a/client/engine/messageservice/test-messageservice_test.go
+++ b/client/engine/messageservice/test-messageservice_test.go
@@ -23,7 +23,7 @@ func TestConnect(t *testing.T) {
 	bobOut := bobMS.Out()
 
 	aliceMS.Connect(bobMS)
-	aliceMS.Send(aToB)
+	aliceMS.in <- aToB
 
 	got := <-bobOut
 

--- a/client/engine/messageservice/test-messageservice_test.go
+++ b/client/engine/messageservice/test-messageservice_test.go
@@ -8,8 +8,9 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-var aliceMS = NewTestMessageService(types.Address{'a'})
-var bobMS = NewTestMessageService(types.Address{'b'})
+var broker = NewBroker()
+var aliceMS = NewTestMessageService(types.Address{'a'}, broker)
+var bobMS = NewTestMessageService(types.Address{'b'}, broker)
 
 var testId protocols.ObjectiveId = "testObjectiveID"
 
@@ -22,7 +23,6 @@ var aToB protocols.Message = protocols.Message{
 func TestConnect(t *testing.T) {
 	bobOut := bobMS.Out()
 
-	aliceMS.Connect(bobMS)
 	aliceMS.in <- aToB
 
 	got := <-bobOut

--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
+	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -34,11 +35,10 @@ func TestDirectFundIntegration(t *testing.T) {
 	truncateLog(logFile)
 
 	chain := chainservice.NewMockChain()
+	broker := messageservice.NewBroker()
 
-	clientA, messageserviceA := setupClient(aliceKey, chain, logFile)
-	clientB, messageserviceB := setupClient(bobKey, chain, logFile)
-
-	connectMessageServices(messageserviceA, messageserviceB)
+	clientA := setupClient(aliceKey, chain, broker, logFile)
+	clientB := setupClient(bobKey, chain, broker, logFile)
 
 	directlyFundALedgerChannel(t, clientA, clientB)
 

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -61,26 +61,15 @@ func waitForCompletedObjectiveIds(client *client.Client, ids ...protocols.Object
 	}
 }
 
-// connectMessageServices connects the message services together so any message service can communicate with another.
-func connectMessageServices(services ...messageservice.TestMessageService) {
-	for i, ms := range services {
-		for j, ms2 := range services {
-			if i != j {
-				ms.Connect(ms2)
-			}
-		}
-	}
-}
-
 // setupClient is a helper function that contructs a client and returns the new client and message service.
-func setupClient(pk []byte, chain chainservice.MockChain, logFilename string) (client.Client, messageservice.TestMessageService) {
+func setupClient(pk []byte, chain chainservice.MockChain, msgBroker messageservice.Broker, logFilename string) client.Client {
 	myAddress := crypto.GetAddressFromSecretKeyBytes(pk)
 	chain.Subscribe(myAddress)
 	chainservice := chainservice.NewSimpleChainService(chain, myAddress)
-	messageservice := messageservice.NewTestMessageService(myAddress)
+	messageservice := messageservice.NewTestMessageService(myAddress, msgBroker)
 	storeA := store.NewMockStore(pk)
 	logDestination := newLogWriter(logFilename)
-	return client.New(messageservice, chainservice, storeA, logDestination), messageservice
+	return client.New(messageservice, chainservice, storeA, logDestination)
 }
 
 // createVirtualOutcome is a helper function to create the outcome for two participants for a virtual channel.

--- a/client_test/virtualfund_integration_test.go
+++ b/client_test/virtualfund_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
+	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -15,12 +16,11 @@ func TestVirtualFundIntegration(t *testing.T) {
 	truncateLog(logFile)
 
 	chain := chainservice.NewMockChain()
+	broker := messageservice.NewBroker()
 
-	clientA, messageserviceA := setupClient(aliceKey, chain, logFile)
-	clientB, messageserviceB := setupClient(bobKey, chain, logFile)
-	clientI, messageserviceI := setupClient(ireneKey, chain, logFile)
-
-	connectMessageServices(messageserviceA, messageserviceB, messageserviceI)
+	clientA := setupClient(aliceKey, chain, broker, logFile)
+	clientB := setupClient(bobKey, chain, broker, logFile)
+	clientI := setupClient(ireneKey, chain, broker, logFile)
 
 	directlyFundALedgerChannel(t, clientA, clientI)
 	directlyFundALedgerChannel(t, clientI, clientB)

--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
+	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -15,13 +16,12 @@ func TestMultiPartyVirtualFundIntegration(t *testing.T) {
 	truncateLog(logFile)
 
 	chain := chainservice.NewMockChain()
+	broker := messageservice.NewBroker()
 
-	clientAlice, aliceMS := setupClient(aliceKey, chain, logFile)
-	clientBob, bobMS := setupClient(bobKey, chain, logFile)
-	clientBrian, brianMS := setupClient(brianKey, chain, logFile)
-	clientIrene, ireneMS := setupClient(ireneKey, chain, logFile)
-
-	connectMessageServices(aliceMS, bobMS, ireneMS, brianMS)
+	clientAlice := setupClient(aliceKey, chain, broker, logFile)
+	clientBob := setupClient(bobKey, chain, broker, logFile)
+	clientBrian := setupClient(brianKey, chain, broker, logFile)
+	clientIrene := setupClient(ireneKey, chain, broker, logFile)
 
 	directlyFundALedgerChannel(t, clientAlice, clientIrene)
 	directlyFundALedgerChannel(t, clientIrene, clientBob)


### PR DESCRIPTION
Instead of connecting peers in a pairwise fashion, this now defines a Broker struct, which is simply a address -> incoming message channel lookup.

(For some reason, the incoming message channel is called out -- why? This is fixed in https://github.com/statechannels/go-nitro/pull/336)

This makes it easier to create more dynamic test scenarios: each message service is already configured to receive messages when NewTestMessageService returns.