### PR TITLE
Implement UpdateConsensus

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -110,6 +110,19 @@ type LedgerOutcome struct {
 	guarantees   map[types.Destination]Guarantee
 }
 
+func (o *LedgerOutcome) includes(g Guarantee) bool {
+	existing, found := o.guarantees[g.target]
+	if !found {
+		return false
+	}
+
+	return g.left == existing.left &&
+		g.right == existing.right &&
+		g.target == existing.target &&
+		types.Equal(&existing.amount, &g.amount)
+}
+
+
 // AsOutcome converts a LedgerOutcome to an on-chain exit according to the following convention:
 // - the "left" balance is first
 // - the "right" balance is second

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -122,7 +122,6 @@ func (o *LedgerOutcome) includes(g Guarantee) bool {
 		types.Equal(&existing.amount, &g.amount)
 }
 
-
 // AsOutcome converts a LedgerOutcome to an on-chain exit according to the following convention:
 // - the "left" balance is first
 // - the "right" balance is second

--- a/channel/consensus_channel/leader_channel.go
+++ b/channel/consensus_channel/leader_channel.go
@@ -18,6 +18,11 @@ func NewLeaderChannel(fp state.FixedPart, outcome LedgerOutcome, signatures [2]s
 	return LeaderChannel{consensusChannel: channel}, err
 }
 
+// ConsensusTurnNum returns the turn number of the current consensus state
+func (c *LeaderChannel) ConsensusTurnNum() uint64 {
+	return c.current.TurnNum
+}
+
 // Propose receives a proposal to add a guarantee, and generates and stores a SignedProposal in
 // the queue, returning the resulting SignedProposal
 // Note: the TurnNum on add is ignored; the correct turn number is computed by c

--- a/channel/consensus_channel/leader_channel.go
+++ b/channel/consensus_channel/leader_channel.go
@@ -23,6 +23,22 @@ func (c *LeaderChannel) ConsensusTurnNum() uint64 {
 	return c.current.TurnNum
 }
 
+// IsProposed returns whether or not the consensus state or any proposed state
+// includes the given guarantee
+func (c *LeaderChannel) IsProposed(g Guarantee) (bool, error) {
+	latest, err := c.latestProposedVars()
+	if err != nil {
+		return false, err
+	}
+
+	return latest.Outcome.includes(g), nil
+}
+
+// Includes returns whether or not the consensus state includes the given guarantee
+func (c *LeaderChannel) Includes(g Guarantee) bool {
+	return c.current.Outcome.includes(g)
+}
+
 // Propose receives a proposal to add a guarantee, and generates and stores a SignedProposal in
 // the queue, returning the resulting SignedProposal
 // Note: the TurnNum on add is ignored; the correct turn number is computed by c

--- a/channel/consensus_channel/leader_channel.go
+++ b/channel/consensus_channel/leader_channel.go
@@ -69,3 +69,66 @@ func (c *LeaderChannel) Propose(add Add, sk []byte) (SignedProposal, error) {
 	c.proposalQueue = append(c.proposalQueue, signed)
 	return signed, nil
 }
+
+// UpdateConsensus iterates through the leader's proposal queue until it finds a proposal
+// matching their proposal. If their signature was the follower:
+// - the consensus state is updated
+// - the proposal queue is trimmed
+//
+// If their proposal is stale (ie. theirP.TurnNum <= c.current.TurnNum) then
+// their proposal is ignored
+func (c *LeaderChannel) UpdateConsensus(theirP SignedProposal) error {
+	vars := c.current.clone()
+
+	received, ok := theirP.Proposal.(Add)
+	if !ok {
+		// TODO: We'll need to expect other proposals in the future!
+		return fmt.Errorf("unexpected proposal")
+	}
+
+	if received.turnNum <= vars.TurnNum {
+		// We've already seen this proposal; return early
+		return nil
+	}
+
+	for i, ourP := range c.proposalQueue {
+		existing, ok := ourP.Proposal.(Add)
+		if !ok {
+			// TODO: We'll need to expect other proposals in the future!
+			return fmt.Errorf("unexpected proposal")
+		}
+
+		err := vars.Add(existing)
+		if err != nil {
+			return err
+		}
+
+		if existing.turnNum == received.turnNum {
+			signer, err := vars.asState(c.fp).RecoverSigner(theirP.Signature)
+
+			if err != nil {
+				return fmt.Errorf("unable to recover signer: %w", err)
+			}
+
+			if signer != c.fp.Participants[1-c.myIndex] { // todo refactor
+				return ErrWrongSigner
+			}
+
+			mySig := ourP.Signature
+			theirSig := theirP.Signature
+			c.current = SignedVars{
+				Vars:       vars,
+				Signatures: [2]state.Signature{mySig, theirSig},
+			}
+
+			c.proposalQueue = c.proposalQueue[i+1:]
+
+			return nil
+		}
+	}
+
+	return ErrProposalQueueExhausted
+}
+
+var ErrProposalQueueExhausted = fmt.Errorf("proposal queue exhausted")
+var ErrWrongSigner = fmt.Errorf("proposal incorrectly signed")

