### PR TITLE
Refactor leader_channel tests

### DIFF
--- a/channel/consensus_channel/follower_channel_test.go
+++ b/channel/consensus_channel/follower_channel_test.go
@@ -9,27 +9,6 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-// createSignedProposal generates a signed proposal given the vars, proposal fixed parts and private key
-// The vars passed in are NOT mutated!
-func createSignedProposal(vars Vars, proposal Proposal, fp state.FixedPart, pk []byte) SignedProposal {
-	if !proposal.isAddProposal() {
-		panic("unimplemented")
-	}
-	proposalVars := Vars{TurnNum: vars.TurnNum, Outcome: vars.Outcome.clone()}
-	_ = proposalVars.Add(proposal.toAdd)
-
-	state := proposalVars.AsState(fp)
-	sig, _ := state.Sign(pk)
-
-	signedProposal := SignedProposal{
-		Proposal:  proposal,
-		Signature: sig,
-	}
-
-	return signedProposal
-
-}
-
 func TestReceive(t *testing.T) {
 	var vAmount = uint64(5)
 	initialVars := Vars{Outcome: ledgerOutcome(), TurnNum: 0}

--- a/channel/consensus_channel/helpers_test.go
+++ b/channel/consensus_channel/helpers_test.go
@@ -87,3 +87,24 @@ func add(turnNum, amount uint64, vId types.Destination, left, right actor) Add {
 		LeftDeposit: bigAmount,
 	}
 }
+
+// createSignedProposal generates a signed proposal given the vars, proposal fixed parts and private key
+// The vars passed in are NOT mutated!
+func createSignedProposal(vars Vars, proposal Proposal, fp state.FixedPart, pk []byte) SignedProposal {
+	if !proposal.isAddProposal() {
+		panic("unimplemented")
+	}
+	proposalVars := Vars{TurnNum: vars.TurnNum, Outcome: vars.Outcome.clone()}
+	_ = proposalVars.Add(proposal.toAdd)
+
+	state := proposalVars.AsState(fp)
+	sig, _ := state.Sign(pk)
+
+	signedProposal := SignedProposal{
+		Proposal:  proposal,
+		Signature: sig,
+	}
+
+	return signedProposal
+
+}

--- a/channel/consensus_channel/helpers_test.go
+++ b/channel/consensus_channel/helpers_test.go
@@ -8,7 +8,12 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
+var channel1Id = types.Destination{1}
 var targetChannel = types.Destination{2}
