### PR TITLE
remove most Equal implementations

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"reflect"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/channel/state"
@@ -134,11 +133,6 @@ func (c *Channel) Clone() *Channel {
 	d.OnChainFunding = c.OnChainFunding.Clone()
 	d.FixedPart = c.FixedPart.Clone()
 	return d
-}
-
-// Equal returns true if the channel is deeply equal to the reciever, false otherwise
-func (c Channel) Equal(d Channel) bool {
-	return reflect.DeepEqual(c, d)
 }
 
 // PreFundState() returns the pre fund setup state for the channel.

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -3,6 +3,7 @@ package channel
 import (
 	"errors"
 	"math/big"
+	"reflect"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -34,7 +35,7 @@ func TestChannel(t *testing.T) {
 		}
 
 		r.latestSupportedStateTurnNum++
-		if r.Equal(*c) {
+		if reflect.DeepEqual(r, *c) {
 			t.Error("Clone: modifying the clone should not modify the original")
 		}
 
@@ -361,7 +362,7 @@ func TestTwoPartyLedger(t *testing.T) {
 		}
 
 		r.latestSupportedStateTurnNum++
-		if r.Channel.Equal(c.Channel) {
+		if reflect.DeepEqual(r.Channel, c.Channel) {
 			t.Error("Clone: modifying the clone should not modify the original")
 		}
 
@@ -396,7 +397,7 @@ func TestSingleHopVirtualChannel(t *testing.T) {
 		}
 
 		r.latestSupportedStateTurnNum++
-		if r.Channel.Equal(c.Channel) {
+		if reflect.DeepEqual(r.Channel, c.Channel) {
 			t.Error("Clone: modifying the clone should not modify the original")
 		}
 

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -13,6 +13,14 @@ import (
 )
 
 func TestChannel(t *testing.T) {
+	compareChannels := func(a, b *Channel) string {
+		return cmp.Diff(*a, *b, cmp.AllowUnexported(*a, big.Int{}, state.SignedState{}))
+	}
+
+	compareStates := func(a, b state.SignedState) string {
+		return cmp.Diff(a, b, cmp.AllowUnexported(a, big.Int{}))
+	}
+
 	s := state.TestState.Clone()
 
 	_, err1 := New(s, 0)
@@ -30,8 +38,9 @@ func TestChannel(t *testing.T) {
 
 	testClone := func(t *testing.T) {
 		r := c.Clone()
-		if diff := cmp.Diff(*r, *c, cmp.Comparer(types.Equal)); diff != "" {
-			t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)
+
+		if diff := compareChannels(c, r); diff != "" {
+			t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
 		}
 
 		r.latestSupportedStateTurnNum++
@@ -287,8 +296,8 @@ func TestChannel(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if diff := cmp.Diff(expectedSignedState, latestSignedState, cmp.Comparer(types.Equal)); diff != "" {
-			t.Fatalf("LatestSignedState: mismatch (-want +got):\n%s", diff)
+		if diff := cmp.Diff(expectedSignedState, latestSignedState, cmp.AllowUnexported(expectedSignedState)); diff != "" {
+			t.Errorf("LatestSignedState: mismatch (-want +got):\n%s", diff)
 		}
 
 		got2 := c.SignedStateForTurnNum[1]
@@ -325,8 +334,9 @@ func TestChannel(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if diff := cmp.Diff(latestSignedState, expectedSignedState, cmp.Comparer(types.Equal)); diff != "" {
-			t.Fatalf("LatestSignedState: mismatch (-want +got):\n%s", diff)
+
+		if diff := compareStates(latestSignedState, expectedSignedState); diff != "" {
+			t.Errorf("LatestSignedState: mismatch (-want +got):\n%s", diff)
 		}
 
 	}
@@ -349,6 +359,10 @@ func TestChannel(t *testing.T) {
 }
 
 func TestTwoPartyLedger(t *testing.T) {
+	compareChannels := func(a, b *TwoPartyLedger) string {
+		return cmp.Diff(*a, *b, cmp.AllowUnexported(*a, big.Int{}, state.SignedState{}, Channel{}))
+	}
+
 	s := state.TestState.Clone()
 	s.TurnNum = 0
 	testClone := func(t *testing.T) {
@@ -357,8 +371,8 @@ func TestTwoPartyLedger(t *testing.T) {
 			t.Fatal(err)
 		}
 		c := r.Clone()
-		if diff := cmp.Diff(*r, *c, cmp.Comparer(types.Equal)); diff != "" {
-			t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)
+		if diff := compareChannels(r, c); diff != "" {
+			t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
 		}
 
 		r.latestSupportedStateTurnNum++
@@ -383,6 +397,10 @@ func TestTwoPartyLedger(t *testing.T) {
 }
 
 func TestSingleHopVirtualChannel(t *testing.T) {
+	compareChannels := func(a, b *SingleHopVirtualChannel) string {
+		return cmp.Diff(*a, *b, cmp.AllowUnexported(*a, big.Int{}, state.SignedState{}, Channel{}))
+	}
+
 	s := state.TestState.Clone()
 	s.Participants = append(s.Participants, s.Participants[0]) // ensure three participants
 	s.TurnNum = 0
@@ -392,8 +410,8 @@ func TestSingleHopVirtualChannel(t *testing.T) {
 			t.Fatal(err)
 		}
 		c := r.Clone()
-		if diff := cmp.Diff(*r, *c, cmp.Comparer(types.Equal)); diff != "" {
-			t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)
+		if diff := compareChannels(r, c); diff != "" {
+			t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
 		}
 
 		r.latestSupportedStateTurnNum++

--- a/channel/ledger.go
+++ b/channel/ledger.go
@@ -26,11 +26,6 @@ func NewTwoPartyLedger(s state.State, myIndex uint) (*TwoPartyLedger, error) {
 	return &TwoPartyLedger{*c}, err
 }
 
-// Equal returns true if the supplied TwoPartyLedger is deeply equal to the receiver, false otherwise.
-func (lc *TwoPartyLedger) Equal(lc2 *TwoPartyLedger) bool {
-	return lc.Channel.Equal(lc2.Channel)
-}
-
 // Clone returns a pointer to a new, deep copy of the receiver, or a nil pointer if the receiver is nil.
 func (lc *TwoPartyLedger) Clone() *TwoPartyLedger {
 	if lc == nil {

--- a/channel/state/signedstate.go
+++ b/channel/state/signedstate.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -123,22 +122,6 @@ func (ss SignedState) Clone() SignedState {
 		state: ss.state.Clone(),
 		sigs:  clonedSigs,
 	}
-}
-
-// Equal returns true if the passed SignedState is deeply equal in value to the receiver.
-func (ss SignedState) Equal(ss2 SignedState) bool {
-	if !ss.state.Equal(ss2.state) {
-		return false
-	}
-	if len(ss.sigs) != len(ss2.sigs) {
-		return false
-	}
-	for i, sig := range ss.sigs {
-		if !bytes.Equal(sig.S, ss2.sigs[i].S) || !bytes.Equal(sig.R, ss2.sigs[i].R) || sig.V != ss2.sigs[i].V {
-			return false
-		}
-	}
-	return true
 }
 
 // MarshalJSON marshals the SignedState into JSON, implementing the Marshaler interface.

--- a/channel/state/signedstate_test.go
+++ b/channel/state/signedstate_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -16,8 +17,8 @@ func TestSignedStateEqual(t *testing.T) {
 	ss2 := NewSignedState(TestState)
 	_ = ss2.AddSignature(sigA)
 
-	if !ss1.Equal(ss2) {
-		t.Fatalf(`expected %v to Equal %v, but it did not`, ss1, ss2)
+	if !reflect.DeepEqual(ss1, ss2) {
+		t.Errorf(`expected %v to Equal %v, but it did not`, ss1, ss2)
 	}
 }
 func TestMergeWithDuplicateSignatures(t *testing.T) {
@@ -47,8 +48,8 @@ func TestMergeWithDuplicateSignatures(t *testing.T) {
 		},
 	}
 
-	if !got.Equal(want) {
-		t.Fatalf(`incorrect merge, got %v, wanted %v`, got, want)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf(`incorrect merge, got %v, wanted %v`, got, want)
 	}
 
 }
@@ -77,8 +78,8 @@ func TestMerge(t *testing.T) {
 		},
 	}
 
-	if !got.Equal(want) {
-		t.Fatalf(`incorrect merge, got %v, wanted %v`, got, want)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf(`incorrect merge, got %v, wanted %v`, got, want)
 	}
 
 }
@@ -109,8 +110,8 @@ func TestJSON(t *testing.T) {
 		}
 		want := ss1
 
-		if !got.Equal(ss1) {
-			t.Fatalf(`incorrect UnmarshalJSON, got %v, wanted %v`, got, want)
+		if !reflect.DeepEqual(got, ss1) {
+			t.Errorf(`incorrect UnmarshalJSON, got %v, wanted %v`, got, want)
 		}
 	})
 

--- a/channel/state/signedstate_test.go
+++ b/channel/state/signedstate_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"encoding/json"
+	"math/big"
 	"reflect"
 	"testing"
 
@@ -118,14 +119,18 @@ func TestJSON(t *testing.T) {
 }
 
 func TestSignedStateClone(t *testing.T) {
+	compareStates := func(a, b SignedState) string {
+		return cmp.Diff(a, b, cmp.AllowUnexported(a, big.Int{}))
+	}
+
 	ss1 := NewSignedState(TestState)
 	sigA, _ := TestState.Sign(common.Hex2Bytes(`caab404f975b4620747174a75f08d98b4e5a7053b691b41bcfc0d839d48b7634`))
 	_ = ss1.AddSignature(sigA)
 
 	clone := ss1.Clone()
 
-	if diff := cmp.Diff(ss1, clone); diff != "" {
-		t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)
+	if diff := compareStates(ss1, clone); diff != "" {
+		t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
 	}
 
 }

--- a/channel/state/signedstate_test.go
+++ b/channel/state/signedstate_test.go
@@ -10,18 +10,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestSignedStateEqual(t *testing.T) {
-	sigA, _ := TestState.Sign(common.Hex2Bytes(`caab404f975b4620747174a75f08d98b4e5a7053b691b41bcfc0d839d48b7634`))
-
-	ss1 := NewSignedState(TestState)
-	_ = ss1.AddSignature(sigA)
-	ss2 := NewSignedState(TestState)
-	_ = ss2.AddSignature(sigA)
-
-	if !reflect.DeepEqual(ss1, ss2) {
-		t.Errorf(`expected %v to Equal %v, but it did not`, ss1, ss2)
-	}
-}
 func TestMergeWithDuplicateSignatures(t *testing.T) {
 	// ss1 has only alice's signature
 	ss1 := NewSignedState(TestState)

--- a/channel/virtual.go
+++ b/channel/virtual.go
@@ -28,11 +28,6 @@ func NewSingleHopVirtualChannel(s state.State, myIndex uint) (*SingleHopVirtualC
 	return &SingleHopVirtualChannel{*c}, err
 }
 
-// Equal returns true if the supplied SingleHopVirtualChannel is deeply equal to the receiver, false otherwise.
-func (v *SingleHopVirtualChannel) Equal(w *SingleHopVirtualChannel) bool {
-	return v.Channel.Equal(w.Channel)
-}
-
 // Clone returns a pointer to a new, deep copy of the receiver, or a nil pointer if the receiver is nil.
 func (v *SingleHopVirtualChannel) Clone() *SingleHopVirtualChannel {
 	if v == nil {

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -15,8 +15,13 @@ import (
 	td "github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/protocols/directfund"
+	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/types"
 )
+
+func compareObjectives(a, b protocols.Objective) string {
+	return cmp.Diff(&a, &b, cmp.AllowUnexported(directfund.Objective{}, virtualfund.Objective{}, channel.Channel{}, big.Int{}, state.SignedState{}))
+}
 
 func TestNewMockStore(t *testing.T) {
 	sk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
@@ -56,16 +61,13 @@ func TestSetGetObjective(t *testing.T) {
 			t.Errorf("expected to retrieve same objective Id as was passed in, but didn't")
 		}
 
-		if diff := cmp.Diff(got, want); diff != "" {
+		if diff := compareObjectives(got, want); diff != "" {
 			t.Errorf("expected no diff between set and retrieved objective, but found:\n%s", diff)
 		}
 	}
 }
 
 func TestGetObjectiveByChannelId(t *testing.T) {
-	compareObjectives := func(a, b protocols.Objective) string {
-		return cmp.Diff(&a, &b, cmp.AllowUnexported(directfund.Objective{}, channel.Channel{}, big.Int{}, state.SignedState{}))
-	}
 
 	sk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
 

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/go-cmp/cmp"
+	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	cc "github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
@@ -13,6 +14,7 @@ import (
 	nc "github.com/statechannels/go-nitro/crypto"
 	td "github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/protocols/directfund"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -61,6 +63,10 @@ func TestSetGetObjective(t *testing.T) {
 }
 
 func TestGetObjectiveByChannelId(t *testing.T) {
+	compareObjectives := func(a, b protocols.Objective) string {
+		return cmp.Diff(&a, &b, cmp.AllowUnexported(directfund.Objective{}, channel.Channel{}, big.Int{}, state.SignedState{}))
+	}
+
 	sk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
 
 	ms := store.NewMockStore(sk)
@@ -87,7 +93,7 @@ func TestGetObjectiveByChannelId(t *testing.T) {
 			if got.Id() != want.Id() {
 				t.Errorf("expected to retrieve same objective Id as was passed in, but didn't")
 			}
-			if diff := cmp.Diff(got, want); diff != "" {
+			if diff := compareObjectives(got, want); diff != "" {
 				t.Errorf("expected no diff between set and retrieved objective, but found:\n%s", diff)
 			}
 		}

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -191,12 +191,6 @@ func (o Objective) Crank(secretKey *[]byte) (Objective, protocols.SideEffects, p
 	return updated, sideEffects, WaitingForNothing, nil
 }
 
-// Equal returns true if the supplied Objective is deeply equal to the receiver.
-func (o Objective) Equal(r Objective) bool {
-	return o.Status == r.Status &&
-		o.C.Equal(*r.C)
-}
-
 // IsDirectDefundObjective inspects a objective id and returns true if the objective id is for a direct defund objective.
 func IsDirectDefundObjective(id protocols.ObjectiveId) bool {
 	return strings.HasPrefix(string(id), ObjectivePrefix)

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -173,6 +173,10 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
+func compareSideEffect(a, b protocols.SideEffects) string {
+	return cmp.Diff(a, b, cmp.AllowUnexported(a, state.SignedState{}))
+}
+
 func TestCrankAlice(t *testing.T) {
 	// The starting channel state is:
 	// - Channel has a non-final consensus state
@@ -206,8 +210,8 @@ func TestCrankAlice(t *testing.T) {
 		},
 		}}
 
-	if diff := cmp.Diff(expectedSE, se); diff != "" {
-		t.Fatalf("Side effects mismatch (-want +got):\n%s", diff)
+	if diff := compareSideEffect(expectedSE, se); diff != "" {
+		t.Errorf("Side effects mismatch (-want +got):\n%s", diff)
 	}
 
 	// The second update and crank. Alice is expected to create a withdrawAll transaction
@@ -295,8 +299,8 @@ func TestCrankBob(t *testing.T) {
 		},
 		}}
 
-	if diff := cmp.Diff(expectedSE, se); diff != "" {
-		t.Fatalf("Side effects mismatch (-want +got):\n%s", diff)
+	if diff := compareSideEffect(expectedSE, se); diff != "" {
+		t.Errorf("Side effects mismatch (-want +got):\n%s", diff)
 	}
 
 	// The second update and crank. Bob is expected to NOT create any transactions or side effects

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -323,15 +323,6 @@ func (o Objective) amountToDeposit() types.Funds {
 	return deposits
 }
 
-// Equal returns true if the supplied Objective is deeply equal to the receiver.
-func (o Objective) Equal(r Objective) bool {
-	return o.Status == r.Status &&
-		o.C.Equal(*r.C) &&
-		o.myDepositSafetyThreshold.Equal(r.myDepositSafetyThreshold) &&
-		o.myDepositTarget.Equal((r.myDepositTarget)) &&
-		o.fullyFundedThreshold.Equal(r.fullyFundedThreshold)
-}
-
 // clone returns a deep copy of the receiver.
 func (o Objective) clone() Objective {
 	clone := Objective{}

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -1,7 +1,6 @@
 package protocols
 
 import (
-	"bytes"
 	"encoding/json"
 
 	"github.com/statechannels/go-nitro/channel/state"
@@ -26,26 +25,6 @@ func DeserializeMessage(s string) (Message, error) {
 	msg := Message{}
 	err := json.Unmarshal([]byte(s), &msg)
 	return msg, err
-}
-
-// Equal returns true if the passed Message is deeply equal in value to the receiver, and false otherwise.
-func (m Message) Equal(n Message) bool {
-	if !bytes.Equal(m.To.Bytes(), n.To.Bytes()) {
-		return false
-	}
-	if m.ObjectiveId != n.ObjectiveId {
-		return false
-	}
-	if len(m.SignedStates) != len(n.SignedStates) {
-		return false
-	}
-	for i, ss := range m.SignedStates {
-		if !ss.Equal(n.SignedStates[i]) {
-			return false
-		}
-	}
-	// TODO handle Proposal field :-/
-	return true
 }
 
 // CreateSignedStateMessages creates a set of messages containing the signed state.

--- a/protocols/messages_test.go
+++ b/protocols/messages_test.go
@@ -1,35 +1,12 @@
 package protocols
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/types"
 )
-
-func TestEquals(t *testing.T) {
-	stateOne := state.TestState.Clone()
-	stateTwo := state.TestState.Clone()
-	stateTwo.TurnNum = 1
-	msg1 := Message{
-		To:          types.Address{'a'},
-		ObjectiveId: `say-hello-to-my-little-friend`,
-		SignedStates: []state.SignedState{
-			state.NewSignedState(stateOne),
-		},
-	}
-
-	msg2 := Message{
-		To:          types.Address{'a'},
-		ObjectiveId: `say-hello-to-my-little-friend`,
-		SignedStates: []state.SignedState{
-			state.NewSignedState(stateTwo),
-		},
-	}
-	if (msg1).Equal(msg2) {
-		t.Error("Equal returned true for two different messages")
-	}
-}
 
 func TestMessage(t *testing.T) {
 
@@ -60,8 +37,8 @@ func TestMessage(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if !got.Equal(want) {
-			t.Fatalf(`incorrect deserialization: got %v wanted %v`, got, want)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf(`incorrect deserialization: got %v wanted %v`, got, want)
 		}
 	})
 

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/big"
+	"reflect"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -156,7 +157,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 	assertSideEffectsContainsMessageWith := func(ses protocols.SideEffects, expectedSignedState state.SignedState, to actor, t *testing.T) {
 		for _, msg := range ses.MessagesToSend {
 			for _, ss := range msg.SignedStates {
-				if ss.Equal(expectedSignedState) && bytes.Equal(msg.To[:], to.address[:]) {
+				if reflect.DeepEqual(ss, expectedSignedState) && bytes.Equal(msg.To[:], to.address[:]) {
 					return
 				}
 			}

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -13,8 +13,13 @@ import (
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/protocols"
+
 	"github.com/statechannels/go-nitro/types"
 )
+
+func compareObjectives(a, b Objective) string {
+	return cmp.Diff(&a, &b, cmp.AllowUnexported(Objective{}, channel.Channel{}, big.Int{}, state.SignedState{}))
+}
 
 // signPreAndPostFundingStates is a test utility function which applies signatures from
 // multiple participants to pre and post fund states
@@ -345,7 +350,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 			clone := o.clone()
 
-			if diff := cmp.Diff(o, clone); diff != "" {
+			if diff := compareObjectives(o, clone); diff != "" {
 				t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)
 			}
 		}

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"reflect"
 	"strings"
 
 	"github.com/statechannels/go-nitro/channel"
@@ -42,21 +41,6 @@ type Connection struct {
 	Channel          *channel.TwoPartyLedger // todo: #420 deprecate in favor of
 	ConsensusChannel *consensus_channel.ConsensusChannel
 	GuaranteeInfo    GuaranteeInfo
-}
-
-// Equal returns true if the Connection pointed to by the supplied pointer is deeply equal to the receiver.
-func (c *Connection) Equal(d *Connection) bool {
-	if c == nil && d == nil {
-		return true
-	}
-	if !c.Channel.Equal(d.Channel) { // todo: #420 replace with a check on ConsensusChannel
-		return false
-	}
-	if !reflect.DeepEqual(c.GuaranteeInfo, d.GuaranteeInfo) {
-		return false
-	}
-	return true
-
 }
 
 // ledgerChannelAffordsExpectedGuarantees returns true if, for the channel inside the connection, and for each asset keying the input variables, the channel can afford the allocation given the funding.
@@ -432,18 +416,6 @@ func (o Objective) fundingComplete() bool {
 		return o.ToMyLeft.ledgerChannelAffordsExpectedGuarantees()
 	}
 
-}
-
-// Equal returns true if the supplied DirectFundObjective is deeply equal to the receiver.
-func (o Objective) Equal(r Objective) bool {
-	return o.Status == r.Status &&
-		o.V.Equal(r.V) &&
-		o.ToMyLeft.Equal(r.ToMyLeft) &&
-		o.ToMyRight.Equal(r.ToMyRight) &&
-		o.n == r.n &&
-		o.MyRole == r.MyRole &&
-		o.a0.Equal(r.a0) &&
-		o.b0.Equal(r.b0)
 }
 
 // Clone returns a deep copy of the receiver.


### PR DESCRIPTION
Most `Equal` implementations are used only in tests. These `Equal` implementations are removed. Other `Equal` implementations are used in application logic, and should be removed in a different PR.

Previously `cmp.Diff` depended on `Equal` being implemented. Now, `cmp.Diff` receives a `AllowUnexported` option, allowing `cmp.Diff` to reflect on specified, unexported options.