### PR TITLE
Create Consensus Channel in the Store when Direct Funding Objective Completes

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -152,6 +152,12 @@ func (c Channel) PostFundState() state.State {
 
 }
 
+// SignedPostFundState() returns the SIGNED post fund setup state for the channel.
+func (c Channel) SignedPostFundState() state.SignedState {
+	return c.SignedStateForTurnNum[PostFundTurnNum]
+
+}
+
 // PreFundSignedByMe() returns true if I have signed the pre fund setup state, false otherwise.
 func (c Channel) PreFundSignedByMe() bool {
 	if _, ok := c.SignedStateForTurnNum[PreFundTurnNum]; ok {

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -9,6 +9,8 @@ import (
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/crypto"
+	"github.com/statechannels/go-nitro/protocols/directfund"
+
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -228,15 +230,15 @@ func (o *LedgerOutcome) includes(g Guarantee) bool {
 // - The first alloction entry is for left
 // - The second alloction entry is for right
 // - We ignore guarantee metadata and just assume that it is [left,right]
-func FromExit(sae outcome.SingleAssetExit) *LedgerOutcome {
+func FromExit(sae outcome.SingleAssetExit) LedgerOutcome {
 
-	left := Balance{destination: sae.Allocations[0].Destination, amount: *sae.Allocations[0].Amount}
-	right := Balance{destination: sae.Allocations[1].Destination, amount: *sae.Allocations[1].Amount}
+	left := Balance{destination: sae.Allocations[0].Destination, amount: sae.Allocations[0].Amount}
+	right := Balance{destination: sae.Allocations[1].Destination, amount: sae.Allocations[1].Amount}
 	guarantees := make(map[types.Destination]Guarantee)
 	for _, a := range sae.Allocations {
 
 		if a.AllocationType == outcome.GuaranteeAllocationType {
-			g := Guarantee{amount: *a.Amount,
+			g := Guarantee{amount: a.Amount,
 				target: a.Destination,
 				// Instead of decoding the metadata we make an assumption that the metadata has the left/right we expect
 				left:  left.destination,
@@ -245,7 +247,7 @@ func FromExit(sae outcome.SingleAssetExit) *LedgerOutcome {
 		}
 
 	}
-	return &LedgerOutcome{left: left, right: right, guarantees: guarantees, assetAddress: sae.Asset}
+	return LedgerOutcome{left: left, right: right, guarantees: guarantees, assetAddress: sae.Asset}
 
 }
 
@@ -453,4 +455,48 @@ func (v Vars) AsState(fp state.FixedPart) state.State {
 // Participants returns the channel participants.
 func (c *ConsensusChannel) Participants() []types.Address {
 	return c.fp.Participants
+}
+
+// CreateFromDirectFundingObjective accepts an objective and generates a new consensus channel from it.
+// It assumes that EVERY DirectFundingObjective is for a ledger channel.
+func CreateFromDirectFundingObjective(dfo directfund.Objective) (*ConsensusChannel, error) {
+	// The current assumption is that ANY direct funding objective is for a ledger channel
+	ledger := dfo.C
+
+	if !ledger.PostFundComplete() {
+		return nil, fmt.Errorf("expected funding for channel %s to be complete", dfo.C.Id)
+	}
+	signedPostFund := ledger.SignedPostFundState()
+	leaderSig, err := signedPostFund.GetParticipantSignature(uint(leader))
+	if err != nil {
+		return nil, fmt.Errorf("could not get leader signature: %w", err)
+	}
+	followerSig, err := signedPostFund.GetParticipantSignature(uint(follower))
+	if err != nil {
+		return nil, fmt.Errorf("could not get follower signature: %w", err)
+	}
+	signatures := [2]state.Signature{leaderSig, followerSig}
+
+	if len(signedPostFund.State().Outcome) != 1 {
+		return nil, fmt.Errorf("a consensus channel only supports a single asset")
+	}
+	assetExit := signedPostFund.State().Outcome[0]
+	turnNum := signedPostFund.State().TurnNum
+	outcome := FromExit(assetExit)
+
+	if ledger.MyIndex == uint(leader) {
+		con, err := NewLeaderChannel(ledger.FixedPart, turnNum, outcome, signatures)
+		if err != nil {
+			return nil, fmt.Errorf("could not create consensus channel as leader: %w", err)
+		}
+		return &con.ConsensusChannel, nil
+
+	} else {
+		con, err := NewLeaderChannel(ledger.FixedPart, turnNum, outcome, signatures)
+		if err != nil {
+			return nil, fmt.Errorf("could not create consensus channel as follower: %w", err)
+		}
+		return &con.ConsensusChannel, nil
+	}
+
 }

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -117,6 +117,12 @@ func (c *ConsensusChannel) recoverSigner(vars Vars, sig state.Signature) (common
 	return state.RecoverSigner(sig)
 }
 
+// ConsensusVars returns the vars of the consensus state
+// The consensus state is the latest state that has been signed by both parties
+func (c *ConsensusChannel) ConsensusVars() Vars {
+	return c.current.Vars
+}
+
 // latestProposedVars returns the latest proposed vars in a consensus channel
 // by cloning its current vars and applying each proposal in the queue
 func (c *ConsensusChannel) latestProposedVars() (Vars, error) {

--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -31,6 +31,7 @@ func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.C
 	id := alpha.CreateDirectChannel(request)
 	waitTimeForCompletedObjectiveIds(t, &alpha, defaultTimeout, id)
 	waitTimeForCompletedObjectiveIds(t, &beta, defaultTimeout, id)
+
 }
 func TestDirectFundIntegration(t *testing.T) {
 
@@ -41,8 +42,8 @@ func TestDirectFundIntegration(t *testing.T) {
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	clientA := setupClient(alice.PrivateKey, chain, broker, logDestination, 0)
-	clientB := setupClient(bob.PrivateKey, chain, broker, logDestination, 0)
+	clientA, _ := setupClient(alice.PrivateKey, chain, broker, logDestination, 0)
+	clientB, _ := setupClient(bob.PrivateKey, chain, broker, logDestination, 0)
 
 	directlyFundALedgerChannel(t, clientA, clientB)
 

--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
+	"github.com/statechannels/go-nitro/client/engine/store"
 	"github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols/directfund"
 	"github.com/statechannels/go-nitro/types"
@@ -42,9 +43,18 @@ func TestDirectFundIntegration(t *testing.T) {
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	clientA, _ := setupClient(alice.PrivateKey, chain, broker, logDestination, 0)
-	clientB, _ := setupClient(bob.PrivateKey, chain, broker, logDestination, 0)
+	clientA, storeA := setupClient(alice.PrivateKey, chain, broker, logDestination, 0)
+	clientB, storeB := setupClient(bob.PrivateKey, chain, broker, logDestination, 0)
 
 	directlyFundALedgerChannel(t, clientA, clientB)
+
+	// Ensure that we create a consensus channel in the store
+	for _, store := range []store.Store{storeA, storeB} {
+		_, ok := store.GetConsensusChannel(*clientA.Address, *clientB.Address)
+		if !ok {
+			t.Fatalf("expected a consensus channel to have been created")
+		}
+
+	}
 
 }

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -65,13 +65,13 @@ func waitTimeForCompletedObjectiveIds(t *testing.T, client *client.Client, timeo
 }
 
 // setupClient is a helper function that contructs a client and returns the new client and message service.
-func setupClient(pk []byte, chain chainservice.MockChain, msgBroker messageservice.Broker, logDestination io.Writer, meanMessageDelay time.Duration) client.Client {
+func setupClient(pk []byte, chain chainservice.MockChain, msgBroker messageservice.Broker, logDestination io.Writer, meanMessageDelay time.Duration) (client.Client, store.Store) {
 	myAddress := crypto.GetAddressFromSecretKeyBytes(pk)
 	chain.Subscribe(myAddress)
 	chainservice := chainservice.NewSimpleChainService(chain, myAddress)
 	messageservice := messageservice.NewTestMessageService(myAddress, msgBroker, meanMessageDelay)
 	storeA := store.NewMockStore(pk)
-	return client.New(messageservice, chainservice, storeA, logDestination)
+	return client.New(messageservice, chainservice, storeA, logDestination), storeA
 }
 
 func flushToFileCleanupFn(w io.Reader, fileName string) func() {

--- a/client_test/virtual_fund_message_delay_test.go
+++ b/client_test/virtual_fund_message_delay_test.go
@@ -33,9 +33,9 @@ func TestVirtualFundWithMessageDelays(t *testing.T) {
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	clientA := setupClient(alice.PrivateKey, chain, broker, logDestination, MAX_MESSAGE_DELAY)
-	clientB := setupClient(bob.PrivateKey, chain, broker, logDestination, MAX_MESSAGE_DELAY)
-	clientI := setupClient(irene.PrivateKey, chain, broker, logDestination, MAX_MESSAGE_DELAY)
+	clientA, _ := setupClient(alice.PrivateKey, chain, broker, logDestination, MAX_MESSAGE_DELAY)
+	clientB, _ := setupClient(bob.PrivateKey, chain, broker, logDestination, MAX_MESSAGE_DELAY)
+	clientI, _ := setupClient(irene.PrivateKey, chain, broker, logDestination, MAX_MESSAGE_DELAY)
 
 	directlyFundALedgerChannel(t, clientA, clientI)
 	directlyFundALedgerChannel(t, clientI, clientB)

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -26,9 +26,9 @@ func TestBenchmark(t *testing.T) {
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	clientAlice := setupClient(alice.PrivateKey, chain, broker, logDestination, 0)
-	clientBob := setupClient(bob.PrivateKey, chain, broker, logDestination, 0)
-	clientIrene := setupClient(irene.PrivateKey, chain, broker, logDestination, 0)
+	clientAlice, _ := setupClient(alice.PrivateKey, chain, broker, logDestination, 0)
+	clientBob, _ := setupClient(bob.PrivateKey, chain, broker, logDestination, 0)
+	clientIrene, _ := setupClient(irene.PrivateKey, chain, broker, logDestination, 0)
 
 	directlyFundALedgerChannel(t, clientAlice, clientIrene)
 	directlyFundALedgerChannel(t, clientIrene, clientBob)

--- a/client_test/virtualfund_integration_test.go
+++ b/client_test/virtualfund_integration_test.go
@@ -22,9 +22,9 @@ func TestVirtualFundIntegration(t *testing.T) {
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	clientA := setupClient(alice.PrivateKey, chain, broker, logDestination, 0)
-	clientB := setupClient(bob.PrivateKey, chain, broker, logDestination, 0)
-	clientI := setupClient(irene.PrivateKey, chain, broker, logDestination, 0)
+	clientA, _ := setupClient(alice.PrivateKey, chain, broker, logDestination, 0)
+	clientB, _ := setupClient(bob.PrivateKey, chain, broker, logDestination, 0)
+	clientI, _ := setupClient(irene.PrivateKey, chain, broker, logDestination, 0)
 
 	directlyFundALedgerChannel(t, clientA, clientI)
 	directlyFundALedgerChannel(t, clientI, clientB)

--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -22,10 +22,10 @@ func TestMultiPartyVirtualFundIntegration(t *testing.T) {
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	clientAlice := setupClient(alice.PrivateKey, chain, broker, logDestination, 0)
-	clientBob := setupClient(bob.PrivateKey, chain, broker, logDestination, 0)
-	clientBrian := setupClient(brian.PrivateKey, chain, broker, logDestination, 0)
-	clientIrene := setupClient(irene.PrivateKey, chain, broker, logDestination, 0)
+	clientAlice, _ := setupClient(alice.PrivateKey, chain, broker, logDestination, 0)
+	clientBob, _ := setupClient(bob.PrivateKey, chain, broker, logDestination, 0)
+	clientBrian, _ := setupClient(brian.PrivateKey, chain, broker, logDestination, 0)
+	clientIrene, _ := setupClient(irene.PrivateKey, chain, broker, logDestination, 0)
 
 	directlyFundALedgerChannel(t, clientAlice, clientIrene)
 	directlyFundALedgerChannel(t, clientIrene, clientBob)


### PR DESCRIPTION
⚠️ Based on #449 

Whenever a direct funding objective completes the engine now constructs a consensus channel and stores it in the `store`.

## Testing

To this test this new functionality the direct funding integration test now inspects the `store` for a consensus channel after the objective has been completed. To support this the `setupClient` now returns the `store` it generates and passes into the client constructor.

~The test currently doesn't inspect the details of the Consensus Channel as that would fail due to #435~
The test checks that the consensus outcome and turn num are what we expect 

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
