### PR TITLE
Chain Event now includes BlockNum

### DIFF
--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -11,6 +11,7 @@ type Event struct {
 	ChannelId          types.Destination
 	Holdings           types.Funds // indexed by asset
 	AdjudicationStatus protocols.AdjudicationStatus
+	BlockNum           uint64
 }
 
 type ChainService interface {

--- a/client/engine/chainservice/mockchain.go
+++ b/client/engine/chainservice/mockchain.go
@@ -45,13 +45,15 @@ func (mc *MockChain) Subscribe(a types.Address) {
 
 // Run starts a listener for transactions on the MockChain's in chan.
 func (mc MockChain) Run() {
+	blockNum := uint64(1)
 	for tx := range mc.in {
-		mc.handleTx(tx)
+		mc.handleTx(tx, blockNum)
+		blockNum++
 	}
 }
 
 // handleTx responds to the given tx.
-func (mc MockChain) handleTx(tx protocols.ChainTransaction) {
+func (mc MockChain) handleTx(tx protocols.ChainTransaction, blockNum uint64) {
 	if tx.Deposit.IsNonZero() {
 		mc.holdings[tx.ChannelId] = mc.holdings[tx.ChannelId].Add(tx.Deposit)
 	}
@@ -59,6 +61,7 @@ func (mc MockChain) handleTx(tx protocols.ChainTransaction) {
 		ChannelId:          tx.ChannelId,
 		Holdings:           mc.holdings[tx.ChannelId],
 		AdjudicationStatus: protocols.AdjudicationStatus{TurnNumRecord: 0},
+		BlockNum:           blockNum,
 	}
 	for _, out := range mc.out {
 		attemptSend(out, event)

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -146,7 +146,12 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) ObjectiveChange
 		e.logger.Printf("handleChainEvent: No objective in store for channel with id %s", chainEvent.ChannelId)
 		return ObjectiveChangeEvent{}
 	}
-	event := protocols.ObjectiveEvent{Holdings: chainEvent.Holdings, BlockNum: chainEvent.BlockNum, AdjudicationStatus: chainEvent.AdjudicationStatus, ObjectiveId: objective.Id()}
+	event := protocols.ObjectiveEvent{
+		Holdings:           chainEvent.Holdings,
+		BlockNum:           chainEvent.BlockNum,
+		AdjudicationStatus: chainEvent.AdjudicationStatus,
+		ObjectiveId:        objective.Id(),
+	}
 	updatedObjective, err := objective.Update(event)
 	if err != nil {
 		// TODO handle error

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -146,7 +146,7 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) ObjectiveChange
 		e.logger.Printf("handleChainEvent: No objective in store for channel with id %s", chainEvent.ChannelId)
 		return ObjectiveChangeEvent{}
 	}
-	event := protocols.ObjectiveEvent{Holdings: chainEvent.Holdings, AdjudicationStatus: chainEvent.AdjudicationStatus, ObjectiveId: objective.Id()}
+	event := protocols.ObjectiveEvent{Holdings: chainEvent.Holdings, BlockNum: chainEvent.BlockNum, AdjudicationStatus: chainEvent.AdjudicationStatus, ObjectiveId: objective.Id()}
 	updatedObjective, err := objective.Update(event)
 	if err != nil {
 		// TODO handle error

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -40,6 +40,7 @@ type Objective struct {
 	myDepositSafetyThreshold types.Funds // if the on chain holdings are equal to this amount it is safe for me to deposit
 	myDepositTarget          types.Funds // I want to get the on chain holdings up to this much
 	fullyFundedThreshold     types.Funds // if the on chain holdings are equal
+	latestBlockNumber        uint64      //the latest block number we've seen
 }
 
 // jsonObjective replaces the directfund.Objective's channel pointer with the
@@ -51,6 +52,7 @@ type jsonObjective struct {
 	MyDepositSafetyThreshold types.Funds
 	MyDepositTarget          types.Funds
 	FullyFundedThreshold     types.Funds
+	LatestBlockNumber        uint64
 }
 
 // NewObjective creates a new direct funding objective from a given request.
@@ -161,9 +163,9 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 
 	updated := o.clone()
 	updated.C.AddSignedStates(event.SignedStates)
-
-	if event.Holdings != nil {
-		updated.C.OnChainFunding = event.Holdings
+	if event.Holdings != nil && event.BlockNum > updated.latestBlockNumber {
+		updated.C.OnChainFunding = event.Holdings.Clone()
+		updated.latestBlockNumber = event.BlockNum
 	}
 
 	return &updated, nil
@@ -250,6 +252,7 @@ func (o Objective) MarshalJSON() ([]byte, error) {
 		o.myDepositSafetyThreshold,
 		o.myDepositTarget,
 		o.fullyFundedThreshold,
+		o.latestBlockNumber,
 	}
 	return json.Marshal(jsonDFO)
 }
@@ -278,6 +281,7 @@ func (o *Objective) UnmarshalJSON(data []byte) error {
 	o.fullyFundedThreshold = jsonDFO.FullyFundedThreshold
 	o.myDepositTarget = jsonDFO.MyDepositTarget
 	o.myDepositSafetyThreshold = jsonDFO.MyDepositSafetyThreshold
+	o.latestBlockNumber = jsonDFO.LatestBlockNumber
 
 	return nil
 }
@@ -354,7 +358,7 @@ func (o Objective) clone() Objective {
 	clone.myDepositSafetyThreshold = o.myDepositSafetyThreshold.Clone()
 	clone.myDepositTarget = o.myDepositTarget.Clone()
 	clone.fullyFundedThreshold = o.fullyFundedThreshold.Clone()
-
+	clone.latestBlockNumber = o.latestBlockNumber
 	return clone
 }
 

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -40,7 +40,7 @@ type Objective struct {
 	myDepositSafetyThreshold types.Funds // if the on chain holdings are equal to this amount it is safe for me to deposit
 	myDepositTarget          types.Funds // I want to get the on chain holdings up to this much
 	fullyFundedThreshold     types.Funds // if the on chain holdings are equal
-	latestBlockNumber        uint64      //the latest block number we've seen
+	latestBlockNumber        uint64      // the latest block number we've seen
 }
 
 // jsonObjective replaces the directfund.Objective's channel pointer with the

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -138,8 +138,9 @@ func TestUpdate(t *testing.T) {
 
 	// Finally, add some Holdings information to the event
 	// Updating the objective with this event should overwrite the holdings that are stored
-	newFunding := types.Funds{}
-	newFunding[common.Address{}] = big.NewInt(3)
+	newFunding := types.Funds{
+		common.Address{}: big.NewInt(3),
+	}
 	highBlockNum := uint64(200)
 	updatedObjective, err = s.Update(protocols.ObjectiveEvent{ObjectiveId: s.Id(), Holdings: newFunding, BlockNum: highBlockNum})
 	if err != nil {

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -138,15 +138,34 @@ func TestUpdate(t *testing.T) {
 
 	// Finally, add some Holdings information to the event
 	// Updating the objective with this event should overwrite the holdings that are stored
-	e.Holdings = types.Funds{}
-	e.Holdings[common.Address{}] = big.NewInt(3)
-	updatedObjective, err = s.Update(e)
+	newFunding := types.Funds{}
+	newFunding[common.Address{}] = big.NewInt(3)
+	highBlockNum := uint64(200)
+	updatedObjective, err = s.Update(protocols.ObjectiveEvent{ObjectiveId: s.Id(), Holdings: newFunding, BlockNum: highBlockNum})
 	if err != nil {
 		t.Error(err)
 	}
 	updated = updatedObjective.(*Objective)
-	if !updated.C.OnChainFunding.Equal(e.Holdings) {
+	if !updated.C.OnChainFunding.Equal(newFunding) {
 		t.Error(`Objective data not updated as expected`, updated.C.OnChainFunding, e.Holdings)
+	}
+	if updated.latestBlockNumber != uint64(highBlockNum) {
+		t.Error("Latest block number not updated as expected", updated.latestBlockNumber, highBlockNum)
+	}
+
+	// Update with stale funding information should be ignored
+	staleFunding := types.Funds{}
+	staleFunding[common.Address{}] = big.NewInt(2)
+	lowBlockNum := uint64(100)
+
+	updatedObjective, _ = updated.Update(protocols.ObjectiveEvent{ObjectiveId: s.Id(), Holdings: staleFunding, BlockNum: uint64(lowBlockNum)})
+	updated = updatedObjective.(*Objective)
+
+	if updated.C.OnChainFunding.Equal(staleFunding) {
+		t.Error("OnChainFunding was updated to stale funding information", updated.C.OnChainFunding, staleFunding)
+	}
+	if updated.latestBlockNumber == uint64(lowBlockNum) {
+		t.Error("latestBlockNumber was updated to stale block number", updated.latestBlockNumber, lowBlockNum)
 	}
 
 }

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -45,6 +45,7 @@ type ObjectiveEvent struct {
 	SignedStates       []state.SignedState
 	Holdings           types.Funds // mapping from asset identifier to amount
 	AdjudicationStatus AdjudicationStatus
+	BlockNum           uint64
 }
 
 // Objective is the interface for off-chain protocols.


### PR DESCRIPTION
Fixes #350 

Currently if chain events arrive out of order the direct funding protocol will overwrite a channels `OnChainFunding` with stale information. I was able to run into this scenario when working on integration tests and it seems slightly dangerous to assume chain events will be received in order.

To address I've added a `BlockNum` to the `ChainEvent`. The direct funding protocol can look at the `BlockNum` and determine if chain event funding is new information or stale.

The `MockChain` has been updated to increase the `BlockNum` for every transaction it handles.

`TestUpdate` has been updated to test that we ignore stale block numbers.

---
#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
