### PR TITLE
use fatalf over errorf so test fails immediately

### DIFF
--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -30,7 +30,7 @@ func TestChannel(t *testing.T) {
 	testClone := func(t *testing.T) {
 		r := c.Clone()
 		if diff := cmp.Diff(*r, *c, cmp.Comparer(types.Equal)); diff != "" {
-			t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+			t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)
 		}
 
 		r.latestSupportedStateTurnNum++
@@ -60,7 +60,7 @@ func TestChannel(t *testing.T) {
 			t.Error(err2)
 		}
 		if got != want {
-			t.Errorf(`incorrect PreFundState returned, got %v wanted %v`, c.PreFundState(), s)
+			t.Fatalf(`incorrect PreFundState returned, got %v wanted %v`, c.PreFundState(), s)
 		}
 	}
 
@@ -76,7 +76,7 @@ func TestChannel(t *testing.T) {
 			t.Error(err2)
 		}
 		if got != want {
-			t.Errorf(`incorrect PreFundState returned, got %v wanted %v`, c.PostFundState(), s)
+			t.Fatalf(`incorrect PreFundState returned, got %v wanted %v`, c.PostFundState(), s)
 		}
 	}
 
@@ -135,7 +135,7 @@ func TestChannel(t *testing.T) {
 			common.Address{}: big.NewInt(10),
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
-			t.Errorf("TestCrank: side effects mismatch (-want +got):\n%s", diff)
+			t.Fatalf("TestCrank: side effects mismatch (-want +got):\n%s", diff)
 		}
 	}
 
@@ -166,7 +166,7 @@ func TestChannel(t *testing.T) {
 
 		// It should properly update the latestSupportedStateNum
 		if myC.latestSupportedStateTurnNum != 0 {
-			t.Errorf("Expected latestSupportedStateTurnNum of 0 but got %d", myC.latestSupportedStateTurnNum)
+			t.Fatalf("Expected latestSupportedStateTurnNum of 0 but got %d", myC.latestSupportedStateTurnNum)
 
 		}
 		// verify the signatures
@@ -178,7 +178,7 @@ func TestChannel(t *testing.T) {
 			}
 			wantSig := expectedSigs[i]
 			if !gotSig.Equal(wantSig) {
-				t.Errorf("Expected to find signature %x at index 0, but got %x", wantSig, gotSig)
+				t.Fatalf("Expected to find signature %x at index 0, but got %x", wantSig, gotSig)
 			}
 		}
 	}
@@ -210,7 +210,7 @@ func TestChannel(t *testing.T) {
 		// It should properly update the latestSupportedStateNum
 		got := myC.latestSupportedStateTurnNum
 		if got != 0 {
-			t.Errorf("Expected latestSupportedStateTurnNum of 0 but got %d", got)
+			t.Fatalf("Expected latestSupportedStateTurnNum of 0 but got %d", got)
 		}
 
 		// verify the signatures
@@ -222,7 +222,7 @@ func TestChannel(t *testing.T) {
 			}
 			wantSig := expectedSigs[i]
 			if !gotSig.Equal(wantSig) {
-				t.Errorf("Expected to find signature %x at index 0, but got %x", wantSig, gotSig)
+				t.Fatalf("Expected to find signature %x at index 0, but got %x", wantSig, gotSig)
 			}
 		}
 
@@ -287,7 +287,7 @@ func TestChannel(t *testing.T) {
 			t.Error(err)
 		}
 		if diff := cmp.Diff(expectedSignedState, latestSignedState, cmp.Comparer(types.Equal)); diff != "" {
-			t.Errorf("LatestSignedState: mismatch (-want +got):\n%s", diff)
+			t.Fatalf("LatestSignedState: mismatch (-want +got):\n%s", diff)
 		}
 
 		got2 := c.SignedStateForTurnNum[1]
@@ -305,14 +305,14 @@ func TestChannel(t *testing.T) {
 		got3 := c.latestSupportedStateTurnNum
 		want3 := uint64(1)
 		if got3 != want3 {
-			t.Errorf(`expected c.latestSupportedStateTurnNum to be %v, but got %v`, want, got)
+			t.Fatalf(`expected c.latestSupportedStateTurnNum to be %v, but got %v`, want, got)
 		}
 		got4, err4 := c.LatestSupportedState()
 		if err4 != nil {
 			t.Error(err4)
 		}
 		if got4.TurnNum != want3 {
-			t.Errorf(`expected LatestSupportedState with turnNum %v`, want3)
+			t.Fatalf(`expected LatestSupportedState with turnNum %v`, want3)
 		}
 
 		// Check whether latestSignedState is correct
@@ -325,7 +325,7 @@ func TestChannel(t *testing.T) {
 			t.Error(err)
 		}
 		if diff := cmp.Diff(latestSignedState, expectedSignedState, cmp.Comparer(types.Equal)); diff != "" {
-			t.Errorf("LatestSignedState: mismatch (-want +got):\n%s", diff)
+			t.Fatalf("LatestSignedState: mismatch (-want +got):\n%s", diff)
 		}
 
 	}
@@ -357,7 +357,7 @@ func TestTwoPartyLedger(t *testing.T) {
 		}
 		c := r.Clone()
 		if diff := cmp.Diff(*r, *c, cmp.Comparer(types.Equal)); diff != "" {
-			t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+			t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)
 		}
 
 		r.latestSupportedStateTurnNum++
@@ -392,7 +392,7 @@ func TestSingleHopVirtualChannel(t *testing.T) {
 		}
 		c := r.Clone()
 		if diff := cmp.Diff(*r, *c, cmp.Comparer(types.Equal)); diff != "" {
-			t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+			t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)
 		}
 
 		r.latestSupportedStateTurnNum++

