### PR TITLE
Implement SignNextProposal

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -87,7 +87,7 @@ type Guarantee struct {
 	right  types.Destination
 }
 
-func (g Guarantee) Equal(g2 Guarantee) bool {
+func (g Guarantee) equal(g2 Guarantee) bool {
 	if !types.Equal(&g.amount, &g2.amount) {
 		return false
 	}
@@ -215,7 +215,7 @@ func (a Add) Equal(a2 Add) bool {
 	if a.turnNum != a2.turnNum {
 		return false
 	}
-	if !a.Guarantee.Equal(a2.Guarantee) {
+	if !a.Guarantee.equal(a2.Guarantee) {
 		return false
 	}
 	return types.Equal(&a.LeftDeposit, &a2.LeftDeposit)

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -211,7 +211,7 @@ func (a Add) RightDeposit() big.Int {
 	return result
 }
 
-func (a Add) Equal(a2 Add) bool {
+func (a Add) equal(a2 Add) bool {
 	if a.turnNum != a2.turnNum {
 		return false
 	}

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -87,6 +87,13 @@ type Guarantee struct {
 	right  types.Destination
 }
 
+func (g Guarantee) Equal(g2 Guarantee) bool {
+	if !types.Equal(&g.amount, &g2.amount) {
+		return false
+	}
+	return g.target == g2.target && g.left == g2.left && g.right == g2.right
+}
+
 // AsAllocation converts a Balance struct into the on-chain outcome.Allocation type
 func (g Guarantee) AsAllocation() outcome.Allocation {
 	return outcome.Allocation{
@@ -202,6 +209,16 @@ func (a Add) RightDeposit() big.Int {
 	result.Sub(&a.amount, &a.LeftDeposit)
 
 	return result
+}
+
+func (a Add) Equal(a2 Add) bool {
+	if a.turnNum != a2.turnNum {
+		return false
+	}
+	if !a.Guarantee.Equal(a2.Guarantee) {
+		return false
+	}
+	return types.Equal(&a.LeftDeposit, &a2.LeftDeposit)
 }
 
 var ErrIncorrectTurnNum = fmt.Errorf("incorrect turn number")

--- a/channel/consensus_channel/follower_channel.go
+++ b/channel/consensus_channel/follower_channel.go
@@ -34,7 +34,7 @@ func (c *FollowerChannel) Includes(g Guarantee) bool {
 
 // SignNextProposal inspects whether the expected proposal matches the first proposal in
 // the queue. If so, the proposal is removed from the queue and integrated into the channel state
-func (c *FollowerChannel) SignNextProposal(expectedUpdate interface{}, pk []byte) error {
+func (c *FollowerChannel) SignNextProposal(expectedProposal interface{}, pk []byte) error {
 	if len(c.proposalQueue) == 0 {
 		return ErrNoProposals
 	}
@@ -42,7 +42,7 @@ func (c *FollowerChannel) SignNextProposal(expectedUpdate interface{}, pk []byte
 	if !ok {
 		return ErrUnsupportedQueuedProposal
 	}
-	expectedP, ok := expectedUpdate.(Add)
+	expectedP, ok := expectedProposal.(Add)
 	if !ok {
 		return ErrUnsupportedExpectedProposal
 	}

--- a/channel/consensus_channel/follower_channel.go
+++ b/channel/consensus_channel/follower_channel.go
@@ -17,7 +17,7 @@ type FollowerChannel struct {
 
 // NewFollowerChannel constructs a new FollowerChannel
 func NewFollowerChannel(fp state.FixedPart, outcome LedgerOutcome, signatures [2]state.Signature) (FollowerChannel, error) {
-	channel, err := newConsensusChannel(fp, leader, outcome, signatures)
+	channel, err := newConsensusChannel(fp, follower, outcome, signatures)
 
 	return FollowerChannel{consensusChannel: channel}, err
 }
@@ -51,14 +51,24 @@ func (c *FollowerChannel) SignNextProposal(expectedProposal interface{}, pk []by
 		return ErrNonMatchingProposals
 	}
 
+	// vars are cloned and modified instead of modified in place to simplify recovering from error
 	vars := Vars{
 		TurnNum: c.current.TurnNum,
 		Outcome: c.current.Outcome.clone(),
 	}
-
 	err := vars.Add(p)
 	if err != nil {
 		return err
+	}
+
+	signature, err := c.sign(vars, pk)
+	if err != nil {
+		return fmt.Errorf("unable to sign state update: %f", err)
+	}
+
+	c.current = SignedVars{
+		Vars:       vars,
+		Signatures: [2]state.Signature{c.proposalQueue[0].Signature, signature},
 	}
 	c.proposalQueue = c.proposalQueue[1:]
 

--- a/channel/consensus_channel/follower_channel.go
+++ b/channel/consensus_channel/follower_channel.go
@@ -1,29 +1,57 @@
 package consensus_channel
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/statechannels/go-nitro/channel/state"
+)
+
+var ErrNoProposals = fmt.Errorf("no proposals in the queue")
+var ErrUnsupportedQueuedProposal = fmt.Errorf("only Add proposal is supported for queued proposals")
+var ErrUnsupportedExpectedProposal = fmt.Errorf("only Add proposal is supported for expected update")
+var ErrNonMatchingProposals = fmt.Errorf("expected proposal does not match first proposal in the queue")
 
 type FollowerChannel struct {
 	consensusChannel
 }
 
+func NewFollowerChannel(fp state.FixedPart, outcome LedgerOutcome, signatures [2]state.Signature) (FollowerChannel, error) {
+	channel, err := newConsensusChannel(fp, leader, outcome, signatures)
+
+	return FollowerChannel{consensusChannel: channel}, err
+}
+
+// ConsensusTurnNum returns the turn number of the current consensus state
+func (c *FollowerChannel) ConsensusTurnNum() uint64 {
+	return c.current.TurnNum
+}
+
+// Includes returns whether or not the consensus state includes the given guarantee
+func (c *FollowerChannel) Includes(g Guarantee) bool {
+	return c.current.Outcome.includes(g)
+}
+
 func (c *FollowerChannel) SignNextProposal(expectedUpdate interface{}, pk []byte) error {
 	if len(c.proposalQueue) == 0 {
-		return fmt.Errorf("no proposals in the queue")
+		return ErrNoProposals
 	}
 	p, ok := c.proposalQueue[0].Proposal.(Add)
 	if !ok {
-		return fmt.Errorf("only Add proposal is supported for queued proposals")
+		return ErrUnsupportedQueuedProposal
 	}
 	expectedP, ok := expectedUpdate.(Add)
 	if !ok {
-		return fmt.Errorf("only Add proposal is supported for expected update")
+		return ErrUnsupportedExpectedProposal
 	}
 
 	if !p.Equal(expectedP) {
-		return fmt.Errorf("expected proposal does not match first proposal in the queue")
+		return ErrNonMatchingProposals
 	}
 
-	vars := c.current.clone()
+	vars := Vars{
+		TurnNum: c.current.TurnNum,
+		Outcome: c.current.Outcome.clone(),
+	}
 
 	err := vars.Add(p)
 	if err != nil {

--- a/channel/consensus_channel/follower_channel.go
+++ b/channel/consensus_channel/follower_channel.go
@@ -47,7 +47,7 @@ func (c *FollowerChannel) SignNextProposal(expectedProposal interface{}, pk []by
 		return ErrUnsupportedExpectedProposal
 	}
 
-	if !p.Equal(expectedP) {
+	if !p.equal(expectedP) {
 		return ErrNonMatchingProposals
 	}
 

--- a/channel/consensus_channel/follower_channel.go
+++ b/channel/consensus_channel/follower_channel.go
@@ -1,0 +1,35 @@
+package consensus_channel
+
+import "fmt"
+
+type FollowerChannel struct {
+	consensusChannel
+}
+
+func (c *FollowerChannel) SignNextProposal(expectedUpdate interface{}, pk []byte) error {
+	if len(c.proposalQueue) == 0 {
+		return fmt.Errorf("no proposals in the queue")
+	}
+	p, ok := c.proposalQueue[0].Proposal.(Add)
+	if !ok {
+		return fmt.Errorf("only Add proposal is supported for queued proposals")
+	}
+	expectedP, ok := expectedUpdate.(Add)
+	if !ok {
+		return fmt.Errorf("only Add proposal is supported for expected update")
+	}
+
+	if !p.Equal(expectedP) {
+		return fmt.Errorf("expected proposal does not match first proposal in the queue")
+	}
+
+	vars := c.current.clone()
+
+	err := vars.Add(p)
+	if err != nil {
+		return err
+	}
+	c.proposalQueue = c.proposalQueue[1:]
+
+	return nil
+}

--- a/channel/consensus_channel/follower_channel.go
+++ b/channel/consensus_channel/follower_channel.go
@@ -15,6 +15,7 @@ type FollowerChannel struct {
 	consensusChannel
 }
 
+// NewFollowerChannel constructs a new FollowerChannel
 func NewFollowerChannel(fp state.FixedPart, outcome LedgerOutcome, signatures [2]state.Signature) (FollowerChannel, error) {
 	channel, err := newConsensusChannel(fp, leader, outcome, signatures)
 
@@ -31,6 +32,8 @@ func (c *FollowerChannel) Includes(g Guarantee) bool {
 	return c.current.Outcome.includes(g)
 }
 
+// SignNextProposal inspects whether the expected proposal matches the first proposal in
+// the queue. If so, the proposal is removed from the queue and integrated into the channel state
 func (c *FollowerChannel) SignNextProposal(expectedUpdate interface{}, pk []byte) error {
 	if len(c.proposalQueue) == 0 {
 		return ErrNoProposals

--- a/channel/consensus_channel/follower_channel_test.go
+++ b/channel/consensus_channel/follower_channel_test.go
@@ -112,7 +112,13 @@ func TestFollowerChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if channel.ConsensusTurnNum() != 0 || channel.Includes(proposal.Guarantee) {
-		t.Fatal("consensus incorrectly updated")
+	if channel.ConsensusTurnNum() != 1 {
+		t.Fatalf("incorrect turn number: expected 1, got %d", channel.ConsensusTurnNum())
+	}
+	if !channel.Includes(proposal.Guarantee) {
+		t.Fatal("expected the channel to not include the guarantee")
+	}
+	if len(channel.proposalQueue) != 0 {
+		t.Fatal("expected the proposal queue to be empty")
 	}
 }

--- a/channel/consensus_channel/follower_channel_test.go
+++ b/channel/consensus_channel/follower_channel_test.go
@@ -19,6 +19,7 @@ var vAmount = uint64(5)
 var existingChannel = types.Destination{1}
 var targetChannel = types.Destination{2}
 
+// TODO these helpers and the helpers in leader_channel should be shared.
 func fp() state.FixedPart {
 	participants := [2]types.Address{
 		testdata.Actors.Alice.Address, testdata.Actors.Bob.Address,
@@ -93,14 +94,13 @@ func TestFollowerChannel(t *testing.T) {
 		t.Fatalf("expected %v, but got %v", ErrNoProposals, err)
 	}
 
-	latest, _ := channel.latestProposedVars()
-	sig, _ := latest.asState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
-	proposal2 := add(1, uint64(6), targetChannel, alice, bob)
 	signedProposal := SignedProposal{
-		Proposal:  proposal,
-		Signature: sig,
+		Proposal: proposal,
+		// Note that this signature is never checked in SignNextProposal
+		Signature: state.Signature{},
 	}
 	channel.proposalQueue = []SignedProposal{signedProposal}
+	proposal2 := add(1, uint64(6), targetChannel, alice, bob)
 
 	err = channel.SignNextProposal(proposal2, testdata.Actors.Bob.PrivateKey)
 	if !errors.Is(ErrNonMatchingProposals, err) {

--- a/channel/consensus_channel/follower_channel_test.go
+++ b/channel/consensus_channel/follower_channel_test.go
@@ -1,0 +1,118 @@
+package consensus_channel
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/internal/testdata"
+	"github.com/statechannels/go-nitro/types"
+)
+
+var alice = types.Destination(common.HexToHash("0x0a"))
+var bob = types.Destination(common.HexToHash("0x0b"))
+var aBal = uint64(200)
+var bBal = uint64(300)
+var vAmount = uint64(5)
+var existingChannel = types.Destination{1}
+var targetChannel = types.Destination{2}
+
+func fp() state.FixedPart {
+	participants := [2]types.Address{
+		testdata.Actors.Alice.Address, testdata.Actors.Bob.Address,
+	}
+	return state.FixedPart{
+		Participants:      participants[:],
+		ChainId:           big.NewInt(0),
+		ChannelNonce:      big.NewInt(9001),
+		ChallengeDuration: big.NewInt(100),
+	}
+}
+
+func allocation(d types.Destination, a uint64) Balance {
+	return Balance{destination: d, amount: *big.NewInt(int64(a))}
+}
+
+func guarantee(amount uint64, target, left, right types.Destination) Guarantee {
+	return Guarantee{
+		target: target,
+		amount: *big.NewInt(int64(amount)),
+		left:   left,
+		right:  right,
+	}
+}
+
+func makeOutcome(left, right Balance, guarantees ...Guarantee) LedgerOutcome {
+	mappedGuarantees := make(map[types.Destination]Guarantee)
+	for _, g := range guarantees {
+		mappedGuarantees[g.target] = g
+	}
+	return LedgerOutcome{left: left, right: right, guarantees: mappedGuarantees}
+}
+
+func ledgerOutcome() LedgerOutcome {
+	return makeOutcome(
+		allocation(alice, aBal),
+		allocation(bob, bBal),
+		guarantee(vAmount, existingChannel, alice, bob),
+	)
+
+}
+
+func add(turnNum, amount uint64, vId, left, right types.Destination) Add {
+	bigAmount := *big.NewInt(int64(amount))
+	return Add{
+		turnNum: turnNum,
+		Guarantee: Guarantee{
+			amount: bigAmount,
+			target: vId,
+			left:   left,
+			right:  right,
+		},
+		LeftDeposit: bigAmount,
+	}
+}
+
+func TestFollowerChannel(t *testing.T) {
+	initialVars := Vars{Outcome: ledgerOutcome(), TurnNum: 0}
+	aliceSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
+	bobsSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
+	sigs := [2]state.Signature{aliceSig, bobsSig}
+
+	channel, err := NewFollowerChannel(fp(), ledgerOutcome(), sigs)
+	if err != nil {
+		t.Fatal("unable to construct channel")
+	}
+
+	proposal := add(1, vAmount, targetChannel, alice, bob)
+
+	err = channel.SignNextProposal(proposal, testdata.Actors.Bob.PrivateKey)
+	if !errors.Is(ErrNoProposals, err) {
+		t.Fatalf("expected %v, but got %v", ErrNoProposals, err)
+	}
+
+	latest, _ := channel.latestProposedVars()
+	sig, _ := latest.asState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
+	proposal2 := add(1, uint64(6), targetChannel, alice, bob)
+	signedProposal := SignedProposal{
+		Proposal:  proposal,
+		Signature: sig,
+	}
+	channel.proposalQueue = []SignedProposal{signedProposal}
+
+	err = channel.SignNextProposal(proposal2, testdata.Actors.Bob.PrivateKey)
+	if !errors.Is(ErrNonMatchingProposals, err) {
+		t.Fatalf("expected %v, but got %v", ErrNonMatchingProposals, err)
+	}
+
+	err = channel.SignNextProposal(proposal, testdata.Actors.Bob.PrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if channel.ConsensusTurnNum() != 0 || channel.Includes(proposal.Guarantee) {
+		t.Fatal("consensus incorrectly updated")
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/statechannels/go-nitro/issues/394.

Test helper functions are shared between leader channel and follower channel tests and should be factored out. Leader channel tests are still under development, so this work is not done in this PR.