### PR TITLE
Vision question part 1: write some unit tests

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -534,7 +534,11 @@ func (vars *Vars) Add(p Add) error {
 		return ErrInvalidDeposit
 	}
 
-	if types.Gt(p.amount, o.left.amount) {
+	if types.Gt(p.LeftDeposit, o.left.amount) {
+		return ErrInsufficientFunds
+	}
+
+	if types.Gt(p.RightDeposit(), o.right.amount) {
 		return ErrInsufficientFunds
 	}
 

--- a/channel/consensus_channel/consensus_channel_test.go
+++ b/channel/consensus_channel/consensus_channel_test.go
@@ -103,7 +103,9 @@ func TestConsensusChannel(t *testing.T) {
 		largeProposal := proposal
 		leftAmount := big.NewInt(0).Set(vars.Outcome.left.amount)
 		largeProposal.amount = leftAmount.Add(leftAmount, big.NewInt(1))
+		largeProposal.LeftDeposit = largeProposal.amount
 		err = vars.Add(largeProposal)
+
 		if !errors.Is(err, ErrInsufficientFunds) {
 			t.Fatalf("expected error when adding too large a guarantee: %v", err)
 		}

--- a/channel/consensus_channel/leader_channel.go
+++ b/channel/consensus_channel/leader_channel.go
@@ -38,6 +38,11 @@ func (c *ConsensusChannel) Propose(proposal Proposal, sk []byte) (SignedProposal
 		return SignedProposal{}, ErrNotLeader
 	}
 
+	// TODO: the Propose API should be less confusing!
+	// Currently, the TurnNum is ignored, and Propose could easily
+	// return the same ChannelId that it's been passed
+	proposal.ChannelID = c.Id
+
 	vars, err := c.latestProposedVars()
 	if err != nil {
 		return SignedProposal{}, fmt.Errorf("unable to construct latest proposed vars: %w", err)

--- a/channel/consensus_channel/leader_channel_test.go
+++ b/channel/consensus_channel/leader_channel_test.go
@@ -227,8 +227,7 @@ func TestLeaderChannel(t *testing.T) {
 
 		c := testChannel(startingOutcome, startingQueue)
 
-		newAdd := Proposal{ToAdd: add(2, amountAdded, types.Destination{3}, alice, bob)}
-		newAdd.ChannelID = p1.ChannelID
+		newAdd := Proposal{ChannelID: p1.ChannelID, ToAdd: add(2, amountAdded, types.Destination{3}, alice, bob)}
 
 		currentlyProposed, _ := c.latestProposedVars()
 		expectedSp := aliceSignedProposal(currentlyProposed, newAdd).SignedProposal

--- a/channel/consensus_channel/leader_channel_test.go
+++ b/channel/consensus_channel/leader_channel_test.go
@@ -228,6 +228,7 @@ func TestLeaderChannel(t *testing.T) {
 		c := testChannel(startingOutcome, startingQueue)
 
 		newAdd := Proposal{ToAdd: add(2, amountAdded, types.Destination{3}, alice, bob)}
+		newAdd.ChannelID = p1.ChannelID
 
 		currentlyProposed, _ := c.latestProposedVars()
 		expectedSp := aliceSignedProposal(currentlyProposed, newAdd).SignedProposal

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -206,8 +206,7 @@ func (ms *MockStore) GetTwoPartyLedger(firstParty types.Address, secondParty typ
 	return ledger, ok
 }
 
-// GetConsensusChannel returns a ConsensusChannel between the calling client and
-// the supplied counterparty, if such channel exists
+// GetConsensusChannelById returns a ConsensusChannel with the given channel id
 func (ms *MockStore) GetConsensusChannelById(id types.Destination) (channel *consensus_channel.ConsensusChannel, err error) {
 
 	chJSON, ok := ms.consensusChannels.Load(id.String())

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -32,18 +32,8 @@ func DeserializeMessage(s string) (Message, error) {
 // CreateSignedStateMessages creates a set of messages containing the signed state.
 // A message will be generated for each participant except for the participant at myIndex.
 func CreateSignedStateMessages(id ObjectiveId, ss state.SignedState, myIndex uint) []Message {
-	return createMessages(id, &ss, nil, myIndex)
-}
-
-// CreateSignedProposalMessages creates a list of messages containing the signed proposal
-// A message will be generated for each participant except for the participant at myIndex.
-func CreateSignedProposalMessages(id ObjectiveId, sp consensus_channel.SignedProposal, myIndex uint) []Message {
-	return createMessages(id, nil, &sp, myIndex)
-}
-
-// createMessages creates a list of messages with the signed state and the signed proposal
-func createMessages(id ObjectiveId, ss *state.SignedState, sp *consensus_channel.SignedProposal, myIndex uint) []Message {
 	messages := make([]Message, 0)
+
 	for i, participant := range ss.State().Participants {
 
 		// Do not generate a message for ourselves
@@ -51,14 +41,8 @@ func createMessages(id ObjectiveId, ss *state.SignedState, sp *consensus_channel
 			continue
 		}
 		signedStates := []state.SignedState{}
-		if ss != nil {
-			signedStates = append(signedStates, *ss)
-		}
-		signedProposals := []consensus_channel.SignedProposal{}
-		if sp != nil {
-			signedProposals = append(signedProposals, *sp)
-		}
-		message := Message{To: participant, ObjectiveId: id, SignedStates: signedStates, SignedProposals: signedProposals}
+		signedStates = append(signedStates, ss)
+		message := Message{To: participant, ObjectiveId: id, SignedStates: signedStates, SignedProposals: []consensus_channel.SignedProposal{}}
 		messages = append(messages, message)
 	}
 	return messages

--- a/protocols/virtualfund/helpers_test.go
+++ b/protocols/virtualfund/helpers_test.go
@@ -41,6 +41,8 @@ var bob = actor{
 	role:        2,
 }
 
+var allActors = []actor{alice, p1, bob}
+
 func prepareConsensusChannel(role uint, left, right actor) *consensus_channel.ConsensusChannel {
 	fp := state.FixedPart{
 		ChainId:           big.NewInt(9001),

--- a/protocols/virtualfund/helpers_test.go
+++ b/protocols/virtualfund/helpers_test.go
@@ -14,6 +14,7 @@ type actor struct {
 	destination types.Destination
 	privateKey  []byte
 	role        uint
+	name        string
 }
 
 ////////////
@@ -25,6 +26,7 @@ var alice = actor{
 	destination: types.AddressToDestination(common.HexToAddress(`0xD9995BAE12FEe327256FFec1e3184d492bD94C31`)),
 	privateKey:  common.Hex2Bytes(`7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8`),
 	role:        0,
+	name:        "alice",
 }
 
 var p1 = actor{ // Aliases: The Hub, Irene
@@ -32,6 +34,7 @@ var p1 = actor{ // Aliases: The Hub, Irene
 	destination: types.AddressToDestination(common.HexToAddress(`0xd4Fa489Eacc52BA59438993f37Be9fcC20090E39`)),
 	privateKey:  common.Hex2Bytes(`2030b463177db2da82908ef90fa55ddfcef56e8183caf60db464bc398e736e6f`),
 	role:        1,
+	name:        "p1",
 }
 
 var bob = actor{
@@ -39,6 +42,7 @@ var bob = actor{
 	destination: types.AddressToDestination(common.HexToAddress(`0x760bf27cd45036a6C486802D30B5D90CfFBE31FE`)),
 	privateKey:  common.Hex2Bytes(`62ecd49c4ccb41a70ad46532aed63cf815de15864bc415c87d507afd6a5e8da2`),
 	role:        2,
+	name:        "bob",
 }
 
 var allActors = []actor{alice, p1, bob}

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -52,7 +52,6 @@ func compareGuarantees(a, b consensus_channel.Guarantee) string {
 // signLatest is a test utility function which applies signatures from
 // multiple participants to the latest recorded state
 // func signLatest(ledger *consensus_channel.ConsensusChannel, secretKeys [][]byte) {
-// 	panic("whoops")
 
 // Find the largest turn num and therefore the latest state
 // turnNum := uint64(0)

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -625,14 +625,19 @@ func (o *Objective) updateLedgerWithGuarantee(ledgerConnection Connection, sk *[
 	ledger := ledgerConnection.Channel // todo: #420 deprecate
 
 	var sideEffects protocols.SideEffects
+	g := ledgerConnection.getExpectedGuarantee()
+	proposed, err := ledger.IsProposed(g)
+
 	if ledger.IsLeader() { // If the user is the proposer craft a new proposal
+		if proposed {
+			return protocols.SideEffects{}, nil
+		}
 		se, err := o.proposeLedgerUpdate(ledgerConnection, sk)
 		if err != nil {
 			return protocols.SideEffects{}, fmt.Errorf("error proposing ledger update: %w", err)
 		}
 		sideEffects = se
 	} else {
-		proposed, err := ledger.IsProposed(ledgerConnection.getExpectedGuarantee())
 		if err != nil {
 			return protocols.SideEffects{}, err
 		}

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -561,8 +561,7 @@ func (c *Connection) expectedProposal() consensus_channel.Proposal {
 		leftAmount = val
 		break
 	}
-	WRONG_ID := types.Destination{} // TODO: Why does NewAddProposal require a channel id?
-	proposal := consensus_channel.NewAddProposal(WRONG_ID, 0, g, leftAmount)
+	proposal := consensus_channel.NewAddProposal(c.Channel.Id, 0, g, leftAmount)
 
 	return proposal
 }

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -335,10 +335,6 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 		case o.V.Id:
 			updated.V.AddSignedState(ss)
 			// We expect pre and post fund state signatures.
-		case toMyLeftId:
-			panic("unexpected state")
-		case toMyRightId:
-			panic("unexpected state")
 		default:
 			return &o, errors.New("event channelId out of scope of objective")
 		}

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -90,6 +90,7 @@ func (c *Connection) handleProposal(sp consensus_channel.SignedProposal) error {
 	return nil
 }
 
+// Funded computes whether the ledger channel on the receiver funds the guarantee expected by this connection
 func (c *Connection) Funded() bool {
 	g := c.getExpectedGuarantee()
 	return c.Channel.Includes(g)

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -606,6 +606,7 @@ func (o *Objective) acceptLedgerUpdate(c Connection, sk *[]byte) (protocols.Side
 	return sideEffects, nil
 }
 
+// createSignedProposalMessage returns a signed proposal message addressed to the counterparty in the given ledger
 func (o *Objective) createSignedProposalMessage(sp consensus_channel.SignedProposal, ledger *consensus_channel.ConsensusChannel) protocols.Message {
 	recipient := ledger.Leader()
 	if ledger.IsLeader() {

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -98,6 +98,11 @@ func (c *Connection) Funded() bool {
 // getExpectedGuarantee returns a map of asset addresses to guarantees for a Connection.
 func (c *Connection) getExpectedGuarantee() consensus_channel.Guarantee {
 	amountFunds := c.GuaranteeInfo.LeftAmount.Add(c.GuaranteeInfo.RightAmount)
+
+	//HACK: GuaranteeInfo stores amounts as types.Funds.
+	// We only expect a single asset type, and we want to know how much is to be
+	// diverted for that asset type.
+	// So, we loop through amountFunds and break after the first asset type ...
 	var amount *big.Int
 	for _, val := range amountFunds {
 		amount = val

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-// Virtual Channel
-
 type actorLedgers struct {
 	left  *consensus_channel.ConsensusChannel
 	right *consensus_channel.ConsensusChannel

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -28,6 +28,7 @@ type testData struct {
 	ledgers   ledgerLookup
 }
 
+// newTestData returns new copies of consistent test data each time it is called
 func newTestData() testData {
 	var vPreFund = state.State{
 		ChainId:           big.NewInt(9001),
@@ -100,8 +101,8 @@ func testNew(a actor) Tester {
 			assert(t, diffFromCorrectConnection(o.ToMyLeft, p1, bob) == "", "incorrect connection")
 			assert(t, o.ToMyRight == nil, "right connection should be nil")
 		}
-		}
 	}
+}
 
 // diffFromCorrectConnection compares the guarantee stored on a connection with
 // the guarantee we expect, given the expected left and right actors
@@ -228,7 +229,7 @@ func TestCrankAsAlice(t *testing.T) {
 	ok(t, err)
 	equals(t, got, emptySideEffects)
 	equals(t, waitingFor, WaitingForCompleteFunding)
-	}
+}
 
 // Copied from https://github.com/benbjohnson/testing
 
@@ -248,7 +249,7 @@ func ok(tb testing.TB, err error) {
 		fmt.Printf("\033[31m%s:%d: unexpected error: %s\033[39m\n\n", filepath.Base(file), line, err.Error())
 		tb.FailNow()
 	}
-	}
+}
 
 // equals fails the test if exp is not equal to act.
 func equals(tb testing.TB, exp, act interface{}) {
@@ -256,8 +257,8 @@ func equals(tb testing.TB, exp, act interface{}) {
 		_, file, line, _ := runtime.Caller(1)
 		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, exp, act)
 		tb.FailNow()
-}
 	}
+}
 
 // The following assertions are inspired by the ok, assert and equals above
 
@@ -279,7 +280,7 @@ func assertProposalSent(t *testing.T, ses protocols.SideEffects, sp consensus_ch
 	if !reflect.DeepEqual(sent.Proposal, sp.Proposal) {
 		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, sent.Proposal, sp.Proposal)
 		t.FailNow()
-}
+	}
 
 	if !bytes.Equal(msg.To[:], to.address[:]) {
 		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, msg.To.String(), to.address.String())
@@ -295,7 +296,7 @@ func assertStateSentTo(t *testing.T, ses protocols.SideEffects, expected state.S
 				return
 			}
 		}
-}
+	}
 
 	_, file, line, _ := runtime.Caller(1)
 	fmt.Printf("\033[31m%s:%d:\n\n\tside effects do not incude signed state", filepath.Base(file), line)

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -113,10 +113,8 @@ func testNew(t *testing.T, a actor) {
 
 }
 
-var actors = []actor{alice, p1, bob}
-
 func TestNew(t *testing.T) {
-	for _, a := range actors {
+	for _, a := range allActors {
 		testNew(t, a)
 	}
 }
@@ -136,7 +134,7 @@ func testClone(t *testing.T, my actor) {
 }
 
 func TestClone(t *testing.T) {
-	for _, a := range actors {
+	for _, a := range allActors {
 		testClone(t, a)
 	}
 }

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -1,0 +1,44 @@
+package virtualfund
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/types"
+)
+
+func TestSingleHopVirtualFundNew(t *testing.T) {
+	/////////////////////
+	// VIRTUAL CHANNEL //
+	/////////////////////
+
+	// Virtual Channel
+	vPreFund := state.State{
+		ChainId:           big.NewInt(9001),
+		Participants:      []types.Address{alice.address, p1.address, bob.address}, // A single hop virtual channel
+		ChannelNonce:      big.NewInt(0),
+		AppDefinition:     types.Address{},
+		ChallengeDuration: big.NewInt(45),
+		AppData:           []byte{},
+		Outcome: outcome.Exit{outcome.SingleAssetExit{
+			Allocations: outcome.Allocations{
+				outcome.Allocation{
+					Destination: alice.destination,
+					Amount:      big.NewInt(6),
+				},
+				outcome.Allocation{
+					Destination: bob.destination,
+					Amount:      big.NewInt(4),
+				},
+			},
+		}},
+		TurnNum: 0,
+		IsFinal: false,
+	}
+	vPostFund := vPreFund.Clone()
+	vPostFund.TurnNum = 1
+
+
+}

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -188,8 +188,11 @@ func TestCrankAsAlice(t *testing.T) {
 
 	// Approve the objective, so that the rest of the test cases can run.
 	o := s.Approve().(*Objective)
+
 	// To test the finite state progression, we are going to progressively mutate o
 	// And then crank it to see which "pause point" (WaitingFor) we end up at.
+	// NOTE: Because crank returns a protocools.Objective interface, after each crank we
+	// need to remember to convert the result back to a virtualfund.Objective struct
 
 	// Initial Crank
 	oObj, got, waitingFor, err := o.Crank(&my.privateKey)

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -131,7 +131,7 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func testClone(my actor) Tester {
+func testCloneAs(my actor) Tester {
 	return func(t *testing.T) {
 		td := newTestData()
 		vPreFund := td.vPreFund
@@ -151,7 +151,7 @@ func testClone(my actor) Tester {
 func TestClone(t *testing.T) {
 	for _, a := range allActors {
 		msg := fmt.Sprintf("Testing clone as %v", a.name)
-		t.Run(msg, testClone(a))
+		t.Run(msg, testCloneAs(a))
 	}
 }
 

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -68,41 +68,35 @@ func TestSingleHopVirtualFundNew(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			var expectedGuaranteeMetadataLeft outcome.GuaranteeMetadata
-			var expectedGuaranteeMetadataRight outcome.GuaranteeMetadata
+			var wantLeft consensus_channel.Guarantee
+			var wantRight consensus_channel.Guarantee
+			expectedAmount := big.NewInt(0).Set(vPreFund.VariablePart().Outcome[0].TotalAllocated())
 			switch my.role {
 			case alice.role:
 				{
-					expectedGuaranteeMetadataRight = outcome.GuaranteeMetadata{Left: alice.destination, Right: p1.destination}
+					wantRight = consensus_channel.NewGuarantee(expectedAmount, o.V.Id, alice.destination, p1.destination)
 				}
 			case p1.role:
 				{
-					expectedGuaranteeMetadataLeft = outcome.GuaranteeMetadata{Left: alice.destination, Right: p1.destination}
-					expectedGuaranteeMetadataRight = outcome.GuaranteeMetadata{Left: p1.destination, Right: bob.destination}
+					wantLeft = consensus_channel.NewGuarantee(expectedAmount, o.V.Id, alice.destination, p1.destination)
+					wantRight = consensus_channel.NewGuarantee(expectedAmount, o.V.Id, p1.destination, bob.destination)
 				}
 			case bob.role:
 				{
-					expectedGuaranteeMetadataLeft = outcome.GuaranteeMetadata{Left: p1.destination, Right: bob.destination}
+					wantLeft = consensus_channel.NewGuarantee(expectedAmount, o.V.Id, p1.destination, bob.destination)
 				}
 			}
-			amount := big.NewInt(0).Set(vPreFund.VariablePart().Outcome[0].TotalAllocated())
-			if (expectedGuaranteeMetadataLeft != outcome.GuaranteeMetadata{}) {
+
+			zeroG := consensus_channel.Guarantee{}
+			if wantLeft != zeroG {
 				gotLeft := o.ToMyLeft.getExpectedGuarantee()
 
-				left := expectedGuaranteeMetadataLeft.Left
-				right := expectedGuaranteeMetadataLeft.Left
-
-				wantLeft := consensus_channel.NewGuarantee(amount, o.V.Id, left, right)
 				if diff := compareGuarantees(wantLeft, gotLeft); diff != "" {
 					t.Fatalf("TestNew: expectedGuarantee mismatch (-want +got):\n%s", diff)
 				}
 			}
-			if (expectedGuaranteeMetadataRight != outcome.GuaranteeMetadata{}) {
+			if wantRight != zeroG {
 				gotRight := o.ToMyRight.getExpectedGuarantee()
-				left := expectedGuaranteeMetadataRight.Left
-				right := expectedGuaranteeMetadataRight.Left
-
-				wantRight := consensus_channel.NewGuarantee(amount, o.V.Id, left, right)
 				if diff := compareGuarantees(wantRight, gotRight); diff != "" {
 					t.Fatalf("TestNew: expectedGuarantee mismatch (-want +got):\n%s", diff)
 				}

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -287,7 +287,6 @@ func assertProposalSent(t *testing.T, ses protocols.SideEffects, sp consensus_ch
 	}
 }
 
-
 // assertMessageSentTo asserts that ses contains a message
 func assertStateSentTo(t *testing.T, ses protocols.SideEffects, expected state.SignedState, to actor) {
 	for _, msg := range ses.MessagesToSend {

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -144,7 +144,7 @@ func TestClone(t *testing.T) {
 }
 
 // assertSideEffectsContainsMessageWith fails the test instantly if the supplied side effects does not contain a message for the supplied actor with the supplied expected signed state.
-func assertSideEffectsContainsMessageWith (ses protocols.SideEffects, expectedSignedState state.SignedState, to actor, t *testing.T) {
+func assertSideEffectsContainsMessageWith(ses protocols.SideEffects, expectedSignedState state.SignedState, to actor, t *testing.T) {
 	for _, msg := range ses.MessagesToSend {
 		for _, ss := range msg.SignedStates {
 			if reflect.DeepEqual(ss, expectedSignedState) && bytes.Equal(msg.To[:], to.address[:]) {
@@ -157,17 +157,13 @@ func assertSideEffectsContainsMessageWith (ses protocols.SideEffects, expectedSi
 
 // assertSideEffectsContainsMessageWith calls assertSideEffectsContainsMessageWith for all peers of the actor with role myRole.
 func assertSideEffectsContainsMessagesForPeersWith(ses protocols.SideEffects, expectedSignedState state.SignedState, myRole uint, t *testing.T) {
-	if myRole != alice.role {
-		assertSideEffectsContainsMessageWith(ses, expectedSignedState, alice, t)
-	}
-	if myRole != p1.role {
-		assertSideEffectsContainsMessageWith(ses, expectedSignedState, p1, t)
-	}
-	if myRole != bob.role {
-		assertSideEffectsContainsMessageWith(ses, expectedSignedState, bob, t)
+	for _, peer := range allActors {
+		if peer.role == myRole {
+			break
+		}
+		assertSideEffectsContainsMessageWith(ses, expectedSignedState, peer, t)
 	}
 }
-
 
 func collectPeerSignaturesOnSetupState(V *channel.SingleHopVirtualChannel, myRole uint, prefund bool) {
 	var state state.State
@@ -284,5 +280,10 @@ func testCrank(t *testing.T, my actor) {
 	if waitingFor != WaitingForNothing {
 		t.Fatalf(`WaitingFor: expected %v, got %v`, WaitingForNothing, waitingFor)
 	}
+}
 
+func TestCrank(t *testing.T) {
+	for _, a := range allActors {
+		testCrank(t, a)
+	}
 }

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -233,11 +233,18 @@ func TestCrankAsAlice(t *testing.T) {
 
 // Copied from https://github.com/benbjohnson/testing
 
+// makeRed sets the colour to red when printed
+const makeRed = "\033[31m"
+
+// makeBlack sets the colour to black when printed.
+// as it is intended to be used at the end of a string, it also adds two linebreaks
+const makeBlack = "\033[39m\n\n"
+
 // assert fails the test if the condition is false.
 func assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
 	if !condition {
 		_, file, line, _ := runtime.Caller(1)
-		fmt.Printf("\033[31m%s:%d: "+msg+"\033[39m\n\n", append([]interface{}{filepath.Base(file), line}, v...)...)
+		fmt.Printf(makeRed+"%s:%d: "+msg+makeBlack, append([]interface{}{filepath.Base(file), line}, v...)...)
 		tb.FailNow()
 	}
 }
@@ -246,7 +253,7 @@ func assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
 func ok(tb testing.TB, err error) {
 	if err != nil {
 		_, file, line, _ := runtime.Caller(1)
-		fmt.Printf("\033[31m%s:%d: unexpected error: %s\033[39m\n\n", filepath.Base(file), line, err.Error())
+		fmt.Printf(makeRed+"%s:%d: unexpected error: %s"+makeBlack, filepath.Base(file), line, err.Error())
 		tb.FailNow()
 	}
 }
@@ -255,7 +262,7 @@ func ok(tb testing.TB, err error) {
 func equals(tb testing.TB, exp, act interface{}) {
 	if !reflect.DeepEqual(exp, act) {
 		_, file, line, _ := runtime.Caller(1)
-		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, exp, act)
+		fmt.Printf(makeRed+"%s:%d:\n\n\texp: %#v\n\n\tgot: %#v"+makeBlack, filepath.Base(file), line, exp, act)
 		tb.FailNow()
 	}
 }
@@ -266,11 +273,11 @@ func equals(tb testing.TB, exp, act interface{}) {
 func assertProposalSent(t *testing.T, ses protocols.SideEffects, sp consensus_channel.SignedProposal, to actor) {
 	_, file, line, _ := runtime.Caller(1)
 	if len(ses.MessagesToSend) != 1 {
-		fmt.Printf("\033[31m%s:%d:\n\n\texpected one message", filepath.Base(file), line)
+		fmt.Printf(makeRed+"%s:%d:\n\n\texpected one message"+makeBlack, filepath.Base(file), line)
 		t.FailNow()
 	}
 	if len(ses.MessagesToSend[0].SignedProposals) != 1 {
-		fmt.Printf("\033[31m%s:%d:\n\n\texpected one signed proposal", filepath.Base(file), line)
+		fmt.Printf(makeRed+"%s:%d:\n\n\texpected one signed proposal"+makeBlack, filepath.Base(file), line)
 		t.FailNow()
 	}
 
@@ -278,12 +285,12 @@ func assertProposalSent(t *testing.T, ses protocols.SideEffects, sp consensus_ch
 	sent := msg.SignedProposals[0]
 
 	if !reflect.DeepEqual(sent.Proposal, sp.Proposal) {
-		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, sent.Proposal, sp.Proposal)
+		fmt.Printf(makeRed+"%s:%d:\n\n\texp: %+v\n\n\tgot: %+v"+makeBlack, filepath.Base(file), line, sent.Proposal, sp.Proposal)
 		t.FailNow()
 	}
 
 	if !bytes.Equal(msg.To[:], to.address[:]) {
-		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, msg.To.String(), to.address.String())
+		fmt.Printf(makeRed+"%s:%d:\n\n\texp: %#v\n\n\tgot: %#v"+makeBlack, filepath.Base(file), line, msg.To.String(), to.address.String())
 		t.FailNow()
 	}
 }
@@ -299,6 +306,6 @@ func assertStateSentTo(t *testing.T, ses protocols.SideEffects, expected state.S
 	}
 
 	_, file, line, _ := runtime.Caller(1)
-	fmt.Printf("\033[31m%s:%d:\n\n\tside effects do not incude signed state", filepath.Base(file), line)
+	fmt.Printf(makeRed+"%s:%d:\n\n\tside effects do not incude signed state"+makeBlack, filepath.Base(file), line)
 	t.FailNow()
 }

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/types"
@@ -40,5 +41,78 @@ func TestSingleHopVirtualFundNew(t *testing.T) {
 	vPostFund := vPreFund.Clone()
 	vPostFund.TurnNum = 1
 
+	TestAs := func(my actor, t *testing.T) {
+		prepareConsensusChannels := func(role uint) (*consensus_channel.ConsensusChannel, *consensus_channel.ConsensusChannel) {
+			var left *consensus_channel.ConsensusChannel
+			var right *consensus_channel.ConsensusChannel
 
+			switch role {
+			case 0:
+				right = prepareConsensusChannel(uint(consensus_channel.Leader), alice, p1)
+			case 1:
+				left = prepareConsensusChannel(uint(consensus_channel.Leader), alice, p1)
+				right = prepareConsensusChannel(uint(consensus_channel.Follower), p1, bob)
+			case 2:
+				left = prepareConsensusChannel(uint(consensus_channel.Leader), p1, bob)
+			}
+
+			return left, right
+		}
+
+		testNew := func(t *testing.T) {
+			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareConsensusChannels(my.role)
+
+			// Assert that a valid set of constructor args does not result in an error
+			o, err := constructFromState(false, vPreFund, my.address, ledgerChannelToMyLeft, ledgerChannelToMyRight) // todo: #420 deprecate TwoPartyLedgers
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var expectedGuaranteeMetadataLeft outcome.GuaranteeMetadata
+			var expectedGuaranteeMetadataRight outcome.GuaranteeMetadata
+			switch my.role {
+			case alice.role:
+				{
+					expectedGuaranteeMetadataRight = outcome.GuaranteeMetadata{Left: alice.destination, Right: p1.destination}
+				}
+			case p1.role:
+				{
+					expectedGuaranteeMetadataLeft = outcome.GuaranteeMetadata{Left: alice.destination, Right: p1.destination}
+					expectedGuaranteeMetadataRight = outcome.GuaranteeMetadata{Left: p1.destination, Right: bob.destination}
+				}
+			case bob.role:
+				{
+					expectedGuaranteeMetadataLeft = outcome.GuaranteeMetadata{Left: p1.destination, Right: bob.destination}
+				}
+			}
+			amount := big.NewInt(0).Set(vPreFund.VariablePart().Outcome[0].TotalAllocated())
+			if (expectedGuaranteeMetadataLeft != outcome.GuaranteeMetadata{}) {
+				gotLeft := o.ToMyLeft.getExpectedGuarantee()
+
+				left := expectedGuaranteeMetadataLeft.Left
+				right := expectedGuaranteeMetadataLeft.Left
+
+				wantLeft := consensus_channel.NewGuarantee(amount, o.V.Id, left, right)
+				if diff := compareGuarantees(wantLeft, gotLeft); diff != "" {
+					t.Fatalf("TestNew: expectedGuarantee mismatch (-want +got):\n%s", diff)
+				}
+			}
+			if (expectedGuaranteeMetadataRight != outcome.GuaranteeMetadata{}) {
+				gotRight := o.ToMyRight.getExpectedGuarantee()
+				left := expectedGuaranteeMetadataRight.Left
+				right := expectedGuaranteeMetadataRight.Left
+
+				wantRight := consensus_channel.NewGuarantee(amount, o.V.Id, left, right)
+				if diff := compareGuarantees(wantRight, gotRight); diff != "" {
+					t.Fatalf("TestNew: expectedGuarantee mismatch (-want +got):\n%s", diff)
+				}
+			}
+		}
+
+		t.Run(`New`, testNew)
+	}
+
+	t.Run(`AsAlice`, func(t *testing.T) { TestAs(alice, t) })
+	t.Run(`AsBob`, func(t *testing.T) { TestAs(bob, t) })
+	t.Run(`AsP1`, func(t *testing.T) { TestAs(p1, t) })
 }

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -84,7 +84,7 @@ func assertCorrectConnection(t *testing.T, c *Connection, left, right actor) {
 	}
 }
 
-func testNewAsActor(t *testing.T, a actor) {
+func testNew(t *testing.T, a actor) {
 	td := newTestData()
 	lookup := td.ledgers
 	vPreFund := td.vPreFund
@@ -119,6 +119,26 @@ var actors = []actor{alice, p1, bob}
 
 func TestNew(t *testing.T) {
 	for _, a := range actors {
-		testNewAsActor(t, a)
+		testNew(t, a)
+	}
+}
+
+func testClone(t *testing.T, my actor) {
+	td := newTestData()
+	vPreFund := td.vPreFund
+	ledgers := td.ledgers
+
+	o, _ := constructFromState(false, vPreFund, my.address, ledgers[my.destination].left, ledgers[my.destination].right)
+
+	clone := o.clone()
+
+	if diff := compareObjectives(o, clone); diff != "" {
+		t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestClone(t *testing.T) {
+	for _, a := range actors {
+		testClone(t, a)
 	}
 }


### PR DESCRIPTION
We were struggling to make progress towards #420, and we identified that there was a key reason we were struggling:
> the virtualfund unit tests take advantage of the fact that `Channel` receives arbitrary states, and test the `Crank` method by sending an arbitrary state for the ledger channel

This has a few implications when switching to ConsensusChannels
- ConsensusChannels are strict about what data they receive: an invalid or unexpected proposal is rejected.
- Our old strategy was to assert on equal behaviour between a ConsensusChannel and a TwoPartyLedger channel. But, because the test took advantage of arbitrary TwoPartyLedger behaviour, we needed to be really careful about setting up ledger channels correctly!
- testCrank and testUpdate are written to apply to Alice, Bob and P1. But, unless they are set up with ledger channels where they have the same role, applying the same test function to all actors is really awkward

This PR is attempting a different strategy towards migrating to ConsensusChannel:
1. remove TwoPartyLedger from a `connection`. This causes the build to break!
2. fix the build errors, and review the failing tests
3. skip the failing virtual fund-related tests
4. write more rigorous virtualfund unit tests

In step 4, I chose to copy the old unit test file (`virtualfund-single-hop_test.go`) to a new file (`virtualfund_single_hop_test.go`). The difference in filename is the old file had hyphens (which I believe are not kosher?)

In the new unit test file, I unwrap some of the nesting from the old file, and rewrite the intent of `testNew`, `testClone`, and (some of) `testCrank` (from Alice's perspective). If you look at the two files side by side, you should hopefully see that they have the same intent.

When writing the new test file, I aimed to make the tests easy to understand. So, I took inspiration from https://github.com/benbjohnson/testing and wrote some assertions that help developers pinpoint test failures

Further work:
- finishing testCrank from Alice's perspective
- write testCrank from p1 & Bob's perspective
- write testUpdate
- delete the old unit test file
- unskip failing integration tests


#### Code quality

- [ ] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [ ] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