--- a/channel/consensus_channel/leader_channel_test.go
+++ b/channel/consensus_channel/leader_channel_test.go
@@ -104,6 +104,9 @@ func TestLeaderChannel(t *testing.T) {
 	if latest.TurnNum != 1 {
 		t.Fatal("incorrect latest proposed vars")
 	}
+	if channel.ConsensusTurnNum() != 0 {
+		t.Fatal("consensus incorrectly updated")
+	}
 
 	outcomeSigned := makeOutcome(
 		allocation(alice, aBal-amountAdded),
@@ -130,6 +133,9 @@ func TestLeaderChannel(t *testing.T) {
 	latest, _ = channel.latestProposedVars()
 	if latest.TurnNum != 2 {
 		t.Fatal("incorrect latest proposed vars")
+	}
+	if channel.ConsensusTurnNum() != 0 {
+		t.Fatal("consensus incorrectly updated")
 	}
 
 }

--- a/channel/consensus_channel/leader_channel_test.go
+++ b/channel/consensus_channel/leader_channel_test.go
@@ -89,7 +89,7 @@ func TestLeaderChannel(t *testing.T) {
 
 	amountAdded := uint64(10)
 
-	latest, _ := channel.latestProposedVars()
+	// latest, _ := channel.latestProposedVars()
 	if initialVars.TurnNum != 0 {
 		t.Fatal("initialized with non-zero turn number")
 	}
@@ -100,11 +100,11 @@ func TestLeaderChannel(t *testing.T) {
 		t.Fatalf("failed to add proposal: %v", err)
 	}
 
-	latest, _ = channel.latestProposedVars()
-	if latest.TurnNum != 1 {
+	success, _ := channel.IsProposed(p.Guarantee)
+	if !success {
 		t.Fatal("incorrect latest proposed vars")
 	}
-	if channel.ConsensusTurnNum() != 0 {
+	if channel.ConsensusTurnNum() != 0 || channel.Includes(p.Guarantee) {
 		t.Fatal("consensus incorrectly updated")
 	}
 
@@ -130,8 +130,8 @@ func TestLeaderChannel(t *testing.T) {
 		t.Fatalf("failed to add another proposal: %v", err)
 	}
 
-	latest, _ = channel.latestProposedVars()
-	if latest.TurnNum != 2 {
+	success, _ = channel.IsProposed(p2.Guarantee)
+	if !success {
 		t.Fatal("incorrect latest proposed vars")
 	}
 	if channel.ConsensusTurnNum() != 0 {

--- a/channel/consensus_channel/leader_channel_test.go
+++ b/channel/consensus_channel/leader_channel_test.go
@@ -90,7 +90,6 @@ func TestLeaderChannel(t *testing.T) {
 
 	amountAdded := uint64(10)
 
-	// latest, _ := channel.latestProposedVars()
 	if initialVars.TurnNum != 0 {
 		t.Fatal("initialized with non-zero turn number")
 	}


### PR DESCRIPTION
Closes #395

I chose to implement Option 2, as it is simple to implement. This implements the full ConsensusChannel behaviour on the leader's side

... except that the leader does not receive a side effect that looks like`{type: 'CrankObjective', ids: ['virtualfund-123', 'virtualdefund-abc']}`. The point of doing it this way is to drive the ConsensusChannel implementation as quickly as possible to a point where it makes sense to begin the **Integration** part of https://github.com/statechannels/go-nitro/issues/391. Once we do the integration, we can check how well Option 2 works, and adjust what's stored in the `proposalQueue` accordingly.
