### PR TITLE
update GetConsensusChannel to one-address lookup..

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -495,14 +495,14 @@ func CreateFromDirectFundingObjective(dfo directfund.Objective) (*ConsensusChann
 		if err != nil {
 			return nil, fmt.Errorf("could not create consensus channel as leader: %w", err)
 		}
-		return &con.ConsensusChannel, nil
+		return &con, nil
 
 	} else {
 		con, err := NewLeaderChannel(ledger.FixedPart, turnNum, outcome, signatures)
 		if err != nil {
 			return nil, fmt.Errorf("could not create consensus channel as follower: %w", err)
 		}
-		return &con.ConsensusChannel, nil
+		return &con, nil
 	}
 
 }

--- a/channel/consensus_channel/follower_channel_test.go
+++ b/channel/consensus_channel/follower_channel_test.go
@@ -144,3 +144,24 @@ func TestFollowerChannel(t *testing.T) {
 		t.Fatal("expected the proposal queue to be empty")
 	}
 }
+
+func TestRestrictedLeaderMethods(t *testing.T) {
+	initialVars := Vars{Outcome: ledgerOutcome(), TurnNum: 0}
+	aliceSig, _ := initialVars.AsState(fp()).Sign(alice.PrivateKey)
+	bobsSig, _ := initialVars.AsState(fp()).Sign(bob.PrivateKey)
+	sigs := [2]state.Signature{aliceSig, bobsSig}
+
+	channel, _ := NewFollowerChannel(fp(), 0, ledgerOutcome(), sigs)
+
+	if _, err := channel.IsProposed(Guarantee{}); err != ErrNotLeader {
+		t.Errorf("Expected error when calling IsProposed() as a follower, but found none")
+	}
+
+	if _, err := channel.Propose(Add{}, alice.PrivateKey); err != ErrNotLeader {
+		t.Errorf("Expected error when calling Propose() as a follower, but found none")
+	}
+
+	if err := channel.UpdateConsensus(SignedProposal{}); err != ErrNotLeader {
+		t.Errorf("Expected error when calling Propose() as a follower, but found none")
+	}
+}

--- a/channel/consensus_channel/leader_channel_test.go
+++ b/channel/consensus_channel/leader_channel_test.go
@@ -180,3 +180,20 @@ func TestLeaderChannel(t *testing.T) {
 		t.Fatal("consensus incorrectly updated")
 	}
 }
+
+func TestRestrictedFollowerMethods(t *testing.T) {
+	initialVars := Vars{Outcome: ledgerOutcome(), TurnNum: 0}
+	aliceSig, _ := initialVars.AsState(fp()).Sign(alice.PrivateKey)
+	bobsSig, _ := initialVars.AsState(fp()).Sign(bob.PrivateKey)
+	sigs := [2]state.Signature{aliceSig, bobsSig}
+
+	channel, _ := NewLeaderChannel(fp(), 0, ledgerOutcome(), sigs)
+
+	if err := channel.SignNextProposal(Proposal{}, alice.PrivateKey); err != ErrNotFollower {
+		t.Errorf("Expected error when calling SignNextProposal as a leader, but found none")
+	}
+
+	if err := channel.Receive(SignedProposal{}); err != ErrNotFollower {
+		t.Errorf("Expected error when calling Receive as a leader, but found none")
+	}
+}

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -199,8 +199,9 @@ func (ms *MockStore) GetTwoPartyLedger(firstParty types.Address, secondParty typ
 	return ledger, ok
 }
 
-// GetConsensusChannel returns a ConsensusChannel between the two parties if it exists.
-func (ms *MockStore) GetConsensusChannel(leader, follower types.Address) (channel *consensus_channel.ConsensusChannel, ok bool) {
+// GetConsensusChannel returns a ConsensusChannel between the calling client and the given counterparty,
+// if such channel exists
+func (ms *MockStore) GetConsensusChannel(counterparty types.Address) (channel *consensus_channel.ConsensusChannel, ok bool) {
 
 	ms.consensusChannels.Range(func(key string, chJSON []byte) bool {
 
@@ -213,7 +214,7 @@ func (ms *MockStore) GetConsensusChannel(leader, follower types.Address) (channe
 
 		participants := ch.Participants()
 		if len(participants) == 2 {
-			if participants[0] == leader && participants[1] == follower {
+			if participants[0] == counterparty || participants[1] == counterparty {
 				channel = &ch
 				ok = true
 				return false // we have found the target channel: break the Range loop

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -157,7 +157,8 @@ func TestConsensusChannelStore(t *testing.T) {
 	}
 
 	// The store only deals with ConsensusChannels
-	want := leader.ConsensusChannel
+	want := leader
+
 	if err := ms.SetConsensusChannel(&want); err != nil {
 		t.Fatalf("error setting consensus channel %v: %s", want, err.Error())
 	}

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -118,7 +118,7 @@ func TestConsensusChannelStore(t *testing.T) {
 
 	ms := store.NewMockStore(sk)
 
-	got, ok := ms.GetConsensusChannel(td.Actors.Alice.Address, td.Actors.Bob.Address)
+	got, ok := ms.GetConsensusChannel(td.Actors.Alice.Address)
 	if ok {
 		t.Fatalf("expected not to find the a consensus channel, but found %v", got)
 	}
@@ -163,7 +163,7 @@ func TestConsensusChannelStore(t *testing.T) {
 		t.Fatalf("error setting consensus channel %v: %s", want, err.Error())
 	}
 
-	got, ok = ms.GetConsensusChannel(fp.Participants[0], fp.Participants[1])
+	got, ok = ms.GetConsensusChannel(fp.Participants[0])
 
 	if !ok {
 		t.Fatalf("expected to find the inserted consensus channel, but didn't")

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -28,6 +28,6 @@ type Store interface {
 }
 
 type ConsensusChannelStore interface {
-	GetConsensusChannel(leader, follower types.Address) (channel *consensus_channel.ConsensusChannel, ok bool)
+	GetConsensusChannel(counterparty types.Address) (channel *consensus_channel.ConsensusChannel, ok bool)
 	SetConsensusChannel(*consensus_channel.ConsensusChannel) error
 }

--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
@@ -52,7 +53,16 @@ func TestDirectFundIntegration(t *testing.T) {
 	want := testdata.Outcomes.Create(*clientA.Address, *clientB.Address, 5, 5)
 	// Ensure that we create a consensus channel in the store
 	for _, store := range []store.Store{storeA, storeB} {
-		con, ok := store.GetConsensusChannel(*clientA.Address, *clientB.Address)
+
+		var con *consensus_channel.ConsensusChannel
+		var ok bool
+
+		// each store looks up via the counterparty
+		if store.GetChannelSecretKey() == &alice.PrivateKey {
+			con, ok = store.GetConsensusChannel(*clientB.Address)
+		} else {
+			con, ok = store.GetConsensusChannel(*clientA.Address)
+		}
 
 		if !ok {
 			t.Fatalf("expected a consensus channel to have been created")


### PR DESCRIPTION
closes #457

Existing lookup for ledger channels requires the calling code to know its status as leader / follower in advance. This change removes the requirement, with the assumptions that:

- `alice`'s store only holds ConsensusChannels where at least one participant is `alice`. (ie, it does not store ConsensusChannels where `alice` is not a participant)
- for each `counterparty`, `alice` and `counterparty` operate only one ConsensusChannel

Future consideration: These assumptions suggest that it could be appropriate / performant to key ConsensusChannels by `counterparty` address rather than `channelID`.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
