### PR TITLE
Add error handling to `engine.go`

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -111,7 +111,6 @@ func (e *Engine) Run() {
 			panic(err)
 			// TODO do not panic if in production.
 			// TODO report errors back to the consuming application
-
 		}
 
 	}

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -101,7 +101,7 @@ func (e *Engine) Run() {
 
 		// Handle errors
 		if err != nil {
-			panic(err)
+			e.logger.Panic()
 			// TODO do not panic if in production.
 			// TODO report errors back to the consuming application
 		}

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -97,20 +97,21 @@ func (e *Engine) Run() {
 
 		case message := <-e.fromMsg:
 			res, err = e.handleMessage(message)
-
 		}
+
+		// Handle errors
+		if err != nil {
+			panic(err)
+			// TODO do not panic if in production.
+			// TODO report errors back to the consuming application
+		}
+
 		// Only send out an event if there are changes
 		if len(res.CompletedObjectives) > 0 {
 			for _, obj := range res.CompletedObjectives {
 				e.logger.Printf("Objective %s is complete & returned to API", obj.Id())
 			}
 			e.toApi <- res
-		}
-		// Handle errors
-		if err != nil {
-			panic(err)
-			// TODO do not panic if in production.
-			// TODO report errors back to the consuming application
 		}
 
 	}

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -150,7 +150,11 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (ObjectiveChang
 	e.logger.Printf("handling chain event %v", chainEvent)
 	objective, ok := e.store.GetObjectiveByChannelId(chainEvent.ChannelId)
 	if !ok {
-		return ObjectiveChangeEvent{}, fmt.Errorf("handleChainEvent: No objective in store for channel with id %s", chainEvent.ChannelId)
+		// Because the MockChain and SimpleChainService broadcast all events to all subscribers,
+		// it is likely that a client receives an irrelevant event. So we log and continue without
+		// returning an error.
+		e.logger.Printf("handleChainEvent: No objective in store for channel with id %s", chainEvent.ChannelId)
+		return ObjectiveChangeEvent{}, nil
 	}
 	event := protocols.ObjectiveEvent{
 		Holdings:           chainEvent.Holdings,


### PR DESCRIPTION
Closes #353.
Closes #355.

Error handling in the engine is next-to non-existent. This PR ensures no errors are swallowed. Instead, they are all passed back up to the engine run loop where they trigger a panic. There is one exception: the chain event handler continues to swallow store read errors when trying to lookup the objective for a chain event. This is because the current mock chain and chain service is quite dumb -- *all* information is broadcast to *all* clients. I have added comments to make this clearer.

Triggering a panic is not the long term solution, since this is irresponsible for library code to do. It has the great advantage, however, of surfacing errors quickly so we can know about them when developing / testing / debugging. 

An advantage of the approach here is that there is a single place where (most) errors will end up. We should make a new issue for having those errors dealt with properly, which should include a mechanism to communicate the errors to the consuming application (see #388 for a sketch).  

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
