### PR TITLE
godoc: Clarify usage of `testdata` package

### DIFF
--- a/internal/testdata/doc.go
+++ b/internal/testdata/doc.go
@@ -1,3 +1,9 @@
-// package testdata (TestData) provides literals and utility functions for generating objects-of-concern
+// package testdata provides literals and utility functions for generating objects-of-concern
 // (objectives, channels, user-agents, etc) for other test packages.
+//
+// testdata should NOT be imported by implementation packages, including the x_test.go files
+// of implementation packages.
+//
+// See github.com/statechannels/go-nitro/issues/242 and github.com/statechannels/go-nitro/issues/438
+// for further detail
 package testdata


### PR DESCRIPTION
closes #438 

This is a godoc-only change, which
- makes usage requrements on the testdata package more explicit
- adds back-references to the description of the package's intent (#242) and potential pitfall (#438)