--- a/channel/state/outcome/allocation_test.go
+++ b/channel/state/outcome/allocation_test.go
@@ -24,11 +24,11 @@ func TestEqualAllocations(t *testing.T) {
 		Metadata:       make(types.Bytes, 0)}}
 
 	if &a1 == &a2 {
-		t.Errorf("expected distinct pointers, but got identical pointers")
+		t.Fatalf("expected distinct pointers, but got identical pointers")
 	}
 
 	if !a1.Equal(a2) {
-		t.Errorf("expected equal Allocations, but got distinct Allocations")
+		t.Fatalf("expected equal Allocations, but got distinct Allocations")
 	}
 
 }
@@ -55,7 +55,7 @@ func TestAffords(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := testcase.Allocations.Affords(testcase.GivenAllocation, testcase.Funding)
 			if got != testcase.Want {
-				t.Errorf(
+				t.Fatalf(
 					`Incorrect AffordFor: expected %v.Affords(%v,%v) to be %v, but got %v`,
 					testcase.Allocations, testcase.GivenAllocation, testcase.Funding, testcase.Want, got)
 			}
@@ -76,7 +76,7 @@ func TestAllocationClone(t *testing.T) {
 	clone := a.Clone()
 
 	if diff := cmp.Diff(a, clone); diff != "" {
-		t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+		t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -96,6 +96,6 @@ func TestAllocationsClone(t *testing.T) {
 	clone := as.Clone()
 
 	if diff := cmp.Diff(as, clone); diff != "" {
-		t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+		t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/channel/state/outcome/deposit-safety_test.go
+++ b/channel/state/outcome/deposit-safety_test.go
@@ -28,7 +28,7 @@ func TestDepositSafetyThreshold(t *testing.T) {
 		t.Run(fmt.Sprint("Case ", i), func(t *testing.T) {
 			got := testCase.Exit.DepositSafetyThreshold(testCase.Participant)
 			if !got.Equal(testCase.Want) {
-				t.Errorf("Expected safety threshold for participant %v on exit %v to be %v, but got %v",
+				t.Fatalf("Expected safety threshold for participant %v on exit %v to be %v, but got %v",
 					testCase.Participant, testCase.Exit, testCase.Want, got)
 			}
 		})

--- a/channel/state/outcome/exit_test.go
+++ b/channel/state/outcome/exit_test.go
@@ -114,7 +114,7 @@ func TestExitEncode(t *testing.T) {
 	}
 
 	if !bytes.Equal(encodedExit, encodedExitReference) {
-		t.Errorf("incorrect encoding. Got %x, wanted %x", encodedExit, encodedExitReference)
+		t.Fatalf("incorrect encoding. Got %x, wanted %x", encodedExit, encodedExitReference)
 	}
 }
 
@@ -133,7 +133,7 @@ func TestTotal(t *testing.T) {
 
 	total := allocsX.Total()
 	if total.Cmp(big.NewInt(5)) != 0 {
-		t.Errorf(`Expected total to be 5, got %v`, total)
+		t.Fatalf(`Expected total to be 5, got %v`, total)
 	}
 }
 
@@ -146,7 +146,7 @@ func TestTotalAllocated(t *testing.T) {
 	got := e.TotalAllocated()
 
 	if !got.Equal(want) {
-		t.Errorf("Expected %v.TotalAllocated() to equal %v, but it was %v",
+		t.Fatalf("Expected %v.TotalAllocated() to equal %v, but it was %v",
 			e, want, got)
 	}
 }
@@ -171,7 +171,7 @@ func TestTotalFor(t *testing.T) {
 		t.Run(fmt.Sprint("Case ", i), func(t *testing.T) {
 			got := testCase.Exit.TotalAllocatedFor(testCase.Participant)
 			if !got.Equal(testCase.Want) {
-				t.Errorf("Expected TotalAllocatedFor for participant %v on exit %v to be %v, but got %v",
+				t.Fatalf("Expected TotalAllocatedFor for participant %v on exit %v to be %v, but got %v",
 					testCase.Participant, testCase.Exit, testCase.Want, got)
 			}
 		})
@@ -256,11 +256,11 @@ func TestExitDivertToGuarantee(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("TestDivertToGuarantee: expectedGuarantee mismatch (-want +got):\n%s", diff)
+		t.Fatalf("TestDivertToGuarantee: expectedGuarantee mismatch (-want +got):\n%s", diff)
 	}
 
 	if e[0].Allocations[0].Amount.Cmp(big.NewInt(243)) != 0 {
-		t.Errorf("TestDivertToGuarantee: input arguments mutated")
+		t.Fatalf("TestDivertToGuarantee: input arguments mutated")
 	}
 
 	got, err = e.DivertToGuarantee(aliceDestination, bobDestination, leftFunds, types.Funds{}, targetChannel)
@@ -296,7 +296,7 @@ func TestExitDivertToGuarantee(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("TestDivertToGuarantee: expectedGuarantee mismatch (-want +got):\n%s", diff)
+		t.Fatalf("TestDivertToGuarantee: expectedGuarantee mismatch (-want +got):\n%s", diff)
 	}
 
 }
@@ -334,7 +334,7 @@ func TestSingleAssetExitClone(t *testing.T) {
 	clone := sae.Clone()
 
 	if diff := cmp.Diff(sae, clone); diff != "" {
-		t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+		t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -384,6 +384,6 @@ func TestClone(t *testing.T) {
 	clone := e.Clone()
 
 	if diff := cmp.Diff(e, clone); diff != "" {
-		t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+		t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/channel/state/outcome/guarantee_test.go
+++ b/channel/state/outcome/guarantee_test.go
@@ -18,7 +18,7 @@ func TestGuaranteeMetadataEncode(t *testing.T) {
 		t.Error(err)
 	}
 	if !bytes.Equal(encodedG, encodedGuaranteeMetadata) {
-		t.Errorf("incorrect encoding. Got %x, wanted %x", encodedG, encodedGuaranteeMetadata)
+		t.Fatalf("incorrect encoding. Got %x, wanted %x", encodedG, encodedGuaranteeMetadata)
 	}
 }
 
@@ -28,6 +28,6 @@ func TestGuaranteeMetadataDecode(t *testing.T) {
 		t.Error(err)
 	}
 	if g != guaranteeMetadata {
-		t.Errorf("incorrect encoding. Got %x, wanted %x", g, encodedGuaranteeMetadata)
+		t.Fatalf("incorrect encoding. Got %x, wanted %x", g, encodedGuaranteeMetadata)
 	}
 }

--- a/channel/state/outcome/transfer_test.go
+++ b/channel/state/outcome/transfer_test.go
@@ -35,11 +35,11 @@ func TestComputeTransferEffectsAndInteractions(t *testing.T) {
 	want2 := expectedExitAllocations
 
 	if !got1.Equal(want1) {
-		t.Errorf("got %+v, wanted %+v", got1, want1)
+		t.Fatalf("got %+v, wanted %+v", got1, want1)
 	}
 
 	if !got2.Equal(want2) {
-		t.Errorf("got %+v, wanted %+v", got2, want2)
+		t.Fatalf("got %+v, wanted %+v", got2, want2)
 	}
 
 }

--- a/channel/state/signedstate_test.go
+++ b/channel/state/signedstate_test.go
@@ -17,7 +17,7 @@ func TestSignedStateEqual(t *testing.T) {
 	_ = ss2.AddSignature(sigA)
 
 	if !ss1.Equal(ss2) {
-		t.Errorf(`expected %v to Equal %v, but it did not`, ss1, ss2)
+		t.Fatalf(`expected %v to Equal %v, but it did not`, ss1, ss2)
 	}
 }
 func TestMergeWithDuplicateSignatures(t *testing.T) {
@@ -48,7 +48,7 @@ func TestMergeWithDuplicateSignatures(t *testing.T) {
 	}
 
 	if !got.Equal(want) {
-		t.Errorf(`incorrect merge, got %v, wanted %v`, got, want)
+		t.Fatalf(`incorrect merge, got %v, wanted %v`, got, want)
 	}
 
 }
@@ -78,7 +78,7 @@ func TestMerge(t *testing.T) {
 	}
 
 	if !got.Equal(want) {
-		t.Errorf(`incorrect merge, got %v, wanted %v`, got, want)
+		t.Fatalf(`incorrect merge, got %v, wanted %v`, got, want)
 	}
 
 }
@@ -97,7 +97,7 @@ func TestJSON(t *testing.T) {
 		}
 		want := msgString
 		if string(got) != want {
-			t.Errorf(`incorrect MarshalJSON, got %v, wanted %v`, string(got), want)
+			t.Fatalf(`incorrect MarshalJSON, got %v, wanted %v`, string(got), want)
 		}
 	})
 
@@ -110,7 +110,7 @@ func TestJSON(t *testing.T) {
 		want := ss1
 
 		if !got.Equal(ss1) {
-			t.Errorf(`incorrect UnmarshalJSON, got %v, wanted %v`, got, want)
+			t.Fatalf(`incorrect UnmarshalJSON, got %v, wanted %v`, got, want)
 		}
 	})
 
@@ -124,7 +124,7 @@ func TestSignedStateClone(t *testing.T) {
 	clone := ss1.Clone()
 
 	if diff := cmp.Diff(ss1, clone); diff != "" {
-		t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+		t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)
 	}
 
 }

--- a/channel/state/state_test.go
+++ b/channel/state/state_test.go
@@ -42,13 +42,13 @@ func TestSign(t *testing.T) {
 		t.Error(error)
 	}
 	if !bytes.Equal(want_r, got_r) {
-		t.Errorf("Incorrect r param in signature. Got %x, wanted %x", got_r, want_r)
+		t.Fatalf("Incorrect r param in signature. Got %x, wanted %x", got_r, want_r)
 	}
 	if !bytes.Equal(want_s, got_s) {
-		t.Errorf("Incorrect s param in signature. Got %x, wanted %x", got_s, want_s)
+		t.Fatalf("Incorrect s param in signature. Got %x, wanted %x", got_s, want_s)
 	}
 	if want_v != got_v {
-		t.Errorf("Incorrect v param in signature. Got %x, wanted %x", got_v, want_v)
+		t.Fatalf("Incorrect v param in signature. Got %x, wanted %x", got_v, want_v)
 	}
 }
 
@@ -90,13 +90,13 @@ func TestEqual(t *testing.T) {
 	got := TestState
 
 	if !got.Equal(want) {
-		t.Errorf(`expected %v to equal %v, but it did not`, got, want)
+		t.Fatalf(`expected %v to equal %v, but it did not`, got, want)
 	}
 
 	want.IsFinal = true
 
 	if got.Equal(want) {
-		t.Errorf(`expected %v to not equal %v, but it did`, got, want)
+		t.Fatalf(`expected %v to not equal %v, but it did`, got, want)
 	}
 
 }
@@ -106,18 +106,18 @@ func TestClone(t *testing.T) {
 	clone := TestState.Clone()
 
 	if diff := cmp.Diff(TestState, clone); diff != "" {
-		t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+		t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)
 	}
 
 	clone.ChannelNonce.Add(clone.ChannelNonce, big.NewInt(1))
 	clone.Outcome[0].Allocations[0].Amount.Add(clone.ChannelNonce, big.NewInt(1))
 
 	if clone.Equal(TestState) {
-		t.Errorf(`expected %v to not equal %v, but it did`, clone, TestState)
+		t.Fatalf(`expected %v to not equal %v, but it did`, clone, TestState)
 	}
 
 	if TestState.ChannelNonce.Cmp(big.NewInt(37140676580)) != 0 || TestState.Outcome[0].Allocations[0].Amount.Cmp(big.NewInt(5)) != 0 {
-		t.Errorf(`State.Clone(): original is modified when clone is modified `)
+		t.Fatalf(`State.Clone(): original is modified when clone is modified `)
 	}
 }
 
@@ -132,6 +132,6 @@ func checkErrorAndTestForEqualBytes(t *testing.T, err error, descriptor string, 
 		t.Error(err)
 	}
 	if !bytes.Equal(want, got) {
-		t.Errorf("Incorrect "+descriptor+". Got %x, wanted %x", got, want)
+		t.Fatalf("Incorrect "+descriptor+". Got %x, wanted %x", got, want)
 	}
 }

--- a/client/engine/chainservice/mockchain_test.go
+++ b/client/engine/chainservice/mockchain_test.go
@@ -43,10 +43,10 @@ func TestDeposit(t *testing.T) {
 	event := <-outA
 
 	if event.ChannelId != testTx.ChannelId {
-		t.Errorf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, event.ChannelId)
+		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, event.ChannelId)
 	}
 	if !event.Holdings.Equal(testTx.Deposit) {
-		t.Errorf(`holdings mismatch: expected %v but got %v`, testTx.Deposit, event.Holdings)
+		t.Fatalf(`holdings mismatch: expected %v but got %v`, testTx.Deposit, event.Holdings)
 	}
 
 	// Send the transaction again and recieve another event
@@ -57,30 +57,30 @@ func TestDeposit(t *testing.T) {
 	expectedHoldings := testTx.Deposit.Add(testTx.Deposit)
 
 	if event.ChannelId != testTx.ChannelId {
-		t.Errorf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, event.ChannelId)
+		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, event.ChannelId)
 	}
 	if !event.Holdings.Equal(expectedHoldings) {
-		t.Errorf(`holdings mismatch: expected %v but got %v`, expectedHoldings, event.Holdings)
+		t.Fatalf(`holdings mismatch: expected %v but got %v`, expectedHoldings, event.Holdings)
 	}
 
 	// Pull an event out of the other mock chain service and check that
 	eventB := <-mcsB.Out()
 
 	if eventB.ChannelId != testTx.ChannelId {
-		t.Errorf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, eventB.ChannelId)
+		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, eventB.ChannelId)
 	}
 	if !eventB.Holdings.Equal(testTx.Deposit) {
-		t.Errorf(`holdings mismatch: expected %v but got %v`, testTx.Deposit, eventB.Holdings)
+		t.Fatalf(`holdings mismatch: expected %v but got %v`, testTx.Deposit, eventB.Holdings)
 	}
 
 	// Pull another event out of the other mock chain service and check that
 	eventB = <-mcsB.Out()
 
 	if eventB.ChannelId != testTx.ChannelId {
-		t.Errorf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, eventB.ChannelId)
+		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, eventB.ChannelId)
 	}
 	if !eventB.Holdings.Equal(expectedHoldings) {
-		t.Errorf(`holdings mismatch: expected %v but got %v`, expectedHoldings, eventB.Holdings)
+		t.Fatalf(`holdings mismatch: expected %v but got %v`, expectedHoldings, eventB.Holdings)
 	}
 
 }

