### PR TITLE
Remove testdata dependency from consensus_channel

### DIFF
--- a/channel/consensus_channel/follower_channel_test.go
+++ b/channel/consensus_channel/follower_channel_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/channel/state"
-	"github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -36,8 +35,8 @@ func TestReceive(t *testing.T) {
 
 	var vAmount = uint64(5)
 	initialVars := Vars{Outcome: ledgerOutcome(), TurnNum: 0}
-	aliceSig, _ := initialVars.AsState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
-	bobsSig, _ := initialVars.AsState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
+	aliceSig, _ := initialVars.AsState(fp()).Sign(Actors.Alice.PrivateKey)
+	bobsSig, _ := initialVars.AsState(fp()).Sign(Actors.Bob.PrivateKey)
 	sigs := [2]state.Signature{aliceSig, bobsSig}
 
 	channel, err := NewFollowerChannel(fp(), 0, ledgerOutcome(), sigs)
@@ -54,7 +53,7 @@ func TestReceive(t *testing.T) {
 		t.Fatalf("expected %v, but got %v", ErrInvalidProposalSignature, err)
 	}
 
-	valid := createSignedProposal(initialVars, proposal, fp(), testdata.Actors.Alice.PrivateKey)
+	valid := createSignedProposal(initialVars, proposal, fp(), Actors.Alice.PrivateKey)
 
 	err = channel.Receive(valid)
 	if err != nil {
@@ -72,7 +71,7 @@ func TestReceive(t *testing.T) {
 	// Generate a second proposal
 	latestProposed, _ := channel.latestProposedVars()
 	secondProposal := add(2, vAmount, types.Destination{3}, alice, bob)
-	anotherValid := createSignedProposal(latestProposed, secondProposal, fp(), testdata.Actors.Alice.PrivateKey)
+	anotherValid := createSignedProposal(latestProposed, secondProposal, fp(), Actors.Alice.PrivateKey)
 	err = channel.Receive(anotherValid)
 	if err != nil {
 		t.Fatalf("unable to receive proposal: %v", err)
@@ -87,14 +86,14 @@ func TestReceive(t *testing.T) {
 	}
 
 	// Check that receive rejects a stale proposal
-	stale := createSignedProposal(Vars{TurnNum: 0, Outcome: ledgerOutcome()}, proposal, fp(), testdata.Actors.Alice.PrivateKey)
+	stale := createSignedProposal(Vars{TurnNum: 0, Outcome: ledgerOutcome()}, proposal, fp(), Actors.Alice.PrivateKey)
 	err = channel.Receive(stale)
 	if !errors.Is(ErrInvalidTurnNum, err) {
 		t.Fatalf("expected %v, but got %v", ErrInvalidTurnNum, err)
 	}
 
 	// Check that  receive rejects a proposal too far in the future
-	tooFar := createSignedProposal(Vars{TurnNum: 10, Outcome: ledgerOutcome()}, proposal, fp(), testdata.Actors.Alice.PrivateKey)
+	tooFar := createSignedProposal(Vars{TurnNum: 10, Outcome: ledgerOutcome()}, proposal, fp(), Actors.Alice.PrivateKey)
 	err = channel.Receive(tooFar)
 	if !errors.Is(ErrInvalidTurnNum, err) {
 		t.Fatalf("expected %v, but got %v", ErrInvalidTurnNum, err)
@@ -102,13 +101,13 @@ func TestReceive(t *testing.T) {
 
 }
 func TestFollowerChannel(t *testing.T) {
-	alice := testdata.Actors.Alice.Destination()
-	bob := testdata.Actors.Bob.Destination()
+	alice := Actors.Alice.Destination()
+	bob := Actors.Bob.Destination()
 	targetChannel := types.Destination{2}
 
 	initialVars := Vars{Outcome: ledgerOutcome(), TurnNum: 0}
-	aliceSig, _ := initialVars.AsState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
-	bobsSig, _ := initialVars.AsState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
+	aliceSig, _ := initialVars.AsState(fp()).Sign(Actors.Alice.PrivateKey)
+	bobsSig, _ := initialVars.AsState(fp()).Sign(Actors.Bob.PrivateKey)
 	sigs := [2]state.Signature{aliceSig, bobsSig}
 
 	channel, err := NewFollowerChannel(fp(), 0, ledgerOutcome(), sigs)
@@ -118,7 +117,7 @@ func TestFollowerChannel(t *testing.T) {
 
 	proposal := add(1, uint64(5), targetChannel, alice, bob)
 
-	err = channel.SignNextProposal(proposal, testdata.Actors.Bob.PrivateKey)
+	err = channel.SignNextProposal(proposal, Actors.Bob.PrivateKey)
 	if !errors.Is(ErrNoProposals, err) {
 		t.Fatalf("expected %v, but got %v", ErrNoProposals, err)
 	}
@@ -131,12 +130,12 @@ func TestFollowerChannel(t *testing.T) {
 	channel.proposalQueue = []SignedProposal{signedProposal}
 	proposal2 := add(1, uint64(6), targetChannel, alice, bob)
 
-	err = channel.SignNextProposal(proposal2, testdata.Actors.Bob.PrivateKey)
+	err = channel.SignNextProposal(proposal2, Actors.Bob.PrivateKey)
 	if !errors.Is(ErrNonMatchingProposals, err) {
 		t.Fatalf("expected %v, but got %v", ErrNonMatchingProposals, err)
 	}
 
-	err = channel.SignNextProposal(proposal, testdata.Actors.Bob.PrivateKey)
+	err = channel.SignNextProposal(proposal, Actors.Bob.PrivateKey)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/channel/consensus_channel/helpers_test.go
+++ b/channel/consensus_channel/helpers_test.go
@@ -4,13 +4,12 @@ import (
 	"math/big"
 
 	"github.com/statechannels/go-nitro/channel/state"
-	"github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/types"
 )
 
 func fp() state.FixedPart {
 	participants := [2]types.Address{
-		testdata.Actors.Alice.Address, testdata.Actors.Bob.Address,
+		Actors.Alice.Address, Actors.Bob.Address,
 	}
 	return state.FixedPart{
 		Participants:      participants[:],
@@ -43,9 +42,9 @@ func makeOutcome(left, right Balance, guarantees ...Guarantee) LedgerOutcome {
 
 func ledgerOutcome() LedgerOutcome {
 	return makeOutcome(
-		allocation(testdata.Actors.Alice.Destination(), uint64(200)),
-		allocation(testdata.Actors.Bob.Destination(), uint64(300)),
-		guarantee(uint64(5), types.Destination{1}, testdata.Actors.Alice.Destination(), testdata.Actors.Bob.Destination()),
+		allocation(Actors.Alice.Destination(), uint64(200)),
+		allocation(Actors.Bob.Destination(), uint64(300)),
+		guarantee(uint64(5), types.Destination{1}, Actors.Alice.Destination(), Actors.Bob.Destination()),
 	)
 
 }

--- a/channel/consensus_channel/leader_channel_test.go
+++ b/channel/consensus_channel/leader_channel_test.go
@@ -6,13 +6,12 @@ import (
 	"testing"
 
 	"github.com/statechannels/go-nitro/channel/state"
-	"github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/types"
 )
 
 func TestLeaderChannel(t *testing.T) {
-	var alice = testdata.Actors.Alice.Destination()
-	var bob = testdata.Actors.Bob.Destination()
+	var alice = Actors.Alice.Destination()
+	var bob = Actors.Bob.Destination()
 
 	existingChannel := types.Destination{1}
 	targetChannel := types.Destination{2}
@@ -21,8 +20,8 @@ func TestLeaderChannel(t *testing.T) {
 	vAmount := uint64(5)
 
 	initialVars := Vars{Outcome: ledgerOutcome(), TurnNum: 0}
-	aliceSig, _ := initialVars.AsState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
-	bobsSig, _ := initialVars.AsState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
+	aliceSig, _ := initialVars.AsState(fp()).Sign(Actors.Alice.PrivateKey)
+	bobsSig, _ := initialVars.AsState(fp()).Sign(Actors.Bob.PrivateKey)
 	sigs := [2]state.Signature{aliceSig, bobsSig}
 
 	channel, err := NewLeaderChannel(fp(), 0, ledgerOutcome(), sigs)
@@ -37,7 +36,7 @@ func TestLeaderChannel(t *testing.T) {
 	}
 
 	p := add(1, amountAdded, targetChannel, alice, bob)
-	sp, err := channel.Propose(p, testdata.Actors.Alice.PrivateKey)
+	sp, err := channel.Propose(p, Actors.Alice.PrivateKey)
 	if err != nil {
 		t.Fatalf("failed to add proposal: %v", err)
 	}
@@ -57,7 +56,7 @@ func TestLeaderChannel(t *testing.T) {
 		guarantee(amountAdded, targetChannel, alice, bob),
 	)
 	stateSigned := Vars{TurnNum: 1, Outcome: outcomeSigned}
-	sig, _ := stateSigned.AsState(fp()).Sign(testdata.Actors.Alice.PrivateKey)
+	sig, _ := stateSigned.AsState(fp()).Sign(Actors.Alice.PrivateKey)
 	expected := SignedProposal{Proposal: p, Signature: sig}
 
 	if !reflect.DeepEqual(sp, expected) {
@@ -68,7 +67,7 @@ func TestLeaderChannel(t *testing.T) {
 	p2 := p
 	p2.target = thirdChannel
 	g2 := p2.Guarantee
-	secondSigned, err := channel.Propose(p2, testdata.Actors.Alice.PrivateKey)
+	secondSigned, err := channel.Propose(p2, Actors.Alice.PrivateKey)
 	if err != nil {
 		t.Fatalf("failed to add another proposal: %v", err)
 	}
@@ -88,12 +87,12 @@ func TestLeaderChannel(t *testing.T) {
 	}
 
 	latest, _ := channel.latestProposedVars()
-	counterSig2, _ := latest.AsState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
+	counterSig2, _ := latest.AsState(fp()).Sign(Actors.Bob.PrivateKey)
 
 	p3 := p
 	p3.target = types.Destination{4}
 	g3 := p3.Guarantee
-	thirdSigned, _ := channel.Propose(p3, testdata.Actors.Alice.PrivateKey)
+	thirdSigned, _ := channel.Propose(p3, Actors.Alice.PrivateKey)
 
 	p2Returned := SignedProposal{
 		Proposal:  secondSigned.Proposal,
@@ -123,7 +122,7 @@ func TestLeaderChannel(t *testing.T) {
 
 	// The incorrect counter signature is received on the latest proposal
 	latest, _ = channel.latestProposedVars()
-	wrongCounterSig3, _ := latest.AsState(fp()).Sign(testdata.Actors.Brian.PrivateKey)
+	wrongCounterSig3, _ := latest.AsState(fp()).Sign(Actors.Brian.PrivateKey)
 	wrongP3Returned := SignedProposal{
 		Proposal:  thirdSigned.Proposal,
 		Signature: wrongCounterSig3,
@@ -139,7 +138,7 @@ func TestLeaderChannel(t *testing.T) {
 
 	// The correct counter signature is received on the latest proposal
 	latest, _ = channel.latestProposedVars()
-	counterSig3, _ := latest.AsState(fp()).Sign(testdata.Actors.Bob.PrivateKey)
+	counterSig3, _ := latest.AsState(fp()).Sign(Actors.Bob.PrivateKey)
 	p3Returned := SignedProposal{
 		Proposal:  thirdSigned.Proposal,
 		Signature: counterSig3,


### PR DESCRIPTION
Having `consensus_channel` depend on `testdata` would create a circular dependency if `consensus_channel` is imported into `virtual_channel`. This problem is resolved by copying the required functionality into `consensus_channel`