### PR TITLE
Require destinations are as expected during construction of VirtualFundObjective

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -174,7 +174,8 @@ func (e *Engine) handleAPIEvent(apiEvent APIEvent) ObjectiveChangeEvent {
 		case virtualfund.ObjectiveRequest:
 			vfo, err := virtualfund.NewObjective(request, e.store.GetTwoPartyLedger)
 			if err != nil {
-				e.logger.Printf("handleAPIEvent: Could not create objective for  %+v", request)
+				e.logger.Printf("handleAPIEvent: Could not create objective for %+v", request)
+				e.logger.Print(err)
 				return ObjectiveChangeEvent{}
 			}
 			return e.attemptProgress(&vfo)
@@ -183,12 +184,12 @@ func (e *Engine) handleAPIEvent(apiEvent APIEvent) ObjectiveChangeEvent {
 			dfo, err := directfund.NewObjective(request, true)
 			if err != nil {
 				e.logger.Printf("handleAPIEvent: Could not create objective for  %+v", request)
+				e.logger.Print(err)
 				return ObjectiveChangeEvent{}
 			}
 			return e.attemptProgress(&dfo)
 
 		default:
-
 			e.logger.Printf("handleAPIEvent: Unknown objective type %T", request)
 			return ObjectiveChangeEvent{}
 

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -44,7 +44,6 @@ type APIEvent struct {
 type ObjectiveChangeEvent struct {
 	// These are objectives that are now completed
 	CompletedObjectives []protocols.Objective
-	InvalidObjectiveIds []protocols.ObjectiveId
 }
 
 type CompletedObjectiveEvent struct {
@@ -177,9 +176,7 @@ func (e *Engine) handleAPIEvent(apiEvent APIEvent) ObjectiveChangeEvent {
 			if err != nil {
 				e.logger.Printf("ERROR handleAPIEvent: Could not create objective for %+v", request)
 				e.logger.Print("ERROR ", err)
-				return ObjectiveChangeEvent{
-					InvalidObjectiveIds: []protocols.ObjectiveId{request.Id()},
-				}
+				return ObjectiveChangeEvent{}
 			}
 			return e.attemptProgress(&vfo)
 
@@ -188,9 +185,7 @@ func (e *Engine) handleAPIEvent(apiEvent APIEvent) ObjectiveChangeEvent {
 			if err != nil {
 				e.logger.Printf("ERROR handleAPIEvent: Could not create objective for  %+v", request)
 				e.logger.Print("ERROR ", err)
-				return ObjectiveChangeEvent{
-					InvalidObjectiveIds: []protocols.ObjectiveId{request.Id()},
-				}
+				return ObjectiveChangeEvent{}
 			}
 			return e.attemptProgress(&dfo)
 

--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -50,7 +50,7 @@ func TestMultiPartyVirtualFundIntegration(t *testing.T) {
 		Intermediary: irene.Address,
 		Outcome: td.Outcomes.Create(
 			alice.Address,
-			bob.Address, // BUG: brian.Address? (likely not a matierial difference, or, Brian is just a generous guy)
+			brian.Address,
 			1,
 			1,
 		),

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -149,7 +149,13 @@ func constructFromState(
 	// Compute a0 and b0 from the initial state of J
 	for i := range initialStateOfV.Outcome {
 		asset := initialStateOfV.Outcome[i].Asset
+		if initialStateOfV.Outcome[i].Allocations[0].Destination != types.AddressToDestination(initialStateOfV.Participants[0]) {
+			return Objective{}, errors.New("Allocation in slot 0 does not correspond to participant 0")
+		}
 		amount0 := initialStateOfV.Outcome[i].Allocations[0].Amount
+		if initialStateOfV.Outcome[i].Allocations[1].Destination != types.AddressToDestination(initialStateOfV.Participants[init.n+1]) {
+			return Objective{}, errors.New("Allocation in slot 1 does not correspond to participant " + fmt.Sprint(init.n+1))
+		}
 		amount1 := initialStateOfV.Outcome[i].Allocations[1].Amount
 		if init.a0[asset] == nil {
 			init.a0[asset] = big.NewInt(0)


### PR DESCRIPTION
Closes #290 .

We have had a couple of "bugs" in our test data, where an "incorrect" outcome for a virtual channel is provided to our client through the API. "Incorrect" here means that the channel may have participants `[A,I,B]` but outcome `[A:x,C:y]`.This does currently not cause any errors, panics or failing tests. 

It is not 100% clear if we can remove the scare quotes from "incorrect" -> incorrect, since use cases could be dreamt up where such requests would be appropriate (e.g. Bob wants funds to go to his other wallet). However, in the absence of some mechanism linking different destinations controlled by Bob, I believe it is useful to simply require that the destination match his participant address.

This PR introduces a requirement that the outcome have destinations which match the participants (taking into account the padding of participant addresses to 32 byte destinations). It therefore establishes that such a mismatch is actually incorrect. If they do not match, an error is returned in the constructor for the objective. 

As that error is passed back up the call stack, it is (currently) eventually swallowed. This PR also modifies that error handling so the error at least makes it into the logs:

```log
0xAAA662: 11:36:57.146163 engine.go:178: ERROR handleAPIEvent: Could not create objective for {MyAddress:0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE CounterParty:0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01 Intermediary:0x111A00868581f73AB42FEEF67D235Ca09ca1E8db AppDefinition:0x0000000000000000000000000000000000000000 AppData:[] ChallengeDuration:+0 Outcome:[{Asset:0x0000000000000000000000000000000000000000 Metadata:[] Allocations:[{Destination:0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce Amount:+1 AllocationType:0 Metadata:[]} {Destination:0x000000000000000000000000bbb676f9cff8d242e9eac39d063848807d3d1d94 Amount:+1 AllocationType:0 Metadata:[]}]}] Nonce:7504504064263669287}
0xAAA662: 11:36:57.146174 engine.go:179: ERROR error creating objective: Allocation in slot 1 does not correspond to participant 2
```
I have also experimented with communicating the error back to the application via the `ObjectiveChanged` event; but this is only a partial implementation. Feedback requested!

Thoughts:
- We could detect if we are in a debug / test environment and `panic` when these errors happen. I believe it would not be appropriate to panic in production, but this could be pretty useful in testing.
- The `CreateVirtualChannel` API call itself could return an `(protocols.ObjectiveId, error)` pair. This is a bit difficult at present because the error is generated asynchronously in the `engine`, most likely _after_ the API call has returned.
    - We could bring the objective creation into the `client`, and have it post the objective to the `engine` (rather than the request). Idea being that problems that can be discovered quickly and synchronously can be reported back immediately to the application. 
     - Doing so is difficult because objective construction requires a read from the store (getting the two party ledger channel) which is not available to the client. 
- If we report the error asynchronously (as in my sketched solution on this PR), it is not really correct to indicate failure by objective id. This is because a subsequent request with the _correct_ parameters should succeed, and then things are ambiguous. It is the request that has failed to spawn an objective, not that the objective itself has failed. We could introduce (sequential?) request IDs to get around this. 





**Changes**
1. Requirements described above are added
2. logging enhanced
3. (Partial / Sketch) Error reporting to application enhanced
4. Incorrect test data rectified

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone


