### PR TITLE
correct alice's lookup of ledger channels in `ConstructObjectiveFromMessage`

### DIFF
--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -612,16 +612,26 @@ func ConstructObjectiveFromMessage(m protocols.Message, myAddress types.Address,
 	var left *channel.TwoPartyLedger
 	var right *channel.TwoPartyLedger
 	var ok bool
-	if myAddress != bob { // everyone other than bob has a right channel
+
+	switch myAddress {
+	case alice:
 		right, ok = getTwoPartyLedger(alice, intermediary)
 		if !ok {
 			return Objective{}, fmt.Errorf("could not find a right ledger channel between %v and %v", alice, intermediary)
 		}
-	}
-	if myAddress != alice { // everyone other than alice has a left channel
+	case bob:
 		left, ok = getTwoPartyLedger(intermediary, bob)
 		if !ok {
 			return Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", intermediary, bob)
+		}
+	case intermediary:
+		left, ok = getTwoPartyLedger(alice, intermediary)
+		if !ok {
+			return Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", alice, intermediary)
+		}
+		right, ok = getTwoPartyLedger(intermediary, bob)
+		if !ok {
+			return Objective{}, fmt.Errorf("could not find a right ledger channel between %v and %v", intermediary, bob)
 		}
 	}
 

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -613,14 +613,14 @@ func ConstructObjectiveFromMessage(m protocols.Message, myAddress types.Address,
 	var right *channel.TwoPartyLedger
 	var ok bool
 	if alice == myAddress {
-		right, ok = getTwoPartyLedger(intermediary, bob)
+		right, ok = getTwoPartyLedger(alice, intermediary)
 		if !ok {
-			return Objective{}, fmt.Errorf("could not find a right ledger channel between %v and %v", intermediary, bob)
+			return Objective{}, fmt.Errorf("could not find a right ledger channel between %v and %v", alice, intermediary)
 		}
 	} else if bob == myAddress {
 		left, ok = getTwoPartyLedger(intermediary, bob)
 		if !ok {
-			return Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", alice, intermediary)
+			return Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", intermediary, bob)
 		}
 	}
 	if intermediary == myAddress {

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -612,25 +612,16 @@ func ConstructObjectiveFromMessage(m protocols.Message, myAddress types.Address,
 	var left *channel.TwoPartyLedger
 	var right *channel.TwoPartyLedger
 	var ok bool
-	if alice == myAddress {
+	if myAddress != bob { // everyone other than bob has a right channel
 		right, ok = getTwoPartyLedger(alice, intermediary)
 		if !ok {
 			return Objective{}, fmt.Errorf("could not find a right ledger channel between %v and %v", alice, intermediary)
 		}
-	} else if bob == myAddress {
+	}
+	if myAddress != alice { // everyone other than alice has a left channel
 		left, ok = getTwoPartyLedger(intermediary, bob)
 		if !ok {
 			return Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", intermediary, bob)
-		}
-	}
-	if intermediary == myAddress {
-		left, ok = getTwoPartyLedger(alice, intermediary)
-		if !ok {
-			return Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", alice, intermediary)
-		}
-		right, ok = getTwoPartyLedger(intermediary, bob)
-		if !ok {
-			return Objective{}, fmt.Errorf("could not find a right ledger channel between %v and %v", intermediary, bob)
 		}
 	}
 


### PR DESCRIPTION
toward #340

Recommended per-commit read.

**How Has This Been Tested?**

existing test suite failed to find this bug because alice is not called upon to create a virtualfund objective from a message. See #340 for discussion.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [ ] I have assigned this PR to the appropriate GitHub Milestone
  -  ? do one-off / small issues like this need assignment to milestones?
