### PR TITLE
[nitro-protocol] fix `valid-transition.test.ts`

### DIFF
--- a/nitro-protocol/test/src/valid-transition.test.ts
+++ b/nitro-protocol/test/src/valid-transition.test.ts
@@ -40,7 +40,7 @@ const incorrectTurnNumCases: TestCaseWithError[] = [
 //prettier-ignore
 const changedAConstantCases: TestCaseWithError[] = [
   [/chainId must not change/, {}, { channel: {...baseToState.channel, chainId: '0x2'}}],
-  [/participants must not change/, {}, { channel: {...baseToState.channel, participants: baseToState.channel.participants}}],
+  [/participants must not change/, {}, { channel: {...baseToState.channel, participants: [baseToState.channel.participants[0]]}}],
   [/channelNonce must not change/, {}, { channel: {... baseToState.channel, channelNonce: baseToState.channel.channelNonce + 1}} ],
   [/appDefinition must not change/, {}, { appDefinition: channel.participants[0]} ],
   [/challengeDuration must not change/, {}, { challengeDuration: baseToState.challengeDuration + 1}],


### PR DESCRIPTION
in order to trigger the desired error condition, we need to supply a "to" state with modified participants

This change should get the continuous integration suite to pass #487. 