### PR TITLE
Store maps channels to objectives

### DIFF
--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -15,9 +15,10 @@ import (
 )
 
 type MockStore struct {
-	objectives        bytesSyncMap
-	channels          bytesSyncMap
-	consensusChannels bytesSyncMap
+	objectives         bytesSyncMap
+	channels           bytesSyncMap
+	consensusChannels  bytesSyncMap
+	channelToObjective bytesSyncMap
 
 	key     []byte        // the signing key of the store's engine
 	address types.Address // the (Ethereum) address associated to the signing key
@@ -131,6 +132,8 @@ func (ms *MockStore) SetObjective(obj protocols.Objective) error {
 			return fmt.Errorf("unexpected type: %T", rel)
 		}
 	}
+
+	ms.channelToObjective.Store(obj.OwnsChannel().String(), []byte(obj.Id()))
 
 	return nil
 }

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -75,6 +75,7 @@ func NewMockStore(key []byte) Store {
 	ms.objectives = syncMap[[]byte]{}
 	ms.channels = syncMap[[]byte]{}
 	ms.consensusChannels = syncMap[[]byte]{}
+	ms.channelToObjective = syncMap[string]{}
 
 	return &ms
 }

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -15,37 +15,38 @@ import (
 )
 
 type MockStore struct {
-	objectives         bytesSyncMap
-	channels           bytesSyncMap
-	consensusChannels  bytesSyncMap
-	channelToObjective bytesSyncMap
+	objectives         syncMap[[]byte]
+	channels           syncMap[[]byte]
+	consensusChannels  syncMap[[]byte]
+	channelToObjective syncMap[string]
 
 	key     []byte        // the signing key of the store's engine
 	address types.Address // the (Ethereum) address associated to the signing key
 }
 
