### PR TITLE
All LedgerOutcome methods are pointer receivers

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -162,9 +162,18 @@ type Vars struct {
 }
 
 // clone returns a deep clone of v
-func (o LedgerOutcome) clone() LedgerOutcome {
-	o.left.amount = *big.NewInt(0).Set(&o.left.amount)
-	o.right.amount = *big.NewInt(0).Set(&o.right.amount)
+func (o *LedgerOutcome) clone() LedgerOutcome {
+	assetAddress := o.assetAddress
+
+	left := Balance{
+		destination: o.left.destination,
+		amount:      *big.NewInt(0).Set(&o.left.amount),
+	}
+
+	right := Balance{
+		destination: o.right.destination,
+		amount:      *big.NewInt(0).Set(&o.right.amount),
+	}
 
 	guarantees := make(map[types.Destination]Guarantee)
 	for d, g := range o.guarantees {
@@ -172,9 +181,13 @@ func (o LedgerOutcome) clone() LedgerOutcome {
 		g2.amount = *big.NewInt(0).Set(&g.amount)
 		guarantees[d] = g2
 	}
-	o.guarantees = guarantees
 
-	return o
+	return LedgerOutcome{
+		assetAddress: assetAddress,
+		left:         left,
+		right:        right,
+		guarantees:   guarantees,
+	}
 }
 
 // SignedVars stores 0-2 signatures for some vars in a consensus channel

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -125,7 +125,7 @@ func (o *LedgerOutcome) includes(g Guarantee) bool {
 // - the "left" balance is first
 // - the "right" balance is second
 // - following [left, right] comes the guarantees in sorted order
-func (o LedgerOutcome) AsOutcome() outcome.Exit {
+func (o *LedgerOutcome) AsOutcome() outcome.Exit {
 	// The first items are [left, right] balances
 	allocations := outcome.Allocations{o.left.AsAllocation(), o.right.AsAllocation()}
 


### PR DESCRIPTION
Following https://statechannels.slack.com/archives/C02CWRSH77X/p1648318876223959 and https://github.com/golang/go/wiki/CodeReviewComments#receiver-type, all LedgerOutcome methods are now pointer receivers.

**How Has This Been Tested?** [Optional]

This refactor is covered by the `consensus_channel_test.go` file.
