### PR TITLE
Implement round 1 of virtual defunding

### DIFF
--- a/channel/state/signedstate.go
+++ b/channel/state/signedstate.go
@@ -66,7 +66,8 @@ func (ss SignedState) State() State {
 }
 
 // Signatures returns a slice of the signatures stored in the SignedState.
-// There will be one signature per participant. Either a valid signature or a zero value.
+// There will be one signature per participant, in order of channel's Participants.
+// Returned signatures are expected either to be valid or zero-valued.
 func (ss SignedState) Signatures() []Signature {
 	sigs := make([]Signature, len(ss.state.Participants))
 	for i := 0; i < len(ss.state.Participants); i++ {

--- a/channel/state/signedstate.go
+++ b/channel/state/signedstate.go
@@ -65,6 +65,16 @@ func (ss SignedState) State() State {
 	return ss.state
 }
 
+// Signatures returns a slice of the signatures stored in the SignedState.
+// There will be one signature per participant. Either a valid signature or a zero value.
+func (ss SignedState) Signatures() []Signature {
+	sigs := make([]Signature, len(ss.state.Participants))
+	for i := 0; i < len(ss.state.Participants); i++ {
+		sigs[i] = ss.sigs[uint(i)]
+	}
+	return sigs
+}
+
 // HasSignatureForParticipant returns true if the participant (at participantIndex) has a valid signature.
 func (ss SignedState) HasSignatureForParticipant(participantIndex uint) bool {
 	_, found := ss.sigs[uint(participantIndex)]

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -228,9 +228,9 @@ func (o Objective) signedByMe() bool {
 
 }
 
-// ValidateSignature returns whether the given signature is valid for the given participant
+// validateSignature returns whether the given signature is valid for the given participant
 // If a signature is invalid an error will be returned containing the reason
-func (o Objective) ValidateSignature(sig state.Signature, participantIndex uint) (bool, error) {
+func (o Objective) validateSignature(sig state.Signature, participantIndex uint) (bool, error) {
 	if participantIndex > 2 {
 		return false, fmt.Errorf("participant index %d is out of bounds", participantIndex)
 	}
@@ -280,7 +280,7 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 					}
 				}
 				// Otherwise we validate the incoming signature and update our signatures
-				isValid, err := updated.ValidateSignature(incomingSig, i)
+				isValid, err := updated.validateSignature(incomingSig, i)
 				if isValid {
 					// Update the signature
 					updated.Signatures[i] = incomingSig

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -229,7 +229,7 @@ func (o Objective) signedByMe() bool {
 }
 
 // ValidateSignature returns whether the given signature is valid for the given participant
-// If a signature is invalid an error will be returned conaining the reason
+// If a signature is invalid an error will be returned containing the reason
 func (o Objective) ValidateSignature(sig state.Signature, participantIndex uint) (bool, error) {
 	if participantIndex > 2 {
 		return false, fmt.Errorf("participant index %d is out of bounds", participantIndex)
@@ -304,7 +304,7 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 		var err error
 		switch sp.Proposal.ChannelID {
 		case types.Destination{}:
-			return &o, fmt.Errorf("signed proposal is for a zero-addressed ledger channel") // catch this case to avoid unspecified behaviour -- because if Alice or Bob we allow a null channel.
+			return &o, fmt.Errorf("signed proposal is for a zero-addressed ledger channel") // catch this case to avoid unspecified behaviour -- because of Alice or Bob we allow a null channel.
 		case toMyLeftId:
 			err = updated.ToMyLeft.Receive(sp)
 		case toMyRightId:

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -78,9 +78,11 @@ func newObjective(preApprove bool, vFixed state.FixedPart, initialOutcome outcom
 func (o Objective) signedFinalState() (state.SignedState, error) {
 	signed := state.NewSignedState(o.finalState())
 	for _, sig := range o.Signatures {
-		err := signed.AddSignature(sig)
-		if err != nil {
-			return state.SignedState{}, err
+		if !isZero(sig) {
+			err := signed.AddSignature(sig)
+			if err != nil {
+				return state.SignedState{}, err
+			}
 		}
 	}
 	return signed, nil

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -132,7 +132,7 @@ func testCrankAs(my ta.Actor) func(t *testing.T) {
 
 		testhelpers.Equals(t, waitingFor, WaitingForCompleteFinal)
 		signedByMe := state.NewSignedState(data.vFinal)
-		signedByMe.Sign(&my.PrivateKey)
+		_ = signedByMe.Sign(&my.PrivateKey)
 		assertStateSentToEveryone(t, se, signedByMe, my)
 
 		// Update the signatures on the objective so the final state is fully signed
@@ -143,7 +143,7 @@ func testCrankAs(my ta.Actor) func(t *testing.T) {
 			}
 		}
 
-		updatedObj, se, waitingFor, err = updated.Crank(&my.PrivateKey)
+		_, se, waitingFor, err = updated.Crank(&my.PrivateKey)
 		testhelpers.Ok(t, err)
 
 		testhelpers.Equals(t, waitingFor, WaitingForCompleteLedgerDefunding)

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -83,16 +83,20 @@ func signByOthers(my ta.Actor, signedState state.SignedState) state.SignedState 
 func assertStateSentToEveryone(t *testing.T, ses protocols.SideEffects, expected state.SignedState, from testactors.Actor) {
 	for _, a := range allActors {
 		if a.Role != from.Role {
-			for _, msg := range ses.MessagesToSend {
-				if bytes.Equal(msg.To[:], a.Address[:]) {
-					for _, ss := range msg.SignedStates {
-						testhelpers.Equals(t, ss, expected)
-					}
-				}
+			assertStateSentTo(t, ses, expected, a)
+		}
+	}
+}
+
+// assertStateSentTo asserts that ses contains a message for the participant
+func assertStateSentTo(t *testing.T, ses protocols.SideEffects, expected state.SignedState, to testactors.Actor) {
+	for _, msg := range ses.MessagesToSend {
+		if bytes.Equal(msg.To[:], to.Address[:]) {
+			for _, ss := range msg.SignedStates {
+				testhelpers.Equals(t, ss, expected)
 			}
 		}
 	}
-
 }
 
 func TestUpdate(t *testing.T) {

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-var alice = ta.Actors.Alice
-var bob = ta.Actors.Bob
-var irene = ta.Actors.Irene
+var alice = ta.Alice
+var bob = ta.Bob
+var irene = ta.Irene
 var allActors = []ta.Actor{alice, irene, bob}
 
 // makeOutcome creates an outcome allocating to alice and bob

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -1,0 +1,100 @@
+package virtualdefund
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/internal/testdata"
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/types"
+)
+
+var alice = testdata.Actors.Alice
+var bob = testdata.Actors.Bob
+var irene = testdata.Actors.Irene
+
+func makeOutcome(aliceAmount uint, bobAmount uint) outcome.SingleAssetExit {
+	return outcome.SingleAssetExit{
+		Allocations: outcome.Allocations{
+			outcome.Allocation{
+				Destination: alice.Destination(),
+				Amount:      big.NewInt(int64(aliceAmount)),
+			},
+			outcome.Allocation{
+				Destination: bob.Destination(),
+				Amount:      big.NewInt(int64(bobAmount)),
+			},
+		},
+	}
+}
+
+func TestSingleHopVirtualDefund(t *testing.T) {
+
+	vFixed := state.FixedPart{
+		ChainId:           big.NewInt(9001),
+		Participants:      []types.Address{alice.Address, irene.Address, bob.Address}, // A single hop virtual channel
+		ChannelNonce:      big.NewInt(0),
+		AppDefinition:     types.Address{},
+		ChallengeDuration: big.NewInt(45),
+	}
+
+	initialOutcome := makeOutcome(7, 2)
+	finalOutcome := makeOutcome(6, 3)
+	paid := 1
+
+	vFinal := state.StateFromFixedAndVariablePart(vFixed, state.VariablePart{IsFinal: true, Outcome: outcome.Exit{finalOutcome}, TurnNum: FinalTurnNum})
+
+	TestAs := func(my testdata.Actor, t *testing.T) {
+		// Determine my role
+		var myRole uint
+		for i, p := range vFixed.Participants {
+			if p == my.Address {
+				myRole = uint(i)
+
+				break
+			}
+		}
+
+		virtualDefund := newObjective(false, vFixed, initialOutcome, big.NewInt(int64(paid)), myRole)
+
+		testUpdate := func(t *testing.T) {
+			signedFinal := state.NewSignedState(vFinal)
+			// Sign the final state by some other participant
+			if myRole == 0 {
+				_ = signedFinal.Sign(&irene.PrivateKey)
+
+			} else {
+				_ = signedFinal.Sign(&alice.PrivateKey)
+			}
+
+			e := protocols.ObjectiveEvent{ObjectiveId: virtualDefund.Id(), SignedStates: []state.SignedState{signedFinal}}
+
+			updatedObj, err := virtualDefund.Update(e)
+			updated := updatedObj.(*Objective)
+			if myRole == 0 {
+				if isZero(updated.Signatures[1]) {
+					t.Fatalf("Expected signature for participant irene to be non-zero")
+				}
+
+			} else {
+				if isZero(updated.Signatures[0]) {
+					t.Fatalf("Expected signature for participant alice to be non-zero")
+				}
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+
+		}
+
+		t.Run(`testUpdate`, testUpdate)
+
+	}
+
+	t.Run(`AsAlice`, func(t *testing.T) { TestAs(alice, t) })
+	t.Run(`AsBob`, func(t *testing.T) { TestAs(bob, t) })
+	t.Run(`AsIrene`, func(t *testing.T) { TestAs(irene, t) })
+
+}

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -117,7 +117,7 @@ func TestInvalidUpdate(t *testing.T) {
 
 	signedFinal := state.NewSignedState(invalidFinal)
 
-	// Sign the final state by some other participant
+	// Sign the final state by other participant
 	signByOthers(alice, signedFinal)
 
 	e := protocols.ObjectiveEvent{ObjectiveId: virtualDefund.Id(), SignedStates: []state.SignedState{signedFinal}}


### PR DESCRIPTION
Fixes #478

This implements the first round of virtual defunding, which is exchanging the final state for `V`.  Tests have been added for `Update` and `Crank` to make sure they properly handle the exchange of final states.

