### PR TITLE
include err in panic

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -101,7 +101,7 @@ func (e *Engine) Run() {
 
 		// Handle errors
 		if err != nil {
-			e.logger.Panic()
+			e.logger.Panic(err)
 			// TODO do not panic if in production.
 			// TODO report errors back to the consuming application
 		}


### PR DESCRIPTION
Updates `e.logger.Panic()` to `e.logger.Panic(err)` so the `err` gets written out to the console/log.