### PR TITLE
Add consensus_channel fetch function (-> `main`)

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -323,7 +323,7 @@ func (e *Engine) constructObjectiveFromMessage(message protocols.Message) (proto
 
 		return &dfo, err
 	case virtualfund.IsVirtualFundObjective(message.ObjectiveId):
-		vfo, err := virtualfund.ConstructObjectiveFromMessage(message, *e.store.GetAddress(), e.store.GetTwoPartyLedger)
+		vfo, err := virtualfund.ConstructObjectiveFromMessage(message, *e.store.GetAddress(), e.store.GetTwoPartyLedger, e.store.GetConsensusChannel)
 		if err != nil {
 			return &virtualfund.Objective{}, fmt.Errorf("could not create virtual fund objective from message: %w", err)
 		}

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -286,7 +286,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 		testNew := func(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
 			// Assert that a valid set of constructor args does not result in an error
-			o, err := constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			o, err := constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, nil, ledgerChannelToMyRight, nil) // todo: #420 deprecate TwoPartyLedgers
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -340,7 +340,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 		testclone := func(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
 
-			o, _ := constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			o, _ := constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, nil, ledgerChannelToMyRight, nil) // todo: #420 deprecate TwoPartyLedgers
 
 			clone := o.clone()
 
@@ -351,7 +351,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 		testCrank := func(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
-			var s, _ = constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			var s, _ = constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, nil, ledgerChannelToMyRight, nil) // todo: #420 deprecate TwoPartyLedgers
 			// Assert that cranking an unapproved objective returns an error
 			if _, _, _, err := s.Crank(&my.privateKey); err == nil {
 				t.Fatal(`Expected error when cranking unapproved objective, but got nil`)
@@ -486,7 +486,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 		testUpdate := func(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
-			var s, _ = constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
+			var s, _ = constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, nil, ledgerChannelToMyRight, nil) // todo: #420 deprecate TwoPartyLedgers
 			// Prepare an event with a mismatched objectiveId
 			e := protocols.ObjectiveEvent{
 				ObjectiveId: "some-other-id",

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -497,7 +497,7 @@ func (o *Objective) isBob() bool {
 type GetTwoPartyLedgerFunction func(firstParty types.Address, secondParty types.Address) (ledger *channel.TwoPartyLedger, ok bool)
 
 // todo: #420 assume name and godoc from GetTwoPartyLedgerFunction
-type GetTwoPartyConsensusLedgerFunction func(leader, follower types.Address) (ledger *consensus_channel.ConsensusChannel, ok bool)
+type GetTwoPartyConsensusLedgerFunction func(counterparty types.Address) (ledger *consensus_channel.ConsensusChannel, ok bool)
 
 // ConstructObjectiveFromMessage takes in a message and constructs an objective from it.
 // It accepts the message, myAddress, and a function to to retrieve ledgers from a store.
@@ -534,7 +534,7 @@ func ConstructObjectiveFromMessage(
 			return Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", intermediary, bob)
 		}
 
-		leftC, _ = getTwoPartyConsensusLedger(intermediary, bob)
+		leftC, _ = getTwoPartyConsensusLedger(intermediary)
 		// if !ok {
 		// 	// todo: #420 handle, after consensus_channel lifecycle is defined & channels present
 		// 	return Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", intermediary, bob)
@@ -546,7 +546,7 @@ func ConstructObjectiveFromMessage(
 			return Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", alice, intermediary)
 		}
 
-		leftC, _ = getTwoPartyConsensusLedger(alice, intermediary)
+		leftC, _ = getTwoPartyConsensusLedger(alice)
 		// if !ok {
 		// 	// todo: #420 handle, after consensus_channel lifecycle is defined & channels present
 		// 	return Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", alice, intermediary)
@@ -557,7 +557,7 @@ func ConstructObjectiveFromMessage(
 			return Objective{}, fmt.Errorf("could not find a right ledger channel between %v and %v", intermediary, bob)
 		}
 
-		rightC, _ = getTwoPartyConsensusLedger(intermediary, bob)
+		rightC, _ = getTwoPartyConsensusLedger(bob)
 		// if !ok {
 		// 	// todo: #420 handle, after consensus_channel lifecycle is defined & channels present
 		// 	return Objective{}, fmt.Errorf("could not find a right ledger channel between %v and %v", intermediary, bob)

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -312,7 +312,7 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 		// toMyRightId = o.ToMyRight.ConsensusChannel.Id
 	}
 
-	// todo: range over event.Proposals (or similar)
+	// todo: #420 range over event.Proposals (or similar)
 
 	for _, ss := range event.SignedStates {
 		channelId, _ := ss.State().ChannelId() // TODO handle error

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -49,13 +49,9 @@ func (c *Connection) Equal(d *Connection) bool {
 	if c == nil && d == nil {
 		return true
 	}
-	if !c.Channel.Equal(d.Channel) {
+	if !c.Channel.Equal(d.Channel) { // todo: #420 replace with a check on ConsensusChannel
 		return false
 	}
-	//
-	// if c.ConsensusChannel.Id != d.ConsensusChannel.Id {
-	// 	return false
-	// }
 	if !reflect.DeepEqual(c.GuaranteeInfo, d.GuaranteeInfo) {
 		return false
 	}

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -347,9 +347,9 @@ func (o Objective) Channels() []*channel.Channel {
 //////////////////////////////////////////////////
 
 // insertGuaranteeInfo mutates the reciever Connection struct.
-func (connection *Connection) insertGuaranteeInfo(a0 types.Funds, b0 types.Funds, vId types.Destination, left types.Destination, right types.Destination) error {
+func (c *Connection) insertGuaranteeInfo(a0 types.Funds, b0 types.Funds, vId types.Destination, left types.Destination, right types.Destination) error {
 
-	connection.GuaranteeInfo = GuaranteeInfo{
+	c.GuaranteeInfo = GuaranteeInfo{
 		Left:                 left,
 		Right:                right,
 		LeftAmount:           a0,
@@ -359,8 +359,8 @@ func (connection *Connection) insertGuaranteeInfo(a0 types.Funds, b0 types.Funds
 
 	// Check that the guarantee metadata can be encoded. This allows us to avoid clunky error-return-chains for getExpectedGuarantees
 	metadata := outcome.GuaranteeMetadata{
-		Left:  connection.GuaranteeInfo.Left,
-		Right: connection.GuaranteeInfo.Right,
+		Left:  c.GuaranteeInfo.Left,
+		Right: c.GuaranteeInfo.Right,
 	}
 	_, err := metadata.Encode()
 	if err != nil {
@@ -371,11 +371,11 @@ func (connection *Connection) insertGuaranteeInfo(a0 types.Funds, b0 types.Funds
 }
 
 // getExpectedGuarantees returns a map of asset addresses to guarantees for a Connection.
-func (connection *Connection) getExpectedGuarantees() map[types.Address]outcome.Allocation {
+func (c *Connection) getExpectedGuarantees() map[types.Address]outcome.Allocation {
 	expectedGuaranteesForLedgerChannel := make(map[types.Address]outcome.Allocation)
 	metadata := outcome.GuaranteeMetadata{
-		Left:  connection.GuaranteeInfo.Left,
-		Right: connection.GuaranteeInfo.Right,
+		Left:  c.GuaranteeInfo.Left,
+		Right: c.GuaranteeInfo.Right,
 	}
 	encodedGuarantee, err := metadata.Encode()
 	// This error is unexpected. insertGuaranteeInfo checks that the guarantee metadata can be encoded.
@@ -384,11 +384,11 @@ func (connection *Connection) getExpectedGuarantees() map[types.Address]outcome.
 		panic(err)
 	}
 
-	channelFunds := connection.GuaranteeInfo.LeftAmount.Add(connection.GuaranteeInfo.RightAmount)
+	channelFunds := c.GuaranteeInfo.LeftAmount.Add(c.GuaranteeInfo.RightAmount)
 
 	for asset, amount := range channelFunds {
 		expectedGuaranteesForLedgerChannel[asset] = outcome.Allocation{
-			Destination:    connection.GuaranteeInfo.GuaranteeDestination,
+			Destination:    c.GuaranteeInfo.GuaranteeDestination,
 			Amount:         amount,
 			AllocationType: outcome.GuaranteeAllocationType,
 			Metadata:       encodedGuarantee,
@@ -419,8 +419,8 @@ func (o Objective) fundingComplete() bool {
 // The decision is made based on the latest supported state of the channel.
 //
 // Both arguments are maps keyed by the same asset.
-func (connection *Connection) ledgerChannelAffordsExpectedGuarantees() bool {
-	return connection.Channel.Affords(connection.getExpectedGuarantees(), connection.Channel.OnChainFunding)
+func (c *Connection) ledgerChannelAffordsExpectedGuarantees() bool {
+	return c.Channel.Affords(c.getExpectedGuarantees(), c.Channel.OnChainFunding)
 }
 
 // Equal returns true if the supplied DirectFundObjective is deeply equal to the receiver.

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -496,6 +496,7 @@ func (o *Objective) isBob() bool {
 // GetTwoPartyLedgerFunction specifies a function that can be used to retreive ledgers from a store.
 type GetTwoPartyLedgerFunction func(firstParty types.Address, secondParty types.Address) (ledger *channel.TwoPartyLedger, ok bool)
 
+// todo: #420 assume name and godoc from GetTwoPartyLedgerFunction
 type GetTwoPartyConsensusLedgerFunction func(leader, follower types.Address) (ledger *consensus_channel.ConsensusChannel, ok bool)
 
 // ConstructObjectiveFromMessage takes in a message and constructs an objective from it.

--- a/protocols/virtualfund/virtualfund_test.go
+++ b/protocols/virtualfund/virtualfund_test.go
@@ -75,8 +75,8 @@ func TestMarshalJSON(t *testing.T) {
 		false,
 		vPreFund,
 		alice.address,
-		&channel.TwoPartyLedger{},
-		right,
+		&channel.TwoPartyLedger{}, nil, // todo: #420 deprecate TwoPartyLedgers
+		right, nil,
 	)
 
 	if err != nil {


### PR DESCRIPTION
This is a copy of PR #458, targeting `main`, so that #442 can be closed as well and a lower merge-conflict workflow can be regained.

(#422 includes earmarked todos & some cleanup refactors of `protocols.virtualfund`)

Alternate strategy: review & merge #442 into main, then add these changes as a separate PR.


This PR is a step toward side-by-side functioning of the existing `TwoPartyLedger` channels and incoming `ConsensusChannel` implementations. It provides the virtualfund objective with the means to populate its consensus channels from the store.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
  - not necessary yet
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
