### PR TITLE
Update GH Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '^1.17.1' # We use the shuffle flag in our tests which was introduced in 1.17
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.1.0
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2.5.2
+        uses: golangci/golangci-lint-action@v3.1.0
 
       - name: Build
         run: go build -v ./...


### PR DESCRIPTION
Two main changes:
# Update the lint action to the most recent version
This should hopefully resolve strange linting bugs we've seen occasionally pop up. I suspect that there was a caching issue where the linter was looking at a stale cache instead of local files. 

# Use a setupgo action with a specfic go version
For some reason after making the first change, I started seeing failures around the `-shuffle` flag we pass into tests. It looks like CI was using an older version of GO. This introduces an action to use a specific version of `go` so we know our go environment will be consistent.