### PR TITLE
log completed objectives

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -100,6 +100,9 @@ func (e *Engine) Run() {
 		}
 		// Only send out an event if there are changes
 		if len(res.CompletedObjectives) > 0 {
+			for _, obj := range res.CompletedObjectives {
+				e.logger.Printf("Objective %s is complete & returned to API", obj.Id())
+			}
 			e.toApi <- res
 		}
 	}


### PR DESCRIPTION
Engine logger currently logs updates to in-progress objectives, but not the return of a completed objective to the API. This PR adds this "closing" log event for a given objective.

---

#### Code quality

- [ ] I have written clear commit messages
- [ ] I have performed a self-review of my own code
- [ ] This change does not have an unduly wide scope
- [ ] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [ ] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
- [ ] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [ ] I have assigned myself to this PR
- [ ] I have linked the appropriate github issue
- [ ] I have assigned this PR to the appropriate GitHub project
- [ ] I have assigned this PR to the appropriate GitHub Milestone
