### PR TITLE
Write logs to a `bytes.Buffer` during tests, and flush to a file when cleaning up the test

### DIFF
--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -2,6 +2,7 @@
 package client_test // import "github.com/statechannels/go-nitro/client_test"
 
 import (
+	"bytes"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -32,9 +33,16 @@ func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.C
 	waitTimeForCompletedObjectiveIds(t, &beta, defaultTimeout, id)
 }
 func TestDirectFundIntegration(t *testing.T) {
-	logFile := "directfund_client_test.log"
-	truncateLog(logFile)
-	logDestination := newLogWriter(logFile)
+
+	// Setup logging
+	logDestination := &bytes.Buffer{}
+	t.Cleanup(func() {
+		logFile := "directfund_client_test.log"
+		truncateLog(logFile)
+		ld := newLogWriter(logFile)
+		_, _ = ld.ReadFrom(logDestination)
+		ld.Close()
+	})
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()

--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -34,12 +34,13 @@ func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.C
 func TestDirectFundIntegration(t *testing.T) {
 	logFile := "directfund_client_test.log"
 	truncateLog(logFile)
+	logDestination := newLogWriter(logFile)
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	clientA := setupClient(alice.PrivateKey, chain, broker, logFile, 0)
-	clientB := setupClient(bob.PrivateKey, chain, broker, logFile, 0)
+	clientA := setupClient(alice.PrivateKey, chain, broker, logDestination, 0)
+	clientB := setupClient(bob.PrivateKey, chain, broker, logDestination, 0)
 
 	directlyFundALedgerChannel(t, clientA, clientB)
 

--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -36,13 +36,7 @@ func TestDirectFundIntegration(t *testing.T) {
 
 	// Setup logging
 	logDestination := &bytes.Buffer{}
-	t.Cleanup(func() {
-		logFile := "directfund_client_test.log"
-		truncateLog(logFile)
-		ld := newLogWriter(logFile)
-		_, _ = ld.ReadFrom(logDestination)
-		ld.Close()
-	})
+	t.Cleanup(flushToFileCleanupFn(logDestination, "directfund_client_test.log"))
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -74,6 +74,13 @@ func setupClient(pk []byte, chain chainservice.MockChain, msgBroker messageservi
 	return client.New(messageservice, chainservice, storeA, logDestination)
 }
 
+func flushToFileCleanupFn(w io.Reader, fileName string) func() {
+	return func() {
+		truncateLog(fileName)
+		ld := newLogWriter(fileName)
+		_, _ = ld.ReadFrom(w)
+	}
+}
 func truncateLog(logFile string) {
 	logDestination := newLogWriter(logFile)
 

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -1,6 +1,7 @@
 package client_test
 
 import (
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -64,13 +65,12 @@ func waitTimeForCompletedObjectiveIds(t *testing.T, client *client.Client, timeo
 }
 
 // setupClient is a helper function that contructs a client and returns the new client and message service.
-func setupClient(pk []byte, chain chainservice.MockChain, msgBroker messageservice.Broker, logFilename string, meanMessageDelay time.Duration) client.Client {
+func setupClient(pk []byte, chain chainservice.MockChain, msgBroker messageservice.Broker, logDestination io.Writer, meanMessageDelay time.Duration) client.Client {
 	myAddress := crypto.GetAddressFromSecretKeyBytes(pk)
 	chain.Subscribe(myAddress)
 	chainservice := chainservice.NewSimpleChainService(chain, myAddress)
 	messageservice := messageservice.NewTestMessageService(myAddress, msgBroker, meanMessageDelay)
 	storeA := store.NewMockStore(pk)
-	logDestination := newLogWriter(logFilename)
 	return client.New(messageservice, chainservice, storeA, logDestination)
 }
 

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -79,6 +79,7 @@ func flushToFileCleanupFn(w io.Reader, fileName string) func() {
 		truncateLog(fileName)
 		ld := newLogWriter(fileName)
 		_, _ = ld.ReadFrom(w)
+		ld.Close()
 	}
 }
 func truncateLog(logFile string) {

--- a/client_test/virtual_fund_message_delay_test.go
+++ b/client_test/virtual_fund_message_delay_test.go
@@ -27,13 +27,14 @@ func TestVirtualFundWithMessageDelays(t *testing.T) {
 	// Set up logging
 	logFile := "virtual_fund_message_delay_test.log"
 	truncateLog(logFile)
+	logDestination := newLogWriter(logFile)
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	clientA := setupClient(alice.PrivateKey, chain, broker, logFile, MAX_MESSAGE_DELAY)
-	clientB := setupClient(bob.PrivateKey, chain, broker, logFile, MAX_MESSAGE_DELAY)
-	clientI := setupClient(irene.PrivateKey, chain, broker, logFile, MAX_MESSAGE_DELAY)
+	clientA := setupClient(alice.PrivateKey, chain, broker, logDestination, MAX_MESSAGE_DELAY)
+	clientB := setupClient(bob.PrivateKey, chain, broker, logDestination, MAX_MESSAGE_DELAY)
+	clientI := setupClient(irene.PrivateKey, chain, broker, logDestination, MAX_MESSAGE_DELAY)
 
 	directlyFundALedgerChannel(t, clientA, clientI)
 	directlyFundALedgerChannel(t, clientI, clientB)

--- a/client_test/virtual_fund_message_delay_test.go
+++ b/client_test/virtual_fund_message_delay_test.go
@@ -1,6 +1,7 @@
 package client_test
 
 import (
+	"bytes"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -24,10 +25,15 @@ func TestVirtualFundWithMessageDelays(t *testing.T) {
 
 	// This test fails due to https://github.com/statechannels/go-nitro/issues/366
 	t.Skip()
-	// Set up logging
-	logFile := "virtual_fund_message_delay_test.log"
-	truncateLog(logFile)
-	logDestination := newLogWriter(logFile)
+
+	// Setup logging
+	logDestination := &bytes.Buffer{}
+	t.Cleanup(func() {
+		logFile := "virtual_fund_message_delay_test.log"
+		truncateLog(logFile)
+		ld := newLogWriter(logFile)
+		_, _ = ld.ReadFrom(logDestination)
+	})
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()

--- a/client_test/virtual_fund_message_delay_test.go
+++ b/client_test/virtual_fund_message_delay_test.go
@@ -28,12 +28,7 @@ func TestVirtualFundWithMessageDelays(t *testing.T) {
 
 	// Setup logging
 	logDestination := &bytes.Buffer{}
-	t.Cleanup(func() {
-		logFile := "virtual_fund_message_delay_test.log"
-		truncateLog(logFile)
-		ld := newLogWriter(logFile)
-		_, _ = ld.ReadFrom(logDestination)
-	})
+	t.Cleanup(flushToFileCleanupFn(logDestination, "virtual_fund_message_delay_test.log"))
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -21,12 +21,7 @@ func TestBenchmark(t *testing.T) {
 
 	// Setup logging
 	logDestination := &bytes.Buffer{}
-	t.Cleanup(func() {
-		logFile := "virtualfund_benchmark_test.log"
-		truncateLog(logFile)
-		ld := newLogWriter(logFile)
-		_, _ = ld.ReadFrom(logDestination)
-	})
+	t.Cleanup(flushToFileCleanupFn(logDestination, "virtualfund_benchmark_test.log"))
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -20,13 +20,14 @@ func TestBenchmark(t *testing.T) {
 
 	logFile := "virtualfund_benchmark_test.log"
 	truncateLog(logFile)
+	logDestination := newLogWriter(logFile)
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	clientAlice := setupClient(alice.PrivateKey, chain, broker, logFile, 0)
-	clientBob := setupClient(bob.PrivateKey, chain, broker, logFile, 0)
-	clientIrene := setupClient(irene.PrivateKey, chain, broker, logFile, 0)
+	clientAlice := setupClient(alice.PrivateKey, chain, broker, logDestination, 0)
+	clientBob := setupClient(bob.PrivateKey, chain, broker, logDestination, 0)
+	clientIrene := setupClient(irene.PrivateKey, chain, broker, logDestination, 0)
 
 	directlyFundALedgerChannel(t, clientAlice, clientIrene)
 	directlyFundALedgerChannel(t, clientIrene, clientBob)

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -1,6 +1,7 @@
 package client_test
 
 import (
+	"bytes"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -18,9 +19,14 @@ import (
 // to the screen.
 func TestBenchmark(t *testing.T) {
 
-	logFile := "virtualfund_benchmark_test.log"
-	truncateLog(logFile)
-	logDestination := newLogWriter(logFile)
+	// Setup logging
+	logDestination := &bytes.Buffer{}
+	t.Cleanup(func() {
+		logFile := "virtualfund_benchmark_test.log"
+		truncateLog(logFile)
+		ld := newLogWriter(logFile)
+		_, _ = ld.ReadFrom(logDestination)
+	})
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()

--- a/client_test/virtualfund_integration_test.go
+++ b/client_test/virtualfund_integration_test.go
@@ -1,6 +1,7 @@
 package client_test
 
 import (
+	"bytes"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -14,10 +15,14 @@ import (
 
 func TestVirtualFundIntegration(t *testing.T) {
 
-	// Set up logging
-	logFile := "virtualfund_client_test.log"
-	truncateLog(logFile)
-	logDestination := newLogWriter(logFile)
+	// Setup logging
+	logDestination := &bytes.Buffer{}
+	t.Cleanup(func() {
+		logFile := "virtualfund_client_test.log"
+		truncateLog(logFile)
+		ld := newLogWriter(logFile)
+		_, _ = ld.ReadFrom(logDestination)
+	})
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()

--- a/client_test/virtualfund_integration_test.go
+++ b/client_test/virtualfund_integration_test.go
@@ -17,13 +17,14 @@ func TestVirtualFundIntegration(t *testing.T) {
 	// Set up logging
 	logFile := "virtualfund_client_test.log"
 	truncateLog(logFile)
+	logDestination := newLogWriter(logFile)
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	clientA := setupClient(alice.PrivateKey, chain, broker, logFile, 0)
-	clientB := setupClient(bob.PrivateKey, chain, broker, logFile, 0)
-	clientI := setupClient(irene.PrivateKey, chain, broker, logFile, 0)
+	clientA := setupClient(alice.PrivateKey, chain, broker, logDestination, 0)
+	clientB := setupClient(bob.PrivateKey, chain, broker, logDestination, 0)
+	clientI := setupClient(irene.PrivateKey, chain, broker, logDestination, 0)
 
 	directlyFundALedgerChannel(t, clientA, clientI)
 	directlyFundALedgerChannel(t, clientI, clientB)

--- a/client_test/virtualfund_integration_test.go
+++ b/client_test/virtualfund_integration_test.go
@@ -17,12 +17,7 @@ func TestVirtualFundIntegration(t *testing.T) {
 
 	// Setup logging
 	logDestination := &bytes.Buffer{}
-	t.Cleanup(func() {
-		logFile := "virtualfund_client_test.log"
-		truncateLog(logFile)
-		ld := newLogWriter(logFile)
-		_, _ = ld.ReadFrom(logDestination)
-	})
+	t.Cleanup(flushToFileCleanupFn(logDestination, "virtualfund_client_test.log"))
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()

--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -1,6 +1,7 @@
 package client_test
 
 import (
+	"bytes"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -14,12 +15,14 @@ import (
 
 // TestMultiPartyVirtualFundIntegration tests the scenario where Alice creates virtual channels with Bob and Brian using Irene as the intermediary.
 func TestMultiPartyVirtualFundIntegration(t *testing.T) {
-	// TODO: This test can occasionally fail due to https://github.com/statechannels/go-nitro/issues/366
-	// It should be re-enabled when this issue is fixed.
 	t.Skip()
-	logFile := "virtualfund_multiparty_client_test.log"
-	truncateLog(logFile)
-	logDestination := newLogWriter(logFile)
+	logDestination := &bytes.Buffer{}
+	t.Cleanup(func() {
+		logFile := "virtualfund_multiparty_client_test.log"
+		truncateLog(logFile)
+		ld := newLogWriter(logFile)
+		_, _ = ld.ReadFrom(logDestination)
+	})
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()

--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -17,12 +17,7 @@ import (
 func TestMultiPartyVirtualFundIntegration(t *testing.T) {
 	t.Skip()
 	logDestination := &bytes.Buffer{}
-	t.Cleanup(func() {
-		logFile := "virtualfund_multiparty_client_test.log"
-		truncateLog(logFile)
-		ld := newLogWriter(logFile)
-		_, _ = ld.ReadFrom(logDestination)
-	})
+	t.Cleanup(flushToFileCleanupFn(logDestination, "virtualfund_multiparty_client_test.log"))
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()

--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -19,14 +19,15 @@ func TestMultiPartyVirtualFundIntegration(t *testing.T) {
 	t.Skip()
 	logFile := "virtualfund_multiparty_client_test.log"
 	truncateLog(logFile)
+	logDestination := newLogWriter(logFile)
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	clientAlice := setupClient(alice.PrivateKey, chain, broker, logFile, 0)
-	clientBob := setupClient(bob.PrivateKey, chain, broker, logFile, 0)
-	clientBrian := setupClient(brian.PrivateKey, chain, broker, logFile, 0)
-	clientIrene := setupClient(irene.PrivateKey, chain, broker, logFile, 0)
+	clientAlice := setupClient(alice.PrivateKey, chain, broker, logDestination, 0)
+	clientBob := setupClient(bob.PrivateKey, chain, broker, logDestination, 0)
+	clientBrian := setupClient(brian.PrivateKey, chain, broker, logDestination, 0)
+	clientIrene := setupClient(irene.PrivateKey, chain, broker, logDestination, 0)
 
 	directlyFundALedgerChannel(t, clientAlice, clientIrene)
 	directlyFundALedgerChannel(t, clientIrene, clientBob)


### PR DESCRIPTION
Closes #375, but reveals a different problem: 

```
> go test ./client_test -count=1000
--- FAIL: TestMultiPartyVirtualFundIntegration (1.02s)
    helpers_test.go:61: Objective ids [VirtualFund-0xfc5ee41721a620147acd2814517c0c06618add28bd0b87d0b5a9377e21247b42] failed to complete on client 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 within 1s
--- FAIL: TestMultiPartyVirtualFundIntegration (1.02s)
    helpers_test.go:61: Objective ids [VirtualFund-0x56e484152ee7b502e7f54f34c2893daaaed11f6294e64bb73beffbaec60d3b37] failed to complete on client 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 within 1s
--- FAIL: TestMultiPartyVirtualFundIntegration (1.03s)
    helpers_test.go:61: Objective ids [VirtualFund-0xd47397b0e9acb2e5223437b01193da1e8f93fe469c59fd1c67b1e26ba6bf019c] failed to complete on client 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 within 1s
FAIL
FAIL	github.com/statechannels/go-nitro/client_test	60.043s
FAIL

```

I think it is still worth merging because it shortens the time a log file is kept open for, and keeps IO out of the main run time of the test. 

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
