### PR TITLE
Consensus Channel constructors now accept a turn number

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -34,11 +34,11 @@ type consensusChannel struct {
 func newConsensusChannel(
 	fp state.FixedPart,
 	myIndex ledgerIndex,
-	turnNum uint64,
+	initialTurnNum uint64,
 	outcome LedgerOutcome,
 	signatures [2]state.Signature,
 ) (consensusChannel, error) {
-	vars := Vars{TurnNum: turnNum, Outcome: outcome.clone()}
+	vars := Vars{TurnNum: initialTurnNum, Outcome: outcome.clone()}
 
 	leaderAddr, err := vars.asState(fp).RecoverSigner(signatures[leader])
 	if err != nil {

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -30,7 +30,7 @@ type consensusChannel struct {
 	proposalQueue []SignedProposal // A queue of proposed changes, starting from the consensus state
 }
 
-// newConsensusChannel constructs a new consensus channel, validating its input by checking that the signatures are as expected on a prefund setup state
+// newConsensusChannel constructs a new consensus channel, validating its input by checking that the signatures are as expected for the given fp, initialTurnNum and outcome]
 func newConsensusChannel(
 	fp state.FixedPart,
 	myIndex ledgerIndex,

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -34,10 +34,11 @@ type consensusChannel struct {
 func newConsensusChannel(
 	fp state.FixedPart,
 	myIndex ledgerIndex,
+	turnNum uint64,
 	outcome LedgerOutcome,
 	signatures [2]state.Signature,
 ) (consensusChannel, error) {
-	vars := Vars{TurnNum: 0, Outcome: outcome.clone()}
+	vars := Vars{TurnNum: turnNum, Outcome: outcome.clone()}
 
 	leaderAddr, err := vars.asState(fp).RecoverSigner(signatures[leader])
 	if err != nil {

--- a/channel/consensus_channel/consensus_channel_test.go
+++ b/channel/consensus_channel/consensus_channel_test.go
@@ -167,7 +167,7 @@ func TestConsensusChannel(t *testing.T) {
 	sigs := [2]state.Signature{aliceSig, bobsSig}
 
 	testConsensusChannelFunctionality := func(t *testing.T) {
-		channel, err := newConsensusChannel(fp(), leader, outcome(), sigs)
+		channel, err := newConsensusChannel(fp(), leader, 0, outcome(), sigs)
 
 		if err != nil {
 			t.Fatalf("unable to construct a new consensus channel: %v", err)
@@ -192,7 +192,7 @@ func TestConsensusChannel(t *testing.T) {
 
 		briansSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Brian.PrivateKey)
 		wrongSigs := [2]state.Signature{sigs[1], briansSig}
-		_, err = newConsensusChannel(fp(), leader, outcome(), wrongSigs)
+		_, err = newConsensusChannel(fp(), leader, 0, outcome(), wrongSigs)
 		if err == nil {
 			t.Fatalf("channel should check that signers are participants")
 		}

--- a/channel/consensus_channel/follower_channel.go
+++ b/channel/consensus_channel/follower_channel.go
@@ -18,8 +18,8 @@ type FollowerChannel struct {
 }
 
 // NewFollowerChannel constructs a new FollowerChannel
-func NewFollowerChannel(fp state.FixedPart, outcome LedgerOutcome, signatures [2]state.Signature) (FollowerChannel, error) {
-	channel, err := newConsensusChannel(fp, follower, outcome, signatures)
+func NewFollowerChannel(fp state.FixedPart, turnNum uint64, outcome LedgerOutcome, signatures [2]state.Signature) (FollowerChannel, error) {
+	channel, err := newConsensusChannel(fp, follower, turnNum, outcome, signatures)
 
 	return FollowerChannel{consensusChannel: channel}, err
 }

--- a/channel/consensus_channel/follower_channel_test.go
+++ b/channel/consensus_channel/follower_channel_test.go
@@ -40,7 +40,7 @@ func TestReceive(t *testing.T) {
 	bobsSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
 	sigs := [2]state.Signature{aliceSig, bobsSig}
 
-	channel, err := NewFollowerChannel(fp(), ledgerOutcome(), sigs)
+	channel, err := NewFollowerChannel(fp(), 0, ledgerOutcome(), sigs)
 	if err != nil {
 		t.Fatal("unable to construct channel")
 	}
@@ -111,7 +111,7 @@ func TestFollowerChannel(t *testing.T) {
 	bobsSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
 	sigs := [2]state.Signature{aliceSig, bobsSig}
 
-	channel, err := NewFollowerChannel(fp(), ledgerOutcome(), sigs)
+	channel, err := NewFollowerChannel(fp(), 0, ledgerOutcome(), sigs)
 	if err != nil {
 		t.Fatal("unable to construct channel")
 	}

--- a/channel/consensus_channel/leader_channel.go
+++ b/channel/consensus_channel/leader_channel.go
@@ -12,8 +12,8 @@ type LeaderChannel struct {
 }
 
 // NewLeaderChannel constructs a new LeaderChannel
-func NewLeaderChannel(fp state.FixedPart, outcome LedgerOutcome, signatures [2]state.Signature) (LeaderChannel, error) {
-	channel, err := newConsensusChannel(fp, leader, outcome, signatures)
+func NewLeaderChannel(fp state.FixedPart, turnNum uint64, outcome LedgerOutcome, signatures [2]state.Signature) (LeaderChannel, error) {
+	channel, err := newConsensusChannel(fp, leader, turnNum, outcome, signatures)
 
 	return LeaderChannel{consensusChannel: channel}, err
 }

--- a/channel/consensus_channel/leader_channel_test.go
+++ b/channel/consensus_channel/leader_channel_test.go
@@ -25,7 +25,7 @@ func TestLeaderChannel(t *testing.T) {
 	bobsSig, _ := initialVars.asState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
 	sigs := [2]state.Signature{aliceSig, bobsSig}
 
-	channel, err := NewLeaderChannel(fp(), ledgerOutcome(), sigs)
+	channel, err := NewLeaderChannel(fp(), 0, ledgerOutcome(), sigs)
 	if err != nil {
 		t.Fatal("unable to construct channel")
 	}


### PR DESCRIPTION
This modifies the constructors for consensus channels to accept a turn number instead of assuming a turn number of 0.

This allows the consensus channel to be agnostic to what turn we're starting at. This means it is unaffected by decisions to sign post fund setups or not.
