### PR TITLE
Remove upcoming import cycle

### DIFF
--- a/channel/consensus_channel/serde_test.go
+++ b/channel/consensus_channel/serde_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/crypto"
-	"github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -15,13 +14,13 @@ func TestSerde(t *testing.T) {
 
 	someGuarantee := Guarantee{
 		amount: big.NewInt(1),
-		left:   testdata.Actors.Alice.Destination(),
-		right:  testdata.Actors.Alice.Destination(),
+		left:   alice.Destination(),
+		right:  alice.Destination(),
 		target: types.Destination{99},
 	}
 	someOutcome := makeOutcome(
-		Balance{testdata.Actors.Alice.Destination(), big.NewInt(2)},
-		Balance{testdata.Actors.Bob.Destination(), big.NewInt(7)},
+		Balance{alice.Destination(), big.NewInt(2)},
+		Balance{bob.Destination(), big.NewInt(7)},
 		someGuarantee)
 
 	t.Run("Guarantee", func(t *testing.T) {


### PR DESCRIPTION
The `internal/testdata` package imports `protocols/virtualfund` package. `virtualfund` package will import `channel/consensus_channel` package for work on https://github.com/statechannels/go-nitro/issues/420