### PR TITLE
Vars.Add explicitly mutates its receiver

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -143,32 +143,6 @@ var ErrInvalidDeposit = fmt.Errorf("unable to divert to guarantee: invalid depos
 var ErrInsufficientFunds = fmt.Errorf("unable to divert to guarantee: insufficient funds")
 var ErrDuplicateGuarantee = fmt.Errorf("duplicate guarantee detected")
 
-// DivertToGuarantee deducts g.amount from o.left's balance, and
-// adds g to o.guarantees
-func (o LedgerOutcome) DivertToGuarantee(p Add) (LedgerOutcome, error) {
-	g := p.Guarantee
-
-	if types.Gt(&p.LeftDeposit, &g.amount) {
-		return LedgerOutcome{}, ErrInvalidDeposit
-	}
-
-	if types.Gt(&g.amount, &o.left.amount) {
-		return LedgerOutcome{}, ErrInsufficientFunds
-	}
-
-	o.left.amount.Sub(&o.left.amount, &p.LeftDeposit)
-	rightDeposit := p.RightDeposit()
-	o.right.amount.Sub(&o.right.amount, &rightDeposit)
-
-	_, found := o.guarantees[g.target]
-	if found {
-		return LedgerOutcome{}, ErrDuplicateGuarantee
-	}
-	o.guarantees[g.target] = g
-
-	return o, nil
-}
-
 // Vars stores the turn number and outcome for a state in a consensus channel
 type Vars struct {
 	TurnNum uint64
@@ -218,22 +192,42 @@ func (a Add) RightDeposit() big.Int {
 
 var ErrIncorrectTurnNum = fmt.Errorf("incorrect turn number")
 
-// Add updates Vars by including a guarantee, updating balances accordingly
-func (vars Vars) Add(p Add) (Vars, error) {
+// Add mutates Vars by
+// - increasing the turn number by 1
+// - including the guarantee
+// - adjusting balances accordingly
+func (vars *Vars) Add(p Add) error {
 	if p.turnNum != vars.TurnNum+1 {
-		return Vars{}, ErrIncorrectTurnNum
+		return ErrIncorrectTurnNum
 	}
 
+	// Increase the turn number
 	vars.TurnNum += 1
 
-	o, err := vars.Outcome.DivertToGuarantee(p)
+	o := vars.Outcome
+	g := p.Guarantee
 
-	if err != nil {
-		return Vars{}, err
+	// Include the guarantee
+	_, found := o.guarantees[g.target]
+	if found {
+		return ErrDuplicateGuarantee
+	}
+	o.guarantees[g.target] = g
+
+	// Adjust balances
+	if types.Gt(&p.LeftDeposit, &g.amount) {
+		return ErrInvalidDeposit
 	}
 
-	vars.Outcome = o
-	return vars, nil
+	if types.Gt(&g.amount, &o.left.amount) {
+		return ErrInsufficientFunds
+	}
+
+	o.left.amount.Sub(&o.left.amount, &p.LeftDeposit)
+	rightDeposit := p.RightDeposit()
+	o.right.amount.Sub(&o.right.amount, &rightDeposit)
+
+	return nil
 }
 
 // Propose receives a proposal to add a guarantee, and generates and stores a SignedProposal in
@@ -257,7 +251,7 @@ func (c *ConsensusChannel) Propose(add Add, sk []byte) (SignedProposal, error) {
 
 	add.turnNum = latestProposal.turnNum + 1
 
-	vars, err = vars.Add(add)
+	err = vars.Add(add)
 	if err != nil {
 		return SignedProposal{}, fmt.Errorf("propose could not add new state vars: %w", err)
 	}
@@ -280,7 +274,7 @@ func (c *ConsensusChannel) latestProposedVars() (Vars, error) {
 
 	var err error
 	for _, p := range c.proposalQueue {
-		vars, err = vars.Add(p.Proposal.(Add))
+		err = vars.Add(p.Proposal.(Add))
 		if err != nil {
 			return Vars{}, err
 		}


### PR DESCRIPTION
Fixes #400 by:
- making `Vars.Add` a pointer receiver that mutates its value
- implementing `latestProposedVars` which uses a new `clone` method to clone the current vars

I decided to get rid of `DivertToGuarantee` (note: it is only used in one place) since this collects the logic for incorporating an `Add` proposal into `Vars`.

`Vars.Add` mutating its receiver may deviate from some other patterns found in `go-nitro`, but this solution seems to be the simplest solution: it avoids having to implement multiple `clone` methods, and avoids creating many unused copies of almost-the-same-data as the ProposalQueue is processed.