### PR TITLE
WIP: Add IsShallowCopy to detect when clones are shallow copies

### DIFF
--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/go-cmp/cmp"
 	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/helpers"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -29,6 +30,9 @@ func TestChannel(t *testing.T) {
 
 	testClone := func(t *testing.T) {
 		r := c.Clone()
+		if helpers.HasShallowCopy(r, c) {
+			t.Fatal("Clone has shallow copy")
+		}
 		if diff := cmp.Diff(*r, *c, cmp.Comparer(types.Equal)); diff != "" {
 			t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)
 		}

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -33,6 +33,7 @@ func TestChannel(t *testing.T) {
 		if helpers.HasShallowCopy(r, c) {
 			t.Fatal("Clone has shallow copy")
 		}
+
 		if diff := cmp.Diff(*r, *c, cmp.Comparer(types.Equal)); diff != "" {
 			t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)
 		}
@@ -52,6 +53,15 @@ func TestChannel(t *testing.T) {
 		if clone != nil {
 			t.Fatal("Tried to clone a Channel via a nil pointer, but got something not nil")
 		}
+
+		// TODO This is just testing hasShallowCopy so it should be moved to the helpers package
+		r = c.Clone()
+		// Modify our clone so it is a shallow copy refering to the same map values
+		c.SignedStateForTurnNum = r.SignedStateForTurnNum
+		if isShallow := helpers.HasShallowCopy(r, c); !isShallow {
+			t.Fatal("Expected isShallowCopy to return true")
+		}
+
 	}
 
 	testPreFund := func(t *testing.T) {

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -1,0 +1,65 @@
+package helpers // import "github.com/statechannels/go-nitro/helpers"
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// HasShallowCopy takes two structs and checks if one is a shallow copy of another.
+// This is done by using reflection and checking that reference types like slices and maps don't point to the same values.
+func HasShallowCopy(a interface{}, b interface{}) bool {
+
+	// Define a recursive function that can be used to determine if there exists a shallow copy between a and b
+	var isShallow func(a, b reflect.Value) bool
+	isShallow = func(aReflect reflect.Value, bReflect reflect.Value) bool {
+		if aReflect.Kind() != bReflect.Kind() {
+			panic(fmt.Errorf("cannot compare two different kinds %s and %s", aReflect.Kind(), bReflect.Kind()))
+		}
+		switch kind := aReflect.Kind(); kind {
+
+		case reflect.Struct:
+			for i := 0; i < aReflect.NumField(); i++ {
+				aVal := aReflect.Field(i)
+				bVal := bReflect.Field(i)
+				if isShallow(aVal, bVal) {
+					return true
+				}
+			}
+
+		case reflect.Slice:
+			for j := 0; j < aReflect.Len(); j++ {
+				aVal := aReflect.Index(j)
+				bVal := bReflect.Index(j)
+				if isShallow(aVal, bVal) {
+					return true
+				}
+			}
+		case reflect.Map:
+			itr := aReflect.MapRange()
+			for itr.Next() {
+				key := itr.Key()
+				aVal := aReflect.MapIndex(key)
+				bVal := bReflect.MapIndex(key)
+				if isShallow(aVal, bVal) {
+					return true
+				}
+
+			}
+		case reflect.Ptr:
+			return aReflect.Pointer() == bReflect.Pointer()
+		default:
+			return false
+
+		}
+		return false
+	}
+	aReflect := reflect.ValueOf(a)
+	bReflect := reflect.ValueOf(b)
+	// IF we have a pointer we're dealing with an interface so we unwrap it.
+	if aReflect.Kind() == reflect.Ptr {
+
+		aReflect = reflect.ValueOf(a).Elem()
+		bReflect = reflect.ValueOf(b).Elem()
+	}
+	return isShallow(aReflect, bReflect)
+}


### PR DESCRIPTION
This is a first stab at using reflection to ensure that cloning does not generate a shallow copy in any way. It seems to work for the basic use case of a shallow slice, but I haven't tested much further than that.

This is definitely a viable approach but I think it requires a bit more time to think through and write tests for. I'm going to pause work on this for now.