### PR TITLE
Migrate `client_test` package to use `testdata`

### DIFF
--- a/client_test/actors_test.go
+++ b/client_test/actors_test.go
@@ -1,15 +1,8 @@
 package client_test
 
-import "github.com/ethereum/go-ethereum/common"
+import "github.com/statechannels/go-nitro/internal/testdata"
 
-var aliceKey = common.Hex2Bytes(`2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d`)
-var alice = common.HexToAddress(`0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE`)
-
-var ireneKey = common.Hex2Bytes(`febb3b74b0b52d0976f6571d555f4ac8b91c308dfa25c7b58d1e6a7c3f50c781`)
-var irene = common.HexToAddress(`0x111A00868581f73AB42FEEF67D235Ca09ca1E8db`)
-
-var bobKey = common.Hex2Bytes(`0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4`)
-var bob = common.HexToAddress(`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`)
-
-var brianKey = common.Hex2Bytes("0aca28ba64679f63d71e671ab4dbb32aaa212d4789988e6ca47da47601c18fe2") //nolint:unused
-var brian = common.HexToAddress("0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01")                       //nolint:unused
+var alice = testdata.Actors.Alice
+var bob = testdata.Actors.Bob
+var irene = testdata.Actors.Irene
+var brian = testdata.Actors.Brian

