### PR TITLE
Add SignedProposals to Message 

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -355,11 +355,6 @@ type SignedProposal struct {
 	Proposal Proposal
 }
 
-// Equal determines whether 2 SignedProposals are equivalent
-func (p SignedProposal) Equal(q SignedProposal) bool {
-	return p.Signature.Equal(q.Signature) && p.Proposal.equal(&q.Proposal)
-}
-
 // Add is a proposal to add a guarantee for the given virtual channel
 // amount is to be deducted from left
 type Add struct {

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -355,6 +355,10 @@ type SignedProposal struct {
 	Proposal Proposal
 }
 
+func (p SignedProposal) Equal(q SignedProposal) bool {
+	return p.Signature.Equal(q.Signature) && p.Proposal.equal(&q.Proposal)
+}
+
 // Add is a proposal to add a guarantee for the given virtual channel
 // amount is to be deducted from left
 type Add struct {

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -355,6 +355,7 @@ type SignedProposal struct {
 	Proposal Proposal
 }
 
+// Equal determines whether 2 SignedProposals are equivalent
 func (p SignedProposal) Equal(q SignedProposal) bool {
 	return p.Signature.Equal(q.Signature) && p.Proposal.equal(&q.Proposal)
 }

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -376,6 +376,11 @@ func NewAdd(turnNum uint64, g Guarantee, leftDeposit *big.Int) Add {
 	}
 }
 
+// NewAddProposal constucts a proposal with a valid Add proposal and empty remove proposal
+func NewAddProposal(turnNum uint64, g Guarantee, leftDeposit *big.Int) Proposal {
+	return Proposal{toAdd: NewAdd(turnNum, g, leftDeposit)}
+}
+
 func (a Add) RightDeposit() *big.Int {
 	result := big.NewInt(0)
 	result.Sub(a.amount, a.LeftDeposit)

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/go-cmp/cmp"
 	"github.com/statechannels/go-nitro/channel"
+	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/protocols"
@@ -207,6 +208,7 @@ func TestCrankAlice(t *testing.T) {
 			SignedStates: []state.SignedState{
 				finalStateSignedByAlice,
 			},
+			SignedProposals: []consensus_channel.SignedProposal{},
 		},
 		}}
 

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -298,6 +298,7 @@ func TestCrankBob(t *testing.T) {
 			SignedStates: []state.SignedState{
 				finalStateSignedByBob,
 			},
+			SignedProposals: []consensus_channel.SignedProposal{},
 		},
 		}}
 

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/go-cmp/cmp"
 	"github.com/statechannels/go-nitro/channel"