--- a/client/engine/messageservice/test-messageservice_test.go
+++ b/client/engine/messageservice/test-messageservice_test.go
@@ -28,7 +28,7 @@ func TestConnect(t *testing.T) {
 	got := <-bobOut
 
 	if got.ObjectiveId != testId {
-		t.Errorf("expected bob to recieve ObjectiveId %v, but recieved %v",
+		t.Fatalf("expected bob to recieve ObjectiveId %v, but recieved %v",
 			testId, got.ObjectiveId)
 	}
 }

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -24,23 +24,23 @@ func TestSetGetObjective(t *testing.T) {
 	id := protocols.ObjectiveId("404")
 	got, err := ms.GetObjectiveById(id)
 	if err == nil {
-		t.Errorf("expected not to find the %s objective, but found %v", id, got)
+		t.Fatalf("expected not to find the %s objective, but found %v", id, got)
 	}
 
 	want := td.Objectives.Directfund.GenericDFO()
 
 	if err := ms.SetObjective(&want); err != nil {
-		t.Errorf("error setting objective %v: %s", want, err.Error())
+		t.Fatalf("error setting objective %v: %s", want, err.Error())
 	}
 
 	got, err = ms.GetObjectiveById(want.Id())
 
 	if err != nil {
-		t.Errorf("expected to find the inserted objective, but didn't: %s", err)
+		t.Fatalf("expected to find the inserted objective, but didn't: %s", err)
 	}
 
 	if got.Id() != want.Id() {
-		t.Errorf("expected to retrieve same objective Id as was passed in, but didn't")
+		t.Fatalf("expected to retrieve same objective Id as was passed in, but didn't")
 	}
 }
 
@@ -52,19 +52,19 @@ func TestGetObjectiveByChannelId(t *testing.T) {
 	want := td.Objectives.Directfund.GenericDFO()
 
 	if err := ms.SetObjective(&want); err != nil {
-		t.Errorf("error setting objective %v: %s", want, err.Error())
+		t.Fatalf("error setting objective %v: %s", want, err.Error())
 	}
 
 	got, ok := ms.GetObjectiveByChannelId(want.C.Id)
 
 	if !ok {
-		t.Errorf("expected to find the inserted objective, but didn't")
+		t.Fatalf("expected to find the inserted objective, but didn't")
 	}
 	if got.Id() != want.Id() {
-		t.Errorf("expected to retrieve same objective Id as was passed in, but didn't")
+		t.Fatalf("expected to retrieve same objective Id as was passed in, but didn't")
 	}
 	if diff := cmp.Diff(got, &want); diff != "" {
-		t.Errorf("expected no diff between set and retrieved objective, but found:\n%s", diff)
+		t.Fatalf("expected no diff between set and retrieved objective, but found:\n%s", diff)
 	}
 }
 
@@ -82,6 +82,6 @@ func TestGetChannelSecretKey(t *testing.T) {
 	recoveredSigner, _ := nc.RecoverEthereumMessageSigner(msg, signedMsg)
 
 	if recoveredSigner != pk {
-		t.Errorf("expected to recover %x, but got %x", pk, recoveredSigner)
+		t.Fatalf("expected to recover %x, but got %x", pk, recoveredSigner)
 	}
 }

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -82,7 +82,7 @@ func expect(t *testing.T, done chan interface{}, num int, timeout time.Duration)
 				return
 			}
 		case <-time.After(timeout):