--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -6,28 +6,18 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
+	"github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols/directfund"
 	"github.com/statechannels/go-nitro/types"
 )
 
 func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.Client) {
 	// Set up an outcome that requires both participants to deposit
-	outcome := outcome.Exit{outcome.SingleAssetExit{
-		Allocations: outcome.Allocations{
-			outcome.Allocation{
-				Destination: types.AddressToDestination(*alpha.Address),
-				Amount:      big.NewInt(5),
-			},
-			outcome.Allocation{
-				Destination: types.AddressToDestination(*beta.Address),
-				Amount:      big.NewInt(5),
-			},
-		},
-	}}
+	outcome := testdata.Outcomes.Create(*alpha.Address, *beta.Address, 5, 5)
+
 	request := directfund.ObjectiveRequest{
 		MyAddress:         *alpha.Address,
 		CounterParty:      *beta.Address,

--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -48,8 +48,8 @@ func TestDirectFundIntegration(t *testing.T) {
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	clientA := setupClient(aliceKey, chain, broker, logFile)
-	clientB := setupClient(bobKey, chain, broker, logFile)
+	clientA := setupClient(alice.PrivateKey, chain, broker, logFile)
+	clientB := setupClient(bob.PrivateKey, chain, broker, logFile)
 
 	directlyFundALedgerChannel(t, clientA, clientB)
 

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -2,20 +2,17 @@ package client_test
 
 import (
 	"log"
-	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	"github.com/statechannels/go-nitro/client/engine/store"
 	"github.com/statechannels/go-nitro/crypto"
 	"github.com/statechannels/go-nitro/protocols"
-	"github.com/statechannels/go-nitro/types"
 )
 
 const defaultTimeout = time.Second
@@ -70,23 +67,6 @@ func setupClient(pk []byte, chain chainservice.MockChain, msgBroker messageservi
 	storeA := store.NewMockStore(pk)
 	logDestination := newLogWriter(logFilename)
 	return client.New(messageservice, chainservice, storeA, logDestination)
-}
-
-// createVirtualOutcome is a helper function to create the outcome for two participants for a virtual channel.
-func createVirtualOutcome(first types.Address, second types.Address) outcome.Exit {
-
-	return outcome.Exit{outcome.SingleAssetExit{
-		Allocations: outcome.Allocations{
-			outcome.Allocation{
-				Destination: types.AddressToDestination(first),
-				Amount:      big.NewInt(1),
-			},
-			outcome.Allocation{
-				Destination: types.AddressToDestination(second),
-				Amount:      big.NewInt(1),
-			},
-		},
-	}}
 }
 
 func truncateLog(logFile string) {

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
+	"github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -44,7 +45,7 @@ func TestBenchmark(t *testing.T) {
 // times how long it takes for the objective to complete (from Bob's point of view)
 // The resulting time is printed to the test runner's output
 func benchmarkVirtualChannelCreation(t *testing.T, alice, bob client.Client, irene types.Address, done chan interface{}) {
-	outcome := createVirtualOutcome(*alice.Address, *bob.Address)
+	outcome := testdata.Outcomes.Create(*alice.Address, *bob.Address, 1, 1)
 	request := virtualfund.ObjectiveRequest{
 		MyAddress:         *alice.Address,
 		CounterParty:      *bob.Address,

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -23,9 +23,9 @@ func TestBenchmark(t *testing.T) {
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	clientAlice := setupClient(aliceKey, chain, broker, logFile)
-	clientBob := setupClient(bobKey, chain, broker, logFile)
-	clientIrene := setupClient(ireneKey, chain, broker, logFile)
+	clientAlice := setupClient(alice.PrivateKey, chain, broker, logFile)
+	clientBob := setupClient(bob.PrivateKey, chain, broker, logFile)
+	clientIrene := setupClient(irene.PrivateKey, chain, broker, logFile)
 
 	directlyFundALedgerChannel(t, clientAlice, clientIrene)
 	directlyFundALedgerChannel(t, clientIrene, clientBob)
@@ -34,7 +34,7 @@ func TestBenchmark(t *testing.T) {
 
 	n := 1
 	for i := 0; i < n; i++ {
-		go benchmarkVirtualChannelCreation(t, clientAlice, clientBob, irene, done)
+		go benchmarkVirtualChannelCreation(t, clientAlice, clientBob, irene.Address, done)
 	}
 
 	expect(t, done, n, time.Second*1)

--- a/client_test/virtualfund_integration_test.go
+++ b/client_test/virtualfund_integration_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
+	td "github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -27,7 +28,7 @@ func TestVirtualFundIntegration(t *testing.T) {
 	directlyFundALedgerChannel(t, clientA, clientI)
 	directlyFundALedgerChannel(t, clientI, clientB)
 
-	outcome := createVirtualOutcome(alice.Address, bob.Address)
+	outcome := td.Outcomes.Create(alice.Address, bob.Address, 1, 1)
 	request := virtualfund.ObjectiveRequest{
 		MyAddress:         alice.Address,
 		CounterParty:      bob.Address,

--- a/client_test/virtualfund_integration_test.go
+++ b/client_test/virtualfund_integration_test.go
@@ -20,18 +20,18 @@ func TestVirtualFundIntegration(t *testing.T) {
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	clientA := setupClient(aliceKey, chain, broker, logFile)
-	clientB := setupClient(bobKey, chain, broker, logFile)
-	clientI := setupClient(ireneKey, chain, broker, logFile)
+	clientA := setupClient(alice.PrivateKey, chain, broker, logFile)
+	clientB := setupClient(bob.PrivateKey, chain, broker, logFile)
+	clientI := setupClient(irene.PrivateKey, chain, broker, logFile)
 
 	directlyFundALedgerChannel(t, clientA, clientI)
 	directlyFundALedgerChannel(t, clientI, clientB)
 
-	outcome := createVirtualOutcome(alice, bob)
+	outcome := createVirtualOutcome(alice.Address, bob.Address)
 	request := virtualfund.ObjectiveRequest{
-		MyAddress:         alice,
-		CounterParty:      bob,
-		Intermediary:      irene,
+		MyAddress:         alice.Address,
+		CounterParty:      bob.Address,
+		Intermediary:      irene.Address,
 		Outcome:           outcome,
 		AppDefinition:     types.Address{},
 		AppData:           types.Bytes{},

--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -20,29 +20,29 @@ func TestMultiPartyVirtualFundIntegration(t *testing.T) {
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	clientAlice := setupClient(aliceKey, chain, broker, logFile)
-	clientBob := setupClient(bobKey, chain, broker, logFile)
-	clientBrian := setupClient(brianKey, chain, broker, logFile)
-	clientIrene := setupClient(ireneKey, chain, broker, logFile)
+	clientAlice := setupClient(alice.PrivateKey, chain, broker, logFile)
+	clientBob := setupClient(bob.PrivateKey, chain, broker, logFile)
+	clientBrian := setupClient(brian.PrivateKey, chain, broker, logFile)
+	clientIrene := setupClient(irene.PrivateKey, chain, broker, logFile)
 
 	directlyFundALedgerChannel(t, clientAlice, clientIrene)
 	directlyFundALedgerChannel(t, clientIrene, clientBob)
 	directlyFundALedgerChannel(t, clientIrene, clientBrian)
 	withBobRequest := virtualfund.ObjectiveRequest{
-		MyAddress:         alice,
-		CounterParty:      bob,
-		Intermediary:      irene,
-		Outcome:           createVirtualOutcome(alice, bob),
+		MyAddress:         alice.Address,
+		CounterParty:      bob.Address,
+		Intermediary:      irene.Address,
+		Outcome:           createVirtualOutcome(alice.Address, bob.Address),
 		AppDefinition:     types.Address{},
 		AppData:           types.Bytes{},
 		ChallengeDuration: big.NewInt(0),
 		Nonce:             rand.Int63(),
 	}
 	withBrianRequest := virtualfund.ObjectiveRequest{
-		MyAddress:         alice,
-		CounterParty:      brian,
-		Intermediary:      irene,
-		Outcome:           createVirtualOutcome(alice, bob),
+		MyAddress:         alice.Address,
+		CounterParty:      brian.Address,
+		Intermediary:      irene.Address,
+		Outcome:           createVirtualOutcome(alice.Address, bob.Address),
 		AppDefinition:     types.Address{},
 		AppData:           types.Bytes{},
 		ChallengeDuration: big.NewInt(0),

--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
+	td "github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -29,20 +30,30 @@ func TestMultiPartyVirtualFundIntegration(t *testing.T) {
 	directlyFundALedgerChannel(t, clientIrene, clientBob)
 	directlyFundALedgerChannel(t, clientIrene, clientBrian)
 	withBobRequest := virtualfund.ObjectiveRequest{
-		MyAddress:         alice.Address,
-		CounterParty:      bob.Address,
-		Intermediary:      irene.Address,
-		Outcome:           createVirtualOutcome(alice.Address, bob.Address),
+		MyAddress:    alice.Address,
+		CounterParty: bob.Address,
+		Intermediary: irene.Address,
+		Outcome: td.Outcomes.Create(
+			alice.Address,
+			bob.Address,
+			1,
+			1,
+		),
 		AppDefinition:     types.Address{},
 		AppData:           types.Bytes{},
 		ChallengeDuration: big.NewInt(0),
 		Nonce:             rand.Int63(),
 	}
 	withBrianRequest := virtualfund.ObjectiveRequest{
-		MyAddress:         alice.Address,
-		CounterParty:      brian.Address,
-		Intermediary:      irene.Address,
-		Outcome:           createVirtualOutcome(alice.Address, bob.Address),
+		MyAddress:    alice.Address,
+		CounterParty: brian.Address,
+		Intermediary: irene.Address,
+		Outcome: td.Outcomes.Create(
+			alice.Address,
+			bob.Address, // BUG: brian.Address? (likely not a matierial difference, or, Brian is just a generous guy)
+			1,
+			1,
+		),
 		AppDefinition:     types.Address{},
 		AppData:           types.Bytes{},
 		ChallengeDuration: big.NewInt(0),

--- a/internal/testdata/actors.go
+++ b/internal/testdata/actors.go
@@ -18,8 +18,8 @@ func (a actor) Destination() types.Destination {
 type actors struct {
 	Alice actor
 	Bob   actor
-	// Brian actor
-	// Irene actor
+	Brian actor
+	Irene actor
 }
 
 // Actors is the endpoint for tests to consume constructed statechannel
@@ -32,5 +32,13 @@ var Actors actors = actors{
 	Bob: actor{
 		common.HexToAddress(`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`),
 		common.Hex2Bytes(`0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4`),
+	},
+	Brian: actor{
+		common.HexToAddress("0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01"),                    //nolint:unused
+		common.Hex2Bytes("0aca28ba64679f63d71e671ab4dbb32aaa212d4789988e6ca47da47601c18fe2"), //nolint:unused
+	},
+	Irene: actor{
+		common.HexToAddress(`0x111A00868581f73AB42FEEF67D235Ca09ca1E8db`),
+		common.Hex2Bytes(`febb3b74b0b52d0976f6571d555f4ac8b91c308dfa25c7b58d1e6a7c3f50c781`),
 	},
 }

--- a/internal/testdata/actors.go
+++ b/internal/testdata/actors.go
@@ -34,8 +34,8 @@ var Actors actors = actors{
 		common.Hex2Bytes(`0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4`),
 	},
 	Brian: actor{
-		common.HexToAddress("0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01"),                    //nolint:unused
-		common.Hex2Bytes("0aca28ba64679f63d71e671ab4dbb32aaa212d4789988e6ca47da47601c18fe2"), //nolint:unused
+		common.HexToAddress("0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01"),
+		common.Hex2Bytes("0aca28ba64679f63d71e671ab4dbb32aaa212d4789988e6ca47da47601c18fe2"),
 	},
 	Irene: actor{
 		common.HexToAddress(`0x111A00868581f73AB42FEEF67D235Ca09ca1E8db`),

--- a/internal/testdata/states.go
+++ b/internal/testdata/states.go
@@ -52,7 +52,7 @@ var testState = state.State{
 	IsFinal:           false,
 }
 
-// createOutcome is a helper function to create the outcome for two participants for a virtual channel.
+// createOutcome is a helper function to create a two-actor outcome
 func createOutcome(first types.Address, second types.Address, x, y uint) outcome.Exit {
 
 	return outcome.Exit{outcome.SingleAssetExit{

--- a/internal/testdata/states.go
+++ b/internal/testdata/states.go
@@ -9,6 +9,16 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
+type outcomes struct {
+	// Create returns a simple outcome {a: aBalance, b: bBalance} in the
+	// zero-asset (chain-native token)
+	Create func(a, b types.Address, aBalance, bBalance uint) outcome.Exit
+}
+
+var Outcomes outcomes = outcomes{
+	Create: createOutcome,
+}
+
 var chainId, _ = big.NewInt(0).SetString("9001", 10)
 
 var testOutcome = outcome.Exit{
@@ -40,4 +50,21 @@ var testState = state.State{
 	Outcome:           testOutcome,
 	TurnNum:           5,
 	IsFinal:           false,
+}
+
+// createOutcome is a helper function to create the outcome for two participants for a virtual channel.
+func createOutcome(first types.Address, second types.Address, x, y uint) outcome.Exit {
+
+	return outcome.Exit{outcome.SingleAssetExit{
+		Allocations: outcome.Allocations{
+			outcome.Allocation{
+				Destination: types.AddressToDestination(first),
+				Amount:      big.NewInt(int64(x)),
+			},
+			outcome.Allocation{
+				Destination: types.AddressToDestination(second),
+				Amount:      big.NewInt(int64(y)),
+			},
+		},
+	}}
 }


### PR DESCRIPTION
More incremental work against #242 & #370

PR strips `client_test` package of some of its in-line literal definitions of network actors & outcomes.

PR moves an `outcome` creation function from `client_test` to `testdata` and generalizes it slightly.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
  - not necessary - refactor only
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 
  - the structs that `testdata` exports are godoc commented. IE, `Outcomes.Create` has a godoc.

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