+	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/protocols"
@@ -197,6 +198,7 @@ func TestCrank(t *testing.T) {
 				SignedStates: []state.SignedState{
 					preFundSS,
 				},
+				SignedProposals: []consensus_channel.SignedProposal{},
 			},
 		}}
 

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -212,6 +212,7 @@ func TestCrank(t *testing.T) {
 				SignedStates: []state.SignedState{
 					postFundSS,
 				},
+				SignedProposals: []consensus_channel.SignedProposal{},
 			},
 		}}
 	expectedFundingSideEffects := protocols.SideEffects{

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -35,7 +35,7 @@ func CreateSignedStateMessages(id ObjectiveId, ss state.SignedState, myIndex uin
 	return createMessages(id, &ss, nil, myIndex)
 }
 
-// CreateSignedProposalMessages creates an list of messages containing the signed proposal
+// CreateSignedProposalMessages creates a list of messages containing the signed proposal
 // A message will be generated for each participant except for the participant at myIndex.
 func CreateSignedProposalMessages(id ObjectiveId, sp consensus_channel.SignedProposal, myIndex uint) []Message {
 	return createMessages(id, nil, &sp, myIndex)

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -32,17 +32,17 @@ func DeserializeMessage(s string) (Message, error) {
 // CreateSignedStateMessages creates a set of messages containing the signed state.
 // A message will be generated for each participant except for the participant at myIndex.
 func CreateSignedStateMessages(id ObjectiveId, ss state.SignedState, myIndex uint) []Message {
-	return createMessages(id, ss, consensus_channel.SignedProposal{}, myIndex)
+	return createMessages(id, &ss, nil, myIndex)
 }
 
 // CreateSignedProposalMessages creates an list of messages containing the signed proposal
 // A message will be generated for each participant except for the participant at myIndex.
 func CreateSignedProposalMessages(id ObjectiveId, sp consensus_channel.SignedProposal, myIndex uint) []Message {
-	return createMessages(id, state.SignedState{}, sp, myIndex)
+	return createMessages(id, nil, &sp, myIndex)
 }
 
 // createMessages creates a list of messages with the signed state and the signed proposal
-func createMessages(id ObjectiveId, ss state.SignedState, sp consensus_channel.SignedProposal, myIndex uint) []Message {
+func createMessages(id ObjectiveId, ss *state.SignedState, sp *consensus_channel.SignedProposal, myIndex uint) []Message {
 	messages := make([]Message, 0)
 	for i, participant := range ss.State().Participants {
 
@@ -50,7 +50,15 @@ func createMessages(id ObjectiveId, ss state.SignedState, sp consensus_channel.S
 		if uint(i) == myIndex {
 			continue
 		}
-		message := Message{To: participant, ObjectiveId: id, SignedStates: []state.SignedState{ss}, SignedProposals: []consensus_channel.SignedProposal{sp}}
+		signedStates := []state.SignedState{}
+		if ss != nil {
+			signedStates = append(signedStates, *ss)
+		}
+		signedProposals := []consensus_channel.SignedProposal{}
+		if sp != nil {
+			signedProposals = append(signedProposals, *sp)
+		}
+		message := Message{To: participant, ObjectiveId: id, SignedStates: signedStates, SignedProposals: signedProposals}
 		messages = append(messages, message)
 	}
 	return messages

--- a/protocols/messages_test.go
+++ b/protocols/messages_test.go
@@ -1,12 +1,28 @@
 package protocols
 
 import (
+	"math/big"
 	"reflect"
 	"testing"
 
+	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/types"
 )
+
+func addProposal() consensus_channel.SignedProposal {
+	amount := big.NewInt(1)
+	add := consensus_channel.NewAddProposal(1, consensus_channel.NewGuarantee(
+		amount,
+		types.Destination{'a'},
+		types.Destination{'b'},
+		types.Destination{'c'},
+	),
+		amount,
+	)
+
+	return consensus_channel.SignedProposal{Proposal: add, Signature: state.Signature{}}
+}
 
 func TestMessage(t *testing.T) {
 
@@ -16,9 +32,10 @@ func TestMessage(t *testing.T) {
 		SignedStates: []state.SignedState{
 			state.NewSignedState(state.TestState),
 		},
+		SignedProposals: []consensus_channel.SignedProposal{addProposal()},
 	}
 
-	msgString := `{"To":"0x6100000000000000000000000000000000000000","ObjectiveId":"say-hello-to-my-little-friend","SignedStates":[{"State":{"ChainId":9001,"Participants":["0xf5a1bb5607c9d079e46d1b3dc33f257d937b43bd","0x760bf27cd45036a6c486802d30b5d90cffbe31fe"],"ChannelNonce":37140676580,"AppDefinition":"0x5e29e5ab8ef33f050c7cc10b5a0456d975c5f88d","ChallengeDuration":60,"AppData":"","Outcome":[{"Asset":"0x0000000000000000000000000000000000000000","Metadata":null,"Allocations":[{"Destination":"0x000000000000000000000000f5a1bb5607c9d079e46d1b3dc33f257d937b43bd","Amount":5,"AllocationType":0,"Metadata":null},{"Destination":"0x000000000000000000000000ee18ff1575055691009aa246ae608132c57a422c","Amount":5,"AllocationType":0,"Metadata":null}]}],"TurnNum":5,"IsFinal":false},"Sigs":{}}],"SignedProposals":null}`
+	msgString := `{"To":"0x6100000000000000000000000000000000000000","ObjectiveId":"say-hello-to-my-little-friend","SignedStates":[{"State":{"ChainId":9001,"Participants":["0xf5a1bb5607c9d079e46d1b3dc33f257d937b43bd","0x760bf27cd45036a6c486802d30b5d90cffbe31fe"],"ChannelNonce":37140676580,"AppDefinition":"0x5e29e5ab8ef33f050c7cc10b5a0456d975c5f88d","ChallengeDuration":60,"AppData":"","Outcome":[{"Asset":"0x0000000000000000000000000000000000000000","Metadata":null,"Allocations":[{"Destination":"0x000000000000000000000000f5a1bb5607c9d079e46d1b3dc33f257d937b43bd","Amount":5,"AllocationType":0,"Metadata":null},{"Destination":"0x000000000000000000000000ee18ff1575055691009aa246ae608132c57a422c","Amount":5,"AllocationType":0,"Metadata":null}]}],"TurnNum":5,"IsFinal":false},"Sigs":{}}],"SignedProposals":[{"R":null,"S":null,"V":0,"Proposal":{"ToAdd":{"TurnNum":1,"Guarantee":{"Amount":1,"Target":"0x6100000000000000000000000000000000000000000000000000000000000000","Left":"0x6200000000000000000000000000000000000000000000000000000000000000","Right":"0x6300000000000000000000000000000000000000000000000000000000000000"},"LeftDeposit":1},"ToRemove":{}}}]}`
 
 	t.Run(`serialize`, func(t *testing.T) {
 		got, err := msg.Serialize()

--- a/protocols/messages_test.go
+++ b/protocols/messages_test.go
@@ -18,7 +18,7 @@ func TestMessage(t *testing.T) {
 		},
 	}
 
-	msgString := `{"To":"0x6100000000000000000000000000000000000000","ObjectiveId":"say-hello-to-my-little-friend","SignedStates":[{"State":{"ChainId":9001,"Participants":["0xf5a1bb5607c9d079e46d1b3dc33f257d937b43bd","0x760bf27cd45036a6c486802d30b5d90cffbe31fe"],"ChannelNonce":37140676580,"AppDefinition":"0x5e29e5ab8ef33f050c7cc10b5a0456d975c5f88d","ChallengeDuration":60,"AppData":"","Outcome":[{"Asset":"0x0000000000000000000000000000000000000000","Metadata":null,"Allocations":[{"Destination":"0x000000000000000000000000f5a1bb5607c9d079e46d1b3dc33f257d937b43bd","Amount":5,"AllocationType":0,"Metadata":null},{"Destination":"0x000000000000000000000000ee18ff1575055691009aa246ae608132c57a422c","Amount":5,"AllocationType":0,"Metadata":null}]}],"TurnNum":5,"IsFinal":false},"Sigs":{}}]}`
+	msgString := `{"To":"0x6100000000000000000000000000000000000000","ObjectiveId":"say-hello-to-my-little-friend","SignedStates":[{"State":{"ChainId":9001,"Participants":["0xf5a1bb5607c9d079e46d1b3dc33f257d937b43bd","0x760bf27cd45036a6c486802d30b5d90cffbe31fe"],"ChannelNonce":37140676580,"AppDefinition":"0x5e29e5ab8ef33f050c7cc10b5a0456d975c5f88d","ChallengeDuration":60,"AppData":"","Outcome":[{"Asset":"0x0000000000000000000000000000000000000000","Metadata":null,"Allocations":[{"Destination":"0x000000000000000000000000f5a1bb5607c9d079e46d1b3dc33f257d937b43bd","Amount":5,"AllocationType":0,"Metadata":null},{"Destination":"0x000000000000000000000000ee18ff1575055691009aa246ae608132c57a422c","Amount":5,"AllocationType":0,"Metadata":null}]}],"TurnNum":5,"IsFinal":false},"Sigs":{}}],"SignedProposals":null}`
 
 	t.Run(`serialize`, func(t *testing.T) {
 		got, err := msg.Serialize()


### PR DESCRIPTION
This PR works toward https://github.com/statechannels/go-nitro/issues/420.

`SignedProposals` field in the `Message` struct might not be the long term solution but perhaps good enough for now. Only a certain type of message needs the `SignedProposal` field populated (messages that are related to a consensus channel). But all messages will contain the field.