-			t.Errorf("Ran out of time. %v out of %v completed", count, num)
+			t.Fatalf("Ran out of time. %v out of %v completed", count, num)
 			t.FailNow()
 		}
 	}

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -187,7 +187,7 @@ func TestCrankAlice(t *testing.T) {
 	}
 
 	if wf != WaitingForFinalization {
-		t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForFinalization, wf)
+		t.Fatalf(`WaitingFor: expected %v, got %v`, WaitingForFinalization, wf)
 	}
 
 	// Create the state we expect Alice to send
@@ -207,7 +207,7 @@ func TestCrankAlice(t *testing.T) {
 		}}
 
 	if diff := cmp.Diff(expectedSE, se); diff != "" {
-		t.Errorf("Side effects mismatch (-want +got):\n%s", diff)
+		t.Fatalf("Side effects mismatch (-want +got):\n%s", diff)
 	}
 
 	// The second update and crank. Alice is expected to create a withdrawAll transaction
@@ -224,7 +224,7 @@ func TestCrankAlice(t *testing.T) {
 	}
 
 	if wf != WaitingForWithdraw {
-		t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForWithdraw, wf)
+		t.Fatalf(`WaitingFor: expected %v, got %v`, WaitingForWithdraw, wf)
 	}
 
 	expectedSE = protocols.SideEffects{TransactionsToSubmit: []protocols.ChainTransaction{{
@@ -234,7 +234,7 @@ func TestCrankAlice(t *testing.T) {
 	}}}
 
 	if diff := cmp.Diff(expectedSE, se); diff != "" {
-		t.Errorf("Side effects mismatch (-want +got):\n%s", diff)
+		t.Fatalf("Side effects mismatch (-want +got):\n%s", diff)
 	}
 
 	// The third crank. Alice is expected to enter the terminal state of the defunding protocol.
@@ -244,12 +244,12 @@ func TestCrankAlice(t *testing.T) {
 		t.Error(err)
 	}
 	if wf != WaitingForNothing {
-		t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForNothing, wf)
+		t.Fatalf(`WaitingFor: expected %v, got %v`, WaitingForNothing, wf)
 	}
 
 	expectedSE = protocols.SideEffects{}
 	if diff := cmp.Diff(expectedSE, se); diff != "" {
-		t.Errorf("Side effects mismatch (-want +got):\n%s", diff)
+		t.Fatalf("Side effects mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -280,7 +280,7 @@ func TestCrankBob(t *testing.T) {
 	}
 
 	if wf != WaitingForWithdraw {
-		t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForWithdraw, wf)
+		t.Fatalf(`WaitingFor: expected %v, got %v`, WaitingForWithdraw, wf)
 	}
 
 	// Create the state we expect Bob to send
