### PR TITLE
exhibit cyclical dependency

### DIFF
--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
+	td "github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -100,6 +101,9 @@ func TestConstructFromState(t *testing.T) {
 func TestUpdate(t *testing.T) {
 	// Construct various variables for use in TestUpdate
 	var s, _ = constructFromState(false, testState, testState.Participants[0])
+	s = td.Objectives.Directfund.GenericDFO()
+
+
 
 	var stateToSign state.State = s.C.PreFundState()
 	var correctSignatureByParticipant, _ = stateToSign.Sign(alice.privateKey)


### PR DESCRIPTION
On CI, the `golangci-lint` command fails, presumably due to the cyclical dependency **in the test files**.

If you run `go test ./...` locally on this branch, you should find:
```
➜  go-nitro git:(ags/exhibit-cyclical-dependency) ✗ go test ./...                                                    
# github.com/statechannels/go-nitro/protocols/directfund
package github.com/statechannels/go-nitro/protocols/directfund
        imports github.com/statechannels/go-nitro/internal/testdata: import cycle not allowed in test
FAIL    github.com/statechannels/go-nitro/protocols/directfund [setup failed]
?       github.com/statechannels/go-nitro/abi   [no test files]
ok      github.com/statechannels/go-nitro/channel       (cached)
ok      github.com/statechannels/go-nitro/channel/consensus_channel     (cached)
ok      github.com/statechannels/go-nitro/channel/state (cached)
ok      github.com/statechannels/go-nitro/channel/state/outcome (cached)
?       github.com/statechannels/go-nitro/client        [no test files]
?       github.com/statechannels/go-nitro/client/engine [no test files]
ok      github.com/statechannels/go-nitro/client/engine/chainservice    (cached)
ok      github.com/statechannels/go-nitro/client/engine/messageservice  (cached)
ok      github.com/statechannels/go-nitro/client/engine/store   (cached)
ok      github.com/statechannels/go-nitro/client_test   0.541s
?       github.com/statechannels/go-nitro/crypto        [no test files]
ok      github.com/statechannels/go-nitro/protocols     (cached)
ok      github.com/statechannels/go-nitro/protocols/directdefund        (cached)
ok      github.com/statechannels/go-nitro/protocols/virtualfund (cached)
ok      github.com/statechannels/go-nitro/types (cached)
FAIL
```