### PR TITLE
fix waitTimeForCompletedObjectiveIds

### DIFF
--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -54,7 +54,8 @@ func waitTimeForCompletedObjectiveIds(t *testing.T, client *client.Client, timeo
 	select {
 	case <-time.After(timeout):
 		incompleteIds := make([]protocols.ObjectiveId, 0)
-		for id, isObjectiveDone := range completed {
+		for _, id := range ids {
+			isObjectiveDone := completed[id]
 			if !isObjectiveDone {
 				incompleteIds = append(incompleteIds, id)
 			}


### PR DESCRIPTION
A small [change](https://github.com/statechannels/go-nitro/pull/379#discussion_r833569672) in my PR accidentally caused  `waitTimeForCompletedObjectiveIds` to always return an empty slice of objective ids. Unfortunately I didn't catch this before merging in the PR!

The problem was that we were relying on iterating through the keys of `completed` to construct the objective id slice. By removing the for loop that was setting `completed[i]=false`  `completed` no longer contains keys for all the objective ids.

 This PR fixes this by iterating through the `ids` instead of the `completed` map.