### PR TITLE
Update VariablePart to match off-chain code

### DIFF
--- a/nitro-protocol/contracts/CountingApp.sol
+++ b/nitro-protocol/contracts/CountingApp.sol
@@ -34,7 +34,6 @@ contract CountingApp is IForceMoveApp {
     function validTransition(
         VariablePart memory a,
         VariablePart memory b,
-        uint48, // turnNumB, unused
         uint256 // nParticipants, unused
     ) public override pure returns (bool) {
         require(

--- a/nitro-protocol/contracts/CountingApp.sol
+++ b/nitro-protocol/contracts/CountingApp.sol
@@ -3,6 +3,7 @@ pragma solidity 0.7.4;
 pragma experimental ABIEncoderV2;
 
 import './interfaces/IForceMoveApp.sol';
+import {ExitFormat as Outcome} from '@statechannels/exit-format/contracts/ExitFormat.sol';
 
 /**
  * @dev The CountingApp contracts complies with the ForceMoveApp interface and allows only for a simple counter to be incremented. Used for testing purposes.
@@ -41,7 +42,7 @@ contract CountingApp is IForceMoveApp {
             'Counter must be incremented'
         );
         // Note this is gas inefficient, and inferior to _bytesEqual in use elsewhere
-        require(keccak256(b.outcome) == keccak256(a.outcome), 'Outcome must not change');
+        require(Outcome.exitsEqual(b.outcome, a.outcome), 'Outcome must not change');
         return true;
     }
 }

--- a/nitro-protocol/contracts/ForceMove.sol
+++ b/nitro-protocol/contracts/ForceMove.sol
@@ -105,7 +105,7 @@ contract ForceMove is IForceMove, StatusManager {
                 largestTurnNum,
                 uint48(block.timestamp) + fixedPart.challengeDuration, //solhint-disable-line not-rely-on-time
                 supportedStateHash,
-                keccak256(variableParts[variableParts.length - 1].outcome)
+                keccak256(Outcome.encodeExit(variableParts[variableParts.length - 1].outcome))
             )
         );
     }
@@ -134,7 +134,7 @@ contract ForceMove is IForceMove, StatusManager {
         bytes32 challengeStateHash = _hashState(
             channelId,
             variablePartAB[0].appData,
-            variablePartAB[0].outcome,
+            Outcome.encodeExit(variablePartAB[0].outcome),
             turnNumRecord,
             isFinalAB[0]
         );
@@ -142,14 +142,14 @@ contract ForceMove is IForceMove, StatusManager {
         bytes32 responseStateHash = _hashState(
             channelId,
             variablePartAB[1].appData,
-            variablePartAB[1].outcome,
+            Outcome.encodeExit(variablePartAB[1].outcome),
             turnNumRecord + 1,
             isFinalAB[1]
         );
 
         // checks
 
-        bytes32 challengeOutcomeHash = keccak256(variablePartAB[0].outcome);
+        bytes32 challengeOutcomeHash = keccak256(Outcome.encodeExit(variablePartAB[0].outcome));
 
         _requireSpecificChallenge(
             ChannelData(turnNumRecord, finalizesAt, challengeStateHash, challengeOutcomeHash),
@@ -542,7 +542,7 @@ contract ForceMove is IForceMove, StatusManager {
             stateHashes[i] = _hashState(
                 channelId,
                 variableParts[i].appData,
-                variableParts[i].outcome,
+                Outcome.encodeExit(variableParts[i].outcome),
                 turnNum,
                 turnNum >= firstFinalTurnNum
             );
@@ -581,11 +581,11 @@ contract ForceMove is IForceMove, StatusManager {
         // chainId, participants, channelNonce, appDefinition, challengeDuration
         // and that the b.turnNum = a.turnNum + 1
         if (isFinalAB[1]) {
-            require(_bytesEqual(ab[1].outcome, ab[0].outcome), 'Outcome change verboten');
+            require(Outcome.exitsEqual(ab[1].outcome, ab[0].outcome), 'Outcome change verboten');
         } else {
             require(!isFinalAB[0], 'isFinal retrograde');
             if (turnNumB < 2 * nParticipants) {
-                require(_bytesEqual(ab[1].outcome, ab[0].outcome), 'Outcome change forbidden');
+                require(Outcome.exitsEqual(ab[1].outcome, ab[0].outcome), 'Outcome change forbidden');
                 require(_bytesEqual(ab[1].appData, ab[0].appData), 'appData change forbidden');
             } else {
                 return IsValidTransition.NeedToCheckApp;

--- a/nitro-protocol/contracts/ForceMove.sol
+++ b/nitro-protocol/contracts/ForceMove.sol
@@ -48,9 +48,9 @@ contract ForceMove is IForceMove, StatusManager {
     function challenge(
         FixedPart memory fixedPart,
         IForceMoveApp.VariablePart[] memory variableParts,
-        Signature[] memory sigs,
-        uint8[] memory whoSignedWhat,
-        Signature memory challengerSig
+        Signature[] calldata sigs,
+        uint8[] calldata whoSignedWhat,
+        Signature calldata challengerSig
     ) external override {
         // input type validation
         requireValidInput(
@@ -117,7 +117,7 @@ contract ForceMove is IForceMove, StatusManager {
         IForceMoveApp.VariablePart[2] memory variablePartAB,
         // variablePartAB[0] = challengeVariablePart
         // variablePartAB[1] = responseVariablePart
-        Signature memory sig
+        Signature calldata sig
     ) external override {
         // No need to validate fixedPart.participants.length here, as that validation would have happened during challenge
 
@@ -176,8 +176,8 @@ contract ForceMove is IForceMove, StatusManager {
     function checkpoint(
         FixedPart memory fixedPart,
         IForceMoveApp.VariablePart[] memory variableParts,
-        Signature[] memory sigs,
-        uint8[] memory whoSignedWhat
+        Signature[] calldata sigs,
+        uint8[] calldata whoSignedWhat
     ) external override {
         // input type validation
         requireValidInput(
@@ -218,8 +218,8 @@ contract ForceMove is IForceMove, StatusManager {
         FixedPart memory fixedPart,
         IForceMoveApp.VariablePart memory latestVariablePart,
         uint8 numStates,
-        uint8[] memory whoSignedWhat,
-        Signature[] memory sigs
+        uint8[] calldata whoSignedWhat,
+        Signature[] calldata sigs
     ) external override {
         _conclude(
             fixedPart,

--- a/nitro-protocol/contracts/ForceMove.sol
+++ b/nitro-protocol/contracts/ForceMove.sol
@@ -40,18 +40,14 @@ contract ForceMove is IForceMove, StatusManager {
      * @notice Registers a challenge against a state channel. A challenge will either prompt another participant into clearing the challenge (via one of the other methods), or cause the channel to finalize at a specific time.
      * @dev Registers a challenge against a state channel. A challenge will either prompt another participant into clearing the challenge (via one of the other methods), or cause the channel to finalize at a specific time.
      * @param fixedPart Data describing properties of the state channel that do not change with state updates.
-     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
      * @param variableParts An ordered array of structs, each decribing the properties of the state channel that may change with each state update. Length is from 1 to the number of participants (inclusive).
-     * @param isFinalCount Describes how many of the submitted states have the `isFinal` property set to `true`. It is implied that the rightmost `isFinalCount` states are final, and the rest are not final.
      * @param sigs An array of signatures that support the state with the `largestTurnNum`. There must be one for each participant, e.g.: [sig-from-p0, sig-from-p1, ...]
      * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
      * @param challengerSig The signature of a participant on the keccak256 of the abi.encode of (supportedStateHash, 'forceMove').
      */
     function challenge(
         FixedPart memory fixedPart,
-        uint48 largestTurnNum,
         IForceMoveApp.VariablePart[] memory variableParts,
-        uint8 isFinalCount, // how many of the states are final
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat,
         Signature memory challengerSig
@@ -65,6 +61,7 @@ contract ForceMove is IForceMove, StatusManager {
         );
 
         bytes32 channelId = _getChannelId(fixedPart);
+        uint48 largestTurnNum = variableParts[variableParts.length - 1].turnNum;
 
         if (_mode(channelId) == ChannelMode.Open) {
             _requireNonDecreasedTurnNumber(channelId, largestTurnNum);
@@ -75,9 +72,7 @@ contract ForceMove is IForceMove, StatusManager {
             _requireChannelNotFinalized(channelId);
         }
         bytes32 supportedStateHash = _requireStateSupportedBy(
-            largestTurnNum,
             variableParts,
-            isFinalCount,
             channelId,
             fixedPart,
             sigs,
@@ -93,7 +88,7 @@ contract ForceMove is IForceMove, StatusManager {
             largestTurnNum,
             uint48(block.timestamp) + fixedPart.challengeDuration, //solhint-disable-line not-rely-on-time
             // This could overflow, so don't join a channel with a huge challengeDuration
-            isFinalCount > 0,
+            variableParts[variableParts.length - 1].isFinal,
             fixedPart,
             variableParts,
             sigs,
@@ -113,13 +108,11 @@ contract ForceMove is IForceMove, StatusManager {
     /**
      * @notice Repsonds to an ongoing challenge registered against a state channel.
      * @dev Repsonds to an ongoing challenge registered against a state channel.
-     * @param isFinalAB An pair of booleans describing if the challenge state and/or the response state have the `isFinal` property set to `true`.
      * @param fixedPart Data describing properties of the state channel that do not change with state updates.
      * @param variablePartAB An pair of structs, each decribing the properties of the state channel that may change with each state update (for the challenge state and for the response state).
      * @param sig The responder's signature on the `responseStateHash`.
      */
     function respond(
-        bool[2] memory isFinalAB,
         FixedPart memory fixedPart,
         IForceMoveApp.VariablePart[2] memory variablePartAB,
         // variablePartAB[0] = challengeVariablePart
@@ -136,7 +129,7 @@ contract ForceMove is IForceMove, StatusManager {
             variablePartAB[0].appData,
             Outcome.encodeExit(variablePartAB[0].outcome),
             turnNumRecord,
-            isFinalAB[0]
+            variablePartAB[0].isFinal
         );
 
         bytes32 responseStateHash = _hashState(
@@ -144,7 +137,7 @@ contract ForceMove is IForceMove, StatusManager {
             variablePartAB[1].appData,
             Outcome.encodeExit(variablePartAB[1].outcome),
             turnNumRecord + 1,
-            isFinalAB[1]
+            variablePartAB[1].isFinal
         );
 
         // checks
@@ -164,9 +157,7 @@ contract ForceMove is IForceMove, StatusManager {
 
         _requireValidTransition(
             fixedPart.participants.length,
-            isFinalAB,
             variablePartAB,
-            turnNumRecord + 1,
             fixedPart.appDefinition
         );
 
@@ -178,17 +169,13 @@ contract ForceMove is IForceMove, StatusManager {
      * @notice Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
      * @dev Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
      * @param fixedPart Data describing properties of the state channel that do not change with state updates.
-     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
      * @param variableParts An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
-     * @param isFinalCount Describes how many of the submitted states have the `isFinal` property set to `true`. It is implied that the rightmost `isFinalCount` states are final, and the rest are not final.
      * @param sigs An array of signatures that support the state with the `largestTurnNum`: one for each participant, in participant order (e.g. [sig of participant[0], sig of participant[1], ...]).
      * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
      */
     function checkpoint(
         FixedPart memory fixedPart,
-        uint48 largestTurnNum,
         IForceMoveApp.VariablePart[] memory variableParts,
-        uint8 isFinalCount, // how many of the states are final
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat
     ) external override {
@@ -201,14 +188,13 @@ contract ForceMove is IForceMove, StatusManager {
         );
 
         bytes32 channelId = _getChannelId(fixedPart);
+        uint48 largestTurnNum = variableParts[variableParts.length - 1].turnNum;
 
         // checks
         _requireChannelNotFinalized(channelId);
         _requireIncreasedTurnNumber(channelId, largestTurnNum);
         _requireStateSupportedBy(
-            largestTurnNum,
             variableParts,
-            isFinalCount,
             channelId,
             fixedPart,
             sigs,
@@ -222,28 +208,22 @@ contract ForceMove is IForceMove, StatusManager {
     /**
      * @notice Finalizes a channel by providing a finalization proof. External wrapper for _conclude.
      * @dev Finalizes a channel by providing a finalization proof. External wrapper for _conclude.
-     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
      * @param fixedPart Data describing properties of the state channel that do not change with state updates.
-     * @param appData Application specific data.
-     * @param outcome Encoded outcome structure. Applies to all states in the finalization proof. Will be decoded to hash the State.
+     * @param latestVariablePart Latest variable part in finalization proof. Must have the largest turnNum and the same appData and outcome as all other variable parts in finalization proof.
      * @param numStates The number of states in the finalization proof.
      * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
      * @param sigs An array of signatures that support the state with the `largestTurnNum`: one for each participant, in participant order (e.g. [sig of participant[0], sig of participant[1], ...]).
      */
     function conclude(
-        uint48 largestTurnNum,
         FixedPart memory fixedPart,
-        bytes memory appData,
-        bytes memory outcome,
+        IForceMoveApp.VariablePart memory latestVariablePart,
         uint8 numStates,
         uint8[] memory whoSignedWhat,
         Signature[] memory sigs
     ) external override {
         _conclude(
-            largestTurnNum,
             fixedPart,
-            appData,
-            outcome,
+            latestVariablePart,
             numStates,
             whoSignedWhat,
             sigs
@@ -253,19 +233,15 @@ contract ForceMove is IForceMove, StatusManager {
     /**
      * @notice Finalizes a channel by providing a finalization proof. Internal method.
      * @dev Finalizes a channel by providing a finalization proof. Internal method.
-     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
      * @param fixedPart Data describing properties of the state channel that do not change with state updates.
-     * @param appData Application specific data.
-     * @param outcome Encoded outcome structure. Applies to all states in the finalization proof. Will be decoded to hash the State.
+     * @param latestVariablePart Latest variable part in finalization proof. Must have the largest turnNum and the same appData and outcome as all other variable parts in finalization proof.
      * @param numStates The number of states in the finalization proof.
      * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
      * @param sigs An array of signatures that support the state with the `largestTurnNum`:: one for each participant, in participant order (e.g. [sig of participant[0], sig of participant[1], ...]).
      */
     function _conclude(
-        uint48 largestTurnNum,
         FixedPart memory fixedPart,
-        bytes memory appData,
-        bytes memory outcome,
+        IForceMoveApp.VariablePart memory latestVariablePart,
         uint8 numStates,
         uint8[] memory whoSignedWhat,
         Signature[] memory sigs
@@ -281,7 +257,7 @@ contract ForceMove is IForceMove, StatusManager {
             whoSignedWhat.length
         );
 
-        require(largestTurnNum + 1 >= numStates, 'largestTurnNum too low');
+        require(latestVariablePart.turnNum + 1 >= numStates, 'largestTurnNum too low');
         // ^^ SW-C101: prevent underflow
 
         // By construction, the following states form a valid transition
@@ -289,9 +265,9 @@ contract ForceMove is IForceMove, StatusManager {
         for (uint48 i = 0; i < numStates; i++) {
             stateHashes[i] = _hashState(
                 channelId,
-                appData,
-                outcome,
-                largestTurnNum + (i + 1) - numStates, // turnNum
+                latestVariablePart.appData,
+                Outcome.encodeExit(latestVariablePart.outcome),
+                latestVariablePart.turnNum + (i + 1) - numStates, // turnNum
                 // ^^ SW-C101: It is not easy to use SafeMath here, since we are not using uint256s
                 // Instead, we are protected by the require statement above
                 true // isFinal
@@ -301,7 +277,7 @@ contract ForceMove is IForceMove, StatusManager {
         // checks
         require(
             _validSignatures(
-                largestTurnNum,
+                latestVariablePart.turnNum,
                 fixedPart.participants,
                 stateHashes,
                 sigs,
@@ -310,7 +286,7 @@ contract ForceMove is IForceMove, StatusManager {
             'Invalid signatures / !isFinal'
         );
 
-        bytes32 outcomeHash = keccak256(outcome);
+        bytes32 outcomeHash = keccak256(Outcome.encodeExit(latestVariablePart.outcome));
 
         // effects
         statusOf[channelId] = _generateStatus(
@@ -474,9 +450,7 @@ contract ForceMove is IForceMove, StatusManager {
     /**
      * @notice Check that the submitted data constitute a support proof.
      * @dev Check that the submitted data constitute a support proof.
-     * @param largestTurnNum Largest turnNum of the support proof
      * @param variableParts Variable parts of the states in the support proof
-     * @param isFinalCount How many of the states are final? The final isFinalCount states are implied final, the remainder are implied not final.
      * @param channelId Unique identifier for a channel.
      * @param fixedPart Fixed Part of the states in the support proof
      * @param sigs A signature from each participant, in participant order (e.g. [sig of participant[0], sig of participant[1], ...]).
@@ -484,25 +458,21 @@ contract ForceMove is IForceMove, StatusManager {
      * @return The hash of the latest state in the proof, if supported, else reverts.
      */
     function _requireStateSupportedBy(
-        uint48 largestTurnNum,
         IForceMoveApp.VariablePart[] memory variableParts,
-        uint8 isFinalCount,
         bytes32 channelId,
         FixedPart memory fixedPart,
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat
     ) internal pure returns (bytes32) {
         bytes32[] memory stateHashes = _requireValidTransitionChain(
-            largestTurnNum,
             variableParts,
-            isFinalCount,
             channelId,
             fixedPart
         );
 
         require(
             _validSignatures(
-                largestTurnNum,
+                variableParts[variableParts.length - 1].turnNum,
                 fixedPart.participants,
                 stateHashes,
                 sigs,
@@ -517,9 +487,7 @@ contract ForceMove is IForceMove, StatusManager {
     /**
      * @notice Check that the submitted states form a chain of valid transitions
      * @dev Check that the submitted states form a chain of valid transitions
-     * @param largestTurnNum Largest turnNum of the support proof
      * @param variableParts Variable parts of the states in the support proof
-     * @param isFinalCount How many of the states are final? The final isFinalCount states are implied final, the remainder are implied not final.
      * @param channelId Unique identifier for a channel.
      * @param fixedPart Fixed Part of the states in the support proof
      * @return true if every state is a validTransition from its predecessor, false otherwise.
@@ -527,31 +495,24 @@ contract ForceMove is IForceMove, StatusManager {
     function _requireValidTransitionChain(
         // returns stateHashes array if valid
         // else, reverts
-        uint48 largestTurnNum,
         IForceMoveApp.VariablePart[] memory variableParts,
-        uint8 isFinalCount,
         bytes32 channelId,
         FixedPart memory fixedPart
     ) internal pure returns (bytes32[] memory) {
         bytes32[] memory stateHashes = new bytes32[](variableParts.length);
-        uint48 firstFinalTurnNum = largestTurnNum - isFinalCount + 1;
-        uint48 turnNum;
 
         for (uint48 i = 0; i < variableParts.length; i++) {
-            turnNum = largestTurnNum - uint48(variableParts.length) + 1 + i;
             stateHashes[i] = _hashState(
                 channelId,
                 variableParts[i].appData,
                 Outcome.encodeExit(variableParts[i].outcome),
-                turnNum,
-                turnNum >= firstFinalTurnNum
+                variableParts[i].turnNum,
+                variableParts[i].isFinal
             );
-            if (turnNum < largestTurnNum) {
+            if (i < variableParts.length - 1) {
                 _requireValidTransition(
                     fixedPart.participants.length,
-                    [turnNum >= firstFinalTurnNum, turnNum + 1 >= firstFinalTurnNum],
                     [variableParts[i], variableParts[i + 1]],
-                    turnNum + 1,
                     fixedPart.appDefinition
                 );
             }
@@ -566,25 +527,21 @@ contract ForceMove is IForceMove, StatusManager {
     * @dev Check that the submitted pair of states form a valid transition
     * @param nParticipants Number of participants in the channel.
     transition
-    * @param isFinalAB Pair of booleans denoting whether the first and second state (resp.) are final.
     * @param ab Variable parts of each of the pair of states
-    * @param turnNumB turnNum of the later state of the pair
     * @return true if the later state is a validTransition from its predecessor, false otherwise.
     */
     function _requireValidProtocolTransition(
         uint256 nParticipants,
-        bool[2] memory isFinalAB, // [a.isFinal, b.isFinal]
-        IForceMoveApp.VariablePart[2] memory ab, // [a,b]
-        uint48 turnNumB
+        IForceMoveApp.VariablePart[2] memory ab // [a,b]
     ) internal pure returns (IsValidTransition) {
         // a separate check on the signatures for the submitted states implies that the following fields are equal for a and b:
         // chainId, participants, channelNonce, appDefinition, challengeDuration
         // and that the b.turnNum = a.turnNum + 1
-        if (isFinalAB[1]) {
+        if (ab[1].isFinal) {
             require(Outcome.exitsEqual(ab[1].outcome, ab[0].outcome), 'Outcome change verboten');
         } else {
-            require(!isFinalAB[0], 'isFinal retrograde');
-            if (turnNumB < 2 * nParticipants) {
+            require(!ab[0].isFinal, 'isFinal retrograde');
+            if (ab[1].turnNum < 2 * nParticipants) {
                 require(Outcome.exitsEqual(ab[1].outcome, ab[0].outcome), 'Outcome change forbidden');
                 require(_bytesEqual(ab[1].appData, ab[0].appData), 'appData change forbidden');
             } else {
@@ -599,29 +556,23 @@ contract ForceMove is IForceMove, StatusManager {
     * @dev Check that the submitted pair of states form a valid transition
     * @param nParticipants Number of participants in the channel.
     transition
-    * @param isFinalAB Pair of booleans denoting whether the first and second state (resp.) are final.
     * @param ab Variable parts of each of the pair of states
-    * @param turnNumB turnNum of the later state of the pair.
     * @param appDefinition Address of deployed contract containing application-specific validTransition function.
     * @return true if the later state is a validTransition from its predecessor, false otherwise.
     */
     function _requireValidTransition(
         uint256 nParticipants,
-        bool[2] memory isFinalAB, // [a.isFinal, b.isFinal]
         IForceMoveApp.VariablePart[2] memory ab, // [a,b]
-        uint48 turnNumB,
         address appDefinition
     ) internal pure returns (bool) {
         IsValidTransition isValidProtocolTransition = _requireValidProtocolTransition(
             nParticipants,
-            isFinalAB, // [a.isFinal, b.isFinal]
-            ab, // [a,b]
-            turnNumB
+            ab // [a,b]
         );
 
         if (isValidProtocolTransition == IsValidTransition.NeedToCheckApp) {
             require(
-                IForceMoveApp(appDefinition).validTransition(ab[0], ab[1], turnNumB, nParticipants),
+                IForceMoveApp(appDefinition).validTransition(ab[0], ab[1], nParticipants),
                 'Invalid ForceMoveApp Transition'
             );
         }

--- a/nitro-protocol/contracts/NitroAdjudicator.sol
+++ b/nitro-protocol/contracts/NitroAdjudicator.sol
@@ -34,28 +34,27 @@ contract NitroAdjudicator is ForceMove, MultiAssetHolder {
             sigs
         );
 
-        transferAllAssets(channelId, Outcome.encodeExit(latestVariablePart.outcome), bytes32(0));
+        transferAllAssets(channelId, latestVariablePart.outcome, bytes32(0));
     }
 
     /**
      * @notice Liquidates all assets for the channel
      * @dev Liquidates all assets for the channel
      * @param channelId Unique identifier for a state channel
-     * @param outcomeBytes abi.encode of an array of Outcome.OutcomeItem structs.
+     * @param outcome An array of SingleAssetExit[] items.
      * @param stateHash stored state hash for the channel
      */
     function transferAllAssets(
         bytes32 channelId,
-        bytes memory outcomeBytes,
+        Outcome.SingleAssetExit[] memory outcome,
         bytes32 stateHash
     ) public {
         // checks
         _requireChannelFinalized(channelId);
-        _requireMatchingFingerprint(stateHash, keccak256(outcomeBytes), channelId);
+        _requireMatchingFingerprint(stateHash, keccak256(Outcome.encodeExit(outcome)), channelId);
 
         // computation
         bool allocatesOnlyZerosForAllAssets = true;
-        Outcome.SingleAssetExit[] memory outcome = Outcome.decodeExit(outcomeBytes);
         Outcome.SingleAssetExit[] memory exit = new Outcome.SingleAssetExit[](outcome.length);
         uint256[] memory initialHoldings = new uint256[](outcome.length);
         uint256[] memory totalPayouts = new uint256[](outcome.length);
@@ -94,7 +93,7 @@ contract NitroAdjudicator is ForceMove, MultiAssetHolder {
         if (allocatesOnlyZerosForAllAssets) {
             delete statusOf[channelId];
         } else {
-            bytes32 outcomeHash = keccak256(abi.encode(outcomeBytes));
+            bytes32 outcomeHash = keccak256(Outcome.encodeExit(outcome));
             _updateFingerprint(channelId, stateHash, outcomeHash);
         }
 

--- a/nitro-protocol/contracts/NitroAdjudicator.sol
+++ b/nitro-protocol/contracts/NitroAdjudicator.sol
@@ -13,34 +13,28 @@ contract NitroAdjudicator is ForceMove, MultiAssetHolder {
     /**
      * @notice Finalizes a channel by providing a finalization proof, and liquidates all assets for the channel.
      * @dev Finalizes a channel by providing a finalization proof, and liquidates all assets for the channel.
-     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
      * @param fixedPart Data describing properties of the state channel that do not change with state updates.
-     * @param appData Application specific data.
-     * @param outcomeBytes abi.encode of an array of Outcome.OutcomeItem structs.
+     * @param latestVariablePart Latest variable part in finalization proof. Must have the largest turnNum and the same appData and outcome as all other variable parts in finalization proof.
      * @param numStates The number of states in the finalization proof.
      * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
      * @param sigs Array of signatures, one for each participant, in participant order (e.g. [sig of participant[0], sig of participant[1], ...]).
      */
     function concludeAndTransferAllAssets(
-        uint48 largestTurnNum,
         FixedPart memory fixedPart,
-        bytes memory appData,
-        bytes memory outcomeBytes,
+        IForceMoveApp.VariablePart memory latestVariablePart,
         uint8 numStates,
         uint8[] memory whoSignedWhat,
         Signature[] memory sigs
     ) public {
         bytes32 channelId = _conclude(
-            largestTurnNum,
             fixedPart,
-            appData,
-            outcomeBytes,
+            latestVariablePart,
             numStates,
             whoSignedWhat,
             sigs
         );
 
-        transferAllAssets(channelId, outcomeBytes, bytes32(0));
+        transferAllAssets(channelId, Outcome.encodeExit(latestVariablePart.outcome), bytes32(0));
     }
 
     /**
@@ -113,20 +107,16 @@ contract NitroAdjudicator is ForceMove, MultiAssetHolder {
     * @dev Check that the submitted pair of states form a valid transition (public wrapper for internal function _requireValidTransition)
     * @param nParticipants Number of participants in the channel.
     transition
-    * @param isFinalAB Pair of booleans denoting whether the first and second state (resp.) are final.
     * @param ab Variable parts of each of the pair of states
-    * @param turnNumB turnNum of the later state of the pair.
     * @param appDefinition Address of deployed contract containing application-specific validTransition function.
     * @return true if the later state is a validTransition from its predecessor, reverts otherwise.
     */
     function validTransition(
         uint256 nParticipants,
-        bool[2] memory isFinalAB, // [a.isFinal, b.isFinal]
         IForceMoveApp.VariablePart[2] memory ab, // [a,b]
-        uint48 turnNumB,
         address appDefinition
     ) public pure returns (bool) {
-        return _requireValidTransition(nParticipants, isFinalAB, ab, turnNumB, appDefinition);
+        return _requireValidTransition(nParticipants, ab, appDefinition);
     }
 
     /**

--- a/nitro-protocol/contracts/TrivialApp.sol
+++ b/nitro-protocol/contracts/TrivialApp.sol
@@ -16,7 +16,6 @@ contract TrivialApp is IForceMoveApp {
     function validTransition(
         VariablePart memory, // a
         VariablePart memory, // b
-        uint48, // turnNumB
         uint256 // nParticipants
     ) public override pure returns (bool) {
         return true;

--- a/nitro-protocol/contracts/examples/HashLockedSwap.sol
+++ b/nitro-protocol/contracts/examples/HashLockedSwap.sol
@@ -59,16 +59,11 @@ contract HashLockedSwap is IForceMoveApp {
         return true;
     }
 
-    function decode2PartyAllocation(bytes memory outcomeBytes)
+    function decode2PartyAllocation(Outcome.SingleAssetExit[] memory outcome)
         private
         pure
         returns (Outcome.Allocation[] memory allocations)
     {
-        Outcome.SingleAssetExit[] memory outcome = abi.decode(
-            outcomeBytes,
-            (Outcome.SingleAssetExit[])
-        );
-
         Outcome.SingleAssetExit memory assetOutcome = outcome[0];
 
         allocations = assetOutcome.allocations; // TODO should we check each allocation is a "simple" one?

--- a/nitro-protocol/contracts/examples/HashLockedSwap.sol
+++ b/nitro-protocol/contracts/examples/HashLockedSwap.sol
@@ -17,11 +17,10 @@ contract HashLockedSwap is IForceMoveApp {
     function validTransition(
         VariablePart memory a,
         VariablePart memory b,
-        uint48 turnNumB,
         uint256
     ) public override pure returns (bool) {
         // is this the first and only swap?
-        require(turnNumB == 4, 'turnNumB != 4');
+        require(b.turnNum == 4, 'turnNumB != 4');
 
         // Decode variables.
         // Assumptions:

--- a/nitro-protocol/contracts/examples/HashLockedSwap.sol
+++ b/nitro-protocol/contracts/examples/HashLockedSwap.sol
@@ -20,7 +20,7 @@ contract HashLockedSwap is IForceMoveApp {
         uint256
     ) public override pure returns (bool) {
         // is this the first and only swap?
-        require(b.turnNum == 4, 'turnNumB != 4');
+        require(b.turnNum == 4, 'b.turnNum != 4');
 
         // Decode variables.
         // Assumptions:

--- a/nitro-protocol/contracts/examples/SingleAssetPayments.sol
+++ b/nitro-protocol/contracts/examples/SingleAssetPayments.sol
@@ -14,14 +14,12 @@ contract SingleAssetPayments is IForceMoveApp {
      * @dev Encodes the payment channel update rules.
      * @param a State being transitioned from.
      * @param b State being transitioned to.
-     * @param turnNumB Turn number being transitioned to.
      * @param nParticipants Number of participants in this state channel.
      * @return true if the transition conforms to the rules, false otherwise.
      */
     function validTransition(
         VariablePart memory a,
         VariablePart memory b,
-        uint48 turnNumB,
         uint256 nParticipants
     ) public override pure returns (bool) {
         // Throws if more than one asset
@@ -63,7 +61,7 @@ contract SingleAssetPayments is IForceMoveApp {
             );
             allocationSumA += allocationsA[i].amount;
             allocationSumB += allocationsB[i].amount;
-            if (i != turnNumB % nParticipants) {
+            if (i != b.turnNum % nParticipants) {
                 require(
                     allocationsB[i].amount >= allocationsA[i].amount,
                     'Nonmover balance decreased'

--- a/nitro-protocol/contracts/examples/SingleAssetPayments.sol
+++ b/nitro-protocol/contracts/examples/SingleAssetPayments.sol
@@ -24,21 +24,12 @@ contract SingleAssetPayments is IForceMoveApp {
         uint48 turnNumB,
         uint256 nParticipants
     ) public override pure returns (bool) {
-        Outcome.SingleAssetExit[] memory outcomeA = abi.decode(
-            a.outcome,
-            (Outcome.SingleAssetExit[])
-        );
-        Outcome.SingleAssetExit[] memory outcomeB = abi.decode(
-            b.outcome,
-            (Outcome.SingleAssetExit[])
-        );
-
         // Throws if more than one asset
-        require(outcomeA.length == 1, 'outcomeA: Only one asset allowed');
-        require(outcomeB.length == 1, 'outcomeB: Only one asset allowed');
+        require(a.outcome.length == 1, 'outcomeA: Only one asset allowed');
+        require(b.outcome.length == 1, 'outcomeB: Only one asset allowed');
 
-        Outcome.SingleAssetExit memory assetOutcomeA = outcomeA[0];
-        Outcome.SingleAssetExit memory assetOutcomeB = outcomeB[0];
+        Outcome.SingleAssetExit memory assetOutcomeA = a.outcome[0];
+        Outcome.SingleAssetExit memory assetOutcomeB = b.outcome[0];
 
         // Throws unless that allocation has exactly n outcomes
         Outcome.Allocation[] memory allocationsA = assetOutcomeA.allocations;

--- a/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -43,9 +43,9 @@ interface IForceMove {
     function challenge(
         FixedPart memory fixedPart,
         IForceMoveApp.VariablePart[] memory variableParts,
-        Signature[] memory sigs,
-        uint8[] memory whoSignedWhat,
-        Signature memory challengerSig
+        Signature[] calldata sigs,
+        uint8[] calldata whoSignedWhat,
+        Signature calldata challengerSig
     ) external;
 
     /**
@@ -60,7 +60,7 @@ interface IForceMove {
         IForceMoveApp.VariablePart[2] memory variablePartAB,
         // variablePartAB[0] = challengeVariablePart
         // variablePartAB[1] = responseVariablePart
-        Signature memory sig
+        Signature calldata sig
     ) external;
 
     /**
@@ -74,8 +74,8 @@ interface IForceMove {
     function checkpoint(
         FixedPart memory fixedPart,
         IForceMoveApp.VariablePart[] memory variableParts,
-        Signature[] memory sigs,
-        uint8[] memory whoSignedWhat
+        Signature[] calldata sigs,
+        uint8[] calldata whoSignedWhat
     ) external;
 
     /**
@@ -91,8 +91,8 @@ interface IForceMove {
         FixedPart memory fixedPart,
         IForceMoveApp.VariablePart memory latestVariablePart,
         uint8 numStates,
-        uint8[] memory whoSignedWhat,
-        Signature[] memory sigs
+        uint8[] calldata whoSignedWhat,
+        Signature[] calldata sigs
     ) external;
 
     // events

--- a/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -35,78 +35,64 @@ interface IForceMove {
      * @notice Registers a challenge against a state channel. A challenge will either prompt another participant into clearing the challenge (via one of the other methods), or cause the channel to finalize at a specific time.
      * @dev Registers a challenge against a state channel. A challenge will either prompt another participant into clearing the challenge (via one of the other methods), or cause the channel to finalize at a specific time.
      * @param fixedPart Data describing properties of the state channel that do not change with state updates.
-     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
-     * @param variableParts An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
-     * @param isFinalCount Describes how many of the submitted states have the `isFinal` property set to `true`. It is implied that the rightmost `isFinalCount` states are final, and the rest are not final.
-     * @param sigs An array of signatures that support the state with the `largestTurnNum`: one for each participant, in participant order (e.g. [sig of participant[0], sig of participant[1], ...]).
+     * @param variableParts An ordered array of structs, each decribing the properties of the state channel that may change with each state update. Length is from 1 to the number of participants (inclusive).
+     * @param sigs An array of signatures that support the state with the `largestTurnNum`. There must be one for each participant, e.g.: [sig-from-p0, sig-from-p1, ...]
      * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
      * @param challengerSig The signature of a participant on the keccak256 of the abi.encode of (supportedStateHash, 'forceMove').
      */
     function challenge(
-        FixedPart calldata fixedPart,
-        uint48 largestTurnNum,
-        IForceMoveApp.VariablePart[] calldata variableParts,
-        uint8 isFinalCount, // how many of the states are final
-        Signature[] calldata sigs,
-        uint8[] calldata whoSignedWhat,
-        Signature calldata challengerSig
+        FixedPart memory fixedPart,
+        IForceMoveApp.VariablePart[] memory variableParts,
+        Signature[] memory sigs,
+        uint8[] memory whoSignedWhat,
+        Signature memory challengerSig
     ) external;
 
     /**
-     * @notice Responds to an ongoing challenge registered against a state channel.
-     * @dev Responds to an ongoing challenge registered against a state channel.
-     * @param isFinalAB An pair of booleans describing if the challenge state and/or the response state have the `isFinal` property set to `true`.
+     * @notice Repsonds to an ongoing challenge registered against a state channel.
+     * @dev Repsonds to an ongoing challenge registered against a state channel.
      * @param fixedPart Data describing properties of the state channel that do not change with state updates.
      * @param variablePartAB An pair of structs, each decribing the properties of the state channel that may change with each state update (for the challenge state and for the response state).
      * @param sig The responder's signature on the `responseStateHash`.
      */
     function respond(
-        bool[2] calldata isFinalAB,
-        FixedPart calldata fixedPart,
-        IForceMoveApp.VariablePart[2] calldata variablePartAB,
+        FixedPart memory fixedPart,
+        IForceMoveApp.VariablePart[2] memory variablePartAB,
         // variablePartAB[0] = challengeVariablePart
         // variablePartAB[1] = responseVariablePart
-        Signature calldata sig
+        Signature memory sig
     ) external;
 
     /**
      * @notice Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
      * @dev Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
      * @param fixedPart Data describing properties of the state channel that do not change with state updates.
-     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
      * @param variableParts An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
-     * @param isFinalCount Describes how many of the submitted states have the `isFinal` property set to `true`. It is implied that the rightmost `isFinalCount` states are final, and the rest are not final.
      * @param sigs An array of signatures that support the state with the `largestTurnNum`: one for each participant, in participant order (e.g. [sig of participant[0], sig of participant[1], ...]).
      * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
      */
     function checkpoint(
-        FixedPart calldata fixedPart,
-        uint48 largestTurnNum,
-        IForceMoveApp.VariablePart[] calldata variableParts,
-        uint8 isFinalCount, // how many of the states are final
-        Signature[] calldata sigs,
-        uint8[] calldata whoSignedWhat
+        FixedPart memory fixedPart,
+        IForceMoveApp.VariablePart[] memory variableParts,
+        Signature[] memory sigs,
+        uint8[] memory whoSignedWhat
     ) external;
 
     /**
-     * @notice Finalizes a channel by providing a finalization proof.
-     * @dev Finalizes a channel by providing a finalization proof.
-     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
+     * @notice Finalizes a channel by providing a finalization proof. External wrapper for _conclude.
+     * @dev Finalizes a channel by providing a finalization proof. External wrapper for _conclude.
      * @param fixedPart Data describing properties of the state channel that do not change with state updates.
-     * @param appData Application specific data. Applies to all states in the finalization proof.
-     * @param outcome An outcome structure bytes.
+     * @param latestVariablePart Latest variable part in finalization proof. Must have the largest turnNum and the same appData and outcome as all other variable parts in finalization proof.
      * @param numStates The number of states in the finalization proof.
      * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
-     * @param sigs An array of signatures that support the state with the `largestTurnNum`:: one for each participant, in participant order (e.g. [sig of participant[0], sig of participant[1], ...]).
+     * @param sigs An array of signatures that support the state with the `largestTurnNum`: one for each participant, in participant order (e.g. [sig of participant[0], sig of participant[1], ...]).
      */
     function conclude(
-        uint48 largestTurnNum,
-        FixedPart calldata fixedPart,
-        bytes memory appData,
-        bytes memory outcome,
+        FixedPart memory fixedPart,
+        IForceMoveApp.VariablePart memory latestVariablePart,
         uint8 numStates,
-        uint8[] calldata whoSignedWhat,
-        Signature[] calldata sigs
+        uint8[] memory whoSignedWhat,
+        Signature[] memory sigs
     ) external;
 
     // events

--- a/nitro-protocol/contracts/interfaces/IForceMoveApp.sol
+++ b/nitro-protocol/contracts/interfaces/IForceMoveApp.sol
@@ -11,6 +11,8 @@ interface IForceMoveApp {
     struct VariablePart {
         Outcome.SingleAssetExit[] outcome;
         bytes appData;
+        uint48 turnNum;
+        bool isFinal;
     }
 
     /**
@@ -18,14 +20,12 @@ interface IForceMoveApp {
      * @dev Encodes application-specific rules for a particular ForceMove-compliant state channel.
      * @param a State being transitioned from.
      * @param b State being transitioned to.
-     * @param turnNumB Turn number being transitioned to.
      * @param nParticipants Number of participants in this state channel.
      * @return true if the transition conforms to this application's rules, false otherwise
      */
     function validTransition(
         VariablePart calldata a,
         VariablePart calldata b,
-        uint48 turnNumB,
         uint256 nParticipants
     ) external pure returns (bool);
 }

--- a/nitro-protocol/contracts/interfaces/IForceMoveApp.sol
+++ b/nitro-protocol/contracts/interfaces/IForceMoveApp.sol
@@ -2,12 +2,14 @@
 pragma solidity 0.7.4;
 pragma experimental ABIEncoderV2;
 
+import {ExitFormat as Outcome} from '@statechannels/exit-format/contracts/ExitFormat.sol';
+
 /**
  * @dev The IForceMoveApp interface calls for its children to implement an application-specific validTransition function, defining the state machine of a ForceMove state channel DApp.
  */
 interface IForceMoveApp {
     struct VariablePart {
-        bytes outcome;
+        Outcome.SingleAssetExit[] outcome;
         bytes appData;
     }
 

--- a/nitro-protocol/package-lock.json
+++ b/nitro-protocol/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@statechannels/exit-format": "^0.0.5",
+        "@statechannels/exit-format": "^0.0.6",
         "@typechain/ethers-v5": "^9.0.0"
       },
       "devDependencies": {
@@ -13441,9 +13441,9 @@
       }
     },
     "node_modules/@statechannels/exit-format": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@statechannels/exit-format/-/exit-format-0.0.5.tgz",
-      "integrity": "sha512-Q+nTtqYIPAmGdue0QzrpBOrlAglE/ZxwDdDkyoqPKCQ4MjoX3JQA3KUGK8ExOTFT8qPxkBGsJmpJdSkY0H3I4g==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@statechannels/exit-format/-/exit-format-0.0.6.tgz",
+      "integrity": "sha512-tzZqWENtSQLNEV7btigvnFnB7PRkwFagm+7tYgqbXrsHudRGjtetLAGGsJcrwGXxx1qqC2uZuDCvVdz0w2y8Nw==",
       "dependencies": {
         "ethers": "^5.1.4",
         "lodash": "^4.17.21"
@@ -49279,9 +49279,9 @@
       }
     },
     "@statechannels/exit-format": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@statechannels/exit-format/-/exit-format-0.0.5.tgz",
-      "integrity": "sha512-Q+nTtqYIPAmGdue0QzrpBOrlAglE/ZxwDdDkyoqPKCQ4MjoX3JQA3KUGK8ExOTFT8qPxkBGsJmpJdSkY0H3I4g==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@statechannels/exit-format/-/exit-format-0.0.6.tgz",
+      "integrity": "sha512-tzZqWENtSQLNEV7btigvnFnB7PRkwFagm+7tYgqbXrsHudRGjtetLAGGsJcrwGXxx1qqC2uZuDCvVdz0w2y8Nw==",
       "requires": {
         "ethers": "^5.1.4",
         "lodash": "^4.17.21"

--- a/nitro-protocol/package.json
+++ b/nitro-protocol/package.json
@@ -42,7 +42,7 @@
     "ts-node": "^10.4.0"
   },
   "dependencies": {
-    "@statechannels/exit-format": "^0.0.5",
+    "@statechannels/exit-format": "^0.0.6",
     "@typechain/ethers-v5": "^9.0.0"
   }
 }

--- a/nitro-protocol/src/contract/challenge.ts
+++ b/nitro-protocol/src/contract/challenge.ts
@@ -60,9 +60,8 @@ export function getChallengeRegisteredEvent(eventResult: any[]): ChallengeRegist
 
   // Variable part
   const variableParts: VariablePart[] = variablePartsUnstructured.map(v => {
-    const outcome = v[0];
-    const appData = v[1];
-    return {outcome, appData};
+    const [outcome, appData, turnNum, isFinal] = v;
+    return {outcome, appData, turnNum, isFinal};
   });
 
   const channel: Channel = {chainId, channelNonce, participants};

--- a/nitro-protocol/src/contract/embedded-application.ts
+++ b/nitro-protocol/src/contract/embedded-application.ts
@@ -1,8 +1,22 @@
 import {defaultAbiCoder, ParamType} from '@ethersproject/abi';
 import {Signature} from '@ethersproject/bytes';
+import { encodeOutcome } from './outcome';
 
-import {FixedPart, VariablePart} from './state';
+import {encodeAppData, FixedPart, State} from './state';
 import {Bytes, Bytes32} from './types';
+
+// redefinition to support EmbeddedApplication.sol logic
+export interface VariablePart {
+  outcome: string;
+  appData: string;
+}
+// redefinition to support EmbeddedApplication.sol logic
+export function getVariablePart(state: State): VariablePart {
+  return {
+    outcome: encodeOutcome(state.outcome),
+    appData: encodeAppData(state.appData),
+  };
+}
 
 export interface SupportProof {
   fixedPart: FixedPart;

--- a/nitro-protocol/src/contract/force-move-app.ts
+++ b/nitro-protocol/src/contract/force-move-app.ts
@@ -21,12 +21,10 @@ export async function validTransition(
   const numberOfParticipants = toState.channel.participants.length;
   const fromVariablePart = getVariablePart(fromState);
   const toVariablePart = getVariablePart(toState);
-  const turnNumB = toState.turnNum;
 
   return await appContract.validTransition(
     fromVariablePart,
     toVariablePart,
-    turnNumB,
     numberOfParticipants
   );
 }
@@ -38,11 +36,9 @@ export function createValidTransitionTransaction(fromState: State, toState: Stat
   const numberOfParticipants = toState.channel.participants.length;
   const fromVariablePart = getVariablePart(fromState);
   const toVariablePart = getVariablePart(toState);
-  const turnNumB = toState.turnNum;
   const data = ForceMoveAppContractInterface.encodeFunctionData('validTransition', [
     fromVariablePart,
     toVariablePart,
-    turnNumB,
     numberOfParticipants,
   ]);
   return {data};

--- a/nitro-protocol/src/contract/state.ts
+++ b/nitro-protocol/src/contract/state.ts
@@ -42,9 +42,11 @@ export function getFixedPart(state: State): FixedPart {
  * The part of a State which usually changes during state channel updates
  */
 export interface VariablePart {
-  outcome: Bytes;
+  outcome: Outcome;
   appData: Bytes; // any encoded app-related type encoded once more as bytes
   //(e.g. if in SC App uint256 is used, firstly enode appData as uint256, then as bytes)
+  turnNum: Uint48;
+  isFinal: boolean;
 }
 
 /**
@@ -53,7 +55,12 @@ export interface VariablePart {
  * @returns the VariablePart, which usually changes during state channel updates
  */
 export function getVariablePart(state: State): VariablePart {
-  return {outcome: encodeOutcome(state.outcome), appData: encodeAppData(state.appData)};
+  return {
+    outcome: state.outcome,
+    appData: encodeAppData(state.appData),
+    turnNum: state.turnNum,
+    isFinal: state.isFinal,
+  };
 }
 
 /**

--- a/nitro-protocol/test/contracts/ForceMove/challenge.test.ts
+++ b/nitro-protocol/test/contracts/ForceMove/challenge.test.ts
@@ -29,6 +29,7 @@ import {
   largeOutcome,
   nonParticipant,
   ongoingChallengeFingerprint,
+  parseOutcomeEventResult,
   setupContract,
 } from '../../test-helpers';
 import {createChallengeTransaction, NITRO_MAX_GAS} from '../../../src/transactions';
@@ -44,7 +45,7 @@ const chainId = process.env.CHAIN_NETWORK_ID;
 const participants = ['', '', ''];
 const wallets = new Array(3);
 const challengeDuration = 86400; // 1 day
-const outcome: Outcome = [{allocations: [], asset: Wallet.createRandom().address, metadata: '0x'}];
+const outcome: Outcome = [{allocations: [{destination: "0x00000000000000000000000096f7123e3a80c9813ef50213aded0e4511cb820f", amount: "0x01", allocationType: 1, metadata: "0x"}], asset: Wallet.createRandom().address, metadata: '0x'}];
 
 const appDefinition = getPlaceHolderContractAddress();
 const keys = [
@@ -169,6 +170,9 @@ describe('challenge', () => {
       const variableParts = states.map(state => getVariablePart(state));
       const fixedPart = getFixedPart(states[0]);
       const channelId = getChannelId(fixedPart);
+      console.log("variableParts");
+      console.log(variableParts);
+      
       
       // Sign the states
       const signatures = await signStates(states, wallets, whoSignedWhat);
@@ -200,9 +204,7 @@ describe('challenge', () => {
 
       const tx = ForceMove.challenge(
         fixedPart,
-        largestTurnNum,
         variableParts,
-        isFinalCount,
         signatures,
         whoSignedWhat,
         challengeSignature
@@ -234,12 +236,13 @@ describe('challenge', () => {
         expect(eventFixedPart[3]).toEqual(fixedPart.appDefinition);
         expect(eventFixedPart[4]).toEqual(fixedPart.challengeDuration);
         expect(eventIsFinal).toEqual(isFinalCount > 0);
-        expect(eventVariableParts[eventVariableParts.length - 1][0]).toEqual(
+        expect(parseOutcomeEventResult(eventVariableParts[eventVariableParts.length - 1][0])).toEqual(
           variableParts[variableParts.length - 1].outcome
         );
         expect(eventVariableParts[eventVariableParts.length - 1][1]).toEqual(
           variableParts[variableParts.length - 1].appData
         );
+          
 
         const expectedChannelStorage: ChannelData = {
           turnNumRecord: largestTurnNum,

--- a/nitro-protocol/test/contracts/ForceMove/challenge.test.ts
+++ b/nitro-protocol/test/contracts/ForceMove/challenge.test.ts
@@ -45,7 +45,7 @@ const chainId = process.env.CHAIN_NETWORK_ID;
 const participants = ['', '', ''];
 const wallets = new Array(3);
 const challengeDuration = 86400; // 1 day
-const outcome: Outcome = [{allocations: [{destination: "0x00000000000000000000000096f7123e3a80c9813ef50213aded0e4511cb820f", amount: "0x01", allocationType: 1, metadata: "0x"}], asset: Wallet.createRandom().address, metadata: '0x'}];
+const outcome: Outcome = [{allocations: [], asset: Wallet.createRandom().address, metadata: '0x'}];
 
 const appDefinition = getPlaceHolderContractAddress();
 const keys = [
@@ -170,9 +170,6 @@ describe('challenge', () => {
       const variableParts = states.map(state => getVariablePart(state));
       const fixedPart = getFixedPart(states[0]);
       const channelId = getChannelId(fixedPart);
-      console.log("variableParts");
-      console.log(variableParts);
-      
       
       // Sign the states
       const signatures = await signStates(states, wallets, whoSignedWhat);

--- a/nitro-protocol/test/contracts/ForceMove/conclude.test.ts
+++ b/nitro-protocol/test/contracts/ForceMove/conclude.test.ts
@@ -7,7 +7,7 @@ import ForceMoveArtifact from '../../../artifacts/contracts/test/TESTForceMove.s
 import {Channel, getChannelId} from '../../../src/contract/channel';
 import {channelDataToStatus} from '../../../src/contract/channel-storage';
 import {Outcome} from '../../../src/contract/outcome';
-import {getFixedPart, State} from '../../../src/contract/state';
+import {getFixedPart, getVariablePart, State} from '../../../src/contract/state';
 import {concludeArgs} from '../../../src/contract/transaction-creators/force-move';
 import {
   CHANNEL_FINALIZED,
@@ -157,14 +157,12 @@ describe('conclude', () => {
       appDefinition,
       appData: '0x00',
       challengeDuration,
-      turnNum: 99,
+      turnNum: 0,
     };
     const signature = signState(state, wallets[0].privateKey).signature;
     const tx = ForceMove.conclude(
-      0,
       getFixedPart(state),
-      ethers.constants.HashZero,
-      ethers.constants.HashZero,
+      getVariablePart(state),
       2,
       [0, 0, 0],
       [signature, signature, signature] // enough to clear the input type validation

--- a/nitro-protocol/test/contracts/NitroAdjudicator/concludeAndTransferAllAssets.test.ts
+++ b/nitro-protocol/test/contracts/NitroAdjudicator/concludeAndTransferAllAssets.test.ts
@@ -1,11 +1,11 @@
 import {expectRevert} from '@statechannels/devtools';
-import {Contract, Wallet, ethers, BigNumber, constants, FixedNumber} from 'ethers';
+import {Contract, Wallet, ethers, BigNumber, constants} from 'ethers';
 import {it} from '@jest/globals'
 
 import TokenArtifact from '../../../artifacts/contracts/Token.sol/Token.json';
 import {Channel, getChannelId} from '../../../src/contract/channel';
-import {encodeOutcome, Outcome} from '../../../src/contract/outcome';
-import {encodeAppData, FixedPart, getFixedPart, State} from '../../../src/contract/state';
+import {Outcome} from '../../../src/contract/outcome';
+import {FixedPart, getFixedPart, getVariablePart, State} from '../../../src/contract/state';
 import {
   computeOutcome,
   getPlaceHolderContractAddress,
@@ -207,10 +207,8 @@ describe('concludeAndTransferAllAssets', () => {
 
       // Form transaction
       const tx = testNitroAdjudicator.concludeAndTransferAllAssets(
-        largestTurnNum,
         getFixedPart(states[0]),
-        encodeAppData(states[0].appData),
-        encodeOutcome(outcome),
+        getVariablePart(states[0]),
         numStates,
         whoSignedWhat,
         sigs,

--- a/nitro-protocol/test/contracts/NitroAdjudicator/transferAllAssets.test.ts
+++ b/nitro-protocol/test/contracts/NitroAdjudicator/transferAllAssets.test.ts
@@ -3,7 +3,7 @@ import {Contract, Wallet, constants} from 'ethers';
 import {it} from '@jest/globals'
 
 import {Channel, getChannelId} from '../../../src/contract/channel';
-import {encodeOutcome, hashOutcome, Outcome} from '../../../src/contract/outcome';
+import {hashOutcome, Outcome} from '../../../src/contract/outcome';
 import {
   computeOutcome,
   getPlaceHolderContractAddress,
@@ -143,9 +143,8 @@ describe('transferAllAssets', () => {
           outcomeHash,
         })
       ).wait();
-      const encodedOutcome = encodeOutcome(outcome);
 
-      const tx1 = testNitroAdjudicator.transferAllAssets(channelId, encodedOutcome, stateHash);
+      const tx1 = testNitroAdjudicator.transferAllAssets(channelId, outcome, stateHash);
 
       // Call method in a slightly different way if expecting a revert
       if (reasonString) {

--- a/nitro-protocol/test/contracts/NullApp/nullApp.test.ts
+++ b/nitro-protocol/test/contracts/NullApp/nullApp.test.ts
@@ -37,10 +37,8 @@ describe('null app', () => {
 
     await expectRevert(async () => {
       await NitroAdjudicator.validTransition(
-        1,
-        [false, false],
+        0,
         [getVariablePart(fromState), getVariablePart(toState)],
-        5,
         ethers.constants.AddressZero
       );
     }, 'VM Exception while processing transaction: revert');

--- a/nitro-protocol/test/contracts/TrivalApp/validTransition.test.ts
+++ b/nitro-protocol/test/contracts/TrivalApp/validTransition.test.ts
@@ -19,8 +19,10 @@ function getRandomVariablePart(): VariablePart {
   const hash = computeSaltedHash(salt, randomNum);
 
   const variablePart: VariablePart = {
-    outcome: hash,
+    outcome: [],
     appData: hash,
+    turnNum: 1,
+    isFinal: false,
   };
   return variablePart;
 }
@@ -35,7 +37,7 @@ describe('validTransition', () => {
     for (let i = 0; i < 5; i++) {
       const from: VariablePart = getRandomVariablePart();
       const to: VariablePart = getRandomVariablePart();
-      const isValidFromCall = await trivialApp.validTransition(from, to, 0, 0);
+      const isValidFromCall = await trivialApp.validTransition(from, to, 0);
       expect(isValidFromCall).toBe(true);
     }
   });

--- a/nitro-protocol/test/contracts/examples/EmbeddedApplication/validTransition.test.ts
+++ b/nitro-protocol/test/contracts/examples/EmbeddedApplication/validTransition.test.ts
@@ -1,20 +1,24 @@
 /* eslint-disable jest/expect-expect */
 import {expectRevert as innerExpectRevert} from '@statechannels/devtools';
-import {constants, Contract, Wallet} from 'ethers';
+import {constants, Contract, Signature, Wallet} from 'ethers';
 import {AllocationType} from '@statechannels/exit-format';
 
 import embeddedApplicationArtifact from '../../../../artifacts/contracts/examples/EmbeddedApplication.sol/EmbeddedApplication.json';
 import {convertAddressToBytes32, getChannelId, signState} from '../../../../src';
 import {encodeOutcome} from '../../../../src/contract/outcome';
-import {getFixedPart, getVariablePart, State, VariablePart} from '../../../../src/contract/state';
+import {getFixedPart, State} from '../../../../src/contract/state';
 import {
   AlreadyMoved,
   encodeEmbeddedApplicationData,
+  VariablePart,
   SupportProof,
+  getVariablePart
 } from '../../../../src/contract/embedded-application';
 import {getTestProvider, setupContract} from '../../../test-helpers';
 import {MAGIC_ADDRESS_INDICATING_ETH} from '../../../../src/transactions';
 import {Outcome} from '../../../../src/contract/outcome';
+
+
 
 type RevertReason =
   // each reason represents a distinct code path that we should check in this test

--- a/nitro-protocol/test/contracts/examples/HashLockedSwap/validTransition.test.ts
+++ b/nitro-protocol/test/contracts/examples/HashLockedSwap/validTransition.test.ts
@@ -6,7 +6,7 @@ import {it} from '@jest/globals'
 const {HashZero} = ethers.constants;
 import HashLockedSwapArtifact from '../../../../artifacts/contracts/examples/HashLockedSwap.sol/HashLockedSwap.json';
 import {Bytes32} from '../../../../src';
-import {encodeOutcome, Outcome} from '../../../../src/contract/outcome';
+import {Outcome} from '../../../../src/contract/outcome';
 import {VariablePart} from '../../../../src/contract/state';
 import {Bytes} from '../../../../src/contract/types';
 import {
@@ -84,6 +84,7 @@ describe('validTransition', () => {
       dataB: HashLockedSwapData;
       balancesB: AssetOutcomeShortHand;
     }) => {
+      let turnNumA = turnNumB - 1;
       balancesA = replaceAddressesAndBigNumberify(balancesA, addresses) as AssetOutcomeShortHand;
       const allocationsA: Allocation[] = [];
       Object.keys(balancesA).forEach(key =>
@@ -102,8 +103,10 @@ describe('validTransition', () => {
         },
       ];
       const variablePartA: VariablePart = {
-        outcome: encodeOutcome(outcomeA),
+        outcome: outcomeA,
         appData: encodeHashLockedSwapData(dataA),
+        turnNum: turnNumA,
+        isFinal: false,
       };
       balancesB = replaceAddressesAndBigNumberify(balancesB, addresses) as AssetOutcomeShortHand;
       const allocationsB: Allocation[] = [];
@@ -119,22 +122,23 @@ describe('validTransition', () => {
         {asset: ethers.constants.AddressZero, allocations: allocationsB, metadata: '0x'},
       ];
       const variablePartB: VariablePart = {
-        outcome: encodeOutcome(outcomeB),
+        outcome: outcomeB,
         appData: encodeHashLockedSwapData(dataB),
+        turnNum: turnNumB,
+        isFinal: false,
       };
 
       if (isValid) {
         const isValidFromCall = await hashTimeLock.validTransition(
           variablePartA,
           variablePartB,
-          turnNumB,
           numParticipants
         );
         expect(isValidFromCall).toBe(true);
       } else {
         await expectRevert(
           () =>
-            hashTimeLock.validTransition(variablePartA, variablePartB, turnNumB, numParticipants),
+            hashTimeLock.validTransition(variablePartA, variablePartB, numParticipants),
           'Incorrect preimage'
         );
       }

--- a/nitro-protocol/test/contracts/examples/SingleAssetPayments/validTransition.test.ts
+++ b/nitro-protocol/test/contracts/examples/SingleAssetPayments/validTransition.test.ts
@@ -5,7 +5,7 @@ import {it} from '@jest/globals'
 
 const {HashZero} = ethers.constants;
 import SingleAssetPaymentsArtifact from '../../../../artifacts/contracts/examples/SingleAssetPayments.sol/SingleAssetPayments.json';
-import {encodeGuaranteeData, encodeOutcome, Outcome} from '../../../../src/contract/outcome';
+import {encodeGuaranteeData, Outcome} from '../../../../src/contract/outcome';
 import {VariablePart} from '../../../../src/contract/state';
 import {
   getTestProvider,
@@ -68,6 +68,7 @@ describe('validTransition', () => {
       balancesB: any;
       reason?: string;
     }) => {
+      let turnNumA = turnNumB - 1;
       balancesA = replaceAddressesAndBigNumberify(balancesA, addresses);
       const allocationsA: Allocation[] = [];
       Object.keys(balancesA).forEach(key =>
@@ -86,8 +87,10 @@ describe('validTransition', () => {
         outcomeA.push(outcomeA[0]);
       }
       const variablePartA: VariablePart = {
-        outcome: encodeOutcome(outcomeA),
+        outcome: outcomeA,
         appData: HashZero,
+        turnNum: turnNumA,
+        isFinal: false,
       };
 
       balancesB = replaceAddressesAndBigNumberify(balancesB, addresses);
@@ -110,15 +113,16 @@ describe('validTransition', () => {
         outcomeB.push(outcomeB[0]);
       }
       const variablePartB: VariablePart = {
-        outcome: encodeOutcome(outcomeB),
+        outcome: outcomeB,
         appData: HashZero,
+        turnNum: turnNumB,
+        isFinal: false,
       };
 
       if (isValid) {
         const isValidFromCall = await singleAssetPayments.validTransition(
           variablePartA,
           variablePartB,
-          turnNumB,
           numParticipants
         );
         expect(isValidFromCall).toBe(true);
@@ -128,7 +132,6 @@ describe('validTransition', () => {
             singleAssetPayments.validTransition(
               variablePartA,
               variablePartB,
-              turnNumB,
               numParticipants
             ),
           reason

--- a/nitro-protocol/test/test-helpers.ts
+++ b/nitro-protocol/test/test-helpers.ts
@@ -1,4 +1,5 @@
-import {Contract, ethers, BigNumberish, BigNumber, providers, Event} from 'ethers';
+import {Contract, ethers, BigNumberish, BigNumber, providers} from 'ethers';
+import { BytesLike } from "@ethersproject/bytes";
 import {Allocation, AllocationType} from '@statechannels/exit-format';
 
 import {ChallengeClearedEvent, ChallengeRegisteredStruct} from '../src/contract/challenge';
@@ -81,6 +82,38 @@ export const finalizedFingerprint = (
     outcome,
     state,
   });
+
+
+ export const parseOutcomeEventResult = (eventOutcomeResult: any[]): Outcome => {
+  eventOutcomeResult = Array.from(eventOutcomeResult);
+  let outcome: Outcome = [];
+
+   if (eventOutcomeResult.length == 0) {
+     return outcome;
+   }
+
+   eventOutcomeResult.forEach((eventSingleAssetExit: any[]) => {
+      const asset: string = eventSingleAssetExit[0];
+      const metadata: BytesLike = eventSingleAssetExit[1];
+      let eventAllocations: any[] = Array.from(eventSingleAssetExit[2]);
+      let allocations: Allocation[] = [];
+      
+      if (eventAllocations.length != 0) {
+        eventAllocations.forEach((eventAllocation: any[]) => {
+          const destination: string = eventAllocation[0];
+          const amount: string = eventAllocation[1]["_hex"];
+          const allocationType: number = eventAllocation[2];
+          const metadata: string = eventAllocation[3];
+
+          allocations.push({destination, amount, allocationType, metadata});
+        });
+      }
+
+      outcome.push({asset, metadata, allocations});
+   });
+
+   return outcome;
+ }
 
 export const newChallengeRegisteredEvent = (
   contract: ethers.Contract,


### PR DESCRIPTION
Relates to #499

### Changes

Update `VariablePart` struct to include:
- [x] `outcome` as `SingleAssetExit[]`
- [x] `turnNum` and `isFinal` flag 

Update function logic (majorly in `ForceMove.sol`) to support aforementioned changes:
- [x] support changing `outcome` as `SingleAssetExit[]`
- [x] support adding `turnNum` and `isFinal` flag 

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [ ] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [ ] I have assigned this PR to the appropriate GitHub project
- [ ] I have assigned this PR to the appropriate GitHub Milestone