@@ -296,7 +296,7 @@ func TestCrankBob(t *testing.T) {
 		}}
 
 	if diff := cmp.Diff(expectedSE, se); diff != "" {
-		t.Errorf("Side effects mismatch (-want +got):\n%s", diff)
+		t.Fatalf("Side effects mismatch (-want +got):\n%s", diff)
 	}
 
 	// The second update and crank. Bob is expected to NOT create any transactions or side effects
@@ -310,13 +310,13 @@ func TestCrankBob(t *testing.T) {
 	}
 
 	if wf != WaitingForWithdraw {
-		t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForWithdraw, wf)
+		t.Fatalf(`WaitingFor: expected %v, got %v`, WaitingForWithdraw, wf)
 	}
 
 	expectedSE = protocols.SideEffects{}
 
 	if diff := cmp.Diff(expectedSE, se); diff != "" {
-		t.Errorf("Side effects mismatch (-want +got):\n%s", diff)
+		t.Fatalf("Side effects mismatch (-want +got):\n%s", diff)
 	}
 
 	// The third crank. Bob is expected to enter the terminal state of the defunding protocol.
@@ -331,12 +331,12 @@ func TestCrankBob(t *testing.T) {
 		t.Error(err)
 	}
 	if wf != WaitingForNothing {
-		t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForNothing, wf)
+		t.Fatalf(`WaitingFor: expected %v, got %v`, WaitingForNothing, wf)
 	}
 
 	expectedSE = protocols.SideEffects{}
 	if diff := cmp.Diff(expectedSE, se); diff != "" {
-		t.Errorf("Side effects mismatch (-want +got):\n%s", diff)
+		t.Fatalf("Side effects mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -346,22 +346,22 @@ func TestMarshalJSON(t *testing.T) {
 	encodedDdfo, err := json.Marshal(ddfo)
 
 	if err != nil {
-		t.Errorf("error encoding directdefund objective %v", ddfo)
+		t.Fatalf("error encoding directdefund objective %v", ddfo)
 	}
 
 	got := Objective{}
 	if err := got.UnmarshalJSON(encodedDdfo); err != nil {
-		t.Errorf("error unmarshaling test directdefund objective: %s", err.Error())
+		t.Fatalf("error unmarshaling test directdefund objective: %s", err.Error())
 	}
 
 	if got.finalTurnNum != ddfo.finalTurnNum {
-		t.Errorf("expected finalTurnNum %d but got %d",
+		t.Fatalf("expected finalTurnNum %d but got %d",
 			ddfo.finalTurnNum, got.finalTurnNum)
 	}
 	if !(got.Status == ddfo.Status) {
-		t.Errorf("expected Status %v but got %v", ddfo.Status, got.Status)
+		t.Fatalf("expected Status %v but got %v", ddfo.Status, got.Status)
 	}
 	if got.C.Id != ddfo.C.Id {
-		t.Errorf("expected channel Id %s but got %s", ddfo.C.Id, got.C.Id)
+		t.Fatalf("expected channel Id %s but got %s", ddfo.C.Id, got.C.Id)
 	}
 }

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -236,11 +236,11 @@ func TestCrank(t *testing.T) {
 		t.Error(err)
 	}
 	if waitingFor != WaitingForCompletePrefund {
-		t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForCompletePrefund, waitingFor)
+		t.Fatalf(`WaitingFor: expected %v, got %v`, WaitingForCompletePrefund, waitingFor)
 	}
 
 	if diff := cmp.Diff(expectedPreFundSideEffects, sideEffects); diff != "" {
-		t.Errorf("Side effects mismatch (-want +got):\n%s", diff)
+		t.Fatalf("Side effects mismatch (-want +got):\n%s", diff)
 	}
 
 	// Manually progress the extended state by collecting prefund signatures
@@ -253,7 +253,7 @@ func TestCrank(t *testing.T) {
 		t.Error(err)
 	}
 	if waitingFor != WaitingForMyTurnToFund {
-		t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForMyTurnToFund, waitingFor)
+		t.Fatalf(`WaitingFor: expected %v, got %v`, WaitingForMyTurnToFund, waitingFor)
 	}
 
 	// Manually make the first "deposit"
