### PR TITLE
replace logger date with high-res timestamp...

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -71,7 +71,7 @@ func New(msg messageservice.MessageService, chain chainservice.ChainService, sto
 
 	// initialize a Logger
 	logPrefix := e.store.GetAddress().String()[0:8] + ": "
-	e.logger = log.New(logDestination, logPrefix, log.Ldate|log.Ltime|log.Lshortfile)
+	e.logger = log.New(logDestination, logPrefix, log.Lmicroseconds|log.Lshortfile)
 
 	e.logger.Println("Constructed Engine")
 


### PR DESCRIPTION
Problem: sometimes it is useful to read an individual engine's logged history, but sorting the existing logs groups all of the `handle inbound message` events together, all of the `Sending message` events together, etc.

this change allows, eg, `cat x.log | sort > sorted-x.log` with the good property that each engine's events are in their own chronological list.

It also drops the date stamp just as a line-length reduction.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary


#### Project management

- [x] I have assigned myself to this PR
- [ ] I have linked the appropriate github issue
  - none exists
- [ ] I have assigned this PR to the appropriate GitHub project
  - functionality seems down
- [ ] I have assigned this PR to the appropriate GitHub Milestone
  - functionality seems down
