### PR TITLE
Switch to pointers to big.int in ConsensusChannel

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -132,6 +132,16 @@ func (c *ConsensusChannel) latestProposedVars() (Vars, error) {
 	return vars, nil
 }
 
+// NewBalance returns a new Balance struct with the given amount and destination
+func NewBalance(destination types.Destination, amount *big.Int) Balance {
+	balanceAmount := big.NewInt(0).Set(amount)
+	return Balance{
+		destination: destination,
+		amount:      balanceAmount,
+	}
+
+}
+
 // Balance represents an Allocation of type 0, ie. a simple allocation.
 type Balance struct {
 	destination types.Destination
@@ -180,6 +190,17 @@ type LedgerOutcome struct {
 	left         Balance       // Balance of participants[0]
 	right        Balance       // Balance of participants[1]
 	guarantees   map[types.Destination]Guarantee
+}
+
+// NewLedgerOutcome creates a new ledger outcome with the given asset address and balances.
+// The outcome will contain no guarantees
+func NewLedgerOutcome(assetAddress types.Address, left, right Balance) *LedgerOutcome {
+	return &LedgerOutcome{
+		assetAddress: assetAddress,
+		left:         left,
+		right:        right,
+		guarantees:   make(map[types.Destination]Guarantee),
+	}
 }
 
 // includes returns true when the receiver includes g in its list of guarantees.

--- a/channel/consensus_channel/consensus_channel_test.go
+++ b/channel/consensus_channel/consensus_channel_test.go
@@ -17,13 +17,13 @@ func TestConsensusChannel(t *testing.T) {
 	var bob = types.Destination(common.HexToHash("0x0b"))
 
 	allocation := func(d types.Destination, a uint64) Balance {
-		return Balance{destination: d, amount: *big.NewInt(int64(a))}
+		return Balance{destination: d, amount: big.NewInt(int64(a))}
 	}
 
 	guarantee := func(amount uint64, target, left, right types.Destination) Guarantee {
 		return Guarantee{
 			target: target,
-			amount: *big.NewInt(int64(amount)),
+			amount: big.NewInt(int64(amount)),
 			left:   left,
 			right:  right,
 		}
@@ -38,7 +38,7 @@ func TestConsensusChannel(t *testing.T) {
 	}
 
 	add := func(turnNum, amount uint64, vId, left, right types.Destination) Add {
-		bigAmount := *big.NewInt(int64(amount))
+		bigAmount := big.NewInt(int64(amount))
 		return Add{
 			turnNum: turnNum,
 			Guarantee: Guarantee{
@@ -141,8 +141,8 @@ func TestConsensusChannel(t *testing.T) {
 		// Proposing a change that depletes a balance should fail
 		vars = Vars{TurnNum: startingTurnNum, Outcome: outcome()}
 		largeProposal := proposal
-		leftAmount := vars.Outcome.left.amount
-		largeProposal.amount = *leftAmount.Add(&leftAmount, big.NewInt(1))
+		leftAmount := big.NewInt(0).Set(vars.Outcome.left.amount)
+		largeProposal.amount = leftAmount.Add(leftAmount, big.NewInt(1))
 		err = vars.Add(largeProposal)
 		if !errors.Is(err, ErrInsufficientFunds) {
 			t.Fatalf("expected error when adding too large a guarantee: %v", err)

--- a/channel/consensus_channel/helpers_test.go
+++ b/channel/consensus_channel/helpers_test.go
@@ -21,13 +21,13 @@ func fp() state.FixedPart {
 }
 
 func allocation(d types.Destination, a uint64) Balance {
-	return Balance{destination: d, amount: *big.NewInt(int64(a))}
+	return Balance{destination: d, amount: big.NewInt(int64(a))}
 }
 
 func guarantee(amount uint64, target, left, right types.Destination) Guarantee {
 	return Guarantee{
 		target: target,
-		amount: *big.NewInt(int64(amount)),
+		amount: big.NewInt(int64(amount)),
 		left:   left,
 		right:  right,
 	}
@@ -51,7 +51,7 @@ func ledgerOutcome() LedgerOutcome {
 }
 
 func add(turnNum, amount uint64, vId, left, right types.Destination) Add {
-	bigAmount := *big.NewInt(int64(amount))
+	bigAmount := big.NewInt(int64(amount))
 	return Add{
 		turnNum: turnNum,
 		Guarantee: Guarantee{

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -1,6 +1,7 @@
 package store_test
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -12,6 +13,7 @@ import (
 	nc "github.com/statechannels/go-nitro/crypto"
 	td "github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/types"
 )
 
 func TestNewMockStore(t *testing.T) {
@@ -124,14 +126,19 @@ func TestConsensusChannelStore(t *testing.T) {
 	fp := td.Objectives.Directfund.GenericDFO().C.FixedPart // TODO replace with testdata not nested under GenericDFO
 	fp.Participants[0] = td.Actors.Alice.Address
 	fp.Participants[1] = td.Actors.Bob.Address
-	initialVars := consensus_channel.Vars{Outcome: cc.LedgerOutcome{}, TurnNum: 0}
+	asset := types.Address{}
+	left := cc.NewBalance(td.Actors.Alice.Destination(), big.NewInt(6))
+	right := cc.NewBalance(td.Actors.Bob.Destination(), big.NewInt(4))
+	outcome := cc.NewLedgerOutcome(asset, left, right)
+	initialVars := consensus_channel.Vars{Outcome: *outcome, TurnNum: 0}
+
 	aliceSig, _ := initialVars.AsState(fp).Sign(td.Actors.Alice.PrivateKey)
 	bobsSig, _ := initialVars.AsState(fp).Sign(td.Actors.Bob.PrivateKey)
 
 	want, err := consensus_channel.NewLeaderChannel(
 		fp,
 		0,
-		consensus_channel.LedgerOutcome{},
+		*outcome,
 		[2]state.Signature{aliceSig, bobsSig})
 
 	if err != nil {


### PR DESCRIPTION
According to the [documentation](https://pkg.go.dev/math/big#Int) shallow copies of `big.Ints` can lead to errors. However we have a couple of structs (like `Balance` and `Guarantee`) that contain `big.Int` instead of a pointer. This means that when these structs get passed around by value (like [here](https://github.com/statechannels/go-nitro/blob/ag/store-bug/channel/consensus_channel/leader_channel.go#L35:L35)) we're creating shallow copies of `big.Int`.

It seems safer to use pointers to `big.Int` in consensus channel so that:
- we follow what's recommended by the documentation
-  we keep consistent with how we deal with big.ints in the rest of the [code](https://github.com/statechannels/go-nitro/blob/ag/store-bug/channel/state/outcome/exit.go#L40:L40)
- BONUS: Using pointers means that big.ints will properly marshal to json

Once I made the change to pointers in [b3bd3ed](https://github.com/statechannels/go-nitro/pull/447/commits/b3bd3eddc796ec4a412001bf64371881739f6b50) I had to update the store test in [da6d998](https://github.com/statechannels/go-nitro/pull/447/commits/da6d9983cb430abb75d9f5c1f9cf46d892576168). This was because the store test was using a nil `LedgerOutcome` which now would contain `nil` big.int pointers and would not serialize out properly. To address this I've added some simple constructor functions and constructed a proper outcome for the store test.

