### PR TITLE
Add virtualfund objective data to `testdata`

### DIFF
--- a/internal/testdata/channels.go
+++ b/internal/testdata/channels.go
@@ -1,1 +1,31 @@
 package testdata
+
+import (
+	"fmt"
+
+	"github.com/statechannels/go-nitro/channel"
+	"github.com/statechannels/go-nitro/protocols/virtualfund"
+	"github.com/statechannels/go-nitro/types"
+)
+
+type channelCollection struct {
+	// MockTwoPartyLedger constructs and returns a ledger channel
+	MockTwoPartyLedger virtualfund.GetTwoPartyLedgerFunction
+}
+
+var Channels channelCollection = channelCollection{
+	MockTwoPartyLedger: mockTwoPartyLedger,
+}
+
+func mockTwoPartyLedger(firstParty, secondParty types.Address) (ledger *channel.TwoPartyLedger, ok bool) {
+	ledger, err := channel.NewTwoPartyLedger(createLedgerState(
+		firstParty,
+		secondParty,
+		100,
+		100,
+	), 0) // todo: make myIndex configurable
+	if err != nil {
+		panic(fmt.Errorf("error mocking a twoPartyLedger: %w", err))
+	}
+	return ledger, true
+}

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -62,8 +62,8 @@ func genericVFO() virtualfund.Objective {
 	ts := testVirtualState.Clone()
 	request := virtualfund.ObjectiveRequest{
 		ts.Participants[0],
-		ts.Participants[2],
 		ts.Participants[1],
+		ts.Participants[2],
 		ts.AppDefinition,
 		ts.AppData,
 		ts.ChallengeDuration,

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -41,7 +41,7 @@ var Objectives objectiveCollection = objectiveCollection{
 }
 
 func genericDFO() directfund.Objective {
-	ts := testState
+	ts := testState.Clone()
 	request := directfund.ObjectiveRequest{
 		MyAddress:         ts.Participants[0],
 		CounterParty:      ts.Participants[1],
@@ -51,7 +51,10 @@ func genericDFO() directfund.Objective {
 		Nonce:             ts.ChannelNonce.Int64(),
 		Outcome:           ts.Outcome,
 	}
-	testObj, _ := directfund.NewObjective(request, false)
+	testObj, err := directfund.NewObjective(request, false)
+	if err != nil {
+		panic(fmt.Errorf("error constructing genericDFO: %w", err))
+	}
 	return testObj
 }
 

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -1,13 +1,17 @@
 package testdata
 
-import "github.com/statechannels/go-nitro/protocols/directfund"
+import (
+	"fmt"
+
+	"github.com/statechannels/go-nitro/protocols/directfund"
+	"github.com/statechannels/go-nitro/protocols/virtualfund"
+)
 
 // objectiveCollection namespaces literal objectives, precomputed objectives, and
 // procedural objective generators for consumption
 type objectiveCollection struct {
-	Directfund dfoCollection
-	// todo
-	// virtualfund  vfoCollection
+	Directfund  dfoCollection
+	Virtualfund vfoCollection
 	// todo
 	// directdefund ddfoCollection
 }
@@ -15,6 +19,11 @@ type objectiveCollection struct {
 type dfoCollection struct {
 	// GenericDFO returns a non-specific directfund.Objective with nonzero data.
 	GenericDFO func() directfund.Objective
+}
+
+type vfoCollection struct {
+	// GenericVFO returns a non-specific virtualfund.Objective with nonzero data.
+	GenericVFO func() virtualfund.Objective
 }
 
 // Objectives is the endpoint for tests to consume constructed objectives or
@@ -25,6 +34,9 @@ type dfoCollection struct {
 var Objectives objectiveCollection = objectiveCollection{
 	Directfund: dfoCollection{
 		GenericDFO: genericDFO,
+	},
+	Virtualfund: vfoCollection{
+		GenericVFO: genericVFO,
 	},
 }
 
@@ -41,4 +53,23 @@ func genericDFO() directfund.Objective {
 	}
 	testObj, _ := directfund.NewObjective(request, false)
 	return testObj
+}
+
+func genericVFO() virtualfund.Objective {
+	ts := testVirtualState.Clone()
+	request := virtualfund.ObjectiveRequest{
+		ts.Participants[0],
+		ts.Participants[2],
+		ts.Participants[1],
+		ts.AppDefinition,
+		ts.AppData,
+		ts.ChallengeDuration,
+		ts.Outcome,
+		ts.ChannelNonce.Int64(),
+	}
+	testVFO, err := virtualfund.NewObjective(request, Channels.MockTwoPartyLedger)
+	if err != nil {
+		panic(fmt.Errorf("error constructing genericVFO: %w", err))
+	}
+	return testVFO
 }

--- a/internal/testdata/states.go
+++ b/internal/testdata/states.go
@@ -13,10 +13,14 @@ type outcomes struct {
 	// Create returns a simple outcome {a: aBalance, b: bBalance} in the
 	// zero-asset (chain-native token)
 	Create func(a, b types.Address, aBalance, bBalance uint) outcome.Exit
+	// CreateFromMap returns a simple outcome {addressOne: balanceOne ...} in the
+	// zero-asset (chain-native token)
+	CreateFromMap func(map[types.Address]uint) outcome.Exit
 }
 
 var Outcomes outcomes = outcomes{
-	Create: createOutcome,
+	Create:        createOutcome,
+	CreateFromMap: createOutcomeFromMap,
 }
 
 var chainId, _ = big.NewInt(0).SetString("9001", 10)
@@ -66,5 +70,20 @@ func createOutcome(first types.Address, second types.Address, x, y uint) outcome
 				Amount:      big.NewInt(int64(y)),
 			},
 		},
+	}}
+}
+
+func createOutcomeFromMap(amounts map[types.Address]uint) outcome.Exit {
+
+	var allocations []outcome.Allocation
+
+	for address, balance := range amounts {
+		allocations = append(allocations, outcome.Allocation{
+			Destination: types.AddressToDestination(address),
+			Amount:      big.NewInt(int64(balance)),
+		})
+	}
+	return outcome.Exit{outcome.SingleAssetExit{
+		Allocations: allocations,
 	}}
 }

