### PR TITLE
Convert expected guarantees to a getter

### DIFF
--- a/protocols/virtualfund/serde.go
+++ b/protocols/virtualfund/serde.go
@@ -20,9 +20,8 @@ type assetGuarantee struct {
 // jsonConnection is a serialization-friendly struct representation
 // of a Connection
 type jsonConnection struct {
-	Channel            types.Destination
-	ExpectedGuarantees []assetGuarantee
-	GuarnateeInfo      GuaranteeInfo
+	Channel       types.Destination
+	GuarnateeInfo GuaranteeInfo
 }
 
 // MarshalJSON returns a JSON representation of the Connection
@@ -30,14 +29,7 @@ type jsonConnection struct {
 // NOTE: Marshal -> Unmarshal is a lossy process. All channel data
 //       other than the ID is dropped
 func (c Connection) MarshalJSON() ([]byte, error) {
-	guarantees := []assetGuarantee{}
-	for asset, guarantee := range c.ExpectedGuarantees {
-		guarantees = append(guarantees, assetGuarantee{
-			asset,
-			guarantee,
-		})
-	}
-	jsonC := jsonConnection{c.Channel.Id, guarantees, c.GuaranteeInfo}
+	jsonC := jsonConnection{c.Channel.Id, c.GuaranteeInfo}
 	bytes, err := json.Marshal(jsonC)
 
 	if err != nil {
@@ -54,7 +46,6 @@ func (c Connection) MarshalJSON() ([]byte, error) {
 //       (other than Id) is discarded
 func (c *Connection) UnmarshalJSON(data []byte) error {
 	c.Channel = &channel.TwoPartyLedger{}
-	c.ExpectedGuarantees = make(map[types.Address]outcome.Allocation)
 
 	if string(data) == "null" {
 		// populate a well-formed but blank-addressed Connection
@@ -71,10 +62,6 @@ func (c *Connection) UnmarshalJSON(data []byte) error {
 
 	c.Channel.Id = jsonC.Channel
 	c.GuaranteeInfo = jsonC.GuarnateeInfo
-
-	for _, eg := range jsonC.ExpectedGuarantees {
-		c.ExpectedGuarantees[eg.Asset] = eg.Guarantee
-	}
 
 	return nil
 }

--- a/protocols/virtualfund/serde.go
+++ b/protocols/virtualfund/serde.go
@@ -13,7 +13,7 @@ import (
 // of a Connection
 type jsonConnection struct {
 	Channel       types.Destination
-	GuarnateeInfo GuaranteeInfo
+	GuaranteeInfo GuaranteeInfo
 }
 
 // MarshalJSON returns a JSON representation of the Connection
@@ -53,7 +53,7 @@ func (c *Connection) UnmarshalJSON(data []byte) error {
 	}
 
 	c.Channel.Id = jsonC.Channel
-	c.GuaranteeInfo = jsonC.GuarnateeInfo
+	c.GuaranteeInfo = jsonC.GuaranteeInfo
 
 	return nil
 }

--- a/protocols/virtualfund/serde.go
+++ b/protocols/virtualfund/serde.go
@@ -5,17 +5,9 @@ import (
 	"fmt"
 
 	"github.com/statechannels/go-nitro/channel"
-	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
-
-// assetGuarantee is a serialization-friendly representation of
-// map[asset]Allocation
-type assetGuarantee struct {
-	Asset     types.Address
-	Guarantee outcome.Allocation
-}
 
 // jsonConnection is a serialization-friendly struct representation
 // of a Connection

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -309,7 +309,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				}
 			}
 			if (expectedGuaranteeMetadataLeft != outcome.GuaranteeMetadata{}) {
-				gotLeft := o.ToMyLeft.ExpectedGuarantees[types.Address{}] // VState only has one (native) asset represented by the zero address
+				gotLeft := o.ToMyLeft.getExpectedGuarantees()[types.Address{}] // VState only has one (native) asset represented by the zero address
 				expectedEncodedGuaranteeMetadataLeft, _ := expectedGuaranteeMetadataLeft.Encode()
 				wantLeft := outcome.Allocation{
 					Destination:    o.V.Id,
@@ -322,7 +322,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				}
 			}
 			if (expectedGuaranteeMetadataRight != outcome.GuaranteeMetadata{}) {
-				gotRight := o.ToMyRight.ExpectedGuarantees[types.Address{}] // VState only has one (native) asset represented by the zero address
+				gotRight := o.ToMyRight.getExpectedGuarantees()[types.Address{}] // VState only has one (native) asset represented by the zero address
 				expectedEncodedGuaranteeMetadataRight, _ := expectedGuaranteeMetadataRight.Encode()
 				wantRight := outcome.Allocation{
 					Destination:    o.V.Id,

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -364,7 +364,7 @@ func (connection *Connection) insertGuaranteeInfo(a0 types.Funds, b0 types.Funds
 	return nil
 }
 
-// insertExpectedGuaranteesForLedgerChannel mutates the reciever Connection struct.
+// getExpectedGuarantees returns a map of asset addresses to guarantees for a Connection.
 func (connection *Connection) getExpectedGuarantees() map[types.Address]outcome.Allocation {
 	expectedGuaranteesForLedgerChannel := make(map[types.Address]outcome.Allocation)
 	metadata := outcome.GuaranteeMetadata{

--- a/protocols/virtualfund/virtualfund_test.go
+++ b/protocols/virtualfund/virtualfund_test.go
@@ -106,7 +106,7 @@ func TestMarshalJSON(t *testing.T) {
 	}
 
 	if vfo.ToMyLeft != nil {
-		if !reflect.DeepEqual(vfo.ToMyLeft.ExpectedGuarantees, got.ToMyLeft.ExpectedGuarantees) {
+		if !reflect.DeepEqual(vfo.ToMyLeft.getExpectedGuarantees(), got.ToMyLeft.getExpectedGuarantees()) {
 			t.Errorf("expected left-channel guarantees %v, but found %v", vfo.ToMyLeft, got.ToMyLeft)
 		}
 
@@ -117,7 +117,7 @@ func TestMarshalJSON(t *testing.T) {
 	}
 
 	if vfo.ToMyRight != nil {
-		if !reflect.DeepEqual(vfo.ToMyRight.ExpectedGuarantees, got.ToMyRight.ExpectedGuarantees) {
+		if !reflect.DeepEqual(vfo.ToMyRight.getExpectedGuarantees(), got.ToMyRight.getExpectedGuarantees()) {
 			t.Errorf("expected right-channel %v, but found %v", vfo.ToMyRight, got.ToMyRight)
 		}
 


### PR DESCRIPTION
Fixes https://github.com/statechannels/go-nitro/issues/318

The changes in this PR are fairly straightforward. The most interesting bit is the introduction of a `panic`. This seems like the lesser evil compared to the changeset required to return errors from `getExpectedGuarantees`. That option is prototyped in https://github.com/statechannels/go-nitro/compare/expected-guarantee?expand=1.