-// bytesSyncMap wraps sync.Map in order to provide type safety
-type bytesSyncMap struct {
+// syncMap wraps sync.Map in order to provide type safety
+type syncMap[T any] struct {
 	m sync.Map
 }
 
 // Load returns the value stored in the map for a key, or nil if no
 // value is present.
 // The ok result indicates whether value was found in the map.
-func (o *bytesSyncMap) Load(id string) (bytes []byte, ok bool) {
+func (o *syncMap[T]) Load(id string) (bytes T, ok bool) {
 	data, ok := o.m.Load(id)
 
 	if !ok {
-		return nil, false
+		var result T
+		return result, false
 	}
 
-	bytes = data.([]byte)
+	bytes = data.(T)
 
 	return bytes, ok
 }
 
 // Store sets the value for a key.
-func (o *bytesSyncMap) Store(key string, data []byte) {
+func (o *syncMap[T]) Store(key string, data T) {
 	o.m.Store(key, data)
 }
 
@@ -59,9 +60,9 @@ func (o *bytesSyncMap) Store(key string, data []byte) {
 //
 // Range may be O(N) with the number of elements in the map even if f returns
 // false after a constant number of calls.
-func (o *bytesSyncMap) Range(f func(key string, value []byte) bool) {
+func (o *syncMap[T]) Range(f func(key string, value T) bool) {
 	untypedF := func(key, value interface{}) bool {
-		return f(key.(string), value.([]byte))
+		return f(key.(string), value.(T))
 	}
 	o.m.Range(untypedF)
 }
@@ -71,9 +72,9 @@ func NewMockStore(key []byte) Store {
 	ms.key = key
 	ms.address = crypto.GetAddressFromSecretKeyBytes(key)
 
-	ms.objectives = bytesSyncMap{}
-	ms.channels = bytesSyncMap{}
-	ms.consensusChannels = bytesSyncMap{}
+	ms.objectives = syncMap[[]byte]{}
+	ms.channels = syncMap[[]byte]{}
+	ms.consensusChannels = syncMap[[]byte]{}
 
 	return &ms
 }
@@ -133,7 +134,7 @@ func (ms *MockStore) SetObjective(obj protocols.Objective) error {
 		}
 	}
 
-	ms.channelToObjective.Store(obj.OwnsChannel().String(), []byte(obj.Id()))
+	ms.channelToObjective.Store(obj.OwnsChannel().String(), string(obj.Id()))
 
 	return nil
 }
@@ -240,7 +241,11 @@ func (ms *MockStore) GetConsensusChannel(counterparty types.Address) (channel *c
 func (ms *MockStore) GetObjectiveByChannelId(channelId types.Destination) (protocols.Objective, bool) {
 	// todo: locking
 
-	id := directfund.ObjectivePrefix + channelId.String()
+	id, found := ms.channelToObjective.Load(channelId.String())
+	if !found {
+		return &directfund.Objective{}, false
+	}
+
 	objJSON, found := ms.objectives.Load(id)
 	if !found {
 		return &directfund.Objective{}, false

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -32,7 +32,7 @@ type syncMap[T any] struct {
 // Load returns the value stored in the map for a key, or nil if no
 // value is present.
 // The ok result indicates whether value was found in the map.
-func (o *syncMap[T]) Load(id string) (bytes T, ok bool) {
+func (o *syncMap[T]) Load(id string) (value T, ok bool) {
 	data, ok := o.m.Load(id)
 
 	if !ok {
@@ -40,9 +40,9 @@ func (o *syncMap[T]) Load(id string) (bytes T, ok bool) {
 		return result, false
 	}
 
-	bytes = data.(T)
+	value = data.(T)
 
-	return bytes, ok
+	return value, ok
 }
 
 // Store sets the value for a key.

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -122,7 +122,7 @@ func constructFromState(
 	return init, nil
 }
 
-// OwnsChannel returns the channel that the objective is funding
+// OwnsChannel returns the channel that the objective is funding.
 func (dfo *Objective) OwnsChannel() types.Destination {
 	return dfo.C.Id
 }

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -122,6 +122,7 @@ func constructFromState(
 	return init, nil
 }
 
+// OwnsChannel returns the channel that the objective is funding
 func (dfo *Objective) OwnsChannel() types.Destination {
 	return dfo.C.Id
 }

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -122,6 +122,10 @@ func constructFromState(
 	return init, nil
 }
 
+func (dfo *Objective) OwnsChannel() types.Destination {
+	return dfo.C.Id
+}
+
 // CreateConsensusChannel creates a ConsensusChannel from the Objective by extracting signatures and a single asset outcome from the post fund state.
 func (dfo *Objective) CreateConsensusChannel() (*consensus_channel.ConsensusChannel, error) {
 	ledger := dfo.C

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -76,7 +76,7 @@ type Objective interface {
 	Related() []Storable
 	Storable
 
-	OwnsChannel() types.Destination
+	OwnsChannel() types.Destination // every objective has exclusive ownership of a channel while active
 }
 
 // ObjectiveId is a unique identifier for an Objective.

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -75,6 +75,8 @@ type Objective interface {
 	// Related returns a slice of related objects that need to be stored along with the objective
 	Related() []Storable
 	Storable
+
+	OwnsChannel() types.Destination
 }
 
 // ObjectiveId is a unique identifier for an Objective.

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -76,7 +76,8 @@ type Objective interface {
 	Related() []Storable
 	Storable
 
-	OwnsChannel() types.Destination // every objective has exclusive ownership of a channel while active
+	// every objective has exclusive ownership of a channel while active
+	OwnsChannel() types.Destination
 }
 
 // ObjectiveId is a unique identifier for an Objective.

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -318,6 +318,7 @@ func (o Objective) Reject() protocols.Objective {
 	return &updated
 }
 
+// OwnsChannel returns the channel that the objective is funding
 func (o Objective) OwnsChannel() types.Destination {
 	return o.V.Id
 }

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -318,6 +318,10 @@ func (o Objective) Reject() protocols.Objective {
 	return &updated
 }
 
+func (o Objective) OwnsChannel() types.Destination {
+	return o.V.Id
+}
+
 // Update receives an protocols.ObjectiveEvent, applies all applicable event data to the VirtualFundObjective,
 // and returns the updated state.
 func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, error) {

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -318,7 +318,7 @@ func (o Objective) Reject() protocols.Objective {
 	return &updated
 }
 
-// OwnsChannel returns the channel that the objective is funding
+// OwnsChannel returns the channel that the objective is funding.
 func (o Objective) OwnsChannel() types.Destination {
 	return o.V.Id
 }


### PR DESCRIPTION
Works toward https://github.com/statechannels/go-nitro/issues/490.

This PR adds a channel-to-objective store mapping and rewires existing functionality of `MockStore.GetObjectiveByChannelId`. Future work needs to manage this mapping by removing entries when an objective succeeds or is rejected.