@@ -263,11 +263,11 @@ func TestCrank(t *testing.T) {
 		t.Error(err)
 	}
 	if waitingFor != WaitingForCompleteFunding {
-		t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForCompleteFunding, waitingFor)
+		t.Fatalf(`WaitingFor: expected %v, got %v`, WaitingForCompleteFunding, waitingFor)
 	}
 
 	if diff := cmp.Diff(expectedFundingSideEffects, sideEffects); diff != "" {
-		t.Errorf("Side effects mismatch (-want +got):\n%s", diff)
+		t.Fatalf("Side effects mismatch (-want +got):\n%s", diff)
 	}
 
 	// Manually make the second "deposit"
@@ -278,10 +278,10 @@ func TestCrank(t *testing.T) {
 		t.Error(err)
 	}
 	if waitingFor != WaitingForCompletePostFund {
-		t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForCompletePostFund, waitingFor)
+		t.Fatalf(`WaitingFor: expected %v, got %v`, WaitingForCompletePostFund, waitingFor)
 	}
 	if diff := cmp.Diff(expectedPostFundSideEffects, sideEffects); diff != "" {
-		t.Errorf("Side effects mismatch (-want +got):\n%s", diff)
+		t.Fatalf("Side effects mismatch (-want +got):\n%s", diff)
 	}
 
 	// Manually progress the extended state by collecting postfund signatures
@@ -295,7 +295,7 @@ func TestCrank(t *testing.T) {
 		t.Error(err)
 	}
 	if waitingFor != WaitingForNothing {
-		t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForNothing, waitingFor)
+		t.Fatalf(`WaitingFor: expected %v, got %v`, WaitingForNothing, waitingFor)
 	}
 }
 
@@ -305,7 +305,7 @@ func TestClone(t *testing.T) {
 	clone := s.clone()
 
 	if diff := cmp.Diff(s, clone); diff != "" {
-		t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+		t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -315,30 +315,30 @@ func TestMarshalJSON(t *testing.T) {
 	encodedDfo, err := json.Marshal(dfo)
 
 	if err != nil {
-		t.Errorf("error encoding direct-fund objective %v", dfo)
+		t.Fatalf("error encoding direct-fund objective %v", dfo)
 	}
 
 	got := Objective{}
 	if err := got.UnmarshalJSON(encodedDfo); err != nil {
-		t.Errorf("error unmarshaling test direct fund objective: %s", err.Error())
+		t.Fatalf("error unmarshaling test direct fund objective: %s", err.Error())
 	}
 
 	if !got.myDepositSafetyThreshold.Equal(dfo.myDepositSafetyThreshold) {
-		t.Errorf("expected myDepositSafetyThreshhold %v but got %v",
+		t.Fatalf("expected myDepositSafetyThreshhold %v but got %v",
 			dfo.myDepositSafetyThreshold, got.myDepositSafetyThreshold)
 	}
 	if !got.myDepositTarget.Equal(dfo.myDepositTarget) {
-		t.Errorf("expected myDepositTarget %v but got %v",
+		t.Fatalf("expected myDepositTarget %v but got %v",
 			dfo.myDepositTarget, got.myDepositTarget)
 	}
 	if !got.fullyFundedThreshold.Equal(dfo.fullyFundedThreshold) {
-		t.Errorf("expected fullyFundedThreshold %v but got %v",
+		t.Fatalf("expected fullyFundedThreshold %v but got %v",
 			dfo.fullyFundedThreshold, got.fullyFundedThreshold)
 	}
 	if !(got.Status == dfo.Status) {
-		t.Errorf("expected Status %v but got %v", dfo.Status, got.Status)
+		t.Fatalf("expected Status %v but got %v", dfo.Status, got.Status)
 	}
 	if got.C.Id != dfo.C.Id {
-		t.Errorf("expected channel Id %s but got %s", dfo.C.Id, got.C.Id)
+		t.Fatalf("expected channel Id %s but got %s", dfo.C.Id, got.C.Id)
 	}
 }

--- a/protocols/messages_test.go
+++ b/protocols/messages_test.go
@@ -50,7 +50,7 @@ func TestMessage(t *testing.T) {
 		}
 		want := msgString
 		if got != want {
-			t.Errorf(`incorrect serialization: got %v wanted %v`, got, want)
+			t.Fatalf(`incorrect serialization: got %v wanted %v`, got, want)
 		}
 	})
 
@@ -61,7 +61,7 @@ func TestMessage(t *testing.T) {
 			t.Error(err)
 		}
 		if !got.Equal(want) {
-			t.Errorf(`incorrect deserialization: got %v wanted %v`, got, want)
+			t.Fatalf(`incorrect deserialization: got %v wanted %v`, got, want)
 		}
 	})
 

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -318,7 +318,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 					Metadata:       expectedEncodedGuaranteeMetadataLeft,
 				}
 				if diff := cmp.Diff(wantLeft, gotLeft); diff != "" {
-					t.Errorf("TestNew: expectedGuarantee mismatch (-want +got):\n%s", diff)
+					t.Fatalf("TestNew: expectedGuarantee mismatch (-want +got):\n%s", diff)
 				}
 			}
 			if (expectedGuaranteeMetadataRight != outcome.GuaranteeMetadata{}) {
@@ -331,7 +331,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 					Metadata:       expectedEncodedGuaranteeMetadataRight,
 				}
 				if diff := cmp.Diff(wantRight, gotRight); diff != "" {
-					t.Errorf("TestNew: expectedGuarantee mismatch (-want +got):\n%s", diff)
+					t.Fatalf("TestNew: expectedGuarantee mismatch (-want +got):\n%s", diff)
 				}
 			}
 
