### PR TITLE
Restrict channel ownership

### DIFF
--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -76,11 +76,22 @@ func TestGetObjectiveByChannelId(t *testing.T) {
 
 	dfo := td.Objectives.Directfund.GenericDFO()
 
+	// Store an unapproved objective
 	if err := ms.SetObjective(&dfo); err != nil {
 		t.Errorf("error setting objective %v: %s", dfo, err.Error())
 	}
 
 	got, ok := ms.GetObjectiveByChannelId(dfo.C.Id)
+	if ok {
+		t.Error("when an unapproved objective is stored, the objective should not own the channel")
+	}
+
+	// Now, approve the objective
+	dfo.Status = protocols.Approved
+	if err := ms.SetObjective(&dfo); err != nil {
+		t.Errorf("error setting objective %v: %s", dfo, err.Error())
+	}
+	got, ok = ms.GetObjectiveByChannelId(dfo.C.Id)
 
 	if !ok {
 		t.Errorf("expected to find the inserted objective, but didn't")

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -127,6 +127,11 @@ func (dfo *Objective) OwnsChannel() types.Destination {
 	return dfo.C.Id
 }
 
+// GetStatus returns the status of the objective.
+func (dfo *Objective) GetStatus() protocols.ObjectiveStatus {
+	return dfo.Status
+}
+
 // CreateConsensusChannel creates a ConsensusChannel from the Objective by extracting signatures and a single asset outcome from the post fund state.
 func (dfo *Objective) CreateConsensusChannel() (*consensus_channel.ConsensusChannel, error) {
 	ledger := dfo.C

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -76,8 +76,10 @@ type Objective interface {
 	Related() []Storable
 	Storable
 
-	// every objective has exclusive ownership of a channel while active
+	// OwnsChannel returns the channel the objective exclusively owns.
 	OwnsChannel() types.Destination
+	// GetStatus returns the status of the objective.
+	GetStatus() ObjectiveStatus
 }
 
 // ObjectiveId is a unique identifier for an Objective.

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -97,6 +97,11 @@ func (o Objective) OwnsChannel() types.Destination {
 	return vId
 }
 
+// GetStatus returns the status of the objective.
+func (o Objective) GetStatus() protocols.ObjectiveStatus {
+	return o.Status
+}
+
 // Relable returns related channels that need to be stored along with the objective.
 func (o *Objective) Related() []protocols.Storable {
 	relatable := []protocols.Storable{}

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -296,6 +296,11 @@ func (o Objective) OwnsChannel() types.Destination {
 	return o.V.Id
 }
 
+// GetStatus returns the status of the objective.
+func (o Objective) GetStatus() protocols.ObjectiveStatus {
+	return o.Status
+}
+
 // Update receives an protocols.ObjectiveEvent, applies all applicable event data to the VirtualFundObjective,
 // and returns the updated state.
 func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, error) {


### PR DESCRIPTION
A channel can be owned by only one objective. When an objective is approved, it owns the channel. If another objective owns the channel when an objective is approved, the result is an error.

Future works should introduce completed/failed objective status and channel ownership release when such status is set. 