### PR TITLE
upgrade to go 1.18

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.17.1' # We use the shuffle flag in our tests which was introduced in 1.17
+          go-version: '^1.18.0' # We use the shuffle flag in our tests which was introduced in 1.17
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.1.0
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.18.0' # We use the shuffle flag in our tests which was introduced in 1.17
+          go-version: '^1.18.0'
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.1.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/statechannels/go-nitro
 
-go 1.17
+go 1.18
 
 require (
 	github.com/ethereum/go-ethereum v1.10.8


### PR DESCRIPTION
Fixes #371 

Upgrades go to 1.18 so we're ready to use generics/fuzzing.