### PR TITLE
do not use marshalling when converting from raw exits

### DIFF
--- a/channel/state/outcome/exit.go
+++ b/channel/state/outcome/exit.go
@@ -2,9 +2,7 @@ package outcome
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
-	"log"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -114,20 +112,31 @@ type rawExitType = []struct {
 
 // convertToExit converts a rawExitType to an Exit
 func convertToExit(r rawExitType) Exit {
-	var exit Exit
-	j, err := json.Marshal(r)
-
-	if err != nil {
-		log.Fatal(`error marshalling`)
-	}
-
-	err = json.Unmarshal(j, &exit)
-
-	if err != nil {
-		log.Fatal(`error unmarshalling`, err)
+	exit := make(Exit, len(r))
+	for i, raw := range r {
+		exit[i] = SingleAssetExit{
+			Asset:       raw.Asset,
+			Metadata:    raw.Metadata,
+			Allocations: convertToAllocations(raw.Allocations),
+		}
 	}
 
 	return exit
+}
+
+// convertToAllocations converts a rawAllocationsType to an Allocations
+func convertToAllocations(r rawAllocationsType) Allocations {
+	allocations := make(Allocations, len(r))
+	for i, raw := range r {
+		allocations[i] = Allocation{
+			Destination:    raw.Destination,
+			AllocationType: raw.AllocationType,
+			Amount:         raw.Amount,
+			Metadata:       raw.Metadata,
+		}
+	}
+
+	return allocations
 }
 
 // Encode returns the abi encoded Exit

--- a/channel/state/outcome/guarantee.go
+++ b/channel/state/outcome/guarantee.go
@@ -1,9 +1,6 @@
 package outcome
 
 import (
-	"encoding/json"
-	"log"
-
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -33,19 +30,8 @@ type rawGuaranteeMetadataType = struct {
 
 // convertToGuaranteeMetadata converts a rawGuaranteeMetadataType to a GuaranteeMetadata
 func convertToGuaranteeMetadata(r rawGuaranteeMetadataType) GuaranteeMetadata {
-	var guaranteeMetadata GuaranteeMetadata
-	j, err := json.Marshal(r)
 
-	if err != nil {
-		log.Fatal(`error marshalling`)
-	}
-
-	err = json.Unmarshal(j, &guaranteeMetadata)
-
-	if err != nil {
-		log.Fatal(`error unmarshalling`, err)
-	}
-
+	guaranteeMetadata := GuaranteeMetadata{Left: types.Destination(r.Left), Right: types.Destination(r.Right)}
 	return guaranteeMetadata
 }
 


### PR DESCRIPTION
Towards #440 

Previously we converted a raw abi-encoded exit into an Exit struct by marshalling the raw to json and then unmarshalling that json into an Exit struct.

However this depends on the assumption that `rawExitType` and `Exit` use the same json. This breaks in #440 as we change the json for `Exit` to marshal `types.Destination` as strings.

To get around this I've modified the `convertTo` functions to manually convert the raw structs. It's a bit more boilerplate but seems much safer.
