### PR TITLE
Refactor exported code

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -231,37 +231,6 @@ func (vars *Vars) Add(p Add) error {
 	return nil
 }
 
-// Propose receives a proposal to add a guarantee, and generates and stores a SignedProposal in
-// the queue, returning the resulting SignedProposal
-// Note: the TurnNum on add is ignored; the correct turn number is computed by c
-func (c *ConsensusChannel) Propose(add Add, sk []byte) (SignedProposal, error) {
-	if c.MyIndex != leader {
-		return SignedProposal{}, fmt.Errorf("only proposer can call Add")
-	}
-
-	vars, err := c.latestProposedVars()
-	if err != nil {
-		return SignedProposal{}, fmt.Errorf("unable to construct latest proposed vars: %w", err)
-	}
-
-	add.turnNum = vars.TurnNum + 1
-
-	err = vars.Add(add)
-	if err != nil {
-		return SignedProposal{}, fmt.Errorf("propose could not add new state vars: %w", err)
-	}
-
-	signature, err := c.sign(vars, sk)
-	if err != nil {
-		return SignedProposal{}, fmt.Errorf("unable to sign state update: %f", err)
-	}
-
-	signed := SignedProposal{Proposal: add, Signature: signature}
-
-	c.proposalQueue = append(c.proposalQueue, signed)
-	return signed, nil
-}
-
 // latestProposedVars returns the latest proposed vars in a consensus channel
 // by cloning its current vars and applying each proposal in the queue
 func (c *ConsensusChannel) latestProposedVars() (Vars, error) {

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -18,41 +18,41 @@ const (
 	follower ledgerIndex = 1
 )
 
-// ConsensusChannel is used to manage states in a running ledger channel
-type ConsensusChannel struct {
+// consensusChannel is used to manage states in a running ledger channel
+type consensusChannel struct {
 	// constants
-	MyIndex ledgerIndex
-	state.FixedPart
+	myIndex ledgerIndex
+	fp      state.FixedPart
 
 	// variables
 	current       SignedVars       // The "consensus state", signed by both parties
 	proposalQueue []SignedProposal // A queue of proposed changes, starting from the consensus state
 }
 
-// NewConsensusChannel constructs a new consensus channel, validating its input by checking that the signatures are as expected on a prefund setup state
-func NewConsensusChannel(
+// newConsensusChannel constructs a new consensus channel, validating its input by checking that the signatures are as expected on a prefund setup state
+func newConsensusChannel(
 	fp state.FixedPart,
 	myIndex ledgerIndex,
 	outcome LedgerOutcome,
 	signatures [2]state.Signature,
-) (ConsensusChannel, error) {
+) (consensusChannel, error) {
 	vars := Vars{TurnNum: 0, Outcome: outcome}
 	vars = vars.clone()
 
 	leaderAddr, err := vars.asState(fp).RecoverSigner(signatures[leader])
 	if err != nil {
-		return ConsensusChannel{}, fmt.Errorf("could not verify sig: %w", err)
+		return consensusChannel{}, fmt.Errorf("could not verify sig: %w", err)
 	}
 	if leaderAddr != fp.Participants[leader] {
-		return ConsensusChannel{}, fmt.Errorf("leader did not sign initial state: %v, %v", leaderAddr, fp.Participants[leader])
+		return consensusChannel{}, fmt.Errorf("leader did not sign initial state: %v, %v", leaderAddr, fp.Participants[leader])
 	}
 
 	followerAddr, err := vars.asState(fp).RecoverSigner(signatures[follower])
 	if err != nil {
-		return ConsensusChannel{}, fmt.Errorf("could not verify sig: %w", err)
+		return consensusChannel{}, fmt.Errorf("could not verify sig: %w", err)
 	}
 	if followerAddr != fp.Participants[follower] {
-		return ConsensusChannel{}, fmt.Errorf("leader did not sign initial state: %v, %v", followerAddr, fp.Participants[leader])
+		return consensusChannel{}, fmt.Errorf("leader did not sign initial state: %v, %v", followerAddr, fp.Participants[leader])
 	}
 
 	current := SignedVars{
@@ -60,9 +60,9 @@ func NewConsensusChannel(
 		signatures,
 	}
 
-	return ConsensusChannel{
-		FixedPart:     fp,
-		MyIndex:       myIndex,
+	return consensusChannel{
+		fp:            fp,
+		myIndex:       myIndex,
 		proposalQueue: make([]SignedProposal, 0),
 		current:       current,
 	}, nil
@@ -233,7 +233,7 @@ func (vars *Vars) Add(p Add) error {
 
 // latestProposedVars returns the latest proposed vars in a consensus channel
 // by cloning its current vars and applying each proposal in the queue
-func (c *ConsensusChannel) latestProposedVars() (Vars, error) {
+func (c *consensusChannel) latestProposedVars() (Vars, error) {
 	vars := c.current.Vars.clone()
 
 	var err error
@@ -249,14 +249,13 @@ func (c *ConsensusChannel) latestProposedVars() (Vars, error) {
 
 // sign constructs a state.State from the given vars, using the ConsensusChannel's constant
 // values. It signs the resulting state using pk.
-func (c *ConsensusChannel) sign(vars Vars, pk []byte) (state.Signature, error) {
+func (c *consensusChannel) sign(vars Vars, pk []byte) (state.Signature, error) {
 	signer := crypto.GetAddressFromSecretKeyBytes(pk)
-	if c.Participants[c.MyIndex] != signer {
+	if c.fp.Participants[c.myIndex] != signer {
 		return state.Signature{}, fmt.Errorf("attempting to sign from wrong address: %s", signer)
 	}
 
-	fp := c.FixedPart
-	state := vars.asState(fp)
+	state := vars.asState(c.fp)
 	return state.Sign(pk)
 }
 
@@ -277,6 +276,6 @@ func (v Vars) asState(fp state.FixedPart) state.State {
 	}
 }
 
-func (c *ConsensusChannel) Accept(p SignedProposal) error {
+func (c *consensusChannel) Accept(p SignedProposal) error {
 	panic("UNIMPLEMENTED")
 }

--- a/channel/consensus_channel/consensus_channel_test.go
+++ b/channel/consensus_channel/consensus_channel_test.go
@@ -3,7 +3,6 @@ package consensus_channel
 import (
 	"errors"
 	"math/big"
-	"reflect"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -198,59 +197,6 @@ func TestConsensusChannel(t *testing.T) {
 		}
 	}
 
-	testAsLeader := func(t *testing.T) {
-		channel, err := NewConsensusChannel(fp(), leader, outcome(), sigs)
-		if err != nil {
-			t.Fatal("unable to construct channel")
-		}
-
-		amountAdded := uint64(10)
-
-		latest, _ := channel.latestProposedVars()
-		if initialVars.TurnNum != 0 {
-			t.Fatal("initialized with non-zero turn number")
-		}
-
-		p := add(1, amountAdded, targetChannel, alice, bob)
-		sp, err := channel.Propose(p, testdata.Actors.Alice.PrivateKey)
-		if err != nil {
-			t.Fatalf("failed to add proposal: %v", err)
-		}
-
-		latest, _ = channel.latestProposedVars()
-		if latest.TurnNum != 1 {
-			t.Fatal("incorrect latest proposed vars")
-		}
-
-		outcomeSigned := makeOutcome(
-			allocation(alice, aBal-amountAdded),
-			allocation(bob, bBal),
-			guarantee(vAmount, existingChannel, alice, bob),
-			guarantee(amountAdded, targetChannel, alice, bob),
-		)
-		stateSigned := Vars{TurnNum: 1, Outcome: outcomeSigned}
-		sig, _ := stateSigned.asState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
-		expected := SignedProposal{Proposal: p, Signature: sig}
-
-		if !reflect.DeepEqual(sp, expected) {
-			t.Fatalf("propose failed")
-		}
-
-		thirdChannel := types.Destination{3}
-		p2 := p
-		p2.target = thirdChannel
-		_, err = channel.Propose(p2, testdata.Actors.Alice.PrivateKey)
-		if err != nil {
-			t.Fatalf("failed to add another proposal: %v", err)
-		}
-
-		latest, _ = channel.latestProposedVars()
-		if latest.TurnNum != 2 {
-			t.Fatal("incorrect latest proposed vars")
-		}
-	}
-
 	t.Run(`TestApplyingAddProposalToVars`, testApplyingAddProposalToVars)
 	t.Run(`TestConsensusChannelFunctionality`, testConsensusChannelFunctionality)
-	t.Run(`TestAsLeader`, testAsLeader)
 }

--- a/channel/consensus_channel/consensus_channel_test.go
+++ b/channel/consensus_channel/consensus_channel_test.go
@@ -166,7 +166,7 @@ func TestConsensusChannel(t *testing.T) {
 	sigs := [2]state.Signature{aliceSig, bobsSig}
 
 	testConsensusChannelFunctionality := func(t *testing.T) {
-		channel, err := NewConsensusChannel(fp(), leader, outcome(), sigs)
+		channel, err := newConsensusChannel(fp(), leader, outcome(), sigs)
 
 		if err != nil {
 			t.Fatalf("unable to construct a new consensus channel: %v", err)
@@ -191,7 +191,7 @@ func TestConsensusChannel(t *testing.T) {
 
 		briansSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Brian.PrivateKey)
 		wrongSigs := [2]state.Signature{sigs[1], briansSig}
-		_, err = NewConsensusChannel(fp(), leader, outcome(), wrongSigs)
+		_, err = newConsensusChannel(fp(), leader, outcome(), wrongSigs)
 		if err == nil {
 			t.Fatalf("channel should check that signers are participants")
 		}

--- a/channel/consensus_channel/leader_channel.go
+++ b/channel/consensus_channel/leader_channel.go
@@ -1,0 +1,53 @@
+package consensus_channel
+
+import (
+	"fmt"
+
+	"github.com/statechannels/go-nitro/channel/state"
+)
+
+type LeaderChannel struct {
+	LeaderInterface
+	ConsensusChannel
+}
+
+func NewLeaderChannel(fp state.FixedPart, outcome LedgerOutcome, signatures [2]state.Signature) (LeaderChannel, error) {
+	channel, err := NewConsensusChannel(fp, leader, outcome, signatures)
+
+	return LeaderChannel{ConsensusChannel: channel}, err
+}
+
+type LeaderInterface interface {
+	Propose(add Add, sk []byte) (SignedProposal, error)
+}
+
+// Propose receives a proposal to add a guarantee, and generates and stores a SignedProposal in
+// the queue, returning the resulting SignedProposal
+// Note: the TurnNum on add is ignored; the correct turn number is computed by c
+func (c *LeaderChannel) Propose(add Add, sk []byte) (SignedProposal, error) {
+	if c.MyIndex != leader {
+		return SignedProposal{}, fmt.Errorf("only proposer can call Add")
+	}
+
+	vars, err := c.latestProposedVars()
+	if err != nil {
+		return SignedProposal{}, fmt.Errorf("unable to construct latest proposed vars: %w", err)
+	}
+
+	add.turnNum = vars.TurnNum + 1
+
+	err = vars.Add(add)
+	if err != nil {
+		return SignedProposal{}, fmt.Errorf("propose could not add new state vars: %w", err)
+	}
+
+	signature, err := c.sign(vars, sk)
+	if err != nil {
+		return SignedProposal{}, fmt.Errorf("unable to sign state update: %f", err)
+	}
+
+	signed := SignedProposal{Proposal: add, Signature: signature}
+
+	c.proposalQueue = append(c.proposalQueue, signed)
+	return signed, nil
+}

--- a/channel/consensus_channel/leader_channel.go
+++ b/channel/consensus_channel/leader_channel.go
@@ -6,26 +6,23 @@ import (
 	"github.com/statechannels/go-nitro/channel/state"
 )
 
+// LeaderChannel is used by a leader's virtualfund objective to make and receive ledger updates
 type LeaderChannel struct {
-	LeaderInterface
-	ConsensusChannel
+	consensusChannel
 }
 
+// NewLeaderChannel constructs a new LeaderChannel
 func NewLeaderChannel(fp state.FixedPart, outcome LedgerOutcome, signatures [2]state.Signature) (LeaderChannel, error) {
-	channel, err := NewConsensusChannel(fp, leader, outcome, signatures)
+	channel, err := newConsensusChannel(fp, leader, outcome, signatures)
 
-	return LeaderChannel{ConsensusChannel: channel}, err
-}
-
-type LeaderInterface interface {
-	Propose(add Add, sk []byte) (SignedProposal, error)
+	return LeaderChannel{consensusChannel: channel}, err
 }
 
 // Propose receives a proposal to add a guarantee, and generates and stores a SignedProposal in
 // the queue, returning the resulting SignedProposal
 // Note: the TurnNum on add is ignored; the correct turn number is computed by c
 func (c *LeaderChannel) Propose(add Add, sk []byte) (SignedProposal, error) {
-	if c.MyIndex != leader {
+	if c.myIndex != leader {
 		return SignedProposal{}, fmt.Errorf("only proposer can call Add")
 	}
 

--- a/channel/consensus_channel/leader_channel_test.go
+++ b/channel/consensus_channel/leader_channel_test.go
@@ -1,0 +1,135 @@
+package consensus_channel
+
+import (
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/internal/testdata"
+	"github.com/statechannels/go-nitro/types"
+)
+
+func TestLeaderChannel(t *testing.T) {
+	var alice = types.Destination(common.HexToHash("0x0a"))
+	var bob = types.Destination(common.HexToHash("0x0b"))
+
+	allocation := func(d types.Destination, a uint64) Balance {
+		return Balance{destination: d, amount: *big.NewInt(int64(a))}
+	}
+
+	guarantee := func(amount uint64, target, left, right types.Destination) Guarantee {
+		return Guarantee{
+			target: target,
+			amount: *big.NewInt(int64(amount)),
+			left:   left,
+			right:  right,
+		}
+	}
+
+	makeOutcome := func(left, right Balance, guarantees ...Guarantee) LedgerOutcome {
+		mappedGuarantees := make(map[types.Destination]Guarantee)
+		for _, g := range guarantees {
+			mappedGuarantees[g.target] = g
+		}
+		return LedgerOutcome{left: left, right: right, guarantees: mappedGuarantees}
+	}
+
+	add := func(turnNum, amount uint64, vId, left, right types.Destination) Add {
+		bigAmount := *big.NewInt(int64(amount))
+		return Add{
+			turnNum: turnNum,
+			Guarantee: Guarantee{
+				amount: bigAmount,
+				target: vId,
+				left:   left,
+				right:  right,
+			},
+			LeftDeposit: bigAmount,
+		}
+	}
+
+	existingChannel := types.Destination{1}
+	targetChannel := types.Destination{2}
+	aBal := uint64(200)
+	bBal := uint64(300)
+	vAmount := uint64(5)
+
+	outcome := func() LedgerOutcome {
+		return makeOutcome(
+			allocation(alice, aBal),
+			allocation(bob, bBal),
+			guarantee(vAmount, existingChannel, alice, bob),
+		)
+
+	}
+
+	fp := func() state.FixedPart {
+		participants := [2]types.Address{
+			testdata.Actors.Alice.Address, testdata.Actors.Bob.Address,
+		}
+		return state.FixedPart{
+			Participants:      participants[:],
+			ChainId:           big.NewInt(0),
+			ChannelNonce:      big.NewInt(9001),
+			ChallengeDuration: big.NewInt(100),
+		}
+	}
+
+	initialVars := Vars{Outcome: outcome(), TurnNum: 0}
+	aliceSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
+	bobsSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
+	sigs := [2]state.Signature{aliceSig, bobsSig}
+
+	channel, err := NewLeaderChannel(fp(), outcome(), sigs)
+	if err != nil {
+		t.Fatal("unable to construct channel")
+	}
+
+	amountAdded := uint64(10)
+
+	latest, _ := channel.latestProposedVars()
+	if initialVars.TurnNum != 0 {
+		t.Fatal("initialized with non-zero turn number")
+	}
+
+	p := add(1, amountAdded, targetChannel, alice, bob)
+	sp, err := channel.Propose(p, testdata.Actors.Alice.PrivateKey)
+	if err != nil {
+		t.Fatalf("failed to add proposal: %v", err)
+	}
+
+	latest, _ = channel.latestProposedVars()
+	if latest.TurnNum != 1 {
+		t.Fatal("incorrect latest proposed vars")
+	}
+
+	outcomeSigned := makeOutcome(
+		allocation(alice, aBal-amountAdded),
+		allocation(bob, bBal),
+		guarantee(vAmount, existingChannel, alice, bob),
+		guarantee(amountAdded, targetChannel, alice, bob),
+	)
+	stateSigned := Vars{TurnNum: 1, Outcome: outcomeSigned}
+	sig, _ := stateSigned.asState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
+	expected := SignedProposal{Proposal: p, Signature: sig}
+
+	if !reflect.DeepEqual(sp, expected) {
+		t.Fatalf("propose failed")
+	}
+
+	thirdChannel := types.Destination{3}
+	p2 := p
+	p2.target = thirdChannel
+	_, err = channel.Propose(p2, testdata.Actors.Alice.PrivateKey)
+	if err != nil {
+		t.Fatalf("failed to add another proposal: %v", err)
+	}
+
+	latest, _ = channel.latestProposedVars()
+	if latest.TurnNum != 2 {
+		t.Fatal("incorrect latest proposed vars")
+	}
+
+}


### PR DESCRIPTION
This aims to simplify the consensus_channel exports by:
1. splitting the API that we expect a leader's `virtualfund` objective to use into `leader_channel.go`
2. making some of the code from `consensus_channel.go` unexported.

 
Perhaps more of `consensus_channel.go` should be un-exported: see https://github.com/statechannels/go-nitro/issues/408