### PR TITLE
Enhance checks for the ConsensusChannel Store test

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -161,6 +161,11 @@ type Guarantee struct {
 	right  types.Destination
 }
 
+// NewGuarantee constructs a new guarantee
+func NewGuarantee(amount *big.Int, target types.Destination, left types.Destination, right types.Destination) Guarantee {
+	return Guarantee{amount, target, left, right}
+}
+
 func (g Guarantee) equal(g2 Guarantee) bool {
 	if !types.Equal(g.amount, g2.amount) {
 		return false
@@ -191,14 +196,17 @@ type LedgerOutcome struct {
 	guarantees   map[types.Destination]Guarantee
 }
 
-// NewLedgerOutcome creates a new ledger outcome with the given asset address and balances.
-// The outcome will contain no guarantees
-func NewLedgerOutcome(assetAddress types.Address, left, right Balance) *LedgerOutcome {
+// NewLedgerOutcome creates a new ledger outcome with the given asset address and balances and guarantees
+func NewLedgerOutcome(assetAddress types.Address, left, right Balance, guarantees []Guarantee) *LedgerOutcome {
+	guaranteeMap := make(map[types.Destination]Guarantee, len(guarantees))
+	for _, g := range guarantees {
+		guaranteeMap[g.target] = g
+	}
 	return &LedgerOutcome{
 		assetAddress: assetAddress,
 		left:         left,
 		right:        right,
-		guarantees:   make(map[types.Destination]Guarantee),
+		guarantees:   guaranteeMap,
 	}
 }
 
@@ -320,6 +328,15 @@ type Add struct {
 	turnNum uint64
 	Guarantee
 	LeftDeposit *big.Int
+}
+
+// NewAdd constructs a new Add proposal
+func NewAdd(turnNum uint64, g Guarantee, leftDeposit *big.Int) Add {
+	return Add{
+		turnNum:     turnNum,
+		Guarantee:   g,
+		LeftDeposit: leftDeposit,
+	}
 }
 
 func (a Add) RightDeposit() *big.Int {

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -135,7 +135,7 @@ func TestConsensusChannelStore(t *testing.T) {
 	aliceSig, _ := initialVars.AsState(fp).Sign(td.Actors.Alice.PrivateKey)
 	bobsSig, _ := initialVars.AsState(fp).Sign(td.Actors.Bob.PrivateKey)
 
-	want, err := consensus_channel.NewLeaderChannel(
+	leader, err := consensus_channel.NewLeaderChannel(
 		fp,
 		0,
 		*outcome,
@@ -145,7 +145,9 @@ func TestConsensusChannelStore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ms.SetConsensusChannel(&want.ConsensusChannel); err != nil {
+	// The store only deals with ConsensusChannels
+	want := leader.ConsensusChannel
+	if err := ms.SetConsensusChannel(&want); err != nil {
 		t.Fatalf("error setting consensus channel %v: %s", want, err.Error())
 	}
 
@@ -158,5 +160,8 @@ func TestConsensusChannelStore(t *testing.T) {
 	if got.Id != want.Id {
 		t.Fatalf("expected to retrieve same channel Id as was passed in, but didn't")
 	}
-	// TODO check that got and want are deeply equal
+
+	if diff := cmp.Diff(*got, want, cmp.AllowUnexported(cc.ConsensusChannel{}, big.Int{}, cc.LedgerOutcome{}, cc.Balance{})); diff != "" {
+		t.Fatalf("fetched result different than expected %s", diff)
+	}
 }


### PR DESCRIPTION
Fixes #460 

This PR:
- Introduces a deep comparison of the fetched value against the expected value
- Updates the mock store test to use a richer consensus channel (that includes a proposal and guarantee)
- Adds some new constructor functions to aid in constructing a richer consensus channel

~This currently fails due to `Add` serialization that is resolved in #459.~ 
Now that #459 is merged into `main` this passes 🎉 