### PR TITLE
add nil checks for recieved ledger channels...

### DIFF
--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -247,6 +247,15 @@ func constructFromState(
 	// Setup Ledger Channel Connections and expected guarantees
 	if !init.isAlice() { // everyone other than Alice has a left-channel
 		init.ToMyLeft = &Connection{}
+
+		if ledgerChannelToMyLeft == nil {
+			return Objective{}, fmt.Errorf("non-alice virtualfund objective requires non-nil ledger channel")
+		}
+		// todo: #420
+		// if consensusChannelToMyLeft == nil {
+		// 	return Objective{}, fmt.Errorf("non-alice virtualfund objective requires non-nil ledger channel")
+		// }
+
 		init.ToMyLeft.Channel = ledgerChannelToMyLeft
 		init.ToMyLeft.ConsensusChannel = consensusChannelToMyLeft
 		err = init.ToMyLeft.insertGuaranteeInfo(
@@ -263,6 +272,15 @@ func constructFromState(
 
 	if !init.isBob() { // everyone other than Bob has a right-channel
 		init.ToMyRight = &Connection{}
+
+		if ledgerChannelToMyRight == nil {
+			return Objective{}, fmt.Errorf("non-bob virtualfund objective requires non-nil ledger channel")
+		}
+		// todo: #420
+		// if consensusChannelToMyRight == nil {
+		// 	return Objective{}, fmt.Errorf("non-bob virtualfund objective requires non-nil ledger channel")
+		// }
+
 		init.ToMyRight.Channel = ledgerChannelToMyRight
 		init.ToMyRight.ConsensusChannel = consensusChannelToMyRight
 		err = init.ToMyRight.insertGuaranteeInfo(


### PR DESCRIPTION
A VFO does not behave correctly if, eg, Alice's incoming right-ledger channel is nil.

This PR adds a nil-check error return on ledger channels we expect are not present. It includes a not-yet-ready check on `ConsensusChannel`s, which are marked with `todo: #420`.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
