### PR TITLE
Allow `ConsensusChannels` to be persisted to the `MockStore`

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -355,3 +355,8 @@ func (v Vars) asState(fp state.FixedPart) state.State {
 		IsFinal:           false,
 	}
 }
+
+// Participants returns the channel participants.
+func (c *ConsensusChannel) Participants() []types.Address {
+	return c.fp.Participants
+}

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -25,6 +25,8 @@ type ConsensusChannel struct {
 	myIndex ledgerIndex
 	fp      state.FixedPart
 
+	Id types.Destination
+
 	// variables
 	current       SignedVars       // The "consensus state", signed by both parties
 	proposalQueue []SignedProposal // A queue of proposed changes, starting from the consensus state
@@ -38,6 +40,12 @@ func newConsensusChannel(
 	outcome LedgerOutcome,
 	signatures [2]state.Signature,
 ) (ConsensusChannel, error) {
+
+	cId, err := fp.ChannelId()
+	if err != nil {
+		return ConsensusChannel{}, err
+	}
+
 	vars := Vars{TurnNum: initialTurnNum, Outcome: outcome.clone()}
 
 	leaderAddr, err := vars.asState(fp).RecoverSigner(signatures[leader])
@@ -63,6 +71,7 @@ func newConsensusChannel(
 
 	return ConsensusChannel{
 		fp:            fp,
+		Id:            cId,
 		myIndex:       myIndex,
 		proposalQueue: make([]SignedProposal, 0),
 		current:       current,

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -1,6 +1,7 @@
 package consensus_channel
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"sort"
@@ -368,4 +369,44 @@ func (v Vars) asState(fp state.FixedPart) state.State {
 // Participants returns the channel participants.
 func (c *ConsensusChannel) Participants() []types.Address {
 	return c.fp.Participants
+}
+
+// jsonConsensusChannel replaces ConsensusChannel's private fields with public ones,
+// making it suitable for serialization
+type jsonConsensusChannel struct {
+	Id            types.Destination
+	MyIndex       ledgerIndex
+	FP            state.FixedPart
+	Current       SignedVars
+	ProposalQueue []SignedProposal
+}
+
+// MarshalJSON returns a JSON representation of the ConsensusChannel
+func (c ConsensusChannel) MarshalJSON() ([]byte, error) {
+	jsonCh := jsonConsensusChannel{
+		Id:            c.Id,
+		MyIndex:       c.myIndex,
+		FP:            c.fp,
+		Current:       c.current,
+		ProposalQueue: c.proposalQueue,
+	}
+	return json.Marshal(jsonCh)
+}
+
+// UnmarshalJSON populates the receiver with the
+// json-encoded data
+func (c *ConsensusChannel) UnmarshalJSON(data []byte) error {
+	var jsonCh jsonConsensusChannel
+	err := json.Unmarshal(data, &jsonCh)
+	if err != nil {
+		return fmt.Errorf("error unmarshaling channel data")
+	}
+
+	c.Id = jsonCh.Id
+	c.myIndex = jsonCh.MyIndex
+	c.fp = jsonCh.FP
+	c.current = jsonCh.Current
+	c.proposalQueue = jsonCh.ProposalQueue
+
+	return nil
 }

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -49,7 +49,7 @@ func newConsensusChannel(
 
 	vars := Vars{TurnNum: initialTurnNum, Outcome: outcome.clone()}
 
-	leaderAddr, err := vars.asState(fp).RecoverSigner(signatures[leader])
+	leaderAddr, err := vars.AsState(fp).RecoverSigner(signatures[leader])
 	if err != nil {
 		return ConsensusChannel{}, fmt.Errorf("could not verify sig: %w", err)
 	}
@@ -57,7 +57,7 @@ func newConsensusChannel(
 		return ConsensusChannel{}, fmt.Errorf("leader did not sign initial state: %v, %v", leaderAddr, fp.Participants[leader])
 	}
 
-	followerAddr, err := vars.asState(fp).RecoverSigner(signatures[follower])
+	followerAddr, err := vars.AsState(fp).RecoverSigner(signatures[follower])
 	if err != nil {
 		return ConsensusChannel{}, fmt.Errorf("could not verify sig: %w", err)
 	}
@@ -106,13 +106,13 @@ func (c *ConsensusChannel) sign(vars Vars, sk []byte) (state.Signature, error) {
 		return state.Signature{}, fmt.Errorf("attempting to sign from wrong address: %s", signer)
 	}
 
-	state := vars.asState(c.fp)
+	state := vars.AsState(c.fp)
 	return state.Sign(sk)
 }
 
 // recoverSigner returns the signer of the vars using the given signature
 func (c *ConsensusChannel) recoverSigner(vars Vars, sig state.Signature) (common.Address, error) {
-	state := vars.asState(c.fp)
+	state := vars.AsState(c.fp)
 	return state.RecoverSigner(sig)
 }
 
@@ -349,7 +349,7 @@ func (vars *Vars) Add(p Add) error {
 	return nil
 }
 
-func (v Vars) asState(fp state.FixedPart) state.State {
+func (v Vars) AsState(fp state.FixedPart) state.State {
 	return state.State{
 		// Variable
 		TurnNum: v.TurnNum,

--- a/channel/consensus_channel/consensus_channel_test.go
+++ b/channel/consensus_channel/consensus_channel_test.go
@@ -69,7 +69,7 @@ func TestConsensusChannel(t *testing.T) {
 	}
 
 	fingerprint := func(v Vars) string {
-		h, err := v.asState(state.TestState.FixedPart()).Hash()
+		h, err := v.AsState(state.TestState.FixedPart()).Hash()
 
 		if err != nil {
 			panic(err)
@@ -162,8 +162,8 @@ func TestConsensusChannel(t *testing.T) {
 	}
 
 	initialVars := Vars{Outcome: outcome(), TurnNum: 0}
-	aliceSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
-	bobsSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
+	aliceSig, _ := initialVars.AsState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
+	bobsSig, _ := initialVars.AsState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
 	sigs := [2]state.Signature{aliceSig, bobsSig}
 
 	testConsensusChannelFunctionality := func(t *testing.T) {
@@ -190,7 +190,7 @@ func TestConsensusChannel(t *testing.T) {
 			t.Fatalf("latestProposedVars did not return a copy")
 		}
 
-		briansSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Brian.PrivateKey)
+		briansSig, _ := initialVars.AsState(fp()).Sign(testdata.Actors.Brian.PrivateKey)
 		wrongSigs := [2]state.Signature{sigs[1], briansSig}
 		_, err = newConsensusChannel(fp(), leader, 0, outcome(), wrongSigs)
 		if err == nil {

--- a/channel/consensus_channel/follower_channel.go
+++ b/channel/consensus_channel/follower_channel.go
@@ -14,14 +14,14 @@ var ErrInvalidProposalSignature = fmt.Errorf("invalid signature for proposal")
 var ErrInvalidTurnNum = fmt.Errorf("the proposal turn number is not the next turn number")
 
 type FollowerChannel struct {
-	consensusChannel
+	ConsensusChannel
 }
 
 // NewFollowerChannel constructs a new FollowerChannel
 func NewFollowerChannel(fp state.FixedPart, turnNum uint64, outcome LedgerOutcome, signatures [2]state.Signature) (FollowerChannel, error) {
 	channel, err := newConsensusChannel(fp, follower, turnNum, outcome, signatures)
 
-	return FollowerChannel{consensusChannel: channel}, err
+	return FollowerChannel{ConsensusChannel: channel}, err
 }
 
 // SignNextProposal inspects whether the expected proposal matches the first proposal in

--- a/channel/consensus_channel/follower_channel_test.go
+++ b/channel/consensus_channel/follower_channel_test.go
@@ -17,7 +17,7 @@ func createSignedProposal(vars Vars, proposal Add, fp state.FixedPart, pk []byte
 	proposalVars := Vars{TurnNum: vars.TurnNum, Outcome: vars.Outcome.clone()}
 	_ = proposalVars.Add(proposal)
 
-	state := proposalVars.asState(fp)
+	state := proposalVars.AsState(fp)
 	sig, _ := state.Sign(pk)
 
 	signedProposal := SignedProposal{
@@ -36,8 +36,8 @@ func TestReceive(t *testing.T) {
 
 	var vAmount = uint64(5)
 	initialVars := Vars{Outcome: ledgerOutcome(), TurnNum: 0}
-	aliceSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
-	bobsSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
+	aliceSig, _ := initialVars.AsState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
+	bobsSig, _ := initialVars.AsState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
 	sigs := [2]state.Signature{aliceSig, bobsSig}
 
 	channel, err := NewFollowerChannel(fp(), 0, ledgerOutcome(), sigs)
@@ -107,8 +107,8 @@ func TestFollowerChannel(t *testing.T) {
 	targetChannel := types.Destination{2}
 
 	initialVars := Vars{Outcome: ledgerOutcome(), TurnNum: 0}
-	aliceSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
-	bobsSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
+	aliceSig, _ := initialVars.AsState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
+	bobsSig, _ := initialVars.AsState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
 	sigs := [2]state.Signature{aliceSig, bobsSig}
 
 	channel, err := NewFollowerChannel(fp(), 0, ledgerOutcome(), sigs)

--- a/channel/consensus_channel/leader_channel.go
+++ b/channel/consensus_channel/leader_channel.go
@@ -102,7 +102,7 @@ func (c *LeaderChannel) UpdateConsensus(countersigned SignedProposal) error {
 		}
 
 		if consensusCandidate.TurnNum == consensusTurnNum {
-			signer, err := consensusCandidate.asState(c.fp).RecoverSigner(countersigned.Signature)
+			signer, err := consensusCandidate.AsState(c.fp).RecoverSigner(countersigned.Signature)
 
 			if err != nil {
 				return fmt.Errorf("unable to recover signer: %w", err)

--- a/channel/consensus_channel/leader_channel.go
+++ b/channel/consensus_channel/leader_channel.go
@@ -8,14 +8,14 @@ import (
 
 // LeaderChannel is used by a leader's virtualfund objective to make and receive ledger updates
 type LeaderChannel struct {
-	consensusChannel
+	ConsensusChannel
 }
 
 // NewLeaderChannel constructs a new LeaderChannel
 func NewLeaderChannel(fp state.FixedPart, turnNum uint64, outcome LedgerOutcome, signatures [2]state.Signature) (LeaderChannel, error) {
 	channel, err := newConsensusChannel(fp, leader, turnNum, outcome, signatures)
 
-	return LeaderChannel{consensusChannel: channel}, err
+	return LeaderChannel{ConsensusChannel: channel}, err
 }
 
 // IsProposed returns whether or not the consensus state or any proposed state

--- a/channel/consensus_channel/leader_channel_test.go
+++ b/channel/consensus_channel/leader_channel_test.go
@@ -21,8 +21,8 @@ func TestLeaderChannel(t *testing.T) {
 	vAmount := uint64(5)
 
 	initialVars := Vars{Outcome: ledgerOutcome(), TurnNum: 0}
-	aliceSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
-	bobsSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
+	aliceSig, _ := initialVars.AsState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
+	bobsSig, _ := initialVars.AsState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
 	sigs := [2]state.Signature{aliceSig, bobsSig}
 
 	channel, err := NewLeaderChannel(fp(), 0, ledgerOutcome(), sigs)
@@ -57,7 +57,7 @@ func TestLeaderChannel(t *testing.T) {
 		guarantee(amountAdded, targetChannel, alice, bob),
 	)
 	stateSigned := Vars{TurnNum: 1, Outcome: outcomeSigned}
-	sig, _ := stateSigned.asState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
+	sig, _ := stateSigned.AsState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
 	expected := SignedProposal{Proposal: p, Signature: sig}
 
 	if !reflect.DeepEqual(sp, expected) {
@@ -88,7 +88,7 @@ func TestLeaderChannel(t *testing.T) {
 	}
 
 	latest, _ := channel.latestProposedVars()
-	counterSig2, _ := latest.asState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
+	counterSig2, _ := latest.AsState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
 
 	p3 := p
 	p3.target = types.Destination{4}
@@ -123,7 +123,7 @@ func TestLeaderChannel(t *testing.T) {
 
 	// The incorrect counter signature is received on the latest proposal
 	latest, _ = channel.latestProposedVars()
-	wrongCounterSig3, _ := latest.asState(fp()).Sign(testdata.Actors.Brian.PrivateKey)
+	wrongCounterSig3, _ := latest.AsState(fp()).Sign(testdata.Actors.Brian.PrivateKey)
 	wrongP3Returned := SignedProposal{
 		Proposal:  thirdSigned.Proposal,
 		Signature: wrongCounterSig3,
@@ -139,7 +139,7 @@ func TestLeaderChannel(t *testing.T) {
 
 	// The correct counter signature is received on the latest proposal
 	latest, _ = channel.latestProposedVars()
-	counterSig3, _ := latest.asState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
+	counterSig3, _ := latest.AsState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
 	p3Returned := SignedProposal{
 		Proposal:  thirdSigned.Proposal,
 		Signature: counterSig3,

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -199,7 +199,7 @@ func (ms *MockStore) GetTwoPartyLedger(firstParty types.Address, secondParty typ
 	return ledger, ok
 }
 
-// GetTwoPartyLedger returns a ledger channel between the two parties if it exists.
+// GetConsensusChannel returns a ConsensusChannel between the two parties if it exists.
 func (ms *MockStore) GetConsensusChannel(firstParty types.Address, secondParty types.Address) (channel *consensus_channel.ConsensusChannel, ok bool) {
 
 	ms.consensusChannels.Range(func(key string, chJSON []byte) bool {

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -200,7 +200,7 @@ func (ms *MockStore) GetTwoPartyLedger(firstParty types.Address, secondParty typ
 }
 
 // GetConsensusChannel returns a ConsensusChannel between the two parties if it exists.
-func (ms *MockStore) GetConsensusChannel(firstParty types.Address, secondParty types.Address) (channel *consensus_channel.ConsensusChannel, ok bool) {
+func (ms *MockStore) GetConsensusChannel(leader, follower types.Address) (channel *consensus_channel.ConsensusChannel, ok bool) {
 
 	ms.consensusChannels.Range(func(key string, chJSON []byte) bool {
 
@@ -214,7 +214,7 @@ func (ms *MockStore) GetConsensusChannel(firstParty types.Address, secondParty t
 		participants := ch.Participants()
 		if len(participants) == 2 {
 			// TODO: Should order matter?
-			if participants[0] == firstParty && participants[1] == secondParty {
+			if participants[0] == leader && participants[1] == follower {
 				channel = &ch
 				ok = true
 				return false // we have found the target channel: break the Range loop

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -213,7 +213,6 @@ func (ms *MockStore) GetConsensusChannel(leader, follower types.Address) (channe
 
 		participants := ch.Participants()
 		if len(participants) == 2 {
-			// TODO: Should order matter?
 			if participants[0] == leader && participants[1] == follower {
 				channel = &ch
 				ok = true

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -140,6 +140,18 @@ func (ms *MockStore) SetChannel(ch *channel.Channel) error {
 	return nil
 }
 
+// SetConsensusChannel sets the channel in the store.
+func (ms *MockStore) SetConsensusChannel(ch *consensus_channel.ConsensusChannel) error {
+	chJSON, err := ch.MarshalJSON()
+
+	if err != nil {
+		return err
+	}
+
+	ms.consensusChannels.Store(ch.Id.String(), chJSON)
+	return nil
+}
+
 // getChannelById returns the stored channel
 func (ms *MockStore) getChannelById(id types.Destination) (channel.Channel, error) {
 	chJSON, ok := ms.channels.Load(id.String())

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -5,6 +5,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/go-cmp/cmp"
+	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	cc "github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/client/engine/store"
 	nc "github.com/statechannels/go-nitro/crypto"
 	td "github.com/statechannels/go-nitro/internal/testdata"
@@ -106,4 +109,47 @@ func TestGetChannelSecretKey(t *testing.T) {
 	if recoveredSigner != pk {
 		t.Fatalf("expected to recover %x, but got %x", pk, recoveredSigner)
 	}
+}
+
+func TestConsensusChannelStore(t *testing.T) {
+	sk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
+
+	ms := store.NewMockStore(sk)
+
+	got, ok := ms.GetConsensusChannel(td.Actors.Alice.Address, td.Actors.Bob.Address)
+	if ok {
+		t.Fatalf("expected not to find the a consensus channel, but found %v", got)
+	}
+
+	fp := td.Objectives.Directfund.GenericDFO().C.FixedPart
+	fp.Participants[0] = td.Actors.Alice.Address
+	fp.Participants[1] = td.Actors.Bob.Address
+	initialVars := consensus_channel.Vars{Outcome: cc.LedgerOutcome{}, TurnNum: 0}
+	aliceSig, _ := initialVars.AsState(fp).Sign(td.Actors.Alice.PrivateKey)
+	bobsSig, _ := initialVars.AsState(fp).Sign(td.Actors.Bob.PrivateKey)
+
+	want, err := consensus_channel.NewLeaderChannel(
+		fp,
+		0,
+		consensus_channel.LedgerOutcome{},
+		[2]state.Signature{aliceSig, bobsSig})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ms.SetConsensusChannel(&want.ConsensusChannel); err != nil {
+		t.Fatalf("error setting consensus channel %v: %s", want, err.Error())
+	}
+
+	got, ok = ms.GetConsensusChannel(fp.Participants[0], fp.Participants[1])
+
+	if !ok {
+		t.Fatalf("expected to find the inserted consensus channel, but didn't")
+	}
+
+	if got.Id != want.Id {
+		t.Fatalf("expected to retrieve same channel Id as was passed in, but didn't")
+	}
+	// TODO check that got and want are deeply equal
 }

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -106,7 +106,6 @@ func TestGetChannelSecretKey(t *testing.T) {
 	signedMsg, _ := nc.SignEthereumMessage(msg, *key)
 	recoveredSigner, _ := nc.RecoverEthereumMessageSigner(msg, signedMsg)
 
-	\
 	if recoveredSigner != pk {
 		t.Fatalf("expected to recover %x, but got %x", pk, recoveredSigner)
 	}

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -106,6 +106,7 @@ func TestGetChannelSecretKey(t *testing.T) {
 	signedMsg, _ := nc.SignEthereumMessage(msg, *key)
 	recoveredSigner, _ := nc.RecoverEthereumMessageSigner(msg, signedMsg)
 
+	\
 	if recoveredSigner != pk {
 		t.Fatalf("expected to recover %x, but got %x", pk, recoveredSigner)
 	}
@@ -121,7 +122,7 @@ func TestConsensusChannelStore(t *testing.T) {
 		t.Fatalf("expected not to find the a consensus channel, but found %v", got)
 	}
 
-	fp := td.Objectives.Directfund.GenericDFO().C.FixedPart
+	fp := td.Objectives.Directfund.GenericDFO().C.FixedPart // TODO replace with testdata not nested under GenericDFO
 	fp.Participants[0] = td.Actors.Alice.Address
 	fp.Participants[1] = td.Actors.Bob.Address
 	initialVars := consensus_channel.Vars{Outcome: cc.LedgerOutcome{}, TurnNum: 0}

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -29,5 +29,5 @@ type Store interface {
 
 type ConsensusChannelStore interface {
 	GetConsensusChannel(firstParty types.Address, secondParty types.Address) (channel *consensus_channel.ConsensusChannel, ok bool)
-	SetConsensusChannel(*consensus_channel.ConsensusChannel)
+	SetConsensusChannel(*consensus_channel.ConsensusChannel) error
 }

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/statechannels/go-nitro/channel"
+	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -22,4 +23,11 @@ type Store interface {
 	SetObjective(protocols.Objective) error                                       // Write an objective
 	GetTwoPartyLedger(firstParty types.Address, secondParty types.Address) (channel *channel.TwoPartyLedger, ok bool)
 	SetChannel(*channel.Channel) error
+
+	ConsensusChannelStore
+}
+
+type ConsensusChannelStore interface {
+	GetConsensusChannel(firstParty types.Address, secondParty types.Address) (channel consensus_channel.ConsensusChannel, ok bool)
+	SetConsensusChannel(*consensus_channel.ConsensusChannel)
 }

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -28,6 +28,6 @@ type Store interface {
 }
 
 type ConsensusChannelStore interface {
-	GetConsensusChannel(firstParty types.Address, secondParty types.Address) (channel *consensus_channel.ConsensusChannel, ok bool)
+	GetConsensusChannel(leader, follower types.Address) (channel *consensus_channel.ConsensusChannel, ok bool)
 	SetConsensusChannel(*consensus_channel.ConsensusChannel) error
 }

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -28,6 +28,6 @@ type Store interface {
 }
 
 type ConsensusChannelStore interface {
-	GetConsensusChannel(firstParty types.Address, secondParty types.Address) (channel consensus_channel.ConsensusChannel, ok bool)
+	GetConsensusChannel(firstParty types.Address, secondParty types.Address) (channel *consensus_channel.ConsensusChannel, ok bool)
 	SetConsensusChannel(*consensus_channel.ConsensusChannel)
 }


### PR DESCRIPTION
Closes #412 .


**Changes** 
* Adds json marshalling / unmarshalling to consensus channels. 
* Adds a getter and setter to the store interface
* Implements the expanded interface in the mock store (by following existing patterns for persisting channels). 
* Exports the following from `consensus_channel` package
    - `ConsensusChannel` itself (necessary to properly type the methods on the store
    - `Vars.asState` helper. Not strictly necessary, but useful for constructing test data
    - a new `Id` field
    - a `Participants()` getter
   
Exporting those symbols leads to a large-ish diff here. I recommend reviewing commit-by-commit to reduce the noise (I did each renaming change in its own commit). 

**Shortcomings**
I did ~little~ nothing to address the issue of storing `LeaderChannels` or `FollowerChannels` (which are sub types of `ConsensusChannel`). For now, to store such types calling code will need to extract a `ConsensusChannel` from them. And when retrieving, a type assertion will be necessary somewhere to enable the channels to be used as intended. 

**How Has This Been Tested?**

A new test has been written, mirroring some of the existing tests in the `mockstore` package. However, I believe the current tests to be a bit broken, and I generally had a miserable time testing for deep equality between a test `ConsensusChannel`, and the result of storing and retrieving it.  So an incomplete set of checks is used, for now. 

https://github.com/statechannels/go-nitro/issues/428


 


---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
