### PR TITLE
fix: godoc bullet list rendering

### DIFF
--- a/abi/types.go
+++ b/abi/types.go
@@ -4,8 +4,8 @@ import "github.com/ethereum/go-ethereum/accounts/abi"
 
 // To encode objects as bytes, we need to construct an encoder, using abi.Arguments.
 // An instance of abi.Arguments implements two functions relevant to us:
-// - `Pack`, which packs go values for a given struct into bytes.
-// - `unPack`, which unpacks bytes into go values
+//  - `Pack`, which packs go values for a given struct into bytes.
+//  - `unPack`, which unpacks bytes into go values
 // To construct an abi.Arguments instance, we need to supply an array of "types", which are
 // actually go values. The following types are used when encoding a state
 

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -274,9 +274,9 @@ func (o *LedgerOutcome) includes(g Guarantee) bool {
 
 // FromExit creates a new LedgerOutcome from the given SingleAssetExit.
 // It makes some assumptions about the exit:
-// - The first alloction entry is for left
-// - The second alloction entry is for right
-// - We ignore guarantee metadata and just assume that it is [left,right]
+//  - The first alloction entry is for left
+//  - The second alloction entry is for right
+//  - We ignore guarantee metadata and just assume that it is [left,right]
 func FromExit(sae outcome.SingleAssetExit) LedgerOutcome {
 
 	left := Balance{destination: sae.Allocations[0].Destination, amount: sae.Allocations[0].Amount}
@@ -299,9 +299,9 @@ func FromExit(sae outcome.SingleAssetExit) LedgerOutcome {
 }
 
 // AsOutcome converts a LedgerOutcome to an on-chain exit according to the following convention:
-// - the "left" balance is first
-// - the "right" balance is second
-// - following [left, right] comes the guarantees in sorted order
+//  - the "left" balance is first
+//  - the "right" balance is second
+//  - following [left, right] comes the guarantees in sorted order
 func (o *LedgerOutcome) AsOutcome() outcome.Exit {
 	// The first items are [left, right] balances
 	allocations := outcome.Allocations{o.left.AsAllocation(), o.right.AsAllocation()}
@@ -559,14 +559,14 @@ func (vars *Vars) Add(p Add) error {
 }
 
 // Remove mutates Vars by
-// - increasing the turn number by 1
-// - removing the guarantee for the Target channel
-// - adjusting balances accordingly based on LeftAmount and RightAmount
+//  - increasing the turn number by 1
+//  - removing the guarantee for the Target channel
+//  - adjusting balances accordingly based on LeftAmount and RightAmount
 //
 // An error is returned if:
-// - the turn number is not incremented
-// - a guarantee is not found for the target
-// - the amounts are too large for the guarantee amount
+//  - the turn number is not incremented
+//  - a guarantee is not found for the target
+//  - the amounts are too large for the guarantee amount
 //
 // If an error is returned, the original vars is not mutated
 func (vars *Vars) Remove(p Remove) error {

--- a/channel/state/signedstate.go
+++ b/channel/state/signedstate.go
@@ -35,8 +35,8 @@ func (ss SignedState) Sign(secretKey *[]byte) error {
 // AddSignature adds a participant's signature to the SignedState.
 //
 // An error is returned if
-// - the signer is not a participant, or
-// - OR the signature was already stored
+//  - the signer is not a participant, or
+//  - OR the signature was already stored
 func (ss SignedState) AddSignature(sig Signature) error {
 	signer, err := ss.state.RecoverSigner(sig)
 	if err != nil {

--- a/client/engine/chainservice/mockchain_test.go
+++ b/client/engine/chainservice/mockchain_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestDeposit(t *testing.T) {
 	// The MockChain and SimpleChainService should work together to react to a deposit transaction for a given channel by:
-	// - sending an event with updated holdings for that channel to all SimpleChainServices which are subscribed
+	//  - sending an event with updated holdings for that channel to all SimpleChainServices which are subscribed
 
 	var a = types.Address(common.HexToAddress(`a`))
 	var b = types.Address(common.HexToAddress(`b`))

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -180,8 +180,8 @@ func compareSideEffect(a, b protocols.SideEffects) string {
 
 func TestCrankAlice(t *testing.T) {
 	// The starting channel state is:
-	// - Channel has a non-final consensus state
-	// - Channel has funds
+	//  - Channel has a non-final consensus state
+	//  - Channel has funds
 	o, _ := newTestObjective(true)
 
 	// The first crank. Alice is expected to create and sign a final state
@@ -261,8 +261,8 @@ func TestCrankAlice(t *testing.T) {
 
 func TestCrankBob(t *testing.T) {
 	// The starting channel state is:
-	// - Channel has a non-final non-consensus state
-	// - Channel has funds
+	//  - Channel has a non-final non-consensus state
+	//  - Channel has funds
 
 	o, _ := newTestObjective(true)
 	o.C.MyIndex = 1

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -235,8 +235,8 @@ func TestCrank(t *testing.T) {
 
 	// To test the finite state progression, we are going to progressively mutate o
 	// And then crank it to see
-	// - which "pause point" (WaitingFor) we end up at,
-	// - what side effects are declared.
+	//  - which "pause point" (WaitingFor) we end up at,
+	//  - what side effects are declared.
 
 	// Initial Crank
 	_, sideEffects, waitingFor, err := o.Crank(&alice.privateKey)


### PR DESCRIPTION
tooling (godoc, as presented at pkg.go.dev, or editor intellisense)
parses the previous formatting as mid-sentence hyphens. See, eg, https://pkg.go.dev/github.com/statechannels/go-nitro@v0.0.0-20220327004325-93271ce843f1/channel/consensus_channel#LedgerOutcome.AsOutcome

Not all of these changes are to godoc strings, but they were applied also to
comments which might, in future, be copied somewhere as godoc strings

---

#### Code quality
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
