### PR TITLE
Introduce a rudimentary "benchmarking" test

### DIFF
--- a/client/engine/messageservice/test-messageservice.go
+++ b/client/engine/messageservice/test-messageservice.go
@@ -47,7 +47,7 @@ func NewTestMessageService(address types.Address, broker Broker) TestMessageServ
 		out:     make(chan protocols.Message, 5),
 	}
 
-	tms.Connect(broker)
+	tms.connect(broker)
 	return tms
 }
 
@@ -59,8 +59,8 @@ func (t TestMessageService) In() chan<- protocols.Message {
 	return t.in
 }
 
-// Connect creates a gochan for message service to send messages to the given peer.
-func (t TestMessageService) Connect(b Broker) {
+// connect creates a gochan for message service to send messages to the given peer.
+func (t TestMessageService) connect(b Broker) {
 	go func() {
 		for message := range t.in {
 			peerChan, ok := b.services[message.To]

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -1,7 +1,6 @@
 package client_test
 
 import (
-	"fmt"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -57,7 +56,7 @@ func benchmarkVirtualChannelCreation(t *testing.T, alice, bob client.Client, ire
 	}
 	id := alice.CreateVirtualChannel(request)
 
-	defer elapsed(string(id))()
+	defer elapsed(t, string(id))()
 	waitTimeForCompletedObjectiveIds(t, &alice, defaultTimeout, id)
 	done <- true
 }
@@ -83,9 +82,9 @@ func expect(t *testing.T, done chan bool, num int, timeout time.Duration) {
 	}
 }
 
-func elapsed(what string) func() {
+func elapsed(t *testing.T, what string) func() {
 	start := time.Now()
 	return func() {
-		fmt.Printf("%s took %v\n", what, time.Since(start))
+		t.Logf("%s took %v\n", what, time.Since(start))
 	}
 }

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -30,7 +30,7 @@ func TestBenchmark(t *testing.T) {
 	directlyFundALedgerChannel(t, clientAlice, clientIrene)
 	directlyFundALedgerChannel(t, clientIrene, clientBob)
 
-	done := make(chan bool)
+	done := make(chan interface{})
 
 	n := 3
 	for i := 0; i < n; i++ {
@@ -40,7 +40,7 @@ func TestBenchmark(t *testing.T) {
 	expect(t, done, n,  time.Second*1)
 }
 
-func benchmarkVirtualChannelCreation(t *testing.T, alice, bob client.Client, irene types.Address, done chan bool) {
+func benchmarkVirtualChannelCreation(t *testing.T, alice, bob client.Client, irene types.Address, done chan interface{}) {
 	outcome := createVirtualOutcome(*alice.Address, *bob.Address)
 	request := virtualfund.ObjectiveRequest{
 		MyAddress:         *alice.Address,
@@ -58,7 +58,7 @@ func benchmarkVirtualChannelCreation(t *testing.T, alice, bob client.Client, ire
 
 	for got := range bob.CompletedObjectives() {
 		if got == id {
-			done <- true
+			done <- nil
 			return
 		}
 	}
@@ -69,7 +69,7 @@ func benchmarkVirtualChannelCreation(t *testing.T, alice, bob client.Client, ire
 // To ensure it eventually returns, it will error after a timeout, which resets
 // whenever `done` receives a message. So, it will return after at most
 // `num * defaultTimeout` time has elapsed.
-func expect(t *testing.T, done chan bool, num int, timeout time.Duration) {
+func expect(t *testing.T, done chan interface{}, num int, timeout time.Duration) {
 	count := 0
 	for {
 		select {

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -1,0 +1,79 @@
+package client_test
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/statechannels/go-nitro/client"
+	"github.com/statechannels/go-nitro/client/engine/chainservice"
+	"github.com/statechannels/go-nitro/client/engine/messageservice"
+	"github.com/statechannels/go-nitro/types"
+)
+
+// TestBenchmark sets up three clients, then runs a virtual funding benchmark, printing the duration
+// to the screen.
+func TestBenchmark(t *testing.T) {
+
+	logFile := "virtualfund_benchmark_test.log"
+	truncateLog(logFile)
+
+	chain := chainservice.NewMockChain()
+	broker := messageservice.NewBroker()
+
+	clientAlice := setupClient(aliceKey, chain, broker, logFile)
+	clientBob := setupClient(bobKey, chain, broker, logFile)
+	clientIrene := setupClient(ireneKey, chain, broker, logFile)
+
+	directlyFundALedgerChannel(t, clientAlice, clientIrene)
+	directlyFundALedgerChannel(t, clientIrene, clientBob)
+
+	done := make(chan bool)
+
+	go benchmarkVirtualChannelCreation(t, clientAlice, clientBob, irene, done)
+	// Once the wallet can safely handle multiple virtual channel creations, we
+	// can do things like the following:
+	// go benchmarkVirtualChannelCreation(t, clientAlice, clientBob, irene, done)
+	// go benchmarkVirtualChannelCreation(t, clientAlice, clientBob, irene, done)
+	// expect(t, done, 3)
+
+	expect(t, done, 1, time.Millisecond*10)
+}
+
+func benchmarkVirtualChannelCreation(t *testing.T, alice, bob client.Client, irene types.Address, done chan bool) {
+	outcome := createVirtualOutcome(*alice.Address, *bob.Address)
+	id := alice.CreateVirtualChannel(*bob.Address, irene, types.Address{}, types.Bytes{}, outcome, big.NewInt(0))
+
+	defer elapsed(string(id))()
+	waitTimeForCompletedObjectiveIds(t, &alice, defaultTimeout, id)
+	done <- true
+}
+
+// Returns after `done` has received `num` messages.
+//
+// To ensure it eventually returns, it will error after a timeout, which resets
+// whenever `done` receives a message. So, it will return after at most
+// `num * defaultTimeout` time has elapsed.
+func expect(t *testing.T, done chan bool, num int, timeout time.Duration) {
+	count := 0
+	for {
+		select {
+		case <-done:
+			count += 1
+			if count == num {
+				return
+			}
+		case <-time.After(timeout):
+			t.Errorf("Ran out of time. %v out of %v completed", count, num)
+			t.FailNow()
+		}
+	}
+}
+
+func elapsed(what string) func() {
+	start := time.Now()
+	return func() {
+		fmt.Printf("%s took %v\n", what, time.Since(start))
+	}
+}

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -37,7 +37,7 @@ func TestBenchmark(t *testing.T) {
 		go benchmarkVirtualChannelCreation(t, clientAlice, clientBob, irene, done)
 	}
 
-	expect(t, done, n,  time.Second*1)
+	expect(t, done, n, time.Second*1)
 }
 
 func benchmarkVirtualChannelCreation(t *testing.T, alice, bob client.Client, irene types.Address, done chan interface{}) {

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -39,7 +39,7 @@ func TestBenchmark(t *testing.T) {
 	// go benchmarkVirtualChannelCreation(t, clientAlice, clientBob, irene, done)
 	// expect(t, done, 3)
 
-	expect(t, done, 1, time.Millisecond*10)
+	expect(t, done, 1, time.Millisecond*1000)
 }
 
 func benchmarkVirtualChannelCreation(t *testing.T, alice, bob client.Client, irene types.Address, done chan bool) {

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -32,7 +32,7 @@ func TestBenchmark(t *testing.T) {
 
 	done := make(chan bool)
 
-	n := 3
+	n := 1
 	for i := 0; i < n; i++ {
 		go benchmarkVirtualChannelCreation(t, clientAlice, clientBob, irene, done)
 	}

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -3,12 +3,14 @@ package client_test
 import (
 	"fmt"
 	"math/big"
+	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
+	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -43,7 +45,17 @@ func TestBenchmark(t *testing.T) {
 
 func benchmarkVirtualChannelCreation(t *testing.T, alice, bob client.Client, irene types.Address, done chan bool) {
 	outcome := createVirtualOutcome(*alice.Address, *bob.Address)
-	id := alice.CreateVirtualChannel(*bob.Address, irene, types.Address{}, types.Bytes{}, outcome, big.NewInt(0))
+	request := virtualfund.ObjectiveRequest{
+		MyAddress:         *alice.Address,
+		CounterParty:      *bob.Address,
+		Intermediary:      irene,
+		Outcome:           outcome,
+		AppDefinition:     types.Address{},
+		AppData:           types.Bytes{},
+		ChallengeDuration: big.NewInt(0),
+		Nonce:             rand.Int63(),
+	}
+	id := alice.CreateVirtualChannel(request)
 
 	defer elapsed(string(id))()
 	waitTimeForCompletedObjectiveIds(t, &alice, defaultTimeout, id)

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -32,14 +32,12 @@ func TestBenchmark(t *testing.T) {
 
 	done := make(chan bool)
 
-	go benchmarkVirtualChannelCreation(t, clientAlice, clientBob, irene, done)
-	// Once the wallet can safely handle multiple virtual channel creations, we
-	// can do things like the following:
-	// go benchmarkVirtualChannelCreation(t, clientAlice, clientBob, irene, done)
-	// go benchmarkVirtualChannelCreation(t, clientAlice, clientBob, irene, done)
-	// expect(t, done, 3)
+	n := 3
+	for i := 0; i < n; i++ {
+		go benchmarkVirtualChannelCreation(t, clientAlice, clientBob, irene, done)
+	}
 
-	expect(t, done, 1, time.Millisecond*1000)
+	expect(t, done, n, time.Millisecond*1000)
 }
 
 func benchmarkVirtualChannelCreation(t *testing.T, alice, bob client.Client, irene types.Address, done chan bool) {

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -32,7 +32,7 @@ func TestBenchmark(t *testing.T) {
 
 	done := make(chan interface{})
 
-	n := 3
+	n := 1
 	for i := 0; i < n; i++ {
 		go benchmarkVirtualChannelCreation(t, clientAlice, clientBob, irene, done)
 	}

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -32,7 +32,7 @@ func TestBenchmark(t *testing.T) {
 
 	done := make(chan bool)
 
-	n := 1
+	n := 3
 	for i := 0; i < n; i++ {
 		go benchmarkVirtualChannelCreation(t, clientAlice, clientBob, irene, done)
 	}
@@ -55,8 +55,13 @@ func benchmarkVirtualChannelCreation(t *testing.T, alice, bob client.Client, ire
 	id := alice.CreateVirtualChannel(request)
 
 	defer elapsed(t, string(id))()
-	waitTimeForCompletedObjectiveIds(t, &alice, defaultTimeout, id)
-	done <- true
+
+	for got := range bob.CompletedObjectives() {
+		if got == id {
+			done <- true
+			return
+		}
+	}
 }
 
 // Returns after `done` has received `num` messages.

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -40,6 +40,9 @@ func TestBenchmark(t *testing.T) {
 	expect(t, done, n, time.Second*1)
 }
 
+// benchmarkVirtualChannelCreation creates a new virtual channel with the given actors, and
+// times how long it takes for the objective to complete (from Bob's point of view)
+// The resulting time is printed to the test runner's output
 func benchmarkVirtualChannelCreation(t *testing.T, alice, bob client.Client, irene types.Address, done chan interface{}) {
 	outcome := createVirtualOutcome(*alice.Address, *bob.Address)
 	request := virtualfund.ObjectiveRequest{

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -37,7 +37,7 @@ func TestBenchmark(t *testing.T) {
 		go benchmarkVirtualChannelCreation(t, clientAlice, clientBob, irene, done)
 	}
 
-	expect(t, done, n, time.Millisecond*1000)
+	expect(t, done, n,  time.Second*1)
 }
 
 func benchmarkVirtualChannelCreation(t *testing.T, alice, bob client.Client, irene types.Address, done chan bool) {


### PR DESCRIPTION
This test asserts that creating one virtual channel takes at most 10ms.

If run locally in verbose mode, it will print how long the VirtualFund objective took to complete:

```
go test ./... -run TestBenchmark -v

...
=== RUN   TestBenchmark
VirtualFund-0xe25bb77c1b36b618f553c1fab4b473c53c2a67a1c63591bdc2a72b244e039fd6 took 6.005875ms
...
```

**How Has This Been Tested?** [Optional]

If you add `time.Sleep(time.Millisecond * 10)` in the body of `benchmarkVirtualChannelCreation`, you will see:

```
➜  go-nitro git:(ags/benchmark) ✗ go test ./... -run TestBenchmark -v

...
=== RUN   TestBenchmark
    virtualfund_benchmark_test.go:68: Ran out of time. 0 out of 1 completed
--- FAIL: TestBenchmark (0.01s)
```

This means that the test will fail in the case where `waitTimeForCompletedObjectiveIds` takes more than 10ms to finish.

#### Code quality

- [ ] I have performed a self-review of my own code

#### Project management

- [ ] I have linked the appropriate github issue
