### PR TITLE
Add consensus_channel logic to `virtualfund.Objective.Update`

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -92,10 +92,29 @@ func (c *ConsensusChannel) Includes(g Guarantee) bool {
 	return c.current.Outcome.includes(g)
 }
 
+// Isleader returns true if the calling client is the leader of the channel,
+// and false otherwise
+func (c *ConsensusChannel) IsLeader() bool {
+	return c.myIndex == Leader
+}
+
+// IsFollower returns true if the calling client is the follower of the channel,
+// and false otherwise
+func (c *ConsensusChannel) IsFollower() bool {
+	return c.myIndex == Follower
+}
+
 // Leader returns the address of the participant responsible for proposing
 func (c *ConsensusChannel) Leader() common.Address {
 	return c.fp.Participants[Leader]
 }
+
+// Follower returns the address of the participant who recieves and contersigns
+// proposals
+func (c *ConsensusChannel) Follower() common.Address {
+	return c.fp.Participants[Follower]
+}
+
 func (c *ConsensusChannel) Accept(p SignedProposal) error {
 	panic("UNIMPLEMENTED")
 }

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -429,14 +429,14 @@ func (a Add) equal(a2 Add) bool {
 var ErrIncorrectTurnNum = fmt.Errorf("incorrect turn number")
 
 // Add mutates Vars by
-// - increasing the turn number by 1
-// - including the guarantee
-// - adjusting balances accordingly
+//  - increasing the turn number by 1
+//  - including the guarantee
+//  - adjusting balances accordingly
 //
 // An error is returned if:
-// - the turn number is not incremented
-// - the balances are incorrectly adjusted, or the deposits are too large
-// - the guarantee is already included in vars.Outcome
+//  - the turn number is not incremented
+//  - the balances are incorrectly adjusted, or the deposits are too large
+//  - the guarantee is already included in vars.Outcome
 //
 // If an error is returned, the original vars is not mutated
 func (vars *Vars) Add(p Add) error {

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -92,7 +92,7 @@ func (c *ConsensusChannel) Includes(g Guarantee) bool {
 	return c.current.Outcome.includes(g)
 }
 
-// Isleader returns true if the calling client is the leader of the channel,
+// IsLeader returns true if the calling client is the leader of the channel,
 // and false otherwise
 func (c *ConsensusChannel) IsLeader() bool {
 	return c.myIndex == Leader

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -185,7 +185,7 @@ func (e *Engine) handleAPIEvent(apiEvent APIEvent) (ObjectiveChangeEvent, error)
 		switch request := (apiEvent.ObjectiveToSpawn).(type) {
 
 		case virtualfund.ObjectiveRequest:
-			vfo, err := virtualfund.NewObjective(request, e.store.GetTwoPartyLedger)
+			vfo, err := virtualfund.NewObjective(request, e.store.GetTwoPartyLedger, e.store.GetConsensusChannel)
 			if err != nil {
 				return ObjectiveChangeEvent{}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 			}

--- a/internal/testdata/channels.go
+++ b/internal/testdata/channels.go
@@ -4,17 +4,21 @@ import (
 	"fmt"
 
 	"github.com/statechannels/go-nitro/channel"
+	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/protocols/directfund"
 	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/types"
 )
 
 type channelCollection struct {
 	// MockTwoPartyLedger constructs and returns a ledger channel
-	MockTwoPartyLedger virtualfund.GetTwoPartyLedgerFunction
+	MockTwoPartyLedger   virtualfund.GetTwoPartyLedgerFunction
+	MockConsensusChannel virtualfund.GetTwoPartyConsensusLedgerFunction
 }
 
 var Channels channelCollection = channelCollection{
-	MockTwoPartyLedger: mockTwoPartyLedger,
+	MockTwoPartyLedger:   mockTwoPartyLedger,
+	MockConsensusChannel: mockConsensusChannel,
 }
 
 func mockTwoPartyLedger(firstParty, secondParty types.Address) (ledger *channel.TwoPartyLedger, ok bool) {
@@ -28,4 +32,20 @@ func mockTwoPartyLedger(firstParty, secondParty types.Address) (ledger *channel.
 		panic(fmt.Errorf("error mocking a twoPartyLedger: %w", err))
 	}
 	return ledger, true
+}
+
+func mockConsensusChannel(counterparty types.Address) (ledger *consensus_channel.ConsensusChannel, ok bool) {
+	ts := testState.Clone()
+	request := directfund.ObjectiveRequest{
+		MyAddress:         ts.Participants[0],
+		CounterParty:      ts.Participants[1],
+		AppData:           ts.AppData,
+		AppDefinition:     ts.AppDefinition,
+		ChallengeDuration: ts.ChallengeDuration,
+		Nonce:             ts.ChannelNonce.Int64(),
+		Outcome:           ts.Outcome,
+	}
+	testObj, _ := directfund.NewObjective(request, false)
+	cc, _ := testObj.CreateConsensusChannel()
+	return cc, true
 }

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -70,7 +70,7 @@ func genericVFO() virtualfund.Objective {
 		ts.Outcome,
 		ts.ChannelNonce.Int64(),
 	}
-	testVFO, err := virtualfund.NewObjective(request, Channels.MockTwoPartyLedger)
+	testVFO, err := virtualfund.NewObjective(request, Channels.MockTwoPartyLedger, Channels.MockConsensusChannel)
 	if err != nil {
 		panic(fmt.Errorf("error constructing genericVFO: %w", err))
 	}

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/go-cmp/cmp"
 	"github.com/statechannels/go-nitro/channel"
+	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/protocols"
@@ -289,8 +290,65 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			return l, r
 		}
 
+		prepareConsensusChannel := func(role uint, left, right actor) *consensus_channel.ConsensusChannel {
+			fp := state.FixedPart{
+				ChainId:           big.NewInt(9001),
+				Participants:      []types.Address{left.address, right.address},
+				ChannelNonce:      big.NewInt(0),
+				AppDefinition:     types.Address{},
+				ChallengeDuration: big.NewInt(45),
+			}
+
+			leftBal := consensus_channel.NewBalance(left.destination, big.NewInt(6))
+			rightBal := consensus_channel.NewBalance(right.destination, big.NewInt(4))
+
+			lo := *consensus_channel.NewLedgerOutcome(types.Address{}, leftBal, rightBal, []consensus_channel.Guarantee{})
+
+			signedVars := consensus_channel.SignedVars{Vars: consensus_channel.Vars{Outcome: lo}}
+			leftSig, err := signedVars.Vars.AsState(fp).Sign(left.privateKey)
+			if err != nil {
+				panic(err)
+			}
+			rightSig, err := signedVars.Vars.AsState(fp).Sign(right.privateKey)
+			if err != nil {
+				panic(err)
+			}
+			sigs := [2]state.Signature{leftSig, rightSig}
+
+			var cc consensus_channel.ConsensusChannel
+
+			if role == 0 {
+				cc, err = consensus_channel.NewLeaderChannel(fp, 0, lo, sigs)
+			} else {
+				cc, err = consensus_channel.NewFollowerChannel(fp, 0, lo, sigs)
+			}
+			if err != nil {
+				panic(err)
+			}
+
+			return &cc
+		}
+
+		prepareConsensusChannels := func(role uint) (*consensus_channel.ConsensusChannel, *consensus_channel.ConsensusChannel) {
+			var left *consensus_channel.ConsensusChannel
+			var right *consensus_channel.ConsensusChannel
+
+			switch role {
+			case 0:
+				right = prepareConsensusChannel(0, alice, p1)
+			case 1:
+				left = prepareConsensusChannel(0, alice, p1)
+				right = prepareConsensusChannel(1, p1, bob)
+			case 2:
+				left = prepareConsensusChannel(0, p1, bob)
+			}
+
+			return left, right
+		}
+
 		testNew := func(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
+
 			// Assert that a valid set of constructor args does not result in an error
 			o, err := constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, nil, ledgerChannelToMyRight, nil) // todo: #420 deprecate TwoPartyLedgers
 			if err != nil {
@@ -340,7 +398,6 @@ func TestSingleHopVirtualFund(t *testing.T) {
 					t.Fatalf("TestNew: expectedGuarantee mismatch (-want +got):\n%s", diff)
 				}
 			}
-
 		}
 
 		testclone := func(t *testing.T) {
@@ -357,7 +414,8 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 		testCrank := func(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
-			var s, _ = constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, nil, ledgerChannelToMyRight, nil) // todo: #420 deprecate TwoPartyLedgers
+			leftCC, rightCC := prepareConsensusChannels(my.role)
+			var s, _ = constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, leftCC, ledgerChannelToMyRight, rightCC) // todo: #420 deprecate TwoPartyLedgers
 			// Assert that cranking an unapproved objective returns an error
 			if _, _, _, err := s.Crank(&my.privateKey); err == nil {
 				t.Fatal(`Expected error when cranking unapproved objective, but got nil`)
@@ -492,28 +550,29 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 		testUpdate := func(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.role)
-			var s, _ = constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, nil, ledgerChannelToMyRight, nil) // todo: #420 deprecate TwoPartyLedgers
+			leftCC, rightCC := prepareConsensusChannels(my.role)
+			var obj, _ = constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, leftCC, ledgerChannelToMyRight, rightCC) // todo: #420 deprecate TwoPartyLedgers
 			// Prepare an event with a mismatched objectiveId
 			e := protocols.ObjectiveEvent{
 				ObjectiveId: "some-other-id",
 			}
 			// Assert that Updating the objective with such an event returns an error
 			// TODO is this the behaviour we want? Below with the signatures, we prefer a log + NOOP (no error)
-			if _, err := s.Update(e); err == nil {
+			if _, err := obj.Update(e); err == nil {
 				t.Fatal(`Objective ID mismatch -- expected an error but did not get one`)
 			}
 
 			// Now modify the event to give it the "correct" channelId (matching the objective),
 			// and make a new Sigs map.
 			// This prepares us for the rest of the test. We will reuse the same event multiple times
-			e.ObjectiveId = s.Id()
+			e.ObjectiveId = obj.Id()
 			e.SignedStates = make([]state.SignedState, 0)
 
 			// Next, attempt to update the objective with correct signature by a participant on a relevant state
 			// Assert that this results in an appropriate change in the extended state of the objective
 			// Part 1: a signature on a state in channel V
 
-			vPostFund := s.V.PostFundState()
+			vPostFund := obj.V.PostFundState()
 			ss := state.NewSignedState(vPostFund)
 
 			switch my.role {
@@ -535,7 +594,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			}
 			e.SignedStates = append(e.SignedStates, ss)
 
-			updatedObj, err := s.Update(e)
+			updatedObj, err := obj.Update(e)
 			updated := updatedObj.(*Objective)
 			if err != nil {
 				t.Fatal(err)
@@ -564,7 +623,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 			// Part 2: a signature on a relevant ledger channel
 			f := protocols.ObjectiveEvent{
-				ObjectiveId: s.Id(),
+				ObjectiveId: obj.Id(),
 			}
 			f.SignedStates = make([]state.SignedState, 0)
 			someTurnNum := uint64(99)
@@ -593,7 +652,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			}
 			f.SignedStates = append(f.SignedStates, ss)
 
-			updatedObj, err = s.Update(f)
+			updatedObj, err = obj.Update(f)
 			updated = updatedObj.(*Objective)
 			if err != nil {
 				t.Fatal(err)

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -75,6 +75,28 @@ func (c *Connection) insertGuaranteeInfo(a0 types.Funds, b0 types.Funds, vId typ
 	return nil
 }
 
+// handleProposal recieves a signed proposal and acts according to the leader / follower
+// status of the Connection's ConsensusChannel
+func (c *Connection) handleProposal(sp consensus_channel.SignedProposal) error {
+	if c == nil {
+		return fmt.Errorf("nil connection should not handle proposals")
+	}
+
+	if sp.Proposal.ChannelID != c.ConsensusChannel.Id {
+		return consensus_channel.ErrIncorrectChannelID
+	}
+
+	if c.ConsensusChannel.IsFollower() {
+		return c.ConsensusChannel.Receive(sp)
+	}
+
+	if c.ConsensusChannel.IsLeader() {
+		return c.ConsensusChannel.UpdateConsensus(sp)
+	}
+
+	return nil
+}
+
 // getExpectedGuarantees returns a map of asset addresses to guarantees for a Connection.
 func (c *Connection) getExpectedGuarantees() map[types.Address]outcome.Allocation {
 	expectedGuaranteesForLedgerChannel := make(map[types.Address]outcome.Allocation)

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -142,14 +142,16 @@ type Objective struct {
 }
 
 // NewObjective creates a new virtual funding objective from a given request.
-func NewObjective(request ObjectiveRequest, getTwoPartyLedger GetTwoPartyLedgerFunction) (Objective, error) {
+func NewObjective(request ObjectiveRequest, getTwoPartyLedger GetTwoPartyLedgerFunction, getTwoPartyConsensusLedger GetTwoPartyConsensusLedgerFunction) (Objective, error) {
 	right, ok := getTwoPartyLedger(request.MyAddress, request.Intermediary)
+	rightCC, ok := getTwoPartyConsensusLedger(request.Intermediary)
 
 	if !ok {
 		return Objective{}, fmt.Errorf("could not find ledger for %s and %s", request.MyAddress, request.Intermediary)
 
 	}
 	var left *channel.TwoPartyLedger
+	var leftCC *consensus_channel.ConsensusChannel
 
 	objective, err := constructFromState(true,
 		state.State{
@@ -163,7 +165,7 @@ func NewObjective(request ObjectiveRequest, getTwoPartyLedger GetTwoPartyLedgerF
 			IsFinal:           false,
 		},
 		request.MyAddress,
-		left, nil, right, nil) // todo: replace nil consensusChannels
+		left, leftCC, right, rightCC) // todo: replace nil consensusChannels
 	if err != nil {
 		return Objective{}, fmt.Errorf("error creating objective: %w", err)
 	}

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -86,12 +86,14 @@ func (c *Connection) handleProposal(sp consensus_channel.SignedProposal) error {
 		return consensus_channel.ErrIncorrectChannelID
 	}
 
-	if c.ConsensusChannel.IsFollower() {
-		return c.ConsensusChannel.Receive(sp)
-	}
+	if c.ConsensusChannel != nil {
+		if c.ConsensusChannel.IsFollower() {
+			return c.ConsensusChannel.Receive(sp)
+		}
 
-	if c.ConsensusChannel.IsLeader() {
-		return c.ConsensusChannel.UpdateConsensus(sp)
+		if c.ConsensusChannel.IsLeader() {
+			return c.ConsensusChannel.UpdateConsensus(sp)
+		}
 	}
 
 	return nil
@@ -144,11 +146,14 @@ type Objective struct {
 // NewObjective creates a new virtual funding objective from a given request.
 func NewObjective(request ObjectiveRequest, getTwoPartyLedger GetTwoPartyLedgerFunction, getTwoPartyConsensusLedger GetTwoPartyConsensusLedgerFunction) (Objective, error) {
 	right, ok := getTwoPartyLedger(request.MyAddress, request.Intermediary)
+	if !ok {
+		return Objective{}, fmt.Errorf("could not find ledger for %s and %s", request.MyAddress, request.Intermediary)
+	}
+
 	rightCC, ok := getTwoPartyConsensusLedger(request.Intermediary)
 
 	if !ok {
 		return Objective{}, fmt.Errorf("could not find ledger for %s and %s", request.MyAddress, request.Intermediary)
-
 	}
 	var left *channel.TwoPartyLedger
 	var leftCC *consensus_channel.ConsensusChannel
@@ -306,16 +311,12 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 
 	var toMyLeftId types.Destination
 	var toMyRightId types.Destination
-	var ccLeftID types.Destination
-	var ccRightID types.Destination
 
 	if !o.isAlice() {
 		toMyLeftId = o.ToMyLeft.Channel.Id // Avoid this if it is nil // todo: #420 deprecate
-		ccLeftID = o.ToMyLeft.ConsensusChannel.Id
 	}
 	if !o.isBob() {
 		toMyRightId = o.ToMyRight.Channel.Id // Avoid this if it is nil // todo: #420 deprecate
-		ccRightID = o.ToMyRight.ConsensusChannel.Id
 	}
 
 	for _, sp := range event.SignedProposals {
@@ -323,9 +324,9 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 		switch sp.Proposal.ChannelID {
 		case types.Destination{}:
 			return &o, errors.New("signed proposal is not addressed to a ledger channel") // catch this case to avoid unspecified behaviour -- because if Alice or Bob we allow a null channel.
-		case ccLeftID:
+		case toMyLeftId:
 			err = updated.ToMyLeft.handleProposal(sp)
-		case ccRightID:
+		case toMyRightId:
 			err = updated.ToMyRight.handleProposal(sp)
 		default:
 			return &o, fmt.Errorf("signed proposal is not addressed to a known ledger connection")


### PR DESCRIPTION
incremental toward #420

This PR introduces some processing of `consensus_channel.SignedProposal` messages in the virtualfund `Update()` method.

The PR adds:
- a range loop in virtualfund.Objective.Update which handles incoming signed proposals
- a `handleProposal` function to the `Connection` struct (VFO's interface with ledger channels)
- a forwarding `GetTwoPartyConsensusLedgerFunction` to virtualfund.NewObjective(...)
- identity helper functions `IsLeader`, `IsFollower`, `Follower` to ConsensusChannel
- `testdata` mocking function for finding ConsensusChannels

2dece03ade9df212325a21f5c842f09620a6df7f is unrelated to the PR. A drive-by change of a godoc.

## :warning: broken tests

test breakage is expected here because consensus channels are not yet serializing / deserializing in mockstore. Because of this, a deserialized `vfo` ends up with `nil` ConsensusChannels where it expects non-nil ones.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
  - testing blocked by storing / retrieving updated consensus channels
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
