### PR TITLE
Refactor multi-party virtual funding integration test

### DIFF
--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -20,11 +20,11 @@ func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.C
 		Allocations: outcome.Allocations{
 			outcome.Allocation{
 				Destination: types.AddressToDestination(*alpha.Address),
-				Amount:      big.NewInt(5),
+				Amount:      big.NewInt(100),
 			},
 			outcome.Allocation{
 				Destination: types.AddressToDestination(*beta.Address),
-				Amount:      big.NewInt(5),
+				Amount:      big.NewInt(100),
 			},
 		},
 	}}

--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -5,8 +5,10 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
+	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -28,33 +30,39 @@ func TestMultiPartyVirtualFundIntegration(t *testing.T) {
 	directlyFundALedgerChannel(t, clientAlice, clientIrene)
 	directlyFundALedgerChannel(t, clientIrene, clientBob)
 	directlyFundALedgerChannel(t, clientIrene, clientBrian)
-	withBobRequest := virtualfund.ObjectiveRequest{
-		MyAddress:         alice,
-		CounterParty:      bob,
-		Intermediary:      irene,
-		Outcome:           createVirtualOutcome(alice, bob),
+
+	bobIds := createVirtualChannels(&clientAlice, bob, irene, 3)
+	brianIds := createVirtualChannels(&clientAlice, brian, irene, 3)
+	allIds := append(bobIds, brianIds...)
+	waitTimeForCompletedObjectiveIds(t, &clientBob, defaultTimeout, bobIds...)
+	waitTimeForCompletedObjectiveIds(t, &clientBrian, defaultTimeout, brianIds...)
+
+	waitTimeForCompletedObjectiveIds(t, &clientAlice, defaultTimeout, allIds...)
+	waitTimeForCompletedObjectiveIds(t, &clientIrene, defaultTimeout, allIds...)
+}
+
+// createVirtualChannels is a helper function to create virtual channels in bulk
+func createVirtualChannels(client *client.Client, counterParty types.Address, intermediary types.Address, amount uint) []protocols.ObjectiveId {
+	request := virtualfund.ObjectiveRequest{
+		MyAddress:         *client.Address,
+		CounterParty:      counterParty,
+		Intermediary:      intermediary,
+		Outcome:           createVirtualOutcome(*client.Address, counterParty),
 		AppDefinition:     types.Address{},
 		AppData:           types.Bytes{},
 		ChallengeDuration: big.NewInt(0),
 		Nonce:             rand.Int63(),
 	}
-	withBrianRequest := virtualfund.ObjectiveRequest{
-		MyAddress:         alice,
-		CounterParty:      brian,
-		Intermediary:      irene,
-		Outcome:           createVirtualOutcome(alice, bob),
-		AppDefinition:     types.Address{},
-		AppData:           types.Bytes{},
-		ChallengeDuration: big.NewInt(0),
-		Nonce:             rand.Int63(),
+
+	ids := []protocols.ObjectiveId{}
+	for i := 0; i < int(amount); i++ {
+		// Generate a unique nonce for each request
+		request.Nonce = rand.Int63()
+
+		id := client.CreateVirtualChannel(request)
+		ids = append(ids, id)
+
 	}
-	id := clientAlice.CreateVirtualChannel(withBobRequest)
-	id2 := clientAlice.CreateVirtualChannel(withBrianRequest)
-
-	waitTimeForCompletedObjectiveIds(t, &clientBob, defaultTimeout, id)
-	waitTimeForCompletedObjectiveIds(t, &clientBrian, defaultTimeout, id2)
-
-	waitTimeForCompletedObjectiveIds(t, &clientAlice, defaultTimeout, id, id2)
-	waitTimeForCompletedObjectiveIds(t, &clientIrene, defaultTimeout, id, id2)
+	return ids
 
 }


### PR DESCRIPTION
This refactor introduces a helper function `createVirtualChannels` that allows us to create virtual channels in bulk. This is handy to easily scale up or down the amount of virtual channels.