### PR TITLE
Remove `channel.SingleHopVirtualChannel`  from Virtual Defunding 

### DIFF
--- a/channel/state/state.go
+++ b/channel/state/state.go
@@ -16,6 +16,21 @@ import (
 
 type Signature = nc.Signature
 
+// CloneSignature creates a deep copy of the provided signature.
+func CloneSignature(s Signature) Signature {
+	clone := Signature{}
+
+	clone.V = s.V
+	clone.R = make([]byte, len(s.R))
+	clone.S = make([]byte, len(s.S))
+
+	copy(clone.R, s.R)
+	copy(clone.S, s.S)
+
+	return clone
+
+}
+
 type (
 	// State holds all of the data describing the state of a channel
 	State struct {

--- a/channel/state/state_test.go
+++ b/channel/state/state_test.go
@@ -21,6 +21,32 @@ var correctSignature = Signature{
 	V: byte(0),
 }
 
+func TestCloneSignature(t *testing.T) {
+
+	toCopy := Signature{
+		R: common.Hex2Bytes(`704b3afcc6e702102ca1af3f73cf3b37f3007f368c40e8b81ca823a65740a053`),
+		S: common.Hex2Bytes(`14040ad4c598dbb055a50430142a13518e1330b79d24eed86fcbdff1a7a95589`),
+		V: byte(0),
+	}
+
+	got := CloneSignature(toCopy)
+
+	// mutate the signature we cloned so we catch a shallow copy
+	toCopy.R = common.Hex2Bytes(`0`)
+	toCopy.S = common.Hex2Bytes(`0`)
+	toCopy.V = byte(1)
+
+	if !bytes.Equal(common.Hex2Bytes(`704b3afcc6e702102ca1af3f73cf3b37f3007f368c40e8b81ca823a65740a053`), got.R) {
+		t.Fatalf("Incorrect r param in signature. Got %x, wanted %x", got.R, common.Hex2Bytes(`704b3afcc6e702102ca1af3f73cf3b37f3007f368c40e8b81ca823a65740a053`))
+	}
+	if !bytes.Equal(common.Hex2Bytes(`14040ad4c598dbb055a50430142a13518e1330b79d24eed86fcbdff1a7a95589`), got.S) {
+		t.Fatalf("Incorrect s param in signature. Got %x, wanted %x", got.S, common.Hex2Bytes(`14040ad4c598dbb055a50430142a13518e1330b79d24eed86fcbdff1a7a95589`))
+	}
+	if byte(0) != got.V {
+		t.Fatalf("Incorrect v param in signature. Got %x, wanted %x", got.V, byte(0))
+	}
+}
+
 func TestChannelId(t *testing.T) {
 	want := correctChannelId
 	got, error := TestState.ChannelId()

--- a/protocols/virtualdefund/serde.go
+++ b/protocols/virtualdefund/serde.go
@@ -3,12 +3,12 @@ package virtualdefund
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/protocols"
-	"github.com/statechannels/go-nitro/types"
 )
 
 // jsonObjective replaces the virtualfund Objective's channel pointers
@@ -16,9 +16,9 @@ import (
 type jsonObjective struct {
 	Status         protocols.ObjectiveStatus
 	VFixed         state.FixedPart
-	InitialOutcome outcome.Exit
+	InitialOutcome outcome.SingleAssetExit
 	Signatures     [3]state.Signature
-	PaidToBob      types.Funds
+	PaidToBob      *big.Int
 	ToMyLeft       []byte
 	ToMyRight      []byte
 

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -115,7 +115,7 @@ func (o *Objective) clone() Objective {
 
 	clone.Signatures = [3]state.Signature{}
 	for i, s := range o.Signatures {
-		clone.Signatures[i] = s
+		clone.Signatures[i] = state.CloneSignature(s)
 	}
 	clone.MyRole = o.MyRole
 

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -16,28 +17,58 @@ const (
 	WaitingForNothing                 protocols.WaitingFor = "WaitingForNothing"                 // Finished
 )
 
-// ObjectiveRequest represents a request to create a new virtual defunding objective.
-type ObjectiveRequest struct {
-	VirtualChannelId types.Destination
-}
-
 // Objective contains relevent information for the defund objective
 type Objective struct {
 	Status protocols.ObjectiveStatus
-	V      *channel.SingleHopVirtualChannel
+
+	// InitialOutcome is the initial outcome of the virtual channel
+	InitialOutcome outcome.Exit
+
+	// PaidToBob is the amount that should be paid from Alice (participant 0) to Bob (participant 2)
+	PaidToBob types.Funds
+
+	// VFixed is the fixed channel information for the virtual channel
+	VFixed state.FixedPart
+
+	// Signatures are the signatures for the final virtual state from each participant
+	// Signatures are ordered by participant order: Signatures[0] is Alice's signature, Signatures[1] is Irene's signature, Signatures[2] is Bob's signature
+	// Signatures gets updated as participants sign and send states to each other.
+	Signatures [3]state.Signature
 
 	ToMyLeft  *consensus_channel.ConsensusChannel
 	ToMyRight *consensus_channel.ConsensusChannel
 
-	MyRole uint // index in the virtual funding protocol. 0 for Alice, 2 for Bob. Otherwise 1 for the intermediary.
-
+	// MyRole is the index of the participant in the participants list
+	// 0 is Alice
+	// 1 is Irene
+	// 2 is Bob
+	MyRole uint
 }
 
 const ObjectivePrefix = "VirtualDefund-"
 
+// finalState returns the final state for the virtual channel
+func (o Objective) finalState() state.State {
+	vp := state.VariablePart{Outcome: o.finalOutcome(), TurnNum: 3, IsFinal: true}
+	return state.StateFromFixedAndVariablePart(o.VFixed, vp)
+}
+
+// finalOutcome returns the outcome for the final state calculated from the InitialOutcome and PaidToBob
+func (o Objective) finalOutcome() outcome.Exit {
+	finalOutcome := o.InitialOutcome.Clone()
+	for _, exit := range finalOutcome {
+		paid := o.PaidToBob[exit.Asset]
+		exit.Allocations[0].Amount.Sub(exit.Allocations[0].Amount, paid)
+		exit.Allocations[1].Amount.Add(exit.Allocations[1].Amount, paid)
+	}
+
+	return finalOutcome
+}
+
 // Id returns the objective id.
 func (o Objective) Id() protocols.ObjectiveId {
-	return protocols.ObjectiveId(ObjectivePrefix + o.V.Id.String())
+	vId, _ := o.VFixed.ChannelId() //TODO: Handle error
+	return protocols.ObjectiveId(ObjectivePrefix + vId.String())
 
 }
 
@@ -58,7 +89,7 @@ func (o Objective) Reject() protocols.Objective {
 
 // Relable returns related channels that need to be stored along with the objective.
 func (o *Objective) Related() []protocols.Storable {
-	relatable := []protocols.Storable{o.V}
+	relatable := []protocols.Storable{}
 
 	if o.ToMyLeft != nil {
 		relatable = append(relatable, o.ToMyLeft)
@@ -74,10 +105,15 @@ func (o *Objective) Related() []protocols.Storable {
 func (o *Objective) clone() Objective {
 	clone := Objective{}
 	clone.Status = o.Status
-	vClone := o.V.Clone()
-	clone.V = vClone
 
-	// todo: #420 consider cloning for consensusChannels
+	clone.VFixed = o.VFixed.Clone()
+	clone.InitialOutcome = o.InitialOutcome.Clone()
+	clone.PaidToBob = o.PaidToBob.Clone()
+
+	clone.Signatures = [3]state.Signature{}
+	for i, s := range o.Signatures {
+		clone.Signatures[i] = s
+	}
 	clone.MyRole = o.MyRole
 
 	return clone
@@ -94,7 +130,6 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 	if o.Id() != event.ObjectiveId {
 		return &o, fmt.Errorf("event and objective Ids do not match: %s and %s respectively", string(event.ObjectiveId), string(o.Id()))
 	}
-
 	return &o, errors.New("TODO: UNIMPLEMENTED")
 
 }

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -17,6 +17,9 @@ const (
 	WaitingForNothing                 protocols.WaitingFor = "WaitingForNothing"                 // Finished
 )
 
+// The turn number used for the final state
+const FinalTurnNum = 3
+
 // Objective contains relevent information for the defund objective
 type Objective struct {
 	Status protocols.ObjectiveStatus
@@ -47,12 +50,14 @@ type Objective struct {
 
 const ObjectivePrefix = "VirtualDefund-"
 
+//nolint:unused // not used yet
 // finalState returns the final state for the virtual channel
 func (o Objective) finalState() state.State {
-	vp := state.VariablePart{Outcome: outcome.Exit{o.finalOutcome()}, TurnNum: 3, IsFinal: true}
+	vp := state.VariablePart{Outcome: outcome.Exit{o.finalOutcome()}, TurnNum: FinalTurnNum, IsFinal: true}
 	return state.StateFromFixedAndVariablePart(o.VFixed, vp)
 }
 
+//nolint:unused // not used yet
 // finalOutcome returns the outcome for the final state calculated from the InitialOutcome and PaidToBob
 func (o Objective) finalOutcome() outcome.SingleAssetExit {
 	finalOutcome := o.InitialOutcome.Clone()


### PR DESCRIPTION
Fixes #511 

Updates the Virtual Defunding Objective to store the information on the objective instead of relying on a `channel.SingleHopVirtualChannel`

We make some simplifying assumptions:
- Every virtual channel will be single hop virtual channel
- Payments are always going from `alice` to `bob`