### PR TITLE
Add temporary `clone` workaround for ConsensusChannels

### DIFF
--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -19,7 +19,18 @@ import (
 )
 
 func compareObjectives(a, b Objective) string {
-	return cmp.Diff(&a, &b, cmp.AllowUnexported(Objective{}, channel.Channel{}, big.Int{}, state.SignedState{}))
+	return cmp.Diff(&a, &b,
+		cmp.AllowUnexported(
+			Objective{},
+			channel.Channel{},
+			big.Int{},
+			state.SignedState{},
+			consensus_channel.ConsensusChannel{},
+			consensus_channel.Vars{},
+			consensus_channel.LedgerOutcome{},
+			consensus_channel.Balance{},
+		),
+	)
 }
 
 // signPreAndPostFundingStates is a test utility function which applies signatures from

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -323,7 +323,7 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 		var err error
 		switch sp.Proposal.ChannelID {
 		case types.Destination{}:
-			return &o, errors.New("signed proposal is not addressed to a ledger channel") // catch this case to avoid unspecified behaviour -- because if Alice or Bob we allow a null channel.
+			return &o, fmt.Errorf("signed proposal is for a zero-addressed ledger channel") // catch this case to avoid unspecified behaviour -- because if Alice or Bob we allow a null channel.
 		case toMyLeftId:
 			err = updated.ToMyLeft.handleProposal(sp)
 		case toMyRightId:

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -509,20 +509,20 @@ func (o *Objective) clone() Objective {
 	clone.V = vClone
 
 	if o.ToMyLeft != nil {
-		// todo: #420 consider cloning for consensusChannels
 		lClone := o.ToMyLeft.Channel.Clone()
 		clone.ToMyLeft = &Connection{
-			Channel:       lClone,
-			GuaranteeInfo: o.ToMyLeft.GuaranteeInfo,
+			Channel:          lClone,
+			ConsensusChannel: o.ToMyLeft.ConsensusChannel, // todo: #420 consider cloning for consensusChannels
+			GuaranteeInfo:    o.ToMyLeft.GuaranteeInfo,
 		}
 	}
 
 	if o.ToMyRight != nil {
-		// todo: #420 consider cloning for consensusChannels
 		rClone := o.ToMyRight.Channel.Clone()
 		clone.ToMyRight = &Connection{
-			Channel:       rClone,
-			GuaranteeInfo: o.ToMyRight.GuaranteeInfo,
+			Channel:          rClone,
+			ConsensusChannel: o.ToMyRight.ConsensusChannel, // todo: #420 consider cloning for consensusChannels
+			GuaranteeInfo:    o.ToMyRight.GuaranteeInfo,
 		}
 	}
 


### PR DESCRIPTION
Previously, `Connetion.ConsensusChannel` was being "reset" to nil with each `virtualfundobjective.clone()` call.

PR
- includes a shallow copy of the ConsensusChannel in the cloned VFO, which allow access to the channel during `Update`, `Crank`, etc.
- earmarks the shallow copy with a `todo`

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