--- a/internal/testdata/states.go
+++ b/internal/testdata/states.go
@@ -24,6 +24,7 @@ var Outcomes outcomes = outcomes{
 }
 
 var chainId, _ = big.NewInt(0).SetString("9001", 10)
+var someAppDefinition = common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`)
 
 var testOutcome = outcome.Exit{
 	outcome.SingleAssetExit{
@@ -41,6 +42,25 @@ var testOutcome = outcome.Exit{
 	},
 }
 
+var testVirtualState = state.State{
+	ChainId: chainId,
+	Participants: []types.Address{
+		Actors.Alice.Address,
+		Actors.Irene.Address,
+		Actors.Bob.Address,
+	},
+	ChannelNonce:      big.NewInt(1234789),
+	AppDefinition:     someAppDefinition,
+	ChallengeDuration: big.NewInt(60),
+	AppData:           []byte{},
+	Outcome: Outcomes.CreateFromMap(map[types.Address]uint{
+		Actors.Alice.Address: 6,
+		Actors.Bob.Address:   4,
+	}),
+	TurnNum: 0,
+	IsFinal: false,
+}
+
 var testState = state.State{
 	ChainId: chainId,
 	Participants: []types.Address{
@@ -48,7 +68,7 @@ var testState = state.State{
 		Actors.Bob.Address,
 	},
 	ChannelNonce:      big.NewInt(37140676580),
-	AppDefinition:     common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),
+	AppDefinition:     someAppDefinition,
 	ChallengeDuration: big.NewInt(60),
 	AppData:           []byte{},
 	Outcome:           testOutcome,

--- a/internal/testdata/states.go
+++ b/internal/testdata/states.go
@@ -56,6 +56,19 @@ var testState = state.State{
 	IsFinal:           false,
 }
 
+func createLedgerState(client, hub types.Address, clientBalance, hubBalance uint) state.State {
+	state := testState.Clone()
+	state.Participants = []types.Address{
+		client,
+		hub,
+	}
+	state.Outcome = Outcomes.Create(client, hub, clientBalance, hubBalance)
+	state.AppDefinition = types.Address{} // ledger channel running the consensus app
+	state.TurnNum = 0                     // a requirement for channel.NewTwoPartyLedger
+
+	return state
+}
+
 // createOutcome is a helper function to create a two-actor outcome
 func createOutcome(first types.Address, second types.Address, x, y uint) outcome.Exit {
 

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -656,8 +656,8 @@ func (o *Objective) updateLedgerWithGuarantee(ledgerConnection Connection, sk *[
 // ObjectiveRequest represents a request to create a new virtual funding objective.
 type ObjectiveRequest struct {
 	MyAddress         types.Address
-	CounterParty      types.Address
 	Intermediary      types.Address
+	CounterParty      types.Address
 	AppDefinition     types.Address
 	AppData           types.Bytes
 	ChallengeDuration *types.Uint256


### PR DESCRIPTION
More incremental work toward #242, #370.

PR adds a generator for virtual fund objectives, and uses this generator to improve coverage for the mockstore, which previously hadn't written and recovered a virtualfundobjective.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary 
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 
  - on the exported `testdata` struct `vfoCollection`
#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
