### PR TITLE
WIP: issue #420

### DIFF
--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -286,7 +286,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 		testNew := func(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
 			// Assert that a valid set of constructor args does not result in an error
-			o, err := constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			o, err := constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, nil, ledgerChannelToMyRight, nil) // todo: #420 deprecate TwoPartyLedgers
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -340,7 +340,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 		testclone := func(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
 
-			o, _ := constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			o, _ := constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, nil, ledgerChannelToMyRight, nil) // todo: #420 deprecate TwoPartyLedgers
 
 			clone := o.clone()
 
@@ -351,7 +351,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 		testCrank := func(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
-			var s, _ = constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			var s, _ = constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, nil, ledgerChannelToMyRight, nil) // todo: #420 deprecate TwoPartyLedgers
 			// Assert that cranking an unapproved objective returns an error
 			if _, _, _, err := s.Crank(&my.privateKey); err == nil {
 				t.Fatal(`Expected error when cranking unapproved objective, but got nil`)
@@ -486,7 +486,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 		testUpdate := func(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
-			var s, _ = constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			var s, _ = constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, nil, ledgerChannelToMyRight, nil) // todo: #420 deprecate TwoPartyLedgers
 			// Prepare an event with a mismatched objectiveId
 			e := protocols.ObjectiveEvent{
 				ObjectiveId: "some-other-id",

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -312,7 +312,7 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 		// toMyRightId = o.ToMyRight.ConsensusChannel.Id
 	}
 
-	// todo: range over event.Proposals (or similar)
+	// todo: #420 range over event.Proposals (or similar)
 
 	for _, ss := range event.SignedStates {
 		channelId, _ := ss.State().ChannelId() // TODO handle error

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -347,9 +347,9 @@ func (o Objective) Channels() []*channel.Channel {
 //////////////////////////////////////////////////
 
 // insertGuaranteeInfo mutates the reciever Connection struct.
-func (connection *Connection) insertGuaranteeInfo(a0 types.Funds, b0 types.Funds, vId types.Destination, left types.Destination, right types.Destination) error {
+func (c *Connection) insertGuaranteeInfo(a0 types.Funds, b0 types.Funds, vId types.Destination, left types.Destination, right types.Destination) error {
 
-	connection.GuaranteeInfo = GuaranteeInfo{
+	c.GuaranteeInfo = GuaranteeInfo{
 		Left:                 left,
 		Right:                right,
 		LeftAmount:           a0,
@@ -359,8 +359,8 @@ func (connection *Connection) insertGuaranteeInfo(a0 types.Funds, b0 types.Funds
 
 	// Check that the guarantee metadata can be encoded. This allows us to avoid clunky error-return-chains for getExpectedGuarantees
 	metadata := outcome.GuaranteeMetadata{
-		Left:  connection.GuaranteeInfo.Left,
-		Right: connection.GuaranteeInfo.Right,
+		Left:  c.GuaranteeInfo.Left,
+		Right: c.GuaranteeInfo.Right,
 	}
 	_, err := metadata.Encode()
 	if err != nil {
@@ -371,11 +371,11 @@ func (connection *Connection) insertGuaranteeInfo(a0 types.Funds, b0 types.Funds
 }
 
 // getExpectedGuarantees returns a map of asset addresses to guarantees for a Connection.
-func (connection *Connection) getExpectedGuarantees() map[types.Address]outcome.Allocation {
+func (c *Connection) getExpectedGuarantees() map[types.Address]outcome.Allocation {
 	expectedGuaranteesForLedgerChannel := make(map[types.Address]outcome.Allocation)
 	metadata := outcome.GuaranteeMetadata{
-		Left:  connection.GuaranteeInfo.Left,
-		Right: connection.GuaranteeInfo.Right,
+		Left:  c.GuaranteeInfo.Left,
+		Right: c.GuaranteeInfo.Right,
 	}
 	encodedGuarantee, err := metadata.Encode()
 	// This error is unexpected. insertGuaranteeInfo checks that the guarantee metadata can be encoded.
@@ -384,11 +384,11 @@ func (connection *Connection) getExpectedGuarantees() map[types.Address]outcome.
 		panic(err)
 	}
 
-	channelFunds := connection.GuaranteeInfo.LeftAmount.Add(connection.GuaranteeInfo.RightAmount)
+	channelFunds := c.GuaranteeInfo.LeftAmount.Add(c.GuaranteeInfo.RightAmount)
 
 	for asset, amount := range channelFunds {
 		expectedGuaranteesForLedgerChannel[asset] = outcome.Allocation{
-			Destination:    connection.GuaranteeInfo.GuaranteeDestination,
+			Destination:    c.GuaranteeInfo.GuaranteeDestination,
 			Amount:         amount,
 			AllocationType: outcome.GuaranteeAllocationType,
 			Metadata:       encodedGuarantee,
@@ -419,8 +419,8 @@ func (o Objective) fundingComplete() bool {
 // The decision is made based on the latest supported state of the channel.
 //
 // Both arguments are maps keyed by the same asset.
-func (connection *Connection) ledgerChannelAffordsExpectedGuarantees() bool {
-	return connection.Channel.Affords(connection.getExpectedGuarantees(), connection.Channel.OnChainFunding)
+func (c *Connection) ledgerChannelAffordsExpectedGuarantees() bool {
+	return c.Channel.Affords(c.getExpectedGuarantees(), c.Channel.OnChainFunding)
 }
 
 // Equal returns true if the supplied DirectFundObjective is deeply equal to the receiver.

--- a/protocols/virtualfund/virtualfund_test.go
+++ b/protocols/virtualfund/virtualfund_test.go
@@ -75,8 +75,8 @@ func TestMarshalJSON(t *testing.T) {
 		false,
 		vPreFund,
 		alice.address,
-		&channel.TwoPartyLedger{},
-		right,
+		&channel.TwoPartyLedger{}, nil, // todo: #420 deprecate TwoPartyLedgers
+		right, nil,
 	)
 
 	if err != nil {


### PR DESCRIPTION
This can be a working branch for #420. PR as stands includes a number of labelled todos of the form `// todo: #420`, and stub inserts of ConsensusChannels into the `Connection` struct.

PR also includes a refactor of `consensus_channel`'s tests to avoid importing `testdata` and the cyclic import issue observed in #434.