### PR TITLE
add some (temporary) assertions on the ledger channel states

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -143,6 +143,18 @@ func (c *ConsensusChannel) ConsensusVars() Vars {
 	return c.current.Vars
 }
 
+// LatestProposedVars is TEMPORARY CODE used for external assertions
+// todo 420: delete this
+func (c *ConsensusChannel) LatestProposedVars() Vars {
+	vars, err := c.latestProposedVars()
+	if err != nil {
+		panic(err)
+	}
+
+	return vars
+}
+
+
 // latestProposedVars returns the latest proposed vars in a consensus channel
 // by cloning its current vars and applying each proposal in the queue
 func (c *ConsensusChannel) latestProposedVars() (Vars, error) {

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -154,7 +154,6 @@ func (c *ConsensusChannel) LatestProposedVars() Vars {
 	return vars
 }
 
-
 // latestProposedVars returns the latest proposed vars in a consensus channel
 // by cloning its current vars and applying each proposal in the queue
 func (c *ConsensusChannel) latestProposedVars() (Vars, error) {

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -304,7 +304,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 			lo := *consensus_channel.NewLedgerOutcome(types.Address{}, leftBal, rightBal, []consensus_channel.Guarantee{})
 
-			signedVars := consensus_channel.SignedVars{Vars: consensus_channel.Vars{Outcome: lo}}
+			signedVars := consensus_channel.SignedVars{Vars: consensus_channel.Vars{Outcome: lo, TurnNum: 1}}
 			leftSig, err := signedVars.Vars.AsState(fp).Sign(left.privateKey)
 			if err != nil {
 				panic(err)
@@ -318,9 +318,9 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			var cc consensus_channel.ConsensusChannel
 
 			if role == 0 {
-				cc, err = consensus_channel.NewLeaderChannel(fp, 0, lo, sigs)
+				cc, err = consensus_channel.NewLeaderChannel(fp, 1, lo, sigs)
 			} else {
-				cc, err = consensus_channel.NewFollowerChannel(fp, 0, lo, sigs)
+				cc, err = consensus_channel.NewFollowerChannel(fp, 1, lo, sigs)
 			}
 			if err != nil {
 				panic(err)


### PR DESCRIPTION
These assertions allow us to check for the same behaviour between the current use of `TwoPartyLedger` and a `ConsensusChannel`.

Note: these assertions should fail, but don't:
- The testUpdate function sends an [arbitrary signed state](https://github.com/statechannels/go-nitro/blob/3956d5ac214bbaf6345d01268428e762457856a1/protocols/virtualfund/virtualfund-single-hop_test.go#L570-L596) destined for the TwoPartyLedger, which the Update function accepts (is this a bug?).
- Then, it checks that this arbitrary state was received by [manually inspecting](https://github.com/statechannels/go-nitro/blob/3956d5ac214bbaf6345d01268428e762457856a1/protocols/virtualfund/virtualfund-single-hop_test.go#L602-L621) that turn number
- Because LatestSignedState doesn't actually return the latest signed state (it should return a state with [turn number 99](https://github.com/statechannels/go-nitro/blob/3956d5ac214bbaf6345d01268428e762457856a1/protocols/virtualfund/virtualfund-single-hop_test.go#L570)), [this sanity check passes](https://github.com/statechannels/go-nitro/compare/cmk.vfo-consensus-update...ags/vfo-assertions?expand=1#diff-e78ba83d3714e679fa001e0cc48267b733ce93be39eb4ab1a37a777d25f6ca57R387) even though it should fail