@@ -345,7 +345,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			clone := o.clone()
 
 			if diff := cmp.Diff(o, clone); diff != "" {
-				t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+				t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)
 			}
 		}
 
@@ -369,7 +369,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				t.Error(err)
 			}
 			if waitingFor != WaitingForCompletePrefund {
-				t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForCompletePrefund, waitingFor)
+				t.Fatalf(`WaitingFor: expected %v, got %v`, WaitingForCompletePrefund, waitingFor)
 			}
 
 			expectedSignedState := state.NewSignedState(o.V.PreFundState())
@@ -479,7 +479,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 				t.Error(err)
 			}
 			if waitingFor != WaitingForNothing {
-				t.Errorf(`WaitingFor: expected %v, got %v`, WaitingForNothing, waitingFor)
+				t.Fatalf(`WaitingFor: expected %v, got %v`, WaitingForNothing, waitingFor)
 			}
 
 		}

--- a/protocols/virtualfund/virtualfund_test.go
+++ b/protocols/virtualfund/virtualfund_test.go
@@ -87,7 +87,7 @@ func TestMarshalJSON(t *testing.T) {
 	encodedVfo, err := json.Marshal(vfo)
 
 	if err != nil {
-		t.Errorf("error encoding direct-fund objective %v", vfo)
+		t.Fatalf("error encoding direct-fund objective %v", vfo)
 	}
 
 	got := Objective{}
@@ -96,48 +96,48 @@ func TestMarshalJSON(t *testing.T) {
 	}
 
 	if !(got.Status == vfo.Status) {
-		t.Errorf("expected Status %v but got %v", vfo.Status, got.Status)
+		t.Fatalf("expected Status %v but got %v", vfo.Status, got.Status)
 	}
 
 	// only checking channel ID rather than whole channel because
 	// marshal / unmarshal loses channel data
 	if got.V.Id != vfo.V.Id {
-		t.Errorf("expected channel Id %s but got %s", vfo.V.Id, got.V.Id)
+		t.Fatalf("expected channel Id %s but got %s", vfo.V.Id, got.V.Id)
 	}
 
 	if vfo.ToMyLeft != nil {
 		if !reflect.DeepEqual(vfo.ToMyLeft.getExpectedGuarantees(), got.ToMyLeft.getExpectedGuarantees()) {
-			t.Errorf("expected left-channel guarantees %v, but found %v", vfo.ToMyLeft, got.ToMyLeft)
+			t.Fatalf("expected left-channel guarantees %v, but found %v", vfo.ToMyLeft, got.ToMyLeft)
 		}
 
 		if got.ToMyLeft.Channel.Id != vfo.ToMyLeft.Channel.Id {
-			t.Errorf("expected left channel Id %s but got %s",
+			t.Fatalf("expected left channel Id %s but got %s",
 				vfo.ToMyLeft.Channel.Id, got.ToMyLeft.Channel.Id)
 		}
 	}
 
 	if vfo.ToMyRight != nil {
 		if !reflect.DeepEqual(vfo.ToMyRight.getExpectedGuarantees(), got.ToMyRight.getExpectedGuarantees()) {
-			t.Errorf("expected right-channel %v, but found %v", vfo.ToMyRight, got.ToMyRight)
+			t.Fatalf("expected right-channel %v, but found %v", vfo.ToMyRight, got.ToMyRight)
 		}
 
 		if got.ToMyRight.Channel.Id != vfo.ToMyRight.Channel.Id {
-			t.Errorf("expected left channel Id %s but got %s",
+			t.Fatalf("expected left channel Id %s but got %s",
 				vfo.ToMyRight.Channel.Id, got.ToMyRight.Channel.Id)
 		}
 	}
 
 	if got.n != vfo.n {
-		t.Errorf("expected %d channel participants but found %d", vfo.n, got.n)
+		t.Fatalf("expected %d channel participants but found %d", vfo.n, got.n)
 	}
 	if got.MyRole != vfo.MyRole {
-		t.Errorf("expected MyRole %d but found %d", vfo.MyRole, got.MyRole)
+		t.Fatalf("expected MyRole %d but found %d", vfo.MyRole, got.MyRole)
 	}
 	if !got.a0.Equal(vfo.a0) {
-		t.Errorf("expected alice initial balance of %v but found %v", vfo.a0, got.a0)
+		t.Fatalf("expected alice initial balance of %v but found %v", vfo.a0, got.a0)
 	}
 	if !got.b0.Equal(vfo.b0) {
-		t.Errorf("expected bob initial balance of %v but found %v", vfo.b0, got.a0)
+		t.Fatalf("expected bob initial balance of %v but found %v", vfo.b0, got.a0)
 	}
 
 }

--- a/types/destination_test.go
+++ b/types/destination_test.go
@@ -12,11 +12,11 @@ func TestIsExternal(t *testing.T) {
 	internal := Destination(common.HexToHash("0x6f7123E3A80C9813eF50213A96f7123E3A80C9813eF50213ADEd0e4511CB820f"))
 
 	if !external.IsExternal() {
-		t.Errorf("Received bytes %x was declared internal, when it is external", external)
+		t.Fatalf("Received bytes %x was declared internal, when it is external", external)
 	}
 
 	if internal.IsExternal() {
-		t.Errorf("Received bytes %x was declared external, when it is internal", internal)
+		t.Fatalf("Received bytes %x was declared external, when it is internal", internal)
 	}
 
 }
@@ -37,11 +37,11 @@ func TestToAddress(t *testing.T) {
 	for i, extAddress := range areExternal {
 		convertedAddress, err := extAddress.ToAddress()
 		if err != nil {
-			t.Errorf("expected to convert %x to an external address, but failed", extAddress)
+			t.Fatalf("expected to convert %x to an external address, but failed", extAddress)
 		}
 
 		if convertedAddress != referenceAddress[i] {
-			t.Errorf("expected %x to convert to %x, but it did not", extAddress, referenceAddress[i])
+			t.Fatalf("expected %x to convert to %x, but it did not", extAddress, referenceAddress[i])
 		}
 	}
 
@@ -53,7 +53,7 @@ func TestToAddress(t *testing.T) {
 
 	for _, notExtAddress := range areNotExternal {
 		if _, err := notExtAddress.ToAddress(); err == nil {
-			t.Errorf("expected to fail when converting %x to an external address, but succeeded", notExtAddress)
+			t.Fatalf("expected to fail when converting %x to an external address, but succeeded", notExtAddress)
 		}
 	}
 }
@@ -64,7 +64,7 @@ func TestToDestination(t *testing.T) {
 		convertedAddress := AddressToDestination(refAddress)
 
 		if convertedAddress != areExternal[i] {
-			t.Errorf("expected %x to convert to %x, but it did not", refAddress, areExternal[i])
+			t.Fatalf("expected %x to convert to %x, but it did not", refAddress, areExternal[i])
 		}
 	}
 

--- a/types/funds_test.go
+++ b/types/funds_test.go
@@ -78,7 +78,7 @@ func TestSum(t *testing.T) {
 
 	for i, p := range equalPairs {
 		if !p.a.Equal(p.b) {
-			t.Errorf("test_sum_%d: expected %s to equal %s, but it did not", i, p.a, p.b)
+			t.Fatalf("test_sum_%d: expected %s to equal %s, but it did not", i, p.a, p.b)
 		}
 	}
 }
@@ -101,7 +101,7 @@ func TestAdd(t *testing.T) {
 
 	for i, p := range equalPairs {
 		if !p.a.Equal(p.b) {
-			t.Errorf("test_sum_%d: expected %s to equal %s, but it did not", i, p.a, p.b)
+			t.Fatalf("test_sum_%d: expected %s to equal %s, but it did not", i, p.a, p.b)
 		}
 	}
 }
@@ -130,7 +130,7 @@ func TestCanAfford(t *testing.T) {
 		canAfford := p.a.canAfford(p.b)
 
 		if !canAfford {
-			t.Errorf("expected %s to afford %s, but it didn't", p.a, p.b)
+			t.Fatalf("expected %s to afford %s, but it didn't", p.a, p.b)
 		}
 	}
 
@@ -152,7 +152,7 @@ func TestCanAfford(t *testing.T) {
 		canAfford := p.a.canAfford(p.b)
 
 		if canAfford {
-			t.Errorf("expected %s to not afford %s, but it did", p.a, p.b)
+			t.Fatalf("expected %s to not afford %s, but it did", p.a, p.b)
 		}
 	}
 }
@@ -172,7 +172,7 @@ func TestEqual(t *testing.T) {
 		equal := p.a.Equal(p.b) && p.b.Equal(p.a)
 
 		if !equal {
-			t.Errorf("expected %s to equal %s, but it didn't", p.a, p.b)
+			t.Fatalf("expected %s to equal %s, but it didn't", p.a, p.b)
 		}
 	}
 
@@ -189,7 +189,7 @@ func TestEqual(t *testing.T) {
 		equal := p.a.Equal(p.b)
 
 		if equal {
-			t.Errorf("expected %s to not equal %s, but it did", p.a, p.b)
+			t.Fatalf("expected %s to not equal %s, but it did", p.a, p.b)
 		}
 	}
 
@@ -205,7 +205,7 @@ func TestFundsClone(t *testing.T) {
 	clone := f.Clone()
 
 	if diff := cmp.Diff(f, clone); diff != "" {
-		t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
+		t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)
 	}
 
 }


### PR DESCRIPTION
Fixes #252.

By using `t.fatalf` the test will fail immediately instead of trying to run other tests.