### PR TITLE
Fix Leader/Follower typo

### DIFF
--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -66,6 +66,9 @@ func TestDirectFundIntegration(t *testing.T) {
 		if vars.TurnNum != 1 {
 			t.Fatal("expected consensus turn number to be the post fund setup 1, received #$v", vars.TurnNum)
 		}
+		if con.Leader() != *clientA.Address {
+			t.Fatalf("Expected %v as leader, but got %v", clientA.Address, con.Leader())
+		}
 
 	}
 

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -155,7 +155,7 @@ func (dfo *Objective) CreateConsensusChannel() (*consensus_channel.ConsensusChan
 		return &con, nil
 
 	} else {
-		con, err := consensus_channel.NewLeaderChannel(ledger.FixedPart, turnNum, outcome, signatures)
+		con, err := consensus_channel.NewFollowerChannel(ledger.FixedPart, turnNum, outcome, signatures)
 		if err != nil {
 			return nil, fmt.Errorf("could not create consensus channel as follower: %w", err)
 		}


### PR DESCRIPTION
⚠️ stacked on #467 

See https://github.com/statechannels/go-nitro/pull/437#discussion_r840565692

Ideally I would have included a failing test to exhibit the bug. But I couldn't find an easy way to do that (it would have surfaced eventually in a virtual fund integration test). 