### PR TITLE
Remove workaround for Store

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -203,17 +203,6 @@ func (e *Engine) attemptProgress(objective protocols.Objective) (outgoing Object
 	crankedObjective, sideEffects, waitingFor, _ := objective.Crank(secretKey) // TODO handle error
 	_ = e.store.SetObjective(crankedObjective)                                 // TODO handle error
 
-	// TODO: This is hack to get around the fact that currently each objective in the store has it's own set of channels.
-	vfo, isVirtual := crankedObjective.(*virtualfund.Objective)
-	if isVirtual {
-		if vfo.ToMyLeft != nil {
-			_ = e.store.SetChannel(&vfo.ToMyLeft.Channel.Channel)
-		}
-		if vfo.ToMyRight != nil {
-			_ = e.store.SetChannel(&vfo.ToMyRight.Channel.Channel)
-		}
-	}
-
 	e.executeSideEffects(sideEffects)
 	e.logger.Printf("Objective %s is %s", objective.Id(), waitingFor)
 


### PR DESCRIPTION
Now that the `MockStore` properly stores channels when calling `SetObjective` we can remove the workaround that manually calls `SetChannel`.

This is tested by the existing integration test. 