### PR TITLE
Add a `testdata` package

### DIFF
--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -27,7 +27,7 @@ func TestSetGetObjective(t *testing.T) {
 		t.Errorf("expected not to find the %s objective, but found %v", id, got)
 	}
 
-	want := td.Objectives.Directfund.GenericDFO
+	want := td.Objectives.Directfund.GenericDFO()
 
 	if err := ms.SetObjective(&want); err != nil {
 		t.Errorf("error setting objective %v: %s", want, err.Error())
@@ -49,7 +49,7 @@ func TestGetObjectiveByChannelId(t *testing.T) {
 
 	ms := store.NewMockStore(sk)
 
-	want := td.Objectives.Directfund.GenericDFO
+	want := td.Objectives.Directfund.GenericDFO()
 
 	if err := ms.SetObjective(&want); err != nil {
 		t.Errorf("error setting objective %v: %s", want, err.Error())

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -1,25 +1,25 @@
-package store
+package store_test
 
 import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/go-cmp/cmp"
-	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/client/engine/store"
 	nc "github.com/statechannels/go-nitro/crypto"
+	td "github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols"
-	"github.com/statechannels/go-nitro/protocols/directfund"
 )
 
 func TestNewMockStore(t *testing.T) {
 	sk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
-	NewMockStore(sk)
+	store.NewMockStore(sk)
 }
 
 func TestSetGetObjective(t *testing.T) {
 	sk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
 
-	ms := NewMockStore(sk)
+	ms := store.NewMockStore(sk)
 
 	id := protocols.ObjectiveId("404")
 	got, err := ms.GetObjectiveById(id)
@@ -27,30 +27,19 @@ func TestSetGetObjective(t *testing.T) {
 		t.Errorf("expected not to find the %s objective, but found %v", id, got)
 	}
 
-	ts := state.TestState
-	ts.TurnNum = 0
-	request := directfund.ObjectiveRequest{
-		MyAddress:         ts.Participants[0],
-		CounterParty:      ts.Participants[1],
-		AppData:           ts.AppData,
-		AppDefinition:     ts.AppDefinition,
-		ChallengeDuration: ts.ChallengeDuration,
-		Nonce:             ts.ChannelNonce.Int64(),
-		Outcome:           ts.Outcome,
-	}
-	testObj, _ := directfund.NewObjective(request, false)
+	want := td.Objectives.Directfund.GenericDFO
 
-	if err := ms.SetObjective(&testObj); err != nil {
-		t.Errorf("error setting objective %v: %s", testObj, err.Error())
+	if err := ms.SetObjective(&want); err != nil {
+		t.Errorf("error setting objective %v: %s", want, err.Error())
 	}
 
-	got, err = ms.GetObjectiveById(testObj.Id())
+	got, err = ms.GetObjectiveById(want.Id())
 
 	if err != nil {
 		t.Errorf("expected to find the inserted objective, but didn't: %s", err)
 	}
 
-	if got.Id() != testObj.Id() {
+	if got.Id() != want.Id() {
 		t.Errorf("expected to retrieve same objective Id as was passed in, but didn't")
 	}
 }
@@ -58,34 +47,23 @@ func TestSetGetObjective(t *testing.T) {
 func TestGetObjectiveByChannelId(t *testing.T) {
 	sk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
 
-	ms := NewMockStore(sk)
+	ms := store.NewMockStore(sk)
 
-	ts := state.TestState
-	ts.TurnNum = 0
-	request := directfund.ObjectiveRequest{
-		MyAddress:         ts.Participants[0],
-		CounterParty:      ts.Participants[1],
-		AppData:           ts.AppData,
-		AppDefinition:     ts.AppDefinition,
-		ChallengeDuration: ts.ChallengeDuration,
-		Nonce:             ts.ChannelNonce.Int64(),
-		Outcome:           ts.Outcome,
-	}
-	testObj, _ := directfund.NewObjective(request, false)
+	want := td.Objectives.Directfund.GenericDFO
 
-	if err := ms.SetObjective(&testObj); err != nil {
-		t.Errorf("error setting objective %v: %s", testObj, err.Error())
+	if err := ms.SetObjective(&want); err != nil {
+		t.Errorf("error setting objective %v: %s", want, err.Error())
 	}
 
-	got, ok := ms.GetObjectiveByChannelId(testObj.C.Id)
+	got, ok := ms.GetObjectiveByChannelId(want.C.Id)
 
 	if !ok {
 		t.Errorf("expected to find the inserted objective, but didn't")
 	}
-	if got.Id() != testObj.Id() {
+	if got.Id() != want.Id() {
 		t.Errorf("expected to retrieve same objective Id as was passed in, but didn't")
 	}
-	if diff := cmp.Diff(got, &testObj); diff != "" {
+	if diff := cmp.Diff(got, &want); diff != "" {
 		t.Errorf("expected no diff between set and retrieved objective, but found:\n%s", diff)
 	}
 }
@@ -95,7 +73,7 @@ func TestGetChannelSecretKey(t *testing.T) {
 	sk := common.Hex2Bytes("caab404f975b4620747174a75f08d98b4e5a7053b691b41bcfc0d839d48b7634")
 	pk := common.HexToAddress("0xF5A1BB5607C9D079E46d1B3Dc33f257d937b43BD")
 
-	ms := NewMockStore(sk)
+	ms := store.NewMockStore(sk)
 	key := ms.GetChannelSecretKey()
 
 	msg := []byte("sign this")

--- a/internal/testdata/actors.go
+++ b/internal/testdata/actors.go
@@ -1,0 +1,33 @@
+package td
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/types"
+)
+
+type actor struct {
+	Address    types.Address
+	PrivateKey []byte
+}
+
+func (a actor) Destination() types.Destination {
+	return types.AddressToDestination(a.Address)
+}
+
+type actors struct {
+	Alice actor
+	Bob   actor
+	Brian actor
+	Irene actor
+}
+
+var Actors actors = actors{
+	Alice: actor{
+		common.HexToAddress(`0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE`),
+		common.Hex2Bytes(`2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d`),
+	},
+	Bob: actor{
+		common.HexToAddress(`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`),
+		common.Hex2Bytes(`0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4`),
+	},
+}

--- a/internal/testdata/actors.go
+++ b/internal/testdata/actors.go
@@ -1,4 +1,4 @@
-package td
+package testdata
 
 import (
 	"github.com/ethereum/go-ethereum/common"

--- a/internal/testdata/actors.go
+++ b/internal/testdata/actors.go
@@ -18,8 +18,8 @@ func (a actor) Destination() types.Destination {
 type actors struct {
 	Alice actor
 	Bob   actor
-	Brian actor
-	Irene actor
+	// Brian actor
+	// Irene actor
 }
 
 // Actors is the endpoint for tests to consume constructed statechannel

--- a/internal/testdata/actors.go
+++ b/internal/testdata/actors.go
@@ -14,6 +14,7 @@ func (a actor) Destination() types.Destination {
 	return types.AddressToDestination(a.Address)
 }
 
+// actors namespaces the actors exported for test consumption
 type actors struct {
 	Alice actor
 	Bob   actor
@@ -21,6 +22,8 @@ type actors struct {
 	Irene actor
 }
 
+// Actors is the endpoint for tests to consume constructed statechannel
+// network participants (public-key secret-key pairs)
 var Actors actors = actors{
 	Alice: actor{
 		common.HexToAddress(`0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE`),

--- a/internal/testdata/channels.go
+++ b/internal/testdata/channels.go
@@ -1,0 +1,1 @@
+package td

--- a/internal/testdata/channels.go
+++ b/internal/testdata/channels.go
@@ -1,1 +1,1 @@
-package td
+package testdata

--- a/internal/testdata/doc.go
+++ b/internal/testdata/doc.go
@@ -1,0 +1,3 @@
+// package td (TestData) provides literals and utility functions for generating objects-of-concern
+// (objectives, channels, user-agents, etc) for other test packages.
+package td

--- a/internal/testdata/doc.go
+++ b/internal/testdata/doc.go
@@ -1,3 +1,3 @@
-// package td (TestData) provides literals and utility functions for generating objects-of-concern
+// package testdata (TestData) provides literals and utility functions for generating objects-of-concern
 // (objectives, channels, user-agents, etc) for other test packages.
-package td
+package testdata

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -1,4 +1,4 @@
-package td
+package testdata
 
 import "github.com/statechannels/go-nitro/protocols/directfund"
 

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -1,0 +1,44 @@
+package td
+
+import "github.com/statechannels/go-nitro/protocols/directfund"
+
+// objectiveCollection namespaces literal objectives, precomputed objectives, and
+// procedural objective generators for consumption
+type objectiveCollection struct {
+	Directfund dfoCollection
+	// todo
+	// virtualfund  vfoCollection
+	// todo
+	// directdefund ddfoCollection
+}
+
+type dfoCollection struct {
+	GenericDFO directfund.Objective
+}
+
+// Objectives is the endpoint for tests to consume constructed objectives or
+// objective generating utility functions
+//
+// eg, a test wanting an Irene-Ivan ledger creation objective could import via
+//     testdata.Objectives.twopartyledgers.irene_ivan
+var Objectives objectiveCollection = objectiveCollection{
+	Directfund: dfoCollection{
+		GenericDFO: genericDFO(),
+	},
+}
+
+// genericDFO returns a non-specific directfund.Objective with nonzero data.
+func genericDFO() directfund.Objective {
+	ts := testState
+	request := directfund.ObjectiveRequest{
+		MyAddress:         ts.Participants[0],
+		CounterParty:      ts.Participants[1],
+		AppData:           ts.AppData,
+		AppDefinition:     ts.AppDefinition,
+		ChallengeDuration: ts.ChallengeDuration,
+		Nonce:             ts.ChannelNonce.Int64(),
+		Outcome:           ts.Outcome,
+	}
+	testObj, _ := directfund.NewObjective(request, false)
+	return testObj
+}

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -13,7 +13,8 @@ type objectiveCollection struct {
 }
 
 type dfoCollection struct {
-	GenericDFO directfund.Objective
+	// GenericDFO returns a non-specific directfund.Objective with nonzero data.
+	GenericDFO func() directfund.Objective
 }
 
 // Objectives is the endpoint for tests to consume constructed objectives or
@@ -23,11 +24,10 @@ type dfoCollection struct {
 //     testdata.Objectives.twopartyledgers.irene_ivan
 var Objectives objectiveCollection = objectiveCollection{
 	Directfund: dfoCollection{
-		GenericDFO: genericDFO(),
+		GenericDFO: genericDFO,
 	},
 }
 
-// genericDFO returns a non-specific directfund.Objective with nonzero data.
 func genericDFO() directfund.Objective {
 	ts := testState
 	request := directfund.ObjectiveRequest{

--- a/internal/testdata/states.go
+++ b/internal/testdata/states.go
@@ -1,0 +1,43 @@
+package td
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/types"
+)
+
+var chainId, _ = big.NewInt(0).SetString("9001", 10)
+
+var testOutcome = outcome.Exit{
+	outcome.SingleAssetExit{
+		Asset: types.Address{}, // the native token of the chain
+		Allocations: outcome.Allocations{
+			outcome.Allocation{
+				Destination: Actors.Alice.Destination(),
+				Amount:      big.NewInt(6),
+			},
+			outcome.Allocation{
+				Destination: Actors.Bob.Destination(),
+				Amount:      big.NewInt(4),
+			},
+		},
+	},
+}
+
+var testState = state.State{
+	ChainId: chainId,
+	Participants: []types.Address{
+		Actors.Alice.Address,
+		Actors.Bob.Address,
+	},
+	ChannelNonce:      big.NewInt(37140676580),
+	AppDefinition:     common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),
+	ChallengeDuration: big.NewInt(60),
+	AppData:           []byte{},
+	Outcome:           testOutcome,
+	TurnNum:           5,
+	IsFinal:           false,
+}

--- a/internal/testdata/states.go
+++ b/internal/testdata/states.go
@@ -1,4 +1,4 @@
-package td
+package testdata
 
 import (
 	"math/big"


### PR DESCRIPTION
This is incremental towards #242, and tangentially #370.

Observation from @andrewgordstewart in #370 is that complex literals in Go are not easy to read. My own experience is that they are tedious to write as well.

This tedium, combined with the namespace problems described in #242, make test authoring some combination of non-DRY / painstaking / error prone.

PR includes a test data package inside an `internal` folder. `internal` has a special interpretation from the compiler - the testdata package defined here cannot be imported by other go modules. (ie, filecoin's lotus package could import `go-nitro/client` package but not `go-nitro/internal/testdata`).

PR includes a defined API for testdata, so that data can be made discoverable & is strongly typed. A test looking for `alice`, `bob`, can access them via `td.Actors.Alice`, etc. This API is possibly an overdesign, but note that it can be optionally used - persons should feel free add one-off data points to the `td` namespace, which can be gathered together under the API in the event that a sensible grouping for them becomes apparent.

PR includes a refactor of the existing `mockstore` test, with an intended follow-up enhancement where `mockstore` is tested against virtualfund & directdefund objectives.

Note: suggesting a slight loosening of inline documentation standards here. EG, the `td.actor` type has a convenience `Destination` function which wraps `types.AddressToDestination`. I can personally live with these types of helpers being undocumented because they are not part of `go-nitro`'s exportable API - only persons writing tests for `go-nitro` ought to see them.


---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
