### PR TITLE
Prohibit `alice` clients from running `virtualfund.ConstructObjectiveFromMessage`

### DIFF
--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -653,6 +653,10 @@ func ConstructObjectiveFromMessage(m protocols.Message, myAddress types.Address,
 	intermediary := participants[1]
 	bob := participants[2]
 
+	if myAddress == alice {
+		return Objective{}, errors.New("participant[0] should not construct objectives from peer messages")
+	}
+
 	var left *channel.TwoPartyLedger
 	var right *channel.TwoPartyLedger
 	var ok bool

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -640,9 +640,10 @@ type GetTwoPartyLedgerFunction func(firstParty types.Address, secondParty types.
 // ConstructObjectiveFromMessage takes in a message and constructs an objective from it.
 // It accepts the message, myAddress, and a function to to retrieve ledgers from a store.
 func ConstructObjectiveFromMessage(m protocols.Message, myAddress types.Address, getTwoPartyLedger GetTwoPartyLedgerFunction) (Objective, error) {
-	if len(m.SignedStates) == 0 {
-		return Objective{}, errors.New("expected at least one signed state in the message")
+	if len(m.SignedStates) != 1 {
+		return Objective{}, errors.New("expected exactly one signed state in the message")
 	}
+
 	initialState := m.SignedStates[0].State()
 	participants := initialState.Participants
 

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -675,6 +675,8 @@ func ConstructObjectiveFromMessage(m protocols.Message, myAddress types.Address,
 		if !ok {
 			return Objective{}, fmt.Errorf("could not find a right ledger channel between %v and %v", intermediary, bob)
 		}
+	} else {
+		return Objective{}, fmt.Errorf("client address not found in an expected participant index")
 	}
 
 	return constructFromState(

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -666,8 +666,7 @@ func ConstructObjectiveFromMessage(m protocols.Message, myAddress types.Address,
 		if !ok {
 			return Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", intermediary, bob)
 		}
-	}
-	if intermediary == myAddress {
+	} else if myAddress == intermediary {
 		left, ok = getTwoPartyLedger(alice, intermediary)
 		if !ok {
 			return Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", alice, intermediary)

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -664,7 +664,7 @@ func ConstructObjectiveFromMessage(m protocols.Message, myAddress types.Address,
 	if myAddress == bob {
 		left, ok = getTwoPartyLedger(intermediary, bob)
 		if !ok {
-			return Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", alice, intermediary)
+			return Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", intermediary, bob)
 		}
 	}
 	if intermediary == myAddress {

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -660,12 +660,8 @@ func ConstructObjectiveFromMessage(m protocols.Message, myAddress types.Address,
 	var left *channel.TwoPartyLedger
 	var right *channel.TwoPartyLedger
 	var ok bool
-	if alice == myAddress {
-		right, ok = getTwoPartyLedger(intermediary, bob)
-		if !ok {
-			return Objective{}, fmt.Errorf("could not find a right ledger channel between %v and %v", intermediary, bob)
-		}
-	} else if bob == myAddress {
+
+	if myAddress == bob {
 		left, ok = getTwoPartyLedger(intermediary, bob)
 		if !ok {
 			return Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", alice, intermediary)

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -653,15 +653,13 @@ func ConstructObjectiveFromMessage(m protocols.Message, myAddress types.Address,
 	intermediary := participants[1]
 	bob := participants[2]
 
-	if myAddress == alice {
-		return Objective{}, errors.New("participant[0] should not construct objectives from peer messages")
-	}
-
 	var left *channel.TwoPartyLedger
 	var right *channel.TwoPartyLedger
 	var ok bool
 
-	if myAddress == bob {
+	if myAddress == alice {
+		return Objective{}, errors.New("participant[0] should not construct objectives from peer messages")
+	} else if myAddress == bob {
 		left, ok = getTwoPartyLedger(intermediary, bob)
 		if !ok {
 			return Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", intermediary, bob)


### PR DESCRIPTION
This PR introduces three validation / sanity checks to `virtualfund.ConstructObjectiveFromMessage`:

- the calling client is not `alice`
- there is exactly one received state
- the calling client **is** one of `bob` or the `intermediary` (participant[1] or [2])

If any of the above is not true, the function returns a zero-objective and an error.

It follows the standup discussion around resolving issue #340.

fixes #340.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
  - discussion point: `virtualfund` has no unit tests?
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