+
+const aBal = uint64(200)
+const bBal = uint64(300)
+const vAmount = uint64(5)
 
 type actor struct {
 	Address    types.Address
@@ -65,11 +70,15 @@ func makeOutcome(left, right Balance, guarantees ...Guarantee) LedgerOutcome {
 	return LedgerOutcome{left: left, right: right, guarantees: mappedGuarantees}
 }
 
+// ledgerOutcome constructs the LedgerOutcome with items
+//  - alice: 200,
+//  - bob: 300,
+//  - guarantee(target: 1, left: alice, right: bob, amount: 5)
 func ledgerOutcome() LedgerOutcome {
 	return makeOutcome(
-		allocation(alice, uint64(200)),
-		allocation(bob, uint64(300)),
-		guarantee(uint64(5), types.Destination{1}, alice, bob),
+		allocation(alice, aBal),
+		allocation(bob, bBal),
+		guarantee(vAmount, channel1Id, alice, bob),
 	)
 
 }
@@ -107,4 +116,21 @@ func createSignedProposal(vars Vars, proposal Proposal, fp state.FixedPart, pk [
 
 	return signedProposal
 
+}
+
+// fingerprint computes a fingerprint for vars by encoding and returning the hash when provided
+// with a consisted FixedPart
+func fingerprint(v Vars) string {
+	h, err := v.AsState(state.TestState.FixedPart()).Hash()
+
+	if err != nil {
+		panic(err)
+	}
+
+	return h.String()
+}
+
+// equals checks that v is other by comparing fingerprints
+func (v *Vars) equals(other Vars) bool {
+	return fingerprint(*v) == fingerprint(other)
 }

--- a/channel/consensus_channel/leader_channel.go
+++ b/channel/consensus_channel/leader_channel.go
@@ -24,7 +24,7 @@ func (c *ConsensusChannel) IsProposed(g Guarantee) (bool, error) {
 		return false, err
 	}
 
-	return latest.Outcome.includes(g), nil
+	return latest.Outcome.includes(g) && !c.Includes(g), nil
 }
 
 // Propose is called by the Leader and receives a proposal to add a guarantee,

--- a/channel/consensus_channel/leader_channel_test.go
+++ b/channel/consensus_channel/leader_channel_test.go
@@ -311,7 +311,7 @@ func TestLeaderChannel(t *testing.T) {
 			if !errors.Is(err, expectedErr) {
 				t.Fatalf("expected error %v, got %v", expectedErr, err)
 			}
-			
+
 			if currentTurnNum != channel.ConsensusTurnNum() {
 				t.Fatalf("consensus changed in error case")
 			}
@@ -334,10 +334,10 @@ func TestLeaderChannel(t *testing.T) {
 		t.Run(msg, testUpdateConsensusOk(counterP))
 	}
 
-	{   // Receiving a valid (but stale) proposal
+	{ // Receiving a valid (but stale) proposal
 		initialVars := Vars{TurnNum: consensusTurnNum, Outcome: startingOutcome.clone()}
 		p0 := createAdd(0, channel1Id)
-		
+
 		counterP := bobSignedProposal(initialVars, p0).SignedProposal
 		channel := testChannel(startingOutcome, populatedQueue())
 		err := channel.UpdateConsensus(counterP)

--- a/channel/consensus_channel/leader_channel_test.go
+++ b/channel/consensus_channel/leader_channel_test.go
@@ -41,7 +41,7 @@ func TestLeaderChannel(t *testing.T) {
 		return []SignedProposalVars{}
 	}
 
-	// aliceSignedProposal generates a proposal given the vars & proposed change
+	// createSignedProposal generates a proposal given the vars & proposed change
 	// The proposal is signed by the given actor, using a generic fixed part
 	createSignedProposal := func(vars Vars, add Add, actor actor) SignedProposalVars {
 		proposalVars := Vars{TurnNum: vars.TurnNum, Outcome: vars.Outcome.clone()}

--- a/channel/consensus_channel/leader_channel_test.go
+++ b/channel/consensus_channel/leader_channel_test.go
@@ -42,7 +42,7 @@ func TestLeaderChannel(t *testing.T) {
 	}
 
 	// aliceSignedProposal generates a proposal given the vars & proposed change
-	// The proposal is signed by alice, using a generic fixed part
+	// The proposal is signed by the given actor, using a generic fixed part
 	createSignedProposal := func(vars Vars, add Add, actor actor) SignedProposalVars {
 		proposalVars := Vars{TurnNum: vars.TurnNum, Outcome: vars.Outcome.clone()}
 		_ = proposalVars.Add(add)

--- a/channel/consensus_channel/leader_channel_test.go
+++ b/channel/consensus_channel/leader_channel_test.go
@@ -2,182 +2,367 @@ package consensus_channel
 
 import (
 	"errors"
+	"fmt"
+	"math/big"
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/types"
 )
 
-func TestLeaderChannel(t *testing.T) {
-	existingChannel := types.Destination{1}
-	aBal := uint64(200)
-	bBal := uint64(300)
-	vAmount := uint64(5)
-
-	initialVars := Vars{Outcome: ledgerOutcome(), TurnNum: 0}
+func TestNewLeaderChannel(t *testing.T) {
+	o := ledgerOutcome()
+	initialVars := Vars{Outcome: o.clone(), TurnNum: 0}
 	aliceSig, _ := initialVars.AsState(fp()).Sign(alice.PrivateKey)
 	bobsSig, _ := initialVars.AsState(fp()).Sign(bob.PrivateKey)
 	sigs := [2]state.Signature{aliceSig, bobsSig}
 
-	channel, err := NewLeaderChannel(fp(), 0, ledgerOutcome(), sigs)
+	channel, err := NewLeaderChannel(fp(), 0, o.clone(), sigs)
 	if err != nil {
 		t.Fatal("unable to construct channel")
 	}
 
-	amountAdded := uint64(10)
+	vars, _ := channel.latestProposedVars()
+	if !vars.equals(initialVars) {
+		t.Fatalf("constructed with the wrong initial vars")
+	}
+}
 
-	if initialVars.TurnNum != 0 {
-		t.Fatal("initialized with non-zero turn number")
+func TestLeaderChannel(t *testing.T) {
+	// SignedProposalVars is a test utility that stores the vars signed along with a SignedProposal
+	type SignedProposalVars struct {
+		SignedProposal
+		Vars
 	}
 
-	p := Proposal{toAdd: add(1, amountAdded, targetChannel, alice, bob)}
-
-	sp, err := channel.Propose(p.toAdd, alice.PrivateKey)
-	if err != nil {
-		t.Fatalf("failed to add proposal: %v", err)
+	emptyQueue := func() []SignedProposalVars {
+		return []SignedProposalVars{}
 	}
 
-	success, _ := channel.IsProposed(p.toAdd.Guarantee)
-	if !success {
-		t.Fatal("incorrect latest proposed vars")
-	}
-	if channel.ConsensusTurnNum() != 0 || channel.Includes(p.toAdd.Guarantee) {
-		t.Fatal("consensus incorrectly updated")
+	// aliceSignedProposal generates a proposal given the vars & proposed change
+	// The proposal is signed by alice, using a generic fixed part
+	createSignedProposal := func(vars Vars, add Add, actor actor) SignedProposalVars {
+		proposalVars := Vars{TurnNum: vars.TurnNum, Outcome: vars.Outcome.clone()}
+		_ = proposalVars.Add(add)
+
+		state := proposalVars.AsState(fp())
+		sig, _ := state.Sign(actor.PrivateKey)
+
+		return SignedProposalVars{SignedProposal{sig, Proposal{toAdd: add}}, proposalVars}
 	}
 
-	outcomeSigned := makeOutcome(
+	aliceSignedProposal := func(vars Vars, add Add) SignedProposalVars {
+		return createSignedProposal(vars, add, alice)
+	}
+
+	bobSignedProposal := func(vars Vars, add Add) SignedProposalVars {
+		return createSignedProposal(vars, add, bob)
+	}
+
+	cId, _ := fp().ChannelId()
+	testChannel := func(lo LedgerOutcome, testProposalQueue []SignedProposalVars) ConsensusChannel {
+		vars := Vars{TurnNum: 0, Outcome: lo}
+		aliceSig, _ := vars.AsState(fp()).Sign(alice.PrivateKey)
+		bobsSig, _ := vars.AsState(fp()).Sign(bob.PrivateKey)
+		sigs := [2]state.Signature{aliceSig, bobsSig}
+
+		current := SignedVars{Vars: vars, Signatures: sigs}
+
+		proposalQueue := []SignedProposal{}
+		for _, p := range testProposalQueue {
+			proposalQueue = append(proposalQueue, p.SignedProposal)
+		}
+
+		return ConsensusChannel{
+			fp:            fp(),
+			Id:            cId,
+			myIndex:       Leader,
+			proposalQueue: proposalQueue,
+			current:       current,
+		}
+	}
+
+	const amountAdded = uint64(10)
+
+	createAdd := func(turnNum uint64, target types.Destination) Add {
+		return Add{
+			turnNum,
+			guarantee(amountAdded, target, alice, bob),
+			big.NewInt(int64(amountAdded)),
+		}
+	}
+
+	// ******* //
+	// Propose //
+	// ******* //
+
+	testPropose := func(
+		channel ConsensusChannel,
+		add Add,
+		expectedSp SignedProposal,
+		expectedErr error,
+	) func(*testing.T) {
+		return func(t *testing.T) {
+			currentTurnNum := channel.ConsensusTurnNum()
+			latest, _ := channel.latestProposedVars()
+			latestTurnNum := latest.TurnNum
+
+			sp, err := channel.Propose(add, alice.PrivateKey)
+
+			if !errors.Is(err, expectedErr) {
+				t.Fatalf("expected error %v, got %v", expectedErr, err)
+			}
+
+			if !reflect.DeepEqual(sp, expectedSp) {
+				diff := cmp.Diff(sp, expectedSp, cmp.AllowUnexported(Proposal{}, Add{}, Guarantee{}, big.Int{}))
+				t.Fatalf("expected signed proposal %v", diff)
+			}
+
+			proposed, _ := channel.IsProposed(add.Guarantee)
+
+			if expectedErr == nil && !proposed {
+				t.Fatalf("failed to propose guarantee in happy case")
+			}
+
+			if !errors.Is(err, expectedErr) {
+				t.Fatalf("unexpected error: got %v, wanted %v", err, expectedErr)
+			}
+
+			if channel.ConsensusTurnNum() != currentTurnNum {
+				t.Fatalf("guarantee is not correctly proposed")
+			}
+
+			var expectedLatest uint64
+			if expectedErr == nil {
+				expectedLatest = latestTurnNum + 1
+			} else {
+				expectedLatest = latestTurnNum
+			}
+
+			latest, _ = channel.latestProposedVars()
+			if latest.TurnNum != expectedLatest {
+				t.Fatalf("turn num malformed")
+			}
+		}
+	}
+
+	{
+		msg := "ok:adding with an empty queue"
+		startingOutcome := makeOutcome(
+			allocation(alice, aBal-amountAdded),
+			allocation(bob, bBal),
+			guarantee(vAmount, channel1Id, alice, bob),
+		)
+		c := testChannel(startingOutcome, emptyQueue())
+		proposalMade := createAdd(1, targetChannel)
+		expectedSp := aliceSignedProposal(c.current.Vars, proposalMade).SignedProposal
+		t.Run(msg, testPropose(c, proposalMade, expectedSp, nil))
+	}
+
+	{
+		msg := "ok:provided turn number is ignored"
+		startingOutcome := makeOutcome(
+			allocation(alice, aBal-amountAdded),
+			allocation(bob, bBal),
+			guarantee(vAmount, channel1Id, alice, bob),
+		)
+		c := testChannel(startingOutcome, emptyQueue())
+		proposalMade := createAdd(1, targetChannel)
+		expectedSp := aliceSignedProposal(c.current.Vars, proposalMade).SignedProposal
+
+		proposalMade.turnNum = 9001
+		t.Run(msg, testPropose(c, proposalMade, expectedSp, nil))
+	}
+
+	{
+		msg := "ok:adding with a non-empty queue"
+		startingOutcome := makeOutcome(
+			allocation(alice, aBal-amountAdded),
+			allocation(bob, bBal),
+			guarantee(vAmount, channel1Id, alice, bob),
+		)
+
+		p1 := createAdd(1, types.Destination{2})
+		sp1 := aliceSignedProposal(Vars{Outcome: startingOutcome}, p1)
+		startingQueue := append(emptyQueue(), sp1)
+
+		c := testChannel(startingOutcome, startingQueue)
+
+		newAdd := add(2, amountAdded, types.Destination{3}, alice, bob)
+
+		currentlyProposed, _ := c.latestProposedVars()
+		expectedSp := aliceSignedProposal(currentlyProposed, newAdd).SignedProposal
+
+		t.Run(msg, testPropose(c, newAdd, expectedSp, nil))
+	}
+
+	{
+		msg := "err:adding a duplicate proposal"
+		startingOutcome := makeOutcome(
+			allocation(alice, aBal-amountAdded),
+			allocation(bob, bBal),
+			guarantee(vAmount, channel1Id, alice, bob),
+		)
+
+		proposedChan := types.Destination{2}
+		p1 := createAdd(1, proposedChan)
+		sp1 := aliceSignedProposal(Vars{Outcome: startingOutcome}, p1)
+
+		startingQueue := append(emptyQueue(), sp1)
+
+		c := testChannel(startingOutcome, startingQueue)
+
+		duplicateAdd := add(2, amountAdded, proposedChan, alice, bob)
+
+		t.Run(msg, testPropose(c, duplicateAdd, SignedProposal{}, ErrDuplicateGuarantee))
+	}
+
+	{
+		msg := "err:overspending"
+		startingOutcome := makeOutcome(
+			allocation(alice, 0),
+			allocation(bob, bBal),
+		)
+
+		proposedChan := types.Destination{2}
+
+		c := testChannel(startingOutcome, emptyQueue())
+
+		p := add(2, amountAdded, proposedChan, alice, bob)
+
+		t.Run(msg, testPropose(c, p, SignedProposal{}, ErrInsufficientFunds))
+	}
+
+	// // *************** //
+	// // UpdateConsensus //
+	// // *************** //
+
+	startingOutcome := makeOutcome(
 		allocation(alice, aBal-amountAdded),
 		allocation(bob, bBal),
-		guarantee(vAmount, existingChannel, alice, bob),
-		guarantee(amountAdded, targetChannel, alice, bob),
 	)
-	stateSigned := Vars{TurnNum: 1, Outcome: outcomeSigned}
-	sig, _ := stateSigned.AsState(fp()).Sign(alice.PrivateKey)
-	expected := SignedProposal{Proposal: p, Signature: sig}
 
-	if !reflect.DeepEqual(sp, expected) {
-		t.Fatalf("propose failed")
-	}
+	const consensusTurnNum = uint64(0)
 
-	thirdChannel := types.Destination{3}
-	p2 := p
-	p2.toAdd.target = thirdChannel
-	g2 := p2.toAdd.Guarantee
-	secondSigned, err := channel.Propose(p2.toAdd, alice.PrivateKey)
-	if err != nil {
-		t.Fatalf("failed to add another proposal: %v", err)
-	}
-	if secondSigned.Proposal.toAdd.turnNum != 2 {
-		t.Fatalf("incorrect proposal generated")
+	populatedQueue := func() []SignedProposalVars {
+		vars := Vars{TurnNum: consensusTurnNum, Outcome: startingOutcome}
+
+		p1 := createAdd(vars.TurnNum+1, types.Destination{byte(vars.TurnNum)})
+		sp1 := aliceSignedProposal(vars, p1)
+
+		p2 := createAdd(sp1.TurnNum+1, types.Destination{byte(sp1.TurnNum)})
+		sp2 := aliceSignedProposal(sp1.Vars, p2)
+
+		p3 := createAdd(sp2.TurnNum+1, types.Destination{byte(sp2.TurnNum)})
+		sp3 := aliceSignedProposal(sp2.Vars, p3)
+
+		return []SignedProposalVars{sp1, sp2, sp3}
 	}
 
-	success, _ = channel.IsProposed(g2)
-	if !success {
-		t.Fatal("incorrect latest proposed vars")
-	}
-	if channel.ConsensusTurnNum() != 0 {
-		t.Fatal("consensus incorrectly updated")
-	}
-	if channel.Includes(g2) {
-		t.Fatal("consensus incorrectly updated")
+	testUpdateConsensusOk := func(
+		counterProposal SignedProposalVars,
+	) func(*testing.T) {
+		channel := testChannel(startingOutcome, populatedQueue())
+
+		return func(t *testing.T) {
+			latest, _ := channel.latestProposedVars()
+			latestTurnNum := latest.TurnNum
+
+			err := channel.UpdateConsensus(counterProposal.SignedProposal)
+
+			if err != nil {
+				t.Fatalf("expected error %v", err)
+			}
+			g := counterProposal.Proposal.toAdd.Guarantee
+			if !channel.Includes(g) {
+				t.Fatalf("failed to fund guarantee given successful counterproposal")
+			}
+
+			if proposed, _ := channel.IsProposed(g); proposed {
+				t.Fatalf("guarantee still proposed given successful counterproposal")
+			}
+
+			if channel.ConsensusTurnNum() != counterProposal.Proposal.toAdd.turnNum {
+				t.Fatalf("consensus not reached")
+			}
+
+			latest, _ = channel.latestProposedVars()
+			if latest.TurnNum != latestTurnNum {
+				t.Fatalf("latest proposed turn number has changed")
+			}
+		}
 	}
 
-	latest, _ := channel.latestProposedVars()
-	counterSig2, _ := latest.AsState(fp()).Sign(bob.PrivateKey)
+	testUpdateConsensusErr := func(
+		counterProposal SignedProposalVars,
+		expectedErr error,
+	) func(*testing.T) {
+		channel := testChannel(startingOutcome, populatedQueue())
 
-	p3 := p
-	p3.toAdd.target = types.Destination{4}
-	g3 := p3.toAdd.Guarantee
-	thirdSigned, _ := channel.Propose(p3.toAdd, alice.PrivateKey)
+		return func(t *testing.T) {
+			currentTurnNum := channel.ConsensusTurnNum()
+			latest, _ := channel.latestProposedVars()
+			latestTurnNum := latest.TurnNum
 
-	p2Returned := SignedProposal{
-		Proposal:  secondSigned.Proposal,
-		Signature: counterSig2,
-	}
+			err := channel.UpdateConsensus(counterProposal.SignedProposal)
 
-	// A counter signature is received on a proposal (but not the latest proposal)
-	err = channel.UpdateConsensus(p2Returned)
-	if err != nil {
-		t.Fatalf("Unable to update consensus: %v", err)
-	}
+			if !errors.Is(err, expectedErr) {
+				t.Fatalf("expected error %v, got %v", expectedErr, err)
+			}
+			
+			if currentTurnNum != channel.ConsensusTurnNum() {
+				t.Fatalf("consensus changed in error case")
+			}
 
-	if channel.ConsensusTurnNum() != 2 {
-		t.Fatalf("consensus turn num not updated")
-	}
-	if !channel.Includes(g2) {
-		t.Fatal("consensus incorrectly updated")
-	}
-	if channel.Includes(g3) {
-		t.Fatal("consensus incorrectly updated")
-	}
+			latest, _ = channel.latestProposedVars()
+			if latest.TurnNum != latestTurnNum {
+				t.Fatalf("latest proposed turn number has changed")
+			}
 
-	err = channel.UpdateConsensus(p2Returned)
-	if err != nil {
-		t.Fatalf("Unable to update consensus: %v", err)
+			if !errors.Is(err, expectedErr) {
+				t.Fatalf("unexpected error: got %v, wanted %v", err, expectedErr)
+			}
+		}
 	}
 
-	// The incorrect counter signature is received on the latest proposal
-	latest, _ = channel.latestProposedVars()
-	wrongCounterSig3, _ := latest.AsState(fp()).Sign(brian.PrivateKey)
-	wrongP3Returned := SignedProposal{
-		Proposal:  thirdSigned.Proposal,
-		Signature: wrongCounterSig3,
-	}
-	err = channel.UpdateConsensus(wrongP3Returned)
-	if !errors.Is(err, ErrWrongSigner) {
-		t.Fatalf("ungracefully handled wrong signature: %v", err)
+	for i, signedbyAlice := range populatedQueue() {
+		msg := fmt.Sprintf("ok: receiving a valid counter proposal in position %v", i)
+
+		counterP := bobSignedProposal(signedbyAlice.Vars, signedbyAlice.Proposal.toAdd)
+		t.Run(msg, testUpdateConsensusOk(counterP))
 	}
 
-	if channel.ConsensusTurnNum() != 2 {
-		t.Fatalf("consensus turn num not updated")
+	{   // Receiving a valid (but stale) proposal
+		initialVars := Vars{TurnNum: consensusTurnNum, Outcome: startingOutcome.clone()}
+		p0 := createAdd(0, channel1Id)
+		
+		counterP := bobSignedProposal(initialVars, p0).SignedProposal
+		channel := testChannel(startingOutcome, populatedQueue())
+		err := channel.UpdateConsensus(counterP)
+		if err != nil {
+			t.Fatalf("unable to update consensus: %v", err)
+		}
+
+		if channel.ConsensusTurnNum() != 0 {
+			t.Fatalf("incorrectly received stale counterproposal")
+		}
 	}
 
-	// The correct counter signature is received on the latest proposal
-	latest, _ = channel.latestProposedVars()
-	counterSig3, _ := latest.AsState(fp()).Sign(bob.PrivateKey)
-	p3Returned := SignedProposal{
-		Proposal:  thirdSigned.Proposal,
-		Signature: counterSig3,
-	}
-	_ = channel.UpdateConsensus(p3Returned)
-
-	if channel.ConsensusTurnNum() != 3 {
-		t.Fatalf("consensus turn num not updated")
-	}
-	if !channel.Includes(g2) {
-		t.Fatal("consensus incorrectly updated")
-	}
-	if !channel.Includes(g3) {
-		t.Fatal("consensus incorrectly updated")
+	{
+		msg := "err:wrong signature"
+		p := populatedQueue()[0]
+		counterP := createSignedProposal(p.Vars, p.Proposal.toAdd, brian)
+		t.Run(msg, testUpdateConsensusErr(counterP, ErrWrongSigner))
 	}
 
-	// A counter signature is received on an old proposal
-	err = channel.UpdateConsensus(p2Returned)
-	if err != nil {
-		t.Fatalf("Unable to receive old proposal")
-	}
-	if channel.ConsensusTurnNum() != 3 {
-		t.Fatalf("consensus turn num not updated")
-	}
-	if !channel.Includes(g3) {
-		t.Fatal("consensus incorrectly updated")
-	}
-
-	// A counter signature is received on an unexpected proposal
-	p4Returned := SignedProposal{
-		Proposal:  Proposal{toAdd: add(4, 10, targetChannel, alice, bob)},
-		Signature: counterSig2,
-	}
-	err = channel.UpdateConsensus(p4Returned)
-	if !errors.Is(err, ErrProposalQueueExhausted) {
-		t.Fatalf("did not gracefully handle future proposal: %v", err)
-	}
-	if channel.ConsensusTurnNum() != 3 {
-		t.Fatalf("consensus turn num not updated")
-	}
-	if !channel.Includes(g3) {
-		t.Fatal("consensus incorrectly updated")
+	{
+		msg := "err:unexpected proposal"
+		p := populatedQueue()[2]
+		p4 := createAdd(p.TurnNum+10, types.Destination{11})
+		counterP := bobSignedProposal(p.Vars, p4)
+		t.Run(msg, testUpdateConsensusErr(counterP, ErrProposalQueueExhausted))
 	}
 }
 


### PR DESCRIPTION
Resolves #417.

It doesn't use table tests: there are a few different ways to set up and call expectations on the outcomes. So, the tests are generally cleaned up and made more readable.

This refactor was done with #479 in mind, though I expect the tests might still change a little bit.
