### PR TITLE
Overhaul JSON marshaling of ConsensusChannel (and friends)

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -1,7 +1,6 @@
 package consensus_channel
 
 import (
-	"encoding/json"
 	"fmt"
 	"math/big"
 	"sort"
@@ -262,43 +261,6 @@ func (o *LedgerOutcome) clone() LedgerOutcome {
 	}
 }
 
-// jsonLedgerOutcome replaces LedgerOutcome's private fields with public ones,
-// making it suitable for serialization
-type jsonLedgerOutcome struct {
-	AssetAddress types.Address // Address of the asset type
-	Left         Balance       // Balance of participants[0]
-	Right        Balance       // Balance of participants[1]
-	Guarantees   map[types.Destination]Guarantee
-}
-
-// MarshalJSON returns a JSON representation of the LedgerOutcome
-func (o *LedgerOutcome) MarshalJSON() ([]byte, error) {
-	jsonLo := jsonLedgerOutcome{
-		AssetAddress: o.assetAddress,
-		Left:         o.left,
-		Right:        o.right,
-		Guarantees:   o.guarantees,
-	}
-	return json.Marshal(jsonLo)
-}
-
-// UnmarshalJSON populates the receiver with the
-// json-encoded data
-func (o *LedgerOutcome) UnmarshalJSON(data []byte) error {
-	var jsonLo jsonLedgerOutcome
-	err := json.Unmarshal(data, &jsonLo)
-	if err != nil {
-		return fmt.Errorf("error unmarshaling ledger outcome data")
-	}
-
-	o.assetAddress = jsonLo.AssetAddress
-	o.left = jsonLo.Left
-	o.right = jsonLo.Right
-	o.guarantees = jsonLo.Guarantees
-
-	return nil
-}
-
 // SignedVars stores 0-2 signatures for some vars in a consensus channel
 type SignedVars struct {
 	Vars
@@ -406,44 +368,4 @@ func (v Vars) AsState(fp state.FixedPart) state.State {
 // Participants returns the channel participants.
 func (c *ConsensusChannel) Participants() []types.Address {
 	return c.fp.Participants
-}
-
-// jsonConsensusChannel replaces ConsensusChannel's private fields with public ones,
-// making it suitable for serialization
-type jsonConsensusChannel struct {
-	Id            types.Destination
-	MyIndex       ledgerIndex
-	FP            state.FixedPart
-	Current       SignedVars
-	ProposalQueue []SignedProposal
-}
-
-// MarshalJSON returns a JSON representation of the ConsensusChannel
-func (c ConsensusChannel) MarshalJSON() ([]byte, error) {
-	jsonCh := jsonConsensusChannel{
-		Id:            c.Id,
-		MyIndex:       c.myIndex,
-		FP:            c.fp,
-		Current:       c.current,
-		ProposalQueue: c.proposalQueue,
-	}
-	return json.Marshal(jsonCh)
-}
-
-// UnmarshalJSON populates the receiver with the
-// json-encoded data
-func (c *ConsensusChannel) UnmarshalJSON(data []byte) error {
-	var jsonCh jsonConsensusChannel
-	err := json.Unmarshal(data, &jsonCh)
-	if err != nil {
-		return fmt.Errorf("error unmarshaling channel data")
-	}
-
-	c.Id = jsonCh.Id
-	c.myIndex = jsonCh.MyIndex
-	c.fp = jsonCh.FP
-	c.current = jsonCh.Current
-	c.proposalQueue = jsonCh.ProposalQueue
-
-	return nil
 }

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -262,6 +262,43 @@ func (o *LedgerOutcome) clone() LedgerOutcome {
 	}
 }
 
+// jsonLedgerOutcome replaces LedgerOutcome's private fields with public ones,
+// making it suitable for serialization
+type jsonLedgerOutcome struct {
+	AssetAddress types.Address // Address of the asset type
+	Left         Balance       // Balance of participants[0]
+	Right        Balance       // Balance of participants[1]
+	Guarantees   map[types.Destination]Guarantee
+}
+
+// MarshalJSON returns a JSON representation of the LedgerOutcome
+func (o *LedgerOutcome) MarshalJSON() ([]byte, error) {
+	jsonLo := jsonLedgerOutcome{
+		AssetAddress: o.assetAddress,
+		Left:         o.left,
+		Right:        o.right,
+		Guarantees:   o.guarantees,
+	}
+	return json.Marshal(jsonLo)
+}
+
+// UnmarshalJSON populates the receiver with the
+// json-encoded data
+func (o *LedgerOutcome) UnmarshalJSON(data []byte) error {
+	var jsonLo jsonLedgerOutcome
+	err := json.Unmarshal(data, &jsonLo)
+	if err != nil {
+		return fmt.Errorf("error unmarshaling ledger outcome data")
+	}
+
+	o.assetAddress = jsonLo.AssetAddress
+	o.left = jsonLo.Left
+	o.right = jsonLo.Right
+	o.guarantees = jsonLo.Guarantees
+
+	return nil
+}
+
 // SignedVars stores 0-2 signatures for some vars in a consensus channel
 type SignedVars struct {
 	Vars

--- a/channel/consensus_channel/serde.go
+++ b/channel/consensus_channel/serde.go
@@ -19,7 +19,7 @@ type jsonGuarantee struct {
 }
 
 // MarshalJSON returns a JSON representation of the Guarantee
-func (g *Guarantee) MarshalJSON() ([]byte, error) {
+func (g Guarantee) MarshalJSON() ([]byte, error) {
 	jsonG := jsonGuarantee{
 		g.amount, g.target, g.left, g.right,
 	}
@@ -53,7 +53,7 @@ type jsonLedgerOutcome struct {
 }
 
 // MarshalJSON returns a JSON representation of the LedgerOutcome
-func (l *LedgerOutcome) MarshalJSON() ([]byte, error) {
+func (l LedgerOutcome) MarshalJSON() ([]byte, error) {
 	jsonLo := jsonLedgerOutcome{
 		AssetAddress: l.assetAddress,
 		Left:         l.left,
@@ -91,7 +91,7 @@ type jsonConsensusChannel struct {
 }
 
 // MarshalJSON returns a JSON representation of the ConsensusChannel
-func (c *ConsensusChannel) MarshalJSON() ([]byte, error) {
+func (c ConsensusChannel) MarshalJSON() ([]byte, error) {
 	jsonCh := jsonConsensusChannel{
 		Id:            c.Id,
 		MyIndex:       c.myIndex,

--- a/channel/consensus_channel/serde.go
+++ b/channel/consensus_channel/serde.go
@@ -1,0 +1,86 @@
+package consensus_channel
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/types"
+)
+
+// jsonLedgerOutcome replaces LedgerOutcome's private fields with public ones,
+// making it suitable for serialization
+type jsonLedgerOutcome struct {
+	AssetAddress types.Address // Address of the asset type
+	Left         Balance       // Balance of participants[0]
+	Right        Balance       // Balance of participants[1]
+	Guarantees   map[types.Destination]Guarantee
+}
+
+// MarshalJSON returns a JSON representation of the LedgerOutcome
+func (o *LedgerOutcome) MarshalJSON() ([]byte, error) {
+	jsonLo := jsonLedgerOutcome{
+		AssetAddress: o.assetAddress,
+		Left:         o.left,
+		Right:        o.right,
+		Guarantees:   o.guarantees,
+	}
+	return json.Marshal(jsonLo)
+}
+
+// UnmarshalJSON populates the receiver with the
+// json-encoded data
+func (o *LedgerOutcome) UnmarshalJSON(data []byte) error {
+	var jsonLo jsonLedgerOutcome
+	err := json.Unmarshal(data, &jsonLo)
+	if err != nil {
+		return fmt.Errorf("error unmarshaling ledger outcome data")
+	}
+
+	o.assetAddress = jsonLo.AssetAddress
+	o.left = jsonLo.Left
+	o.right = jsonLo.Right
+	o.guarantees = jsonLo.Guarantees
+
+	return nil
+}
+
+// jsonConsensusChannel replaces ConsensusChannel's private fields with public ones,
+// making it suitable for serialization
+type jsonConsensusChannel struct {
+	Id            types.Destination
+	MyIndex       ledgerIndex
+	FP            state.FixedPart
+	Current       SignedVars
+	ProposalQueue []SignedProposal
+}
+
+// MarshalJSON returns a JSON representation of the ConsensusChannel
+func (c ConsensusChannel) MarshalJSON() ([]byte, error) {
+	jsonCh := jsonConsensusChannel{
+		Id:            c.Id,
+		MyIndex:       c.myIndex,
+		FP:            c.fp,
+		Current:       c.current,
+		ProposalQueue: c.proposalQueue,
+	}
+	return json.Marshal(jsonCh)
+}
+
+// UnmarshalJSON populates the receiver with the
+// json-encoded data
+func (c *ConsensusChannel) UnmarshalJSON(data []byte) error {
+	var jsonCh jsonConsensusChannel
+	err := json.Unmarshal(data, &jsonCh)
+	if err != nil {
+		return fmt.Errorf("error unmarshaling channel data")
+	}
+
+	c.Id = jsonCh.Id
+	c.myIndex = jsonCh.MyIndex
+	c.fp = jsonCh.FP
+	c.current = jsonCh.Current
+	c.proposalQueue = jsonCh.ProposalQueue
+
+	return nil
+}

--- a/channel/consensus_channel/serde.go
+++ b/channel/consensus_channel/serde.go
@@ -18,29 +18,29 @@ type jsonLedgerOutcome struct {
 }
 
 // MarshalJSON returns a JSON representation of the LedgerOutcome
-func (o *LedgerOutcome) MarshalJSON() ([]byte, error) {
+func (l *LedgerOutcome) MarshalJSON() ([]byte, error) {
 	jsonLo := jsonLedgerOutcome{
-		AssetAddress: o.assetAddress,
-		Left:         o.left,
-		Right:        o.right,
-		Guarantees:   o.guarantees,
+		AssetAddress: l.assetAddress,
+		Left:         l.left,
+		Right:        l.right,
+		Guarantees:   l.guarantees,
 	}
 	return json.Marshal(jsonLo)
 }
 
 // UnmarshalJSON populates the receiver with the
 // json-encoded data
-func (o *LedgerOutcome) UnmarshalJSON(data []byte) error {
+func (l *LedgerOutcome) UnmarshalJSON(data []byte) error {
 	var jsonLo jsonLedgerOutcome
 	err := json.Unmarshal(data, &jsonLo)
 	if err != nil {
 		return fmt.Errorf("error unmarshaling ledger outcome data")
 	}
 
-	o.assetAddress = jsonLo.AssetAddress
-	o.left = jsonLo.Left
-	o.right = jsonLo.Right
-	o.guarantees = jsonLo.Guarantees
+	l.assetAddress = jsonLo.AssetAddress
+	l.left = jsonLo.Left
+	l.right = jsonLo.Right
+	l.guarantees = jsonLo.Guarantees
 
 	return nil
 }

--- a/channel/consensus_channel/serde.go
+++ b/channel/consensus_channel/serde.go
@@ -3,10 +3,45 @@ package consensus_channel
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/types"
 )
+
+// jsonGuarantee replaces Guarantee's private fields with public ones,
+// making it suitable for serialization
+type jsonGuarantee struct {
+	Amount big.Int
+	Target types.Destination
+	Left   types.Destination
+	Right  types.Destination
+}
+
+// MarshalJSON returns a JSON representation of the Guarantee
+func (g *Guarantee) MarshalJSON() ([]byte, error) {
+	jsonG := jsonGuarantee{
+		g.amount, g.target, g.left, g.right,
+	}
+	return json.Marshal(jsonG)
+}
+
+// UnmarshalJSON populates the receiver with the
+// json-encoded data
+func (g *Guarantee) UnmarshalJSON(data []byte) error {
+	var jsonG jsonGuarantee
+	err := json.Unmarshal(data, &jsonG)
+	if err != nil {
+		return fmt.Errorf("error unmarshaling guarantee data")
+	}
+
+	g.amount = jsonG.Amount
+	g.target = jsonG.Target
+	g.left = jsonG.Left
+	g.right = jsonG.Right
+
+	return nil
+}
 
 // jsonLedgerOutcome replaces LedgerOutcome's private fields with public ones,
 // making it suitable for serialization
@@ -56,7 +91,7 @@ type jsonConsensusChannel struct {
 }
 
 // MarshalJSON returns a JSON representation of the ConsensusChannel
-func (c ConsensusChannel) MarshalJSON() ([]byte, error) {
+func (c *ConsensusChannel) MarshalJSON() ([]byte, error) {
 	jsonCh := jsonConsensusChannel{
 		Id:            c.Id,
 		MyIndex:       c.myIndex,

--- a/channel/consensus_channel/serde.go
+++ b/channel/consensus_channel/serde.go
@@ -9,6 +9,36 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
+// jsonBalance replaces Balance's private fields with public ones,
+// making it suitable for serialization
+type jsonBalance struct {
+	Destination types.Destination
+	Amount      big.Int
+}
+
+// MarshalJSON returns a JSON representation of the Balance
+func (b Balance) MarshalJSON() ([]byte, error) {
+	jsonB := jsonBalance{
+		b.destination, b.amount,
+	}
+	return json.Marshal(jsonB)
+}
+
+// UnmarshalJSON populates the receiver with the
+// json-encoded data
+func (b *Balance) UnmarshalJSON(data []byte) error {
+	var jsonB jsonBalance
+	err := json.Unmarshal(data, &jsonB)
+	if err != nil {
+		return fmt.Errorf("error unmarshaling guarantee data")
+	}
+
+	b.destination = jsonB.Destination
+	b.amount = jsonB.Amount
+
+	return nil
+}
+
 // jsonGuarantee replaces Guarantee's private fields with public ones,
 // making it suitable for serialization
 type jsonGuarantee struct {

--- a/channel/consensus_channel/serde_test.go
+++ b/channel/consensus_channel/serde_test.go
@@ -1,0 +1,87 @@
+package consensus_channel
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/crypto"
+	"github.com/statechannels/go-nitro/internal/testdata"
+	"github.com/statechannels/go-nitro/types"
+)
+
+func TestSerde(t *testing.T) {
+
+	someOutcome := makeOutcome(
+		Balance{testdata.Actors.Alice.Destination(), *big.NewInt(2)},
+		Balance{testdata.Actors.Bob.Destination(), *big.NewInt(7)},
+		Guarantee{
+			amount: *big.NewInt(1),
+			left:   testdata.Actors.Alice.Destination(),
+			right:  testdata.Actors.Alice.Destination(),
+			target: types.Destination{99},
+		})
+
+	t.Run("LedgerOutcome", func(t *testing.T) {
+		// got, err := json.MarshalIndent(someOutcome, " ", "    ")
+		got, err := someOutcome.MarshalJSON()
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Logf("%+v", someOutcome)
+		want := "{something}"
+
+		if string(got) != want {
+
+			t.Fatalf("incorrect json marshalling, expected %v got %v", want, string(got))
+		}
+	})
+
+	t.Run("ConsensusChannel", func(t *testing.T) {
+		cc := ConsensusChannel{
+			myIndex: leader,
+			fp:      fp(),
+			Id:      types.Destination{1},
+			current: SignedVars{
+				Vars: Vars{
+					TurnNum: 0,
+					Outcome: someOutcome,
+				},
+				Signatures: [2]crypto.Signature{{
+					R: common.Hex2Bytes(`704b3afcc6e702102ca1af3f73cf3b37f3007f368c40e8b81ca823a65740a053`),
+					S: common.Hex2Bytes(`14040ad4c598dbb055a50430142a13518e1330b79d24eed86fcbdff1a7a95589`),
+					V: byte(0),
+				}, {
+					S: common.Hex2Bytes(`704b3afcc6e702102ca1af3f73cf3b37f3007f368c40e8b81ca823a65740a053`),
+					R: common.Hex2Bytes(`14040ad4c598dbb055a50430142a13518e1330b79d24eed86fcbdff1a7a95589`),
+					V: byte(0),
+				}},
+			},
+			proposalQueue: []SignedProposal{{
+				Signature: crypto.Signature{
+					S: common.Hex2Bytes(`704b3afcc6e702102ca1af3f73cf3b37f3007f368c40e8b81ca823a65740a053`),
+					R: common.Hex2Bytes(`14040ad4c598dbb055a50430142a13518e1330b79d24eed86fcbdff1a7a95589`),
+					V: byte(0),
+				},
+				Proposal: add(1, 2, types.Destination{3}, types.Destination{4}, types.Destination{5}),
+			}},
+		}
+
+		got, err := json.Marshal(cc)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		want := "{somethingelse}"
+
+		if string(got) != want {
+
+			t.Fatalf("incorrect json marshalling, expected %v got %v", want, string(got))
+		}
+	})
+
+}

--- a/channel/consensus_channel/serde_test.go
+++ b/channel/consensus_channel/serde_test.go
@@ -12,30 +12,40 @@ import (
 )
 
 func TestSerde(t *testing.T) {
-
+	// TODO unskip this test when we have solved the issue for persisting big.Ints
+	// https://github.com/statechannels/go-nitro/issues/439
+	t.Skip()
+	someGuarantee := Guarantee{
+		amount: *big.NewInt(1),
+		left:   testdata.Actors.Alice.Destination(),
+		right:  testdata.Actors.Alice.Destination(),
+		target: types.Destination{99},
+	}
 	someOutcome := makeOutcome(
 		Balance{testdata.Actors.Alice.Destination(), *big.NewInt(2)},
 		Balance{testdata.Actors.Bob.Destination(), *big.NewInt(7)},
-		Guarantee{
-			amount: *big.NewInt(1),
-			left:   testdata.Actors.Alice.Destination(),
-			right:  testdata.Actors.Alice.Destination(),
-			target: types.Destination{99},
-		})
+		someGuarantee)
 
-	t.Run("LedgerOutcome", func(t *testing.T) {
-		// got, err := json.MarshalIndent(someOutcome, " ", "    ")
-		got, err := someOutcome.MarshalJSON()
-
+	t.Run("Guarantee", func(t *testing.T) {
+		got, err := json.Marshal(someGuarantee)
 		if err != nil {
 			t.Fatal(err)
 		}
-
-		t.Logf("%+v", someOutcome)
-		want := "{something}"
-
+		// TODO: this expectation is not right and currently has some placeholders  / gaps
+		want := `{"Amount":{SOMETHING!},"Target":"0x6300000000000000000000000000000000000000000000000000000000000000","Left":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce","Right":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce"}`
 		if string(got) != want {
+			t.Fatalf("incorrect json marshalling, expected %v got %v", want, string(got))
+		}
+	})
 
+	t.Run("LedgerOutcome", func(t *testing.T) {
+		got, err := json.Marshal(someOutcome)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// TODO: this expectation is not right and currently has some placeholders  / gaps
+		want := `{"AssetAddress":"0x0000000000000000000000000000000000000000","Left":{"Destination":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce","Amount":{SOMETHING!}},"Right":{"Destination":"0x000000000000000000000000bbb676f9cff8d242e9eac39d063848807d3d1d94","Amount":{}},"Guarantees":{"0x6300000000000000000000000000000000000000000000000000000000000000":{"Amount":{},"Target":"0x6300000000000000000000000000000000000000000000000000000000000000","Left":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce","Right":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce"}}}`
+		if string(got) != want {
 			t.Fatalf("incorrect json marshalling, expected %v got %v", want, string(got))
 		}
 	})
@@ -76,7 +86,8 @@ func TestSerde(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		want := "{somethingelse}"
+		// TODO: this expectation is not right and currently has some placeholders  / gaps
+		want := `{"Id":"0x0100000000000000000000000000000000000000000000000000000000000000","MyIndex":0,"FP":{"ChainId":0,"Participants":["0xaaa6628ec44a8a742987ef3a114ddfe2d4f7adce","0xbbb676f9cff8d242e9eac39d063848807d3d1d94"],"ChannelNonce":9001,"AppDefinition":"0x0000000000000000000000000000000000000000","ChallengeDuration":100},"Current":{"TurnNum":0,"Outcome":{"AssetAddress":"0x0000000000000000000000000000000000000000","Left":{"Destination":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce","Amount":{}},"Right":{"Destination":"0x000000000000000000000000bbb676f9cff8d242e9eac39d063848807d3d1d94","Amount":{}},"Guarantees":{"0x6300000000000000000000000000000000000000000000000000000000000000":{"Amount":{},"Target":"0x6300000000000000000000000000000000000000000000000000000000000000","Left":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce","Right":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce"}}},"Signatures":[{"R":"cEs6/MbnAhAsoa8/c887N/MAfzaMQOi4HKgjpldAoFM=","S":"FAQK1MWY27BVpQQwFCoTUY4TMLedJO7Yb8vf8aepVYk=","V":0},{"R":"FAQK1MWY27BVpQQwFCoTUY4TMLedJO7Yb8vf8aepVYk=","S":"cEs6/MbnAhAsoa8/c887N/MAfzaMQOi4HKgjpldAoFM=","V":0}]},"ProposalQueue":[{"R":"FAQK1MWY27BVpQQwFCoTUY4TMLedJO7Yb8vf8aepVYk=","S":"cEs6/MbnAhAsoa8/c887N/MAfzaMQOi4HKgjpldAoFM=","V":0,"Proposal":{"Amount":{SOMETHING},"Target":"0x0300000000000000000000000000000000000000000000000000000000000000","Left":"0x0400000000000000000000000000000000000000000000000000000000000000","Right":"0x0500000000000000000000000000000000000000000000000000000000000000"}}]}`
 
 		if string(got) != want {
 


### PR DESCRIPTION
Towards #435 

* Moves serde to separate file
* Ensures `MarshalJSON` has a value receiver and `UnmarshalJSON` has a pointer receiver
* Adds some (skipped and incomplete) unit tests for serde alone (not using mock store)
    - the tests use literal string expectations


TODO
- [ ] fix test expectations so there are no gaps / placeholders
- [ ] figure out why big.Ints don't appear (this was why I created #439  😕 )
- [ ] unskip tests
- [ ] possiblty add deserialisation tests (separate PR?)