### PR TITLE
Add message delay to test message service

### DIFF
--- a/client/engine/messageservice/test-messageservice.go
+++ b/client/engine/messageservice/test-messageservice.go
@@ -63,7 +63,10 @@ func (t TestMessageService) In() chan<- protocols.Message {
 	return t.in
 }
 
-func (t TestMessageService) handleMessage(message protocols.Message, b Broker) {
+// dispatchMessage is responsible for dispatching a message to the appropriate peer message service.
+// If there is a mean delay it will wait a random amount of time(based on meanDelay) before sending the message.
+// It serializes and deserializes a message to mimic a real message service.
+func (t TestMessageService) dispatchMessage(message protocols.Message, b Broker) {
 
 	if t.meanDelay > 0 {
 		randomDelay := time.Duration(rand.Int63n(t.meanDelay.Nanoseconds()))
@@ -95,7 +98,7 @@ func (t TestMessageService) connect(b Broker) {
 	go func() {
 		for message := range t.in {
 
-			go t.handleMessage(message, b)
+			go t.dispatchMessage(message, b)
 		}
 
 	}()

--- a/client/engine/messageservice/test-messageservice_test.go
+++ b/client/engine/messageservice/test-messageservice_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 var broker = NewBroker()
-var aliceMS = NewTestMessageService(types.Address{'a'}, broker)
-var bobMS = NewTestMessageService(types.Address{'b'}, broker)
+var aliceMS = NewTestMessageService(types.Address{'a'}, broker, 0)
+var bobMS = NewTestMessageService(types.Address{'b'}, broker, 0)
 
 var testId protocols.ObjectiveId = "testObjectiveID"
 

--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -38,8 +38,8 @@ func TestDirectFundIntegration(t *testing.T) {
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	clientA := setupClient(alice.PrivateKey, chain, broker, logFile)
-	clientB := setupClient(bob.PrivateKey, chain, broker, logFile)
+	clientA := setupClient(alice.PrivateKey, chain, broker, logFile, 0)
+	clientB := setupClient(bob.PrivateKey, chain, broker, logFile, 0)
 
 	directlyFundALedgerChannel(t, clientA, clientB)
 

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -64,11 +64,11 @@ func waitTimeForCompletedObjectiveIds(t *testing.T, client *client.Client, timeo
 }
 
 // setupClient is a helper function that contructs a client and returns the new client and message service.
-func setupClient(pk []byte, chain chainservice.MockChain, msgBroker messageservice.Broker, logFilename string) client.Client {
+func setupClient(pk []byte, chain chainservice.MockChain, msgBroker messageservice.Broker, logFilename string, meanMessageDelay time.Duration) client.Client {
 	myAddress := crypto.GetAddressFromSecretKeyBytes(pk)
 	chain.Subscribe(myAddress)
 	chainservice := chainservice.NewSimpleChainService(chain, myAddress)
-	messageservice := messageservice.NewTestMessageService(myAddress, msgBroker)
+	messageservice := messageservice.NewTestMessageService(myAddress, msgBroker, meanMessageDelay)
 	storeA := store.NewMockStore(pk)
 	logDestination := newLogWriter(logFilename)
 	return client.New(messageservice, chainservice, storeA, logDestination)

--- a/client_test/virtual_fund_message_delay_test.go
+++ b/client_test/virtual_fund_message_delay_test.go
@@ -1,0 +1,65 @@
+package client_test
+
+import (
+	"math/big"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/statechannels/go-nitro/client"
+	"github.com/statechannels/go-nitro/client/engine/chainservice"
+	"github.com/statechannels/go-nitro/client/engine/messageservice"
+	td "github.com/statechannels/go-nitro/internal/testdata"
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/protocols/virtualfund"
+	"github.com/statechannels/go-nitro/types"
+)
+
+const MAX_MESSAGE_DELAY = time.Millisecond * 100
+
+// Since we are delaying messages we allow for slightly more time to complete the objective
+const OBJECTIVE_TIMEOUT = time.Second * 2
+
+func TestVirtualFundWithMessageDelays(t *testing.T) {
+
+	// Set up logging
+	logFile := "virtual_fund_message_delay_test.log"
+	truncateLog(logFile)
+
+	chain := chainservice.NewMockChain()
+	broker := messageservice.NewBroker()
+
+	clientA := setupClient(alice.PrivateKey, chain, broker, logFile, MAX_MESSAGE_DELAY)
+	clientB := setupClient(bob.PrivateKey, chain, broker, logFile, MAX_MESSAGE_DELAY)
+	clientI := setupClient(irene.PrivateKey, chain, broker, logFile, MAX_MESSAGE_DELAY)
+
+	directlyFundALedgerChannel(t, clientA, clientI)
+	directlyFundALedgerChannel(t, clientI, clientB)
+
+	ids := createVirtualChannels(clientA, bob.Address, irene.Address, 5)
+	waitTimeForCompletedObjectiveIds(t, &clientA, OBJECTIVE_TIMEOUT, ids...)
+	waitTimeForCompletedObjectiveIds(t, &clientB, OBJECTIVE_TIMEOUT, ids...)
+	waitTimeForCompletedObjectiveIds(t, &clientI, OBJECTIVE_TIMEOUT, ids...)
+
+}
+
+// createVirtualChannels creates a number of virtual channels between the given parties and returns the objective ids.
+func createVirtualChannels(client client.Client, counterParty types.Address, intermediary types.Address, amountOfChannels uint) []protocols.ObjectiveId {
+	ids := make([]protocols.ObjectiveId, amountOfChannels)
+	for i := uint(0); i < amountOfChannels; i++ {
+		outcome := td.Outcomes.Create(*client.Address, counterParty, 1, 1)
+		request := virtualfund.ObjectiveRequest{
+			MyAddress:         *client.Address,
+			CounterParty:      counterParty,
+			Intermediary:      intermediary,
+			Outcome:           outcome,
+			AppDefinition:     types.Address{},
+			AppData:           types.Bytes{},
+			ChallengeDuration: big.NewInt(0),
+			Nonce:             rand.Int63(),
+		}
+
+		ids[i] = client.CreateVirtualChannel(request)
+	}
+	return ids
+}

--- a/client_test/virtual_fund_message_delay_test.go
+++ b/client_test/virtual_fund_message_delay_test.go
@@ -15,12 +15,13 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-const MAX_MESSAGE_DELAY = time.Millisecond * 100
-
-// Since we are delaying messages we allow for enough time to complete the objective
-const OBJECTIVE_TIMEOUT = time.Second * 2
-
 func TestVirtualFundWithMessageDelays(t *testing.T) {
+
+	const MAX_MESSAGE_DELAY = time.Millisecond * 100
+
+	// Since we are delaying messages we allow for enough time to complete the objective
+	const OBJECTIVE_TIMEOUT = time.Second * 2
+
 	// This test fails due to https://github.com/statechannels/go-nitro/issues/366
 	t.Skip()
 	// Set up logging

--- a/client_test/virtual_fund_message_delay_test.go
+++ b/client_test/virtual_fund_message_delay_test.go
@@ -17,7 +17,7 @@ import (
 
 const MAX_MESSAGE_DELAY = time.Millisecond * 100
 
-// Since we are delaying messages we allow for slightly more time to complete the objective
+// Since we are delaying messages we allow for enough time to complete the objective
 const OBJECTIVE_TIMEOUT = time.Second * 2
 
 func TestVirtualFundWithMessageDelays(t *testing.T) {

--- a/client_test/virtual_fund_message_delay_test.go
+++ b/client_test/virtual_fund_message_delay_test.go
@@ -21,7 +21,8 @@ const MAX_MESSAGE_DELAY = time.Millisecond * 100
 const OBJECTIVE_TIMEOUT = time.Second * 2
 
 func TestVirtualFundWithMessageDelays(t *testing.T) {
-
+	// This test fails due to https://github.com/statechannels/go-nitro/issues/366
+	t.Skip()
 	// Set up logging
 	logFile := "virtual_fund_message_delay_test.log"
 	truncateLog(logFile)
@@ -44,6 +45,7 @@ func TestVirtualFundWithMessageDelays(t *testing.T) {
 }
 
 // createVirtualChannels creates a number of virtual channels between the given parties and returns the objective ids.
+//nolint:unused // unused due to skipped test
 func createVirtualChannels(client client.Client, counterParty types.Address, intermediary types.Address, amountOfChannels uint) []protocols.ObjectiveId {
 	ids := make([]protocols.ObjectiveId, amountOfChannels)
 	for i := uint(0); i < amountOfChannels; i++ {

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -24,9 +24,9 @@ func TestBenchmark(t *testing.T) {
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	clientAlice := setupClient(alice.PrivateKey, chain, broker, logFile)
-	clientBob := setupClient(bob.PrivateKey, chain, broker, logFile)
-	clientIrene := setupClient(irene.PrivateKey, chain, broker, logFile)
+	clientAlice := setupClient(alice.PrivateKey, chain, broker, logFile, 0)
+	clientBob := setupClient(bob.PrivateKey, chain, broker, logFile, 0)
+	clientIrene := setupClient(irene.PrivateKey, chain, broker, logFile, 0)
 
 	directlyFundALedgerChannel(t, clientAlice, clientIrene)
 	directlyFundALedgerChannel(t, clientIrene, clientBob)

--- a/client_test/virtualfund_integration_test.go
+++ b/client_test/virtualfund_integration_test.go
@@ -21,9 +21,9 @@ func TestVirtualFundIntegration(t *testing.T) {
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	clientA := setupClient(alice.PrivateKey, chain, broker, logFile)
-	clientB := setupClient(bob.PrivateKey, chain, broker, logFile)
-	clientI := setupClient(irene.PrivateKey, chain, broker, logFile)
+	clientA := setupClient(alice.PrivateKey, chain, broker, logFile, 0)
+	clientB := setupClient(bob.PrivateKey, chain, broker, logFile, 0)
+	clientI := setupClient(irene.PrivateKey, chain, broker, logFile, 0)
 
 	directlyFundALedgerChannel(t, clientA, clientI)
 	directlyFundALedgerChannel(t, clientI, clientB)

--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -21,10 +21,10 @@ func TestMultiPartyVirtualFundIntegration(t *testing.T) {
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	clientAlice := setupClient(alice.PrivateKey, chain, broker, logFile)
-	clientBob := setupClient(bob.PrivateKey, chain, broker, logFile)
-	clientBrian := setupClient(brian.PrivateKey, chain, broker, logFile)
-	clientIrene := setupClient(irene.PrivateKey, chain, broker, logFile)
+	clientAlice := setupClient(alice.PrivateKey, chain, broker, logFile, 0)
+	clientBob := setupClient(bob.PrivateKey, chain, broker, logFile, 0)
+	clientBrian := setupClient(brian.PrivateKey, chain, broker, logFile, 0)
+	clientIrene := setupClient(irene.PrivateKey, chain, broker, logFile, 0)
 
 	directlyFundALedgerChannel(t, clientAlice, clientIrene)
 	directlyFundALedgerChannel(t, clientIrene, clientBob)


### PR DESCRIPTION
The test message service now accepts a `maxDelay` that can be used to simulate message latency when testing.

The `TestMessageService` handles the message in a separate go routine after reading it from the `t.in` chan. This allows one message to be delayed without blocking the `TestMessageService` from handling other messages. Otherwise we'd simply slow down the `TestMessageService` but not affect the order in which messages are processed.

A new test has been added that takes advantage of the `maxDelay` to reproduce #366. It has been skipped for now.