### PR TITLE
Add json marshaling functions for `directdefund`

### DIFF
--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -1,5 +1,5 @@
-// Package directfund implements an off-chain protocol to defund a directly-funded channel.
-package directfund // import "github.com/statechannels/go-nitro/directfund"
+// Package directdefund implements an off-chain protocol to defund a directly-funded channel.
+package directdefund // import "github.com/statechannels/go-nitro/directfund"
 
 import (
 	"errors"

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -1,6 +1,7 @@
 package directdefund
 
 import (
+	"encoding/json"
 	"errors"
 	"math/big"
 	"testing"
@@ -336,5 +337,31 @@ func TestCrankBob(t *testing.T) {
 	expectedSE = protocols.SideEffects{}
 	if diff := cmp.Diff(expectedSE, se); diff != "" {
 		t.Errorf("Side effects mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMarshalJSON(t *testing.T) {
+	ddfo, _ := newTestObjective(true)
+
+	encodedDdfo, err := json.Marshal(ddfo)
+
+	if err != nil {
+		t.Errorf("error encoding directdefund objective %v", ddfo)
+	}
+
+	got := Objective{}
+	if err := got.UnmarshalJSON(encodedDdfo); err != nil {
+		t.Errorf("error unmarshaling test directdefund objective: %s", err.Error())
+	}
+
+	if got.finalTurnNum != ddfo.finalTurnNum {
+		t.Errorf("expected finalTurnNum %d but got %d",
+			ddfo.finalTurnNum, got.finalTurnNum)
+	}
+	if !(got.Status == ddfo.Status) {
+		t.Errorf("expected Status %v but got %v", ddfo.Status, got.Status)
+	}
+	if got.C.Id != ddfo.C.Id {
+		t.Errorf("expected channel Id %s but got %s", ddfo.C.Id, got.C.Id)
 	}
 }

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -1,4 +1,4 @@
-package directfund
+package directdefund
 
 import (
 	"errors"

--- a/protocols/directdefund/serde.go
+++ b/protocols/directdefund/serde.go
@@ -16,7 +16,7 @@ type jsonObjective struct {
 	FinalTurnNum uint64
 }
 
-// MarshalJSON returns a JSON representation of the DirectDeundObjective
+// MarshalJSON returns a JSON representation of the DirectDefundObjective
 //
 // NOTE: Marshal -> Unmarshal is a lossy process. All channel data
 //       (other than Id) from the field C is discarded

--- a/protocols/directdefund/serde.go
+++ b/protocols/directdefund/serde.go
@@ -1,0 +1,57 @@
+package directdefund
+
+import (
+	"encoding/json"
+
+	"github.com/statechannels/go-nitro/channel"
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/types"
+)
+
+// jsonObjective replaces the directdefund.Objective's channel pointer with
+// the channel's ID, making jsonObjective suitable for serialization
+type jsonObjective struct {
+	Status       protocols.ObjectiveStatus
+	C            types.Destination
+	FinalTurnNum uint64
+}
+
+// MarshalJSON returns a JSON representation of the DirectDeundObjective
+//
+// NOTE: Marshal -> Unmarshal is a lossy process. All channel data
+//       (other than Id) from the field C is discarded
+func (o Objective) MarshalJSON() ([]byte, error) {
+	jsonDDFO := jsonObjective{
+		o.Status,
+		o.C.Id,
+		o.finalTurnNum,
+	}
+
+	return json.Marshal(jsonDDFO)
+}
+
+// UnmarshalJSON populates the calling DirectDefundObjective with the
+// json-encoded data
+//
+// NOTE: Marshal -> Unmarshal is a lossy process. All channel data
+//       (other than Id) from the field C is discarded
+func (o *Objective) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
+
+	var jsonDDFO jsonObjective
+	err := json.Unmarshal(data, &jsonDDFO)
+
+	if err != nil {
+		return err
+	}
+
+	o.C = &channel.Channel{}
+
+	o.Status = jsonDDFO.Status
+	o.C.Id = jsonDDFO.C
+	o.finalTurnNum = jsonDDFO.FinalTurnNum
+
+	return nil
+}


### PR DESCRIPTION
Existing `directdefund` protocol was missing its persistence methods. This PR adds them (MarshalJSON, UnmarshalJSON) and a test.

**How Has This Been Tested?** [Optional]

a testDirectDefundObjective is created, serialized, and value-checked.

closes #356
---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
