### PR TITLE
Unite leader & follower ConsensusChannels

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -495,14 +495,14 @@ func CreateFromDirectFundingObjective(dfo directfund.Objective) (*ConsensusChann
 		if err != nil {
 			return nil, fmt.Errorf("could not create consensus channel as leader: %w", err)
 		}
-		return &con.ConsensusChannel, nil
+		return &con, nil
 
 	} else {
 		con, err := NewLeaderChannel(ledger.FixedPart, turnNum, outcome, signatures)
 		if err != nil {
 			return nil, fmt.Errorf("could not create consensus channel as follower: %w", err)
 		}
-		return &con.ConsensusChannel, nil
+		return &con, nil
 	}
 
 }

--- a/channel/consensus_channel/follower_channel.go
+++ b/channel/consensus_channel/follower_channel.go
@@ -22,6 +22,10 @@ func NewFollowerChannel(fp state.FixedPart, turnNum uint64, outcome LedgerOutcom
 // SignNextProposal inspects whether the expected proposal matches the first proposal in
 // the queue. If so, the proposal is removed from the queue and integrated into the channel state
 func (c *ConsensusChannel) SignNextProposal(expectedProposal Proposal, sk []byte) error {
+	if c.myIndex != follower {
+		return ErrNotFollower
+	}
+
 	if len(c.proposalQueue) == 0 {
 		return ErrNoProposals
 	}
@@ -60,6 +64,9 @@ func (c *ConsensusChannel) SignNextProposal(expectedProposal Proposal, sk []byte
 
 // Receive is called by the follower to validate a proposal from the leader and add it to the proposal queue
 func (c *ConsensusChannel) Receive(p SignedProposal) error {
+	if c.myIndex != follower {
+		return ErrNotFollower
+	}
 	// Get the latest proposal vars we have
 	vars, err := c.latestProposedVars()
 	if err != nil {

--- a/channel/consensus_channel/follower_channel.go
+++ b/channel/consensus_channel/follower_channel.go
@@ -19,8 +19,9 @@ func NewFollowerChannel(fp state.FixedPart, turnNum uint64, outcome LedgerOutcom
 	return newConsensusChannel(fp, follower, turnNum, outcome, signatures)
 }
 
-// SignNextProposal inspects whether the expected proposal matches the first proposal in
-// the queue. If so, the proposal is removed from the queue and integrated into the channel state
+// SignNextProposal is called by the follower and inspects whether the
+// expected proposal matches the first proposal in the queue. If so,
+// the proposal is removed from the queue and integrated into the channel state.
 func (c *ConsensusChannel) SignNextProposal(expectedProposal Proposal, sk []byte) error {
 	if c.myIndex != follower {
 		return ErrNotFollower

--- a/channel/consensus_channel/follower_channel.go
+++ b/channel/consensus_channel/follower_channel.go
@@ -6,6 +6,7 @@ import (
 	"github.com/statechannels/go-nitro/channel/state"
 )
 
+var ErrNotFollower = fmt.Errorf("method may only be called by channel follower")
 var ErrNoProposals = fmt.Errorf("no proposals in the queue")
 var ErrUnsupportedQueuedProposal = fmt.Errorf("only Add proposal is supported for queued proposals")
 var ErrUnsupportedExpectedProposal = fmt.Errorf("only Add proposal is supported for expected update")

--- a/channel/consensus_channel/follower_channel.go
+++ b/channel/consensus_channel/follower_channel.go
@@ -13,20 +13,14 @@ var ErrNonMatchingProposals = fmt.Errorf("expected proposal does not match first
 var ErrInvalidProposalSignature = fmt.Errorf("invalid signature for proposal")
 var ErrInvalidTurnNum = fmt.Errorf("the proposal turn number is not the next turn number")
 
-type FollowerChannel struct {
-	ConsensusChannel
-}
-
 // NewFollowerChannel constructs a new FollowerChannel
-func NewFollowerChannel(fp state.FixedPart, turnNum uint64, outcome LedgerOutcome, signatures [2]state.Signature) (FollowerChannel, error) {
-	channel, err := newConsensusChannel(fp, follower, turnNum, outcome, signatures)
-
-	return FollowerChannel{ConsensusChannel: channel}, err
+func NewFollowerChannel(fp state.FixedPart, turnNum uint64, outcome LedgerOutcome, signatures [2]state.Signature) (ConsensusChannel, error) {
+	return newConsensusChannel(fp, follower, turnNum, outcome, signatures)
 }
 
 // SignNextProposal inspects whether the expected proposal matches the first proposal in
 // the queue. If so, the proposal is removed from the queue and integrated into the channel state
-func (c *FollowerChannel) SignNextProposal(expectedProposal Proposal, sk []byte) error {
+func (c *ConsensusChannel) SignNextProposal(expectedProposal Proposal, sk []byte) error {
 	if len(c.proposalQueue) == 0 {
 		return ErrNoProposals
 	}
@@ -64,7 +58,7 @@ func (c *FollowerChannel) SignNextProposal(expectedProposal Proposal, sk []byte)
 }
 
 // Receive is called by the follower to validate a proposal from the leader and add it to the proposal queue
-func (c *FollowerChannel) Receive(p SignedProposal) error {
+func (c *ConsensusChannel) Receive(p SignedProposal) error {
 	// Get the latest proposal vars we have
 	vars, err := c.latestProposedVars()
 	if err != nil {

--- a/channel/consensus_channel/follower_channel_test.go
+++ b/channel/consensus_channel/follower_channel_test.go
@@ -144,3 +144,24 @@ func TestFollowerChannel(t *testing.T) {
 		t.Fatal("expected the proposal queue to be empty")
 	}
 }
+
+func TestRestrictedLeaderMethods(t *testing.T) {
+	initialVars := Vars{Outcome: ledgerOutcome(), TurnNum: 0}
+	aliceSig, _ := initialVars.AsState(fp()).Sign(alice.PrivateKey)
+	bobsSig, _ := initialVars.AsState(fp()).Sign(bob.PrivateKey)
+	sigs := [2]state.Signature{aliceSig, bobsSig}
+
+	channel, _ := NewFollowerChannel(fp(), 0, ledgerOutcome(), sigs)
+
+	if _, err := channel.IsProposed(Guarantee{}); err != ErrNotLeader {
+		t.Errorf("Expected error when calling IsProposed() as a follower, but found none")
+	}
+
+	if _, err := channel.Propose(Add{}, alice.PrivateKey); err != ErrNotLeader {
+		t.Errorf("Expected error when calling Propose() as a follower, but found none")
+	}
+
+	if err := channel.UpdateConsensus(SignedProposal{}); err != ErrNotLeader {
+		t.Errorf("Expected error when calling Propose() as a follower, but found none")
+	}
+}

--- a/channel/consensus_channel/leader_channel.go
+++ b/channel/consensus_channel/leader_channel.go
@@ -16,6 +16,9 @@ func NewLeaderChannel(fp state.FixedPart, turnNum uint64, outcome LedgerOutcome,
 // IsProposed returns whether or not the consensus state or any proposed state
 // includes the given guarantee.
 func (c *ConsensusChannel) IsProposed(g Guarantee) (bool, error) {
+	if c.myIndex != leader {
+		return false, ErrNotLeader
+	}
 	latest, err := c.latestProposedVars()
 	if err != nil {
 		return false, err
@@ -67,6 +70,10 @@ func (c *ConsensusChannel) Propose(add Add, sk []byte) (SignedProposal, error) {
 //  - the countersupplied proposal is not found
 //  - or if it is found but not correctly by the Follower
 func (c *ConsensusChannel) UpdateConsensus(countersigned SignedProposal) error {
+	if c.myIndex != leader {
+		return ErrNotLeader
+	}
+
 	consensusCandidate := Vars{
 		TurnNum: c.current.TurnNum,
 		Outcome: c.current.Outcome.clone(),

--- a/channel/consensus_channel/leader_channel.go
+++ b/channel/consensus_channel/leader_channel.go
@@ -6,6 +6,7 @@ import (
 	"github.com/statechannels/go-nitro/channel/state"
 )
 
+var ErrNotLeader = fmt.Errorf("method may only be called by the channel leader")
 
 // NewLeaderChannel constructs a new LeaderChannel
 func NewLeaderChannel(fp state.FixedPart, turnNum uint64, outcome LedgerOutcome, signatures [2]state.Signature) (ConsensusChannel, error) {

--- a/channel/consensus_channel/leader_channel.go
+++ b/channel/consensus_channel/leader_channel.go
@@ -6,10 +6,6 @@ import (
 	"github.com/statechannels/go-nitro/channel/state"
 )
 
-// LeaderChannel is used by a leader's virtualfund objective to make and receive ledger updates
-type LeaderChannel struct {
-	ConsensusChannel
-}
 
 // NewLeaderChannel constructs a new LeaderChannel
 func NewLeaderChannel(fp state.FixedPart, turnNum uint64, outcome LedgerOutcome, signatures [2]state.Signature) (LeaderChannel, error) {
@@ -20,7 +16,7 @@ func NewLeaderChannel(fp state.FixedPart, turnNum uint64, outcome LedgerOutcome,
 
 // IsProposed returns whether or not the consensus state or any proposed state
 // includes the given guarantee.
-func (c *LeaderChannel) IsProposed(g Guarantee) (bool, error) {
+func (c *ConsensusChannel) IsProposed(g Guarantee) (bool, error) {
 	latest, err := c.latestProposedVars()
 	if err != nil {
 		return false, err
@@ -32,7 +28,7 @@ func (c *LeaderChannel) IsProposed(g Guarantee) (bool, error) {
 // Propose receives a proposal to add a guarantee, and generates and stores a SignedProposal in
 // the queue, returning the resulting SignedProposal
 // Note: the TurnNum on add is ignored; the correct turn number is computed by c
-func (c *LeaderChannel) Propose(add Add, sk []byte) (SignedProposal, error) {
+func (c *ConsensusChannel) Propose(add Add, sk []byte) (SignedProposal, error) {
 	if c.myIndex != leader {
 		return SignedProposal{}, fmt.Errorf("only proposer can call Add")
 	}
@@ -71,7 +67,7 @@ func (c *LeaderChannel) Propose(add Add, sk []byte) (SignedProposal, error) {
 // An error is returned if:
 //  - the countersupplied proposal is not found
 //  - or if it is found but not correctly by the Follower
-func (c *LeaderChannel) UpdateConsensus(countersigned SignedProposal) error {
+func (c *ConsensusChannel) UpdateConsensus(countersigned SignedProposal) error {
 	consensusCandidate := Vars{
 		TurnNum: c.current.TurnNum,
 		Outcome: c.current.Outcome.clone(),

--- a/channel/consensus_channel/leader_channel.go
+++ b/channel/consensus_channel/leader_channel.go
@@ -8,10 +8,8 @@ import (
 
 
 // NewLeaderChannel constructs a new LeaderChannel
-func NewLeaderChannel(fp state.FixedPart, turnNum uint64, outcome LedgerOutcome, signatures [2]state.Signature) (LeaderChannel, error) {
-	channel, err := newConsensusChannel(fp, leader, turnNum, outcome, signatures)
-
-	return LeaderChannel{ConsensusChannel: channel}, err
+func NewLeaderChannel(fp state.FixedPart, turnNum uint64, outcome LedgerOutcome, signatures [2]state.Signature) (ConsensusChannel, error) {
+	return newConsensusChannel(fp, leader, turnNum, outcome, signatures)
 }
 
 // IsProposed returns whether or not the consensus state or any proposed state

--- a/channel/consensus_channel/leader_channel.go
+++ b/channel/consensus_channel/leader_channel.go
@@ -27,12 +27,15 @@ func (c *ConsensusChannel) IsProposed(g Guarantee) (bool, error) {
 	return latest.Outcome.includes(g), nil
 }
 
-// Propose receives a proposal to add a guarantee, and generates and stores a SignedProposal in
-// the queue, returning the resulting SignedProposal
-// Note: the TurnNum on add is ignored; the correct turn number is computed by c
+// Propose is called by the leader and receives a proposal to add a guarantee,
+// and generates and stores a SignedProposal in the queue, returning the
+// resulting SignedProposal
+//
+// Note: the TurnNum on add is ignored; the correct turn number is computed
+// and applied by c
 func (c *ConsensusChannel) Propose(add Add, sk []byte) (SignedProposal, error) {
 	if c.myIndex != leader {
-		return SignedProposal{}, fmt.Errorf("only proposer can call Add")
+		return SignedProposal{}, ErrNotLeader
 	}
 
 	vars, err := c.latestProposedVars()
@@ -58,7 +61,9 @@ func (c *ConsensusChannel) Propose(add Add, sk []byte) (SignedProposal, error) {
 	return signed, nil
 }
 
-// UpdateConsensus iterates through the proposal queue until it finds the countersigned proposal.
+// UpdateConsensus is called by the leader and iterates through
+// the proposal queue until it finds the countersigned proposal.
+//
 // If this proposal was signed by the Follower:
 //  - the consensus state is updated with the supplied proposal
 //  - the proposal queue is trimmed

--- a/channel/consensus_channel/leader_channel_test.go
+++ b/channel/consensus_channel/leader_channel_test.go
@@ -180,3 +180,20 @@ func TestLeaderChannel(t *testing.T) {
 		t.Fatal("consensus incorrectly updated")
 	}
 }
+
+func TestRestrictedFollowerMethods(t *testing.T) {
+	initialVars := Vars{Outcome: ledgerOutcome(), TurnNum: 0}
+	aliceSig, _ := initialVars.AsState(fp()).Sign(alice.PrivateKey)
+	bobsSig, _ := initialVars.AsState(fp()).Sign(bob.PrivateKey)
+	sigs := [2]state.Signature{aliceSig, bobsSig}
+
+	channel, _ := NewLeaderChannel(fp(), 0, ledgerOutcome(), sigs)
+
+	if err := channel.SignNextProposal(Proposal{}, alice.PrivateKey); err != ErrNotFollower {
+		t.Errorf("Expected error when calling SignNextProposal as a leader, but found none")
+	}
+
+	if err := channel.Receive(SignedProposal{}); err != ErrNotFollower {
+		t.Errorf("Expected error when calling Receive as a leader, but found none")
+	}
+}

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -157,7 +157,7 @@ func TestConsensusChannelStore(t *testing.T) {
 	}
 
 	// The store only deals with ConsensusChannels
-	want := leader.ConsensusChannel
+	want := leader
 
 	if err := ms.SetConsensusChannel(&want); err != nil {
 		t.Fatalf("error setting consensus channel %v: %s", want, err.Error())

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -145,7 +145,7 @@ func TestConsensusChannelStore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ms.SetConsensusChannel(&want.ConsensusChannel); err != nil {
+	if err := ms.SetConsensusChannel(&want); err != nil {
 		t.Fatalf("error setting consensus channel %v: %s", want, err.Error())
 	}
 


### PR DESCRIPTION
closes #462

This PR is slightly minimalist: it retains the separate files AND constructors for `leader` and `follower` channels, which are semantically useful.

It adds checks on each function call, plus a test assertion that each incorrect call fails with the expected `ErrNot(correctcaller)` error.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
