### PR TITLE
Add basic consensus channel functionality + tests

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/crypto"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -248,6 +249,11 @@ func (c *ConsensusChannel) Propose(add Add, sk []byte) (SignedProposal, error) {
 // sign constructs a state.State from the given vars, using the ConsensusChannel's constant
 // values. It signs the resulting state using pk.
 func (c *ConsensusChannel) sign(vars Vars, pk []byte) (state.Signature, error) {
+	signer := crypto.GetAddressFromSecretKeyBytes(pk)
+	if c.Participants[c.MyIndex] != signer {
+		return state.Signature{}, fmt.Errorf("attempting to sign from wrong address: %s", signer)
+	}
+
 	fp := c.FixedPart
 	state := vars.asState(fp)
 	return state.Sign(pk)

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -28,6 +28,27 @@ type ConsensusChannel struct {
 	proposalQueue []SignedProposal // A queue of proposed changes, starting from the consensus state
 }
 
+func NewConsensusChannel(
+	fp state.FixedPart,
+	myIndex ledgerIndex,
+	outcome LedgerOutcome,
+	signatures [2]state.Signature,
+) (ConsensusChannel, error) {
+
+	current := SignedVars{
+		Vars{TurnNum: 0, Outcome: outcome},
+		signatures,
+	}
+
+	return ConsensusChannel{
+		FixedPart:     fp,
+		MyIndex:       myIndex,
+		proposalQueue: make([]SignedProposal, 0),
+		current:       current,
+	}, nil
+
+}
+
 // Balance represents an Allocation of type 0, ie. a simple allocation.
 type Balance struct {
 	destination types.Destination
@@ -138,7 +159,7 @@ type Vars struct {
 // SignedVars stores 0-2 signatures for some vars in a consensus channel
 type SignedVars struct {
 	Vars
-	Signatures [2]*state.Signature
+	Signatures [2]state.Signature
 }
 
 // SignedProposal is a proposal with a signature on it

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -249,10 +249,15 @@ func (c *ConsensusChannel) Propose(add Add, sk []byte) (SignedProposal, error) {
 // values. It signs the resulting state using pk.
 func (c *ConsensusChannel) sign(vars Vars, pk []byte) (state.Signature, error) {
 	fp := c.FixedPart
-	state := state.State{
+	state := vars.asState(fp)
+	return state.Sign(pk)
+}
+
+func (v Vars) asState(fp state.FixedPart) state.State {
+	return state.State{
 		// Variable
-		TurnNum: vars.TurnNum,
-		Outcome: vars.Outcome.AsOutcome(),
+		TurnNum: v.TurnNum,
+		Outcome: v.Outcome.AsOutcome(),
 
 		// Constant
 		ChainId:           fp.ChainId,
@@ -263,8 +268,6 @@ func (c *ConsensusChannel) sign(vars Vars, pk []byte) (state.Signature, error) {
 		AppDefinition:     types.Address{},
 		IsFinal:           false,
 	}
-
-	return state.Sign(pk)
 }
 
 func (c *ConsensusChannel) Accept(p SignedProposal) error {

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -29,6 +29,7 @@ type ConsensusChannel struct {
 	proposalQueue []SignedProposal // A queue of proposed changes, starting from the consensus state
 }
 
+// NewConsensusChannel constructs a new consensus channel, validating its input by checking that the signatures are as expected on a prefund setup state
 func NewConsensusChannel(
 	fp state.FixedPart,
 	myIndex ledgerIndex,

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -10,13 +10,18 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-const proposerIndex = uint(0)
+type ledgerIndex uint
+
+const (
+	leader ledgerIndex = 0
+	// follower ledgerIndex = 1 // TODO: uncomment when used
+)
 
 // ConsensusChannel is used to manage states in a running ledger channel
 type ConsensusChannel struct {
 	// constants
 	Id             types.Destination
-	MyIndex        uint
+	MyIndex        ledgerIndex
 	OnChainFunding types.Funds
 	state.FixedPart
 
@@ -183,7 +188,7 @@ func (vars Vars) Add(p Add) (Vars, error) {
 // the queue, returning the resulting SignedProposal
 // Note: the TurnNum on add is ignored; the correct turn number is computed by c
 func (c *ConsensusChannel) Propose(add Add, sk []byte) (SignedProposal, error) {
-	if c.MyIndex != proposerIndex {
+	if c.MyIndex != leader {
 		return SignedProposal{}, fmt.Errorf("only proposer can call Add")
 	}
 

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -20,9 +20,7 @@ const (
 // ConsensusChannel is used to manage states in a running ledger channel
 type ConsensusChannel struct {
 	// constants
-	Id             types.Destination
-	MyIndex        ledgerIndex
-	OnChainFunding types.Funds
+	MyIndex ledgerIndex
 	state.FixedPart
 
 	// variables

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -40,7 +40,7 @@ func NewConsensusChannel(
 
 	leaderAddr, err := vars.asState(fp).RecoverSigner(signatures[leader])
 	if err != nil {
-		return ConsensusChannel{}, fmt.Errorf("could not verify sig: %v", err)
+		return ConsensusChannel{}, fmt.Errorf("could not verify sig: %w", err)
 	}
 	if leaderAddr != fp.Participants[leader] {
 		return ConsensusChannel{}, fmt.Errorf("leader did not sign initial state: %v, %v", leaderAddr, fp.Participants[leader])
@@ -48,7 +48,7 @@ func NewConsensusChannel(
 
 	followerAddr, err := vars.asState(fp).RecoverSigner(signatures[follower])
 	if err != nil {
-		return ConsensusChannel{}, fmt.Errorf("could not verify sig: %v", err)
+		return ConsensusChannel{}, fmt.Errorf("could not verify sig: %w", err)
 	}
 	if followerAddr != fp.Participants[follower] {
 		return ConsensusChannel{}, fmt.Errorf("leader did not sign initial state: %v, %v", followerAddr, fp.Participants[leader])

--- a/channel/consensus_channel/consensus_channel_test.go
+++ b/channel/consensus_channel/consensus_channel_test.go
@@ -73,11 +73,11 @@ func TestConsensusChannel(t *testing.T) {
 		after, err := before.Add(proposal)
 
 		if err != nil {
-			t.Error("unable to compute next state: ", err)
+			t.Fatalf("unable to compute next state: %v", err)
 		}
 
 		if after.TurnNum != before.TurnNum+1 {
-			t.Error("incorrect state calculation", err)
+			t.Fatalf("incorrect state calculation: %v", err)
 		}
 
 		expected := makeOutcome(
@@ -88,7 +88,7 @@ func TestConsensusChannel(t *testing.T) {
 		)
 
 		if diff := cmp.Diff(after.Outcome, expected, cmp.AllowUnexported(expected, Balance{}, big.Int{}, Guarantee{})); diff != "" {
-			t.Errorf("incorrect outcome: %v", diff)
+			t.Fatalf("incorrect outcome: %v", diff)
 		}
 
 		largeProposal := proposal
@@ -97,7 +97,7 @@ func TestConsensusChannel(t *testing.T) {
 
 		_, err = before.Add(largeProposal)
 		if !errors.Is(err, ErrInsufficientFunds) {
-			t.Error("expected error when adding too large a guarantee")
+			t.Fatal("expected error when adding too large a guarantee")
 		}
 
 		duplicateProposal := proposal
@@ -105,8 +105,7 @@ func TestConsensusChannel(t *testing.T) {
 		_, err = after.Add(duplicateProposal)
 
 		if !errors.Is(err, ErrDuplicateGuarantee) {
-			t.Log(err)
-			t.Error("expected error when adding duplicate guarantee")
+			t.Fatalf("expected error when adding duplicate guarantee: %v", err)
 		}
 	}
 
@@ -136,14 +135,14 @@ func TestConsensusChannel(t *testing.T) {
 
 		_, err = channel.sign(initialVars, testdata.Actors.Bob.PrivateKey)
 		if err == nil {
-			t.Errorf("channel should check that signer is participant")
+			t.Fatalf("channel should check that signer is participant")
 		}
 
 		briansSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Brian.PrivateKey)
 		sigs[1] = briansSig
 		_, err = NewConsensusChannel(fp(), leader, outcome(), sigs)
 		if err == nil {
-			t.Errorf("channel should check that signers are participants")
+			t.Fatalf("channel should check that signers are participants")
 		}
 	}
 

--- a/channel/consensus_channel/consensus_channel_test.go
+++ b/channel/consensus_channel/consensus_channel_test.go
@@ -61,10 +61,10 @@ func TestConsensusChannel(t *testing.T) {
 
 	outcome := func() LedgerOutcome {
 		return makeOutcome(
-		allocation(alice, aBal),
-		allocation(bob, bBal),
-		guarantee(vAmount, existingChannel, alice, bob),
-	)
+			allocation(alice, aBal),
+			allocation(bob, bBal),
+			guarantee(vAmount, existingChannel, alice, bob),
+		)
 
 	}
 	testApplyingAddProposalToVars := func(t *testing.T) {
@@ -111,9 +111,9 @@ func TestConsensusChannel(t *testing.T) {
 	}
 
 	fp := func() state.FixedPart {
-	participants := [2]types.Address{
-		testdata.Actors.Alice.Address, testdata.Actors.Bob.Address,
-	}
+		participants := [2]types.Address{
+			testdata.Actors.Alice.Address, testdata.Actors.Bob.Address,
+		}
 		return state.FixedPart{
 			Participants:      participants[:],
 			ChainId:           big.NewInt(0),
@@ -125,7 +125,7 @@ func TestConsensusChannel(t *testing.T) {
 	initialVars := Vars{Outcome: outcome(), TurnNum: 0}
 	aliceSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
 	bobsSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
-		sigs := [2]state.Signature{aliceSig, bobsSig}
+	sigs := [2]state.Signature{aliceSig, bobsSig}
 
 	testConsensusChannelFunctionality := func(t *testing.T) {
 		channel, err := NewConsensusChannel(fp(), leader, outcome(), sigs)
@@ -138,8 +138,15 @@ func TestConsensusChannel(t *testing.T) {
 		if err == nil {
 			t.Errorf("channel should check that signer is participant")
 		}
+
+		briansSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Brian.PrivateKey)
+		sigs[1] = briansSig
+		_, err = NewConsensusChannel(fp(), leader, outcome(), sigs)
+		if err == nil {
+			t.Errorf("channel should check that signers are participants")
+		}
 	}
 
-	t.Run(`TestConsensusChannelFunctionality`, testConsensusChannelFunctionality)
 	t.Run(`TestApplyingAddProposalToVars`, testApplyingAddProposalToVars)
+	t.Run(`TestConsensusChannelFunctionality`, testConsensusChannelFunctionality)
 }


### PR DESCRIPTION
This PR adds a `NewConsensusChannel` function. This function performs basic input validation before returning a new ConsensusChannel.

In addition, `ConsensusChannel.sign(...)` checks that the private key provided. This is a failsafe that was missing from #373, but helps prevent surprising behaviour.
