### PR TITLE
Add failing multiparty test

### DIFF
--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -5,8 +5,10 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
+	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -28,33 +30,39 @@ func TestMultiPartyVirtualFundIntegration(t *testing.T) {
 	directlyFundALedgerChannel(t, clientAlice, clientIrene)
 	directlyFundALedgerChannel(t, clientIrene, clientBob)
 	directlyFundALedgerChannel(t, clientIrene, clientBrian)
-	withBobRequest := virtualfund.ObjectiveRequest{
-		MyAddress:         alice,
-		CounterParty:      bob,
-		Intermediary:      irene,
-		Outcome:           createVirtualOutcome(alice, bob),
+
+	bobIds := createVirtualChannels(&clientAlice, bob, irene, 5)
+	brianIds := createVirtualChannels(&clientAlice, brian, irene, 5)
+	allIds := append(bobIds, brianIds...)
+	waitTimeForCompletedObjectiveIds(t, &clientBob, defaultTimeout, bobIds...)
+	waitTimeForCompletedObjectiveIds(t, &clientBrian, defaultTimeout, brianIds...)
+
+	waitTimeForCompletedObjectiveIds(t, &clientAlice, defaultTimeout, allIds...)
+	waitTimeForCompletedObjectiveIds(t, &clientIrene, defaultTimeout, allIds...)
+}
+
+// createVirtualChannels is a helper function to create virtual channels in bulk
+func createVirtualChannels(client *client.Client, counterParty types.Address, intermediary types.Address, amount uint) []protocols.ObjectiveId {
+	request := virtualfund.ObjectiveRequest{
+		MyAddress:         *client.Address,
+		CounterParty:      counterParty,
+		Intermediary:      intermediary,
+		Outcome:           createVirtualOutcome(*client.Address, counterParty),
 		AppDefinition:     types.Address{},
 		AppData:           types.Bytes{},
 		ChallengeDuration: big.NewInt(0),
 		Nonce:             rand.Int63(),
 	}
-	withBrianRequest := virtualfund.ObjectiveRequest{
-		MyAddress:         alice,
-		CounterParty:      brian,
-		Intermediary:      irene,
-		Outcome:           createVirtualOutcome(alice, bob),
-		AppDefinition:     types.Address{},
-		AppData:           types.Bytes{},
-		ChallengeDuration: big.NewInt(0),
-		Nonce:             rand.Int63(),
+
+	ids := []protocols.ObjectiveId{}
+	for i := 0; i < int(amount); i++ {
+		// Generate a unique nonce for each request
+		request.Nonce = rand.Int63()
+
+		id := client.CreateVirtualChannel(request)
+		ids = append(ids, id)
+
 	}
-	id := clientAlice.CreateVirtualChannel(withBobRequest)
-	id2 := clientAlice.CreateVirtualChannel(withBrianRequest)
-
-	waitTimeForCompletedObjectiveIds(t, &clientBob, defaultTimeout, id)
-	waitTimeForCompletedObjectiveIds(t, &clientBrian, defaultTimeout, id2)
-
-	waitTimeForCompletedObjectiveIds(t, &clientAlice, defaultTimeout, id, id2)
-	waitTimeForCompletedObjectiveIds(t, &clientIrene, defaultTimeout, id, id2)
+	return ids
 
 }

--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -15,7 +15,8 @@ import (
 
 // TestMultiPartyVirtualFundIntegration tests the scenario where Alice creates virtual channels with Bob and Brian using Irene as the intermediary.
 func TestMultiPartyVirtualFundIntegration(t *testing.T) {
-
+	// TODO This test fails due to https://github.com/statechannels/go-nitro/issues/366
+	t.Skip()
 	logFile := "virtualfund_multiparty_client_test.log"
 	truncateLog(logFile)
 
@@ -42,6 +43,7 @@ func TestMultiPartyVirtualFundIntegration(t *testing.T) {
 }
 
 // createVirtualChannels is a helper function to create virtual channels in bulk
+//nolint:unused// Skipping the test makes this unused
 func createVirtualChannels(client *client.Client, counterParty types.Address, intermediary types.Address, amount uint) []protocols.ObjectiveId {
 	request := virtualfund.ObjectiveRequest{
 		MyAddress:         *client.Address,


### PR DESCRIPTION
Previously our virtual funding multi-party integration test was passing even though we knew about an [issue](https://github.com/statechannels/go-nitro/issues/366) that would cause it to fail.


This updates the test to create more virtual channels. This is enough to trigger the [ledger funding issue](https://github.com/statechannels/go-nitro/issues/366) as all it takes is one ledger proposal to arrive out of order. 

The test has been skipped to prevent CI from failing.