### PR TITLE
Update tests to use test actors

### DIFF
--- a/channel/consensus_channel/helpers_test.go
+++ b/channel/consensus_channel/helpers_test.go
@@ -3,8 +3,8 @@ package consensus_channel
 import (
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -15,27 +15,7 @@ const aBal = uint64(200)
 const bBal = uint64(300)
 const vAmount = uint64(5)
 
-type actor struct {
-	Address    types.Address
-	PrivateKey []byte
-}
-
-func (a actor) Destination() types.Destination {
-	return types.AddressToDestination(a.Address)
-}
-
-var alice = actor{
-	common.HexToAddress(`0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE`),
-	common.Hex2Bytes(`2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d`),
-}
-var bob = actor{
-	common.HexToAddress(`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`),
-	common.Hex2Bytes(`0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4`),
-}
-var brian = actor{
-	common.HexToAddress("0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01"),
-	common.Hex2Bytes("0aca28ba64679f63d71e671ab4dbb32aaa212d4789988e6ca47da47601c18fe2"),
-}
+var alice, bob, brian testactors.Actor = testactors.Actors.Alice, testactors.Actors.Bob, testactors.Actors.Brian
 
 func fp() state.FixedPart {
 	participants := [2]types.Address{
@@ -49,11 +29,11 @@ func fp() state.FixedPart {
 	}
 }
 
-func allocation(d actor, a uint64) Balance {
+func allocation(d testactors.Actor, a uint64) Balance {
 	return Balance{destination: d.Destination(), amount: big.NewInt(int64(a))}
 }
 
-func guarantee(amount uint64, target types.Destination, left, right actor) Guarantee {
+func guarantee(amount uint64, target types.Destination, left, right testactors.Actor) Guarantee {
 	return Guarantee{
 		target: target,
 		amount: big.NewInt(int64(amount)),
@@ -83,7 +63,7 @@ func ledgerOutcome() LedgerOutcome {
 
 }
 
-func add(turnNum, amount uint64, vId types.Destination, left, right actor) Add {
+func add(turnNum, amount uint64, vId types.Destination, left, right testactors.Actor) Add {
 	bigAmount := big.NewInt(int64(amount))
 	return Add{
 		turnNum: turnNum,

--- a/channel/consensus_channel/helpers_test.go
+++ b/channel/consensus_channel/helpers_test.go
@@ -15,7 +15,7 @@ const aBal = uint64(200)
 const bBal = uint64(300)
 const vAmount = uint64(5)
 
-var alice, bob, brian testactors.Actor = testactors.Actors.Alice, testactors.Actors.Bob, testactors.Actors.Brian
+var alice, bob, brian testactors.Actor = testactors.Alice, testactors.Bob, testactors.Brian
 
 func fp() state.FixedPart {
 	participants := [2]types.Address{

--- a/channel/consensus_channel/leader_channel_test.go
+++ b/channel/consensus_channel/leader_channel_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -43,7 +44,7 @@ func TestLeaderChannel(t *testing.T) {
 
 	// createSignedProposal generates a proposal given the vars & proposed change
 	// The proposal is signed by the given actor, using a generic fixed part
-	createSignedProposal := func(vars Vars, p Proposal, actor actor) SignedProposalVars {
+	createSignedProposal := func(vars Vars, p Proposal, actor testactors.Actor) SignedProposalVars {
 		proposalVars := Vars{TurnNum: vars.TurnNum, Outcome: vars.Outcome.clone()}
 		_ = proposalVars.HandleProposal(p)
 

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -117,25 +117,25 @@ func TestConsensusChannelStore(t *testing.T) {
 
 	ms := store.NewMockStore(sk)
 
-	got, ok := ms.GetConsensusChannel(ta.Actors.Alice.Address)
+	got, ok := ms.GetConsensusChannel(ta.Alice.Address)
 	if ok {
 		t.Fatalf("expected not to find the a consensus channel, but found %v", got)
 	}
 
 	fp := td.Objectives.Directfund.GenericDFO().C.FixedPart // TODO replace with testdata not nested under GenericDFO
-	fp.Participants[0] = ta.Actors.Alice.Address
-	fp.Participants[1] = ta.Actors.Bob.Address
+	fp.Participants[0] = ta.Alice.Address
+	fp.Participants[1] = ta.Bob.Address
 	asset := types.Address{}
-	left := cc.NewBalance(ta.Actors.Alice.Destination(), big.NewInt(6))
-	right := cc.NewBalance(ta.Actors.Bob.Destination(), big.NewInt(4))
+	left := cc.NewBalance(ta.Alice.Destination(), big.NewInt(6))
+	right := cc.NewBalance(ta.Bob.Destination(), big.NewInt(4))
 
 	existingGuarantee := cc.NewGuarantee(big.NewInt(1), types.Destination{1}, left.AsAllocation().Destination, right.AsAllocation().Destination)
 	outcome := cc.NewLedgerOutcome(asset, left, right, []cc.Guarantee{existingGuarantee})
 
 	initialVars := consensus_channel.Vars{Outcome: *outcome, TurnNum: 0}
 
-	aliceSig, _ := initialVars.AsState(fp).Sign(ta.Actors.Alice.PrivateKey)
-	bobsSig, _ := initialVars.AsState(fp).Sign(ta.Actors.Bob.PrivateKey)
+	aliceSig, _ := initialVars.AsState(fp).Sign(ta.Alice.PrivateKey)
+	bobsSig, _ := initialVars.AsState(fp).Sign(ta.Bob.PrivateKey)
 
 	leader, err := consensus_channel.NewLeaderChannel(
 		fp,
@@ -150,7 +150,7 @@ func TestConsensusChannelStore(t *testing.T) {
 	// Generate a new proposal so we test that the proposal queue is being fetched properly
 	proposedGuarantee := cc.NewGuarantee(big.NewInt(1), types.Destination{2}, left.AsAllocation().Destination, right.AsAllocation().Destination)
 	proposal := cc.NewAddProposal(types.Destination{3}, 2, proposedGuarantee, big.NewInt(1))
-	_, err = leader.Propose(proposal, ta.Actors.Alice.PrivateKey)
+	_, err = leader.Propose(proposal, ta.Alice.PrivateKey)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/client/engine/store"
 	nc "github.com/statechannels/go-nitro/crypto"
+	ta "github.com/statechannels/go-nitro/internal/testactors"
 	td "github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/protocols/directfund"
@@ -116,25 +117,25 @@ func TestConsensusChannelStore(t *testing.T) {
 
 	ms := store.NewMockStore(sk)
 
-	got, ok := ms.GetConsensusChannel(td.Actors.Alice.Address)
+	got, ok := ms.GetConsensusChannel(ta.Actors.Alice.Address)
 	if ok {
 		t.Fatalf("expected not to find the a consensus channel, but found %v", got)
 	}
 
 	fp := td.Objectives.Directfund.GenericDFO().C.FixedPart // TODO replace with testdata not nested under GenericDFO
-	fp.Participants[0] = td.Actors.Alice.Address
-	fp.Participants[1] = td.Actors.Bob.Address
+	fp.Participants[0] = ta.Actors.Alice.Address
+	fp.Participants[1] = ta.Actors.Bob.Address
 	asset := types.Address{}
-	left := cc.NewBalance(td.Actors.Alice.Destination(), big.NewInt(6))
-	right := cc.NewBalance(td.Actors.Bob.Destination(), big.NewInt(4))
+	left := cc.NewBalance(ta.Actors.Alice.Destination(), big.NewInt(6))
+	right := cc.NewBalance(ta.Actors.Bob.Destination(), big.NewInt(4))
 
 	existingGuarantee := cc.NewGuarantee(big.NewInt(1), types.Destination{1}, left.AsAllocation().Destination, right.AsAllocation().Destination)
 	outcome := cc.NewLedgerOutcome(asset, left, right, []cc.Guarantee{existingGuarantee})
 
 	initialVars := consensus_channel.Vars{Outcome: *outcome, TurnNum: 0}
 
-	aliceSig, _ := initialVars.AsState(fp).Sign(td.Actors.Alice.PrivateKey)
-	bobsSig, _ := initialVars.AsState(fp).Sign(td.Actors.Bob.PrivateKey)
+	aliceSig, _ := initialVars.AsState(fp).Sign(ta.Actors.Alice.PrivateKey)
+	bobsSig, _ := initialVars.AsState(fp).Sign(ta.Actors.Bob.PrivateKey)
 
 	leader, err := consensus_channel.NewLeaderChannel(
 		fp,
@@ -149,7 +150,7 @@ func TestConsensusChannelStore(t *testing.T) {
 	// Generate a new proposal so we test that the proposal queue is being fetched properly
 	proposedGuarantee := cc.NewGuarantee(big.NewInt(1), types.Destination{2}, left.AsAllocation().Destination, right.AsAllocation().Destination)
 	proposal := cc.NewAddProposal(types.Destination{3}, 2, proposedGuarantee, big.NewInt(1))
-	_, err = leader.Propose(proposal, td.Actors.Alice.PrivateKey)
+	_, err = leader.Propose(proposal, ta.Actors.Alice.PrivateKey)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client_test/actors_test.go
+++ b/client_test/actors_test.go
@@ -2,7 +2,7 @@ package client_test
 
 import "github.com/statechannels/go-nitro/internal/testactors"
 
-var alice = testactors.Actors.Alice
-var bob = testactors.Actors.Bob
-var irene = testactors.Actors.Irene
-var brian = testactors.Actors.Brian
+var alice = testactors.Alice
+var bob = testactors.Bob
+var irene = testactors.Irene
+var brian = testactors.Brian

--- a/client_test/actors_test.go
+++ b/client_test/actors_test.go
@@ -1,8 +1,8 @@
 package client_test
 
-import "github.com/statechannels/go-nitro/internal/testdata"
+import "github.com/statechannels/go-nitro/internal/testactors"
 
-var alice = testdata.Actors.Alice
-var bob = testdata.Actors.Bob
-var irene = testdata.Actors.Irene
-var brian = testdata.Actors.Brian
+var alice = testactors.Actors.Alice
+var bob = testactors.Actors.Bob
+var irene = testactors.Actors.Irene
+var brian = testactors.Actors.Brian

--- a/internal/testactors/actors.go
+++ b/internal/testactors/actors.go
@@ -8,6 +8,8 @@ import (
 type Actor struct {
 	Address    types.Address
 	PrivateKey []byte
+	Role       uint
+	Name       string
 }
 
 func (a Actor) Destination() types.Destination {
@@ -28,17 +30,25 @@ var Actors actors = actors{
 	Alice: Actor{
 		common.HexToAddress(`0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE`),
 		common.Hex2Bytes(`2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d`),
+		0,
+		"alice",
 	},
 	Bob: Actor{
 		common.HexToAddress(`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`),
 		common.Hex2Bytes(`0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4`),
+		2,
+		"bob",
 	},
 	Brian: Actor{
 		common.HexToAddress("0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01"),
 		common.Hex2Bytes("0aca28ba64679f63d71e671ab4dbb32aaa212d4789988e6ca47da47601c18fe2"),
+		2,
+		"brian",
 	},
 	Irene: Actor{
 		common.HexToAddress(`0x111A00868581f73AB42FEEF67D235Ca09ca1E8db`),
 		common.Hex2Bytes(`febb3b74b0b52d0976f6571d555f4ac8b91c308dfa25c7b58d1e6a7c3f50c781`),
+		1,
+		"irene",
 	},
 }

--- a/internal/testactors/actors.go
+++ b/internal/testactors/actors.go
@@ -16,39 +16,27 @@ func (a Actor) Destination() types.Destination {
 	return types.AddressToDestination(a.Address)
 }
 
-// actors namespaces the actors exported for test consumption
-type actors struct {
-	Alice Actor
-	Bob   Actor
-	Brian Actor
-	Irene Actor
+var Alice Actor = Actor{
+	common.HexToAddress(`0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE`),
+	common.Hex2Bytes(`2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d`),
+	0,
+	"alice",
 }
-
-// Actors is the endpoint for tests to consume constructed statechannel
-// network participants (public-key secret-key pairs)
-var Actors actors = actors{
-	Alice: Actor{
-		common.HexToAddress(`0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE`),
-		common.Hex2Bytes(`2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d`),
-		0,
-		"alice",
-	},
-	Bob: Actor{
-		common.HexToAddress(`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`),
-		common.Hex2Bytes(`0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4`),
-		2,
-		"bob",
-	},
-	Brian: Actor{
-		common.HexToAddress("0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01"),
-		common.Hex2Bytes("0aca28ba64679f63d71e671ab4dbb32aaa212d4789988e6ca47da47601c18fe2"),
-		2,
-		"brian",
-	},
-	Irene: Actor{
-		common.HexToAddress(`0x111A00868581f73AB42FEEF67D235Ca09ca1E8db`),
-		common.Hex2Bytes(`febb3b74b0b52d0976f6571d555f4ac8b91c308dfa25c7b58d1e6a7c3f50c781`),
-		1,
-		"irene",
-	},
+var Bob Actor = Actor{
+	common.HexToAddress(`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`),
+	common.Hex2Bytes(`0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4`),
+	2,
+	"bob",
+}
+var Brian Actor = Actor{
+	common.HexToAddress("0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01"),
+	common.Hex2Bytes("0aca28ba64679f63d71e671ab4dbb32aaa212d4789988e6ca47da47601c18fe2"),
+	2,
+	"brian",
+}
+var Irene Actor = Actor{
+	common.HexToAddress(`0x111A00868581f73AB42FEEF67D235Ca09ca1E8db`),
+	common.Hex2Bytes(`febb3b74b0b52d0976f6571d555f4ac8b91c308dfa25c7b58d1e6a7c3f50c781`),
+	1,
+	"irene",
 }

--- a/internal/testactors/actors.go
+++ b/internal/testactors/actors.go
@@ -1,4 +1,4 @@
-package testdata
+package testactors
 
 import (
 	"github.com/ethereum/go-ethereum/common"

--- a/internal/testdata/actors.go
+++ b/internal/testdata/actors.go
@@ -5,39 +5,39 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-type actor struct {
+type Actor struct {
 	Address    types.Address
 	PrivateKey []byte
 }
 
-func (a actor) Destination() types.Destination {
+func (a Actor) Destination() types.Destination {
 	return types.AddressToDestination(a.Address)
 }
 
 // actors namespaces the actors exported for test consumption
 type actors struct {
-	Alice actor
-	Bob   actor
-	Brian actor
-	Irene actor
+	Alice Actor
+	Bob   Actor
+	Brian Actor
+	Irene Actor
 }
 
 // Actors is the endpoint for tests to consume constructed statechannel
 // network participants (public-key secret-key pairs)
 var Actors actors = actors{
-	Alice: actor{
+	Alice: Actor{
 		common.HexToAddress(`0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE`),
 		common.Hex2Bytes(`2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d`),
 	},
-	Bob: actor{
+	Bob: Actor{
 		common.HexToAddress(`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`),
 		common.Hex2Bytes(`0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4`),
 	},
-	Brian: actor{
+	Brian: Actor{
 		common.HexToAddress("0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01"),
 		common.Hex2Bytes("0aca28ba64679f63d71e671ab4dbb32aaa212d4789988e6ca47da47601c18fe2"),
 	},
-	Irene: actor{
+	Irene: Actor{
 		common.HexToAddress(`0x111A00868581f73AB42FEEF67D235Ca09ca1E8db`),
 		common.Hex2Bytes(`febb3b74b0b52d0976f6571d555f4ac8b91c308dfa25c7b58d1e6a7c3f50c781`),
 	},

--- a/internal/testdata/states.go
+++ b/internal/testdata/states.go
@@ -35,24 +35,24 @@ var chainId, _ = big.NewInt(0).SetString("9001", 10)
 var someAppDefinition = common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`)
 
 var testOutcome = createLongOutcome(
-	SimpleItem{testactors.Actors.Alice.Destination(), 6},
-	SimpleItem{testactors.Actors.Bob.Destination(), 6},
+	SimpleItem{testactors.Alice.Destination(), 6},
+	SimpleItem{testactors.Bob.Destination(), 6},
 )
 
 var testVirtualState = state.State{
 	ChainId: chainId,
 	Participants: []types.Address{
-		testactors.Actors.Alice.Address,
-		testactors.Actors.Irene.Address,
-		testactors.Actors.Bob.Address,
+		testactors.Alice.Address,
+		testactors.Irene.Address,
+		testactors.Bob.Address,
 	},
 	ChannelNonce:      big.NewInt(1234789),
 	AppDefinition:     someAppDefinition,
 	ChallengeDuration: big.NewInt(60),
 	AppData:           []byte{},
 	Outcome: Outcomes.CreateLongOutcome(
-		SimpleItem{testactors.Actors.Alice.Destination(), 6},
-		SimpleItem{testactors.Actors.Bob.Destination(), 4},
+		SimpleItem{testactors.Alice.Destination(), 6},
+		SimpleItem{testactors.Bob.Destination(), 4},
 	),
 	TurnNum: 0,
 	IsFinal: false,
@@ -61,8 +61,8 @@ var testVirtualState = state.State{
 var testState = state.State{
 	ChainId: chainId,
 	Participants: []types.Address{
-		testactors.Actors.Alice.Address,
-		testactors.Actors.Bob.Address,
+		testactors.Alice.Address,
+		testactors.Bob.Address,
 	},
 	ChannelNonce:      big.NewInt(37140676580),
 	AppDefinition:     someAppDefinition,

--- a/internal/testdata/states.go
+++ b/internal/testdata/states.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -34,24 +35,24 @@ var chainId, _ = big.NewInt(0).SetString("9001", 10)
 var someAppDefinition = common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`)
 
 var testOutcome = createLongOutcome(
-	SimpleItem{Actors.Alice.Destination(), 6},
-	SimpleItem{Actors.Bob.Destination(), 6},
+	SimpleItem{testactors.Actors.Alice.Destination(), 6},
+	SimpleItem{testactors.Actors.Bob.Destination(), 6},
 )
 
 var testVirtualState = state.State{
 	ChainId: chainId,
 	Participants: []types.Address{
-		Actors.Alice.Address,
-		Actors.Irene.Address,
-		Actors.Bob.Address,
+		testactors.Actors.Alice.Address,
+		testactors.Actors.Irene.Address,
+		testactors.Actors.Bob.Address,
 	},
 	ChannelNonce:      big.NewInt(1234789),
 	AppDefinition:     someAppDefinition,
 	ChallengeDuration: big.NewInt(60),
 	AppData:           []byte{},
 	Outcome: Outcomes.CreateLongOutcome(
-		SimpleItem{Actors.Alice.Destination(), 6},
-		SimpleItem{Actors.Bob.Destination(), 4},
+		SimpleItem{testactors.Actors.Alice.Destination(), 6},
+		SimpleItem{testactors.Actors.Bob.Destination(), 4},
 	),
 	TurnNum: 0,
 	IsFinal: false,
@@ -60,8 +61,8 @@ var testVirtualState = state.State{
 var testState = state.State{
 	ChainId: chainId,
 	Participants: []types.Address{
-		Actors.Alice.Address,
-		Actors.Bob.Address,
+		testactors.Actors.Alice.Address,
+		testactors.Actors.Bob.Address,
 	},
 	ChannelNonce:      big.NewInt(37140676580),
 	AppDefinition:     someAppDefinition,

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-var alice, bob testactors.Actor = testactors.Actors.Alice, testactors.Actors.Bob
+var alice, bob testactors.Actor = testactors.Alice, testactors.Bob
 
 var testState = state.State{
 	ChainId:           big.NewInt(9001),

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -12,34 +12,16 @@ import (
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
 
-type actor struct {
-	address     types.Address
-	destination types.Destination
-	privateKey  []byte
-}
-
-var alicePK = common.Hex2Bytes(`caab404f975b4620747174a75f08d98b4e5a7053b691b41bcfc0d839d48b7634`)
-var bobPK = common.Hex2Bytes(`62ecd49c4ccb41a70ad46532aed63cf815de15864bc415c87d507afd6a5e8da2`)
-
-var alice = actor{
-	address:     common.HexToAddress(`0xF5A1BB5607C9D079E46d1B3Dc33f257d937b43BD`),
-	destination: types.AddressToDestination(common.HexToAddress(`0xF5A1BB5607C9D079E46d1B3Dc33f257d937b43BD`)),
-	privateKey:  alicePK,
-}
-
-var bob = actor{
-	address:     common.HexToAddress(`0x760bf27cd45036a6C486802D30B5D90CfFBE31FE`),
-	destination: types.AddressToDestination(common.HexToAddress(`0x760bf27cd45036a6C486802D30B5D90CfFBE31FE`)),
-	privateKey:  bobPK,
-}
+var alice, bob testactors.Actor = testactors.Actors.Alice, testactors.Actors.Bob
 
 var testState = state.State{
 	ChainId:           big.NewInt(9001),
-	Participants:      []types.Address{alice.address, bob.address},
+	Participants:      []types.Address{alice.Address, bob.Address},
 	ChannelNonce:      big.NewInt(37140676580),
 	AppDefinition:     common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),
 	ChallengeDuration: big.NewInt(60),
@@ -49,11 +31,11 @@ var testState = state.State{
 			Asset: types.Address{},
 			Allocations: outcome.Allocations{
 				outcome.Allocation{
-					Destination: bob.destination, // Bob is first so we can easily test WaitingForMyTurnToFund
+					Destination: bob.Destination(), // Bob is first so we can easily test WaitingForMyTurnToFund
 					Amount:      big.NewInt(5),
 				},
 				outcome.Allocation{
-					Destination: alice.destination,
+					Destination: alice.Destination(),
 					Amount:      big.NewInt(5),
 				},
 			},
@@ -66,7 +48,7 @@ var testState = state.State{
 // signedTestState returns a signed state with signatures requested in toSign
 func signedTestState(s state.State, toSign []bool) (state.SignedState, error) {
 	ss := state.NewSignedState(s)
-	pks := [2][]byte{alicePK, bobPK}
+	pks := [2][]byte{alice.PrivateKey, bob.PrivateKey}
 	for i, pk := range pks {
 		if !toSign[i] {
 			continue
@@ -185,7 +167,7 @@ func TestCrankAlice(t *testing.T) {
 	o, _ := newTestObjective(true)
 
 	// The first crank. Alice is expected to create and sign a final state
-	updated, se, wf, err := o.Crank(&alicePK)
+	updated, se, wf, err := o.Crank(&alice.PrivateKey)
 
 	if err != nil {
 		t.Error(err)
@@ -203,7 +185,7 @@ func TestCrankAlice(t *testing.T) {
 
 	expectedSE := protocols.SideEffects{
 		MessagesToSend: []protocols.Message{{
-			To:          bob.address,
+			To:          bob.Address,
 			ObjectiveId: o.Id(),
 			SignedStates: []state.SignedState{
 				finalStateSignedByAlice,
@@ -224,7 +206,7 @@ func TestCrankAlice(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, se, wf, err = updated.Crank(&alicePK)
+	_, se, wf, err = updated.Crank(&alice.PrivateKey)
 	if err != nil {
 		t.Error(err)
 	}
@@ -245,7 +227,7 @@ func TestCrankAlice(t *testing.T) {
 
 	// The third crank. Alice is expected to enter the terminal state of the defunding protocol.
 	updated.C.OnChainFunding = types.Funds{}
-	_, se, wf, err = updated.Crank(&alicePK)
+	_, se, wf, err = updated.Crank(&alice.PrivateKey)
 	if err != nil {
 		t.Error(err)
 	}
@@ -279,7 +261,7 @@ func TestCrankBob(t *testing.T) {
 	}
 
 	// The first crank. Bob is expected to create and sign a final state
-	o, se, wf, err := o.Crank(&bobPK)
+	o, se, wf, err := o.Crank(&bob.PrivateKey)
 
 	if err != nil {
 		t.Error(err)
@@ -293,7 +275,7 @@ func TestCrankBob(t *testing.T) {
 	finalStateSignedByBob, _ := signedTestState(finalState, []bool{false, true})
 	expectedSE := protocols.SideEffects{
 		MessagesToSend: []protocols.Message{{
-			To:          alice.address,
+			To:          alice.Address,
 			ObjectiveId: o.Id(),
 			SignedStates: []state.SignedState{
 				finalStateSignedByBob,
@@ -311,7 +293,7 @@ func TestCrankBob(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, se, wf, err = o.Crank(&bobPK)
+	_, se, wf, err = o.Crank(&bob.PrivateKey)
 	if err != nil {
 		t.Error(err)
 	}
@@ -333,7 +315,7 @@ func TestCrankBob(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, se, wf, err = o.Crank(&bobPK)
+	_, se, wf, err = o.Crank(&bob.PrivateKey)
 	if err != nil {
 		t.Error(err)
 	}

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-var alice, bob testactors.Actor = testactors.Actors.Alice, testactors.Actors.Bob
+var alice, bob testactors.Actor = testactors.Alice, testactors.Bob
 
 var testState = state.State{
 	ChainId:           big.NewInt(9001),

--- a/protocols/virtualfund/helpers_test.go
+++ b/protocols/virtualfund/helpers_test.go
@@ -3,70 +3,32 @@ package virtualfund
 import (
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/types"
 )
 
-type actor struct {
-	address     types.Address
-	destination types.Destination
-	privateKey  []byte
-	role        uint
-	name        string
-}
-
-////////////
-// ACTORS //
-////////////
-
-var alice = actor{
-	address:     common.HexToAddress(`0xD9995BAE12FEe327256FFec1e3184d492bD94C31`),
-	destination: types.AddressToDestination(common.HexToAddress(`0xD9995BAE12FEe327256FFec1e3184d492bD94C31`)),
-	privateKey:  common.Hex2Bytes(`7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8`),
-	role:        0,
-	name:        "alice",
-}
-
-var p1 = actor{ // Aliases: The Hub, Irene
-	address:     common.HexToAddress(`0xd4Fa489Eacc52BA59438993f37Be9fcC20090E39`),
-	destination: types.AddressToDestination(common.HexToAddress(`0xd4Fa489Eacc52BA59438993f37Be9fcC20090E39`)),
-	privateKey:  common.Hex2Bytes(`2030b463177db2da82908ef90fa55ddfcef56e8183caf60db464bc398e736e6f`),
-	role:        1,
-	name:        "p1",
-}
-
-var bob = actor{
-	address:     common.HexToAddress(`0x760bf27cd45036a6C486802D30B5D90CfFBE31FE`),
-	destination: types.AddressToDestination(common.HexToAddress(`0x760bf27cd45036a6C486802D30B5D90CfFBE31FE`)),
-	privateKey:  common.Hex2Bytes(`62ecd49c4ccb41a70ad46532aed63cf815de15864bc415c87d507afd6a5e8da2`),
-	role:        2,
-	name:        "bob",
-}
-
-var allActors = []actor{alice, p1, bob}
-
-func prepareConsensusChannel(role uint, left, right actor) *consensus_channel.ConsensusChannel {
+func prepareConsensusChannel(role uint, left, right testactors.Actor) *consensus_channel.ConsensusChannel {
 	fp := state.FixedPart{
 		ChainId:           big.NewInt(9001),
-		Participants:      []types.Address{left.address, right.address},
+		Participants:      []types.Address{left.Address, right.Address},
 		ChannelNonce:      big.NewInt(0),
 		AppDefinition:     types.Address{},
 		ChallengeDuration: big.NewInt(45),
 	}
 
-	leftBal := consensus_channel.NewBalance(left.destination, big.NewInt(6))
-	rightBal := consensus_channel.NewBalance(right.destination, big.NewInt(4))
+	leftBal := consensus_channel.NewBalance(left.Destination(), big.NewInt(6))
+	rightBal := consensus_channel.NewBalance(right.Destination(), big.NewInt(4))
 
 	lo := *consensus_channel.NewLedgerOutcome(types.Address{}, leftBal, rightBal, []consensus_channel.Guarantee{})
 
 	signedVars := consensus_channel.SignedVars{Vars: consensus_channel.Vars{Outcome: lo, TurnNum: 1}}
-	leftSig, err := signedVars.Vars.AsState(fp).Sign(left.privateKey)
+	leftSig, err := signedVars.Vars.AsState(fp).Sign(left.PrivateKey)
 	if err != nil {
 		panic(err)
 	}
-	rightSig, err := signedVars.Vars.AsState(fp).Sign(right.privateKey)
+	rightSig, err := signedVars.Vars.AsState(fp).Sign(right.PrivateKey)
 	if err != nil {
 		panic(err)
 	}

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -29,7 +29,7 @@ type testData struct {
 	ledgers   ledgerLookup
 }
 
-var alice, p1, bob actors.Actor = actors.Actors.Alice, actors.Actors.Irene, actors.Actors.Bob
+var alice, p1, bob actors.Actor = actors.Alice, actors.Irene, actors.Bob
 var allActors []actors.Actor = []actors.Actor{alice, p1, bob}
 
 // newTestData returns new copies of consistent test data each time it is called

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
+	actors "github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -28,11 +29,14 @@ type testData struct {
 	ledgers   ledgerLookup
 }
 
+var alice, p1, bob actors.Actor = actors.Actors.Alice, actors.Actors.Irene, actors.Actors.Bob
+var allActors []actors.Actor = []actors.Actor{alice, p1, bob}
+
 // newTestData returns new copies of consistent test data each time it is called
 func newTestData() testData {
 	var vPreFund = state.State{
 		ChainId:           big.NewInt(9001),
-		Participants:      []types.Address{alice.address, p1.address, bob.address}, // A single hop virtual channel
+		Participants:      []types.Address{alice.Address, p1.Address, bob.Address},
 		ChannelNonce:      big.NewInt(0),
 		AppDefinition:     types.Address{},
 		ChallengeDuration: big.NewInt(45),
@@ -40,11 +44,11 @@ func newTestData() testData {
 		Outcome: outcome.Exit{outcome.SingleAssetExit{
 			Allocations: outcome.Allocations{
 				outcome.Allocation{
-					Destination: alice.destination,
+					Destination: alice.Destination(),
 					Amount:      big.NewInt(6),
 				},
 				outcome.Allocation{
-					Destination: bob.destination,
+					Destination: bob.Destination(),
 					Amount:      big.NewInt(4),
 				},
 			},
@@ -56,14 +60,14 @@ func newTestData() testData {
 	vPostFund.TurnNum = 1
 
 	ledgers := make(map[types.Destination]actorLedgers)
-	ledgers[alice.destination] = actorLedgers{
+	ledgers[alice.Destination()] = actorLedgers{
 		right: prepareConsensusChannel(uint(consensus_channel.Leader), alice, p1),
 	}
-	ledgers[p1.destination] = actorLedgers{
+	ledgers[p1.Destination()] = actorLedgers{
 		left:  prepareConsensusChannel(uint(consensus_channel.Follower), alice, p1),
 		right: prepareConsensusChannel(uint(consensus_channel.Leader), p1, bob),
 	}
-	ledgers[bob.destination] = actorLedgers{
+	ledgers[bob.Destination()] = actorLedgers{
 		left: prepareConsensusChannel(uint(consensus_channel.Follower), p1, bob),
 	}
 
@@ -72,7 +76,7 @@ func newTestData() testData {
 
 type Tester func(t *testing.T)
 
-func testNew(a actor) Tester {
+func testNew(a actors.Actor) Tester {
 	return func(t *testing.T) {
 		td := newTestData()
 		lookup := td.ledgers
@@ -82,22 +86,22 @@ func testNew(a actor) Tester {
 		o, err := constructFromState(
 			false,
 			vPreFund,
-			a.address,
-			lookup[a.destination].left,
-			lookup[a.destination].right,
+			a.Address,
+			lookup[a.Destination()].left,
+			lookup[a.Destination()].right,
 		)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		switch a.role {
-		case alice.role:
+		switch a.Role {
+		case alice.Role:
 			assert(t, o.ToMyLeft == nil, "left connection should be nil")
 			assert(t, diffFromCorrectConnection(o.ToMyRight, alice, p1) == "", "incorrect connection")
-		case p1.role:
+		case p1.Role:
 			assert(t, diffFromCorrectConnection(o.ToMyLeft, alice, p1) == "", "incorrect connection")
 			assert(t, diffFromCorrectConnection(o.ToMyRight, p1, bob) == "", "incorrect connection")
-		case bob.role:
+		case bob.Role:
 			assert(t, diffFromCorrectConnection(o.ToMyLeft, p1, bob) == "", "incorrect connection")
 			assert(t, o.ToMyRight == nil, "right connection should be nil")
 		}
@@ -106,7 +110,7 @@ func testNew(a actor) Tester {
 
 // diffFromCorrectConnection compares the guarantee stored on a connection with
 // the guarantee we expect, given the expected left and right actors
-func diffFromCorrectConnection(c *Connection, left, right actor) string {
+func diffFromCorrectConnection(c *Connection, left, right actors.Actor) string {
 	td := newTestData()
 	vPreFund := td.vPreFund
 
@@ -118,7 +122,7 @@ func diffFromCorrectConnection(c *Connection, left, right actor) string {
 	// comparing the _guarantees_ that we expect to include, instead of the GuaranteeInfo
 
 	expectedAmount := big.NewInt(0).Set(vPreFund.VariablePart().Outcome[0].TotalAllocated())
-	want := consensus_channel.NewGuarantee(expectedAmount, Id, left.destination, right.destination)
+	want := consensus_channel.NewGuarantee(expectedAmount, Id, left.Destination(), right.Destination())
 	got := c.getExpectedGuarantee()
 
 	return compareGuarantees(want, got)
@@ -126,18 +130,18 @@ func diffFromCorrectConnection(c *Connection, left, right actor) string {
 
 func TestNew(t *testing.T) {
 	for _, a := range allActors {
-		msg := fmt.Sprintf("Testing new as %v", a.name)
+		msg := fmt.Sprintf("Testing new as %v", a.Name)
 		t.Run(msg, testNew(a))
 	}
 }
 
-func testCloneAs(my actor) Tester {
+func testCloneAs(my actors.Actor) Tester {
 	return func(t *testing.T) {
 		td := newTestData()
 		vPreFund := td.vPreFund
 		ledgers := td.ledgers
 
-		o, _ := constructFromState(false, vPreFund, my.address, ledgers[my.destination].left, ledgers[my.destination].right)
+		o, _ := constructFromState(false, vPreFund, my.Address, ledgers[my.Destination()].left, ledgers[my.Destination()].right)
 
 		clone := o.clone()
 
@@ -150,7 +154,7 @@ func testCloneAs(my actor) Tester {
 
 func TestClone(t *testing.T) {
 	for _, a := range allActors {
-		msg := fmt.Sprintf("Testing clone as %v", a.name)
+		msg := fmt.Sprintf("Testing clone as %v", a.Name)
 		t.Run(msg, testCloneAs(a))
 	}
 }
@@ -163,16 +167,16 @@ func collectPeerSignaturesOnSetupState(V *channel.SingleHopVirtualChannel, myRol
 		state = V.PostFundState()
 	}
 
-	if myRole != alice.role {
-		aliceSig, _ := state.Sign(alice.privateKey)
+	if myRole != alice.Role {
+		aliceSig, _ := state.Sign(alice.PrivateKey)
 		V.AddStateWithSignature(state, aliceSig)
 	}
-	if myRole != p1.role {
-		p1Sig, _ := state.Sign(p1.privateKey)
+	if myRole != p1.Role {
+		p1Sig, _ := state.Sign(p1.PrivateKey)
 		V.AddStateWithSignature(state, p1Sig)
 	}
-	if myRole != bob.role {
-		bobSig, _ := state.Sign(bob.privateKey)
+	if myRole != bob.Role {
+		bobSig, _ := state.Sign(bob.PrivateKey)
 		V.AddStateWithSignature(state, bobSig)
 	}
 }
@@ -182,9 +186,9 @@ func TestCrankAsAlice(t *testing.T) {
 	td := newTestData()
 	vPreFund := td.vPreFund
 	ledgers := td.ledgers
-	var s, _ = constructFromState(false, vPreFund, my.address, ledgers[my.destination].left, ledgers[my.destination].right) // todo: #420 deprecate TwoPartyLedgers
+	var s, _ = constructFromState(false, vPreFund, my.Address, ledgers[my.Destination()].left, ledgers[my.Destination()].right) // todo: #420 deprecate TwoPartyLedgers
 	// Assert that cranking an unapproved objective returns an error
-	_, _, _, err := s.Crank(&my.privateKey)
+	_, _, _, err := s.Crank(&my.PrivateKey)
 	assert(t, err != nil, `Expected error when cranking unapproved objective, but got nil`)
 
 	// Approve the objective, so that the rest of the test cases can run.
@@ -196,11 +200,11 @@ func TestCrankAsAlice(t *testing.T) {
 	// need to remember to convert the result back to a virtualfund.Objective struct
 
 	// Initial Crank
-	oObj, got, waitingFor, err := o.Crank(&my.privateKey)
+	oObj, got, waitingFor, err := o.Crank(&my.PrivateKey)
 	o = oObj.(*Objective)
 
 	expectedSignedState := state.NewSignedState(o.V.PreFundState())
-	mySig, _ := o.V.PreFundState().Sign(my.privateKey)
+	mySig, _ := o.V.PreFundState().Sign(my.PrivateKey)
 	_ = expectedSignedState.AddSignature(mySig)
 
 	ok(t, err)
@@ -209,11 +213,11 @@ func TestCrankAsAlice(t *testing.T) {
 	assertStateSentTo(t, got, expectedSignedState, p1)
 
 	// Manually progress the extended state by collecting prefund signatures
-	collectPeerSignaturesOnSetupState(o.V, my.role, true)
+	collectPeerSignaturesOnSetupState(o.V, my.Role, true)
 
 	// Cranking should move us to the next waiting point, update the ledger channel, and alter the extended state to reflect that
 	// TODO: Check that ledger channel is updated as expected
-	oObj, got, waitingFor, err = o.Crank(&my.privateKey)
+	oObj, got, waitingFor, err = o.Crank(&my.PrivateKey)
 	o = oObj.(*Objective)
 
 	p := consensus_channel.NewAddProposal(o.ToMyRight.Channel.Id, 2, o.ToMyRight.getExpectedGuarantee(), big.NewInt(6))
@@ -224,7 +228,7 @@ func TestCrankAsAlice(t *testing.T) {
 
 	// Check idempotency
 	emptySideEffects := protocols.SideEffects{}
-	oObj, got, waitingFor, err = o.Crank(&my.privateKey)
+	oObj, got, waitingFor, err = o.Crank(&my.PrivateKey)
 	o = oObj.(*Objective)
 	ok(t, err)
 	equals(t, got, emptySideEffects)
@@ -270,7 +274,7 @@ func equals(tb testing.TB, exp, act interface{}) {
 // The following assertions are inspired by the ok, assert and equals above
 
 // assertSideEffectsContainsMessageWith fails the test instantly if the supplied side effects does not contain a message for the supplied actor with the supplied expected signed state.
-func assertProposalSent(t *testing.T, ses protocols.SideEffects, sp consensus_channel.SignedProposal, to actor) {
+func assertProposalSent(t *testing.T, ses protocols.SideEffects, sp consensus_channel.SignedProposal, to actors.Actor) {
 	_, file, line, _ := runtime.Caller(1)
 	if len(ses.MessagesToSend) != 1 {
 		fmt.Printf(makeRed+"%s:%d:\n\n\texpected one message"+makeBlack, filepath.Base(file), line)
@@ -289,17 +293,17 @@ func assertProposalSent(t *testing.T, ses protocols.SideEffects, sp consensus_ch
 		t.FailNow()
 	}
 
-	if !bytes.Equal(msg.To[:], to.address[:]) {
-		fmt.Printf(makeRed+"%s:%d:\n\n\texp: %#v\n\n\tgot: %#v"+makeBlack, filepath.Base(file), line, msg.To.String(), to.address.String())
+	if !bytes.Equal(msg.To[:], to.Address[:]) {
+		fmt.Printf(makeRed+"%s:%d:\n\n\texp: %#v\n\n\tgot: %#v"+makeBlack, filepath.Base(file), line, msg.To.String(), to.Address.String())
 		t.FailNow()
 	}
 }
 
 // assertMessageSentTo asserts that ses contains a message
-func assertStateSentTo(t *testing.T, ses protocols.SideEffects, expected state.SignedState, to actor) {
+func assertStateSentTo(t *testing.T, ses protocols.SideEffects, expected state.SignedState, to actors.Actor) {
 	for _, msg := range ses.MessagesToSend {
 		for _, ss := range msg.SignedStates {
-			if reflect.DeepEqual(ss, expected) && bytes.Equal(msg.To[:], to.address[:]) {
+			if reflect.DeepEqual(ss, expected) && bytes.Equal(msg.To[:], to.Address[:]) {
 				return
 			}
 		}

--- a/protocols/virtualfund/virtualfund_test.go
+++ b/protocols/virtualfund/virtualfund_test.go
@@ -7,39 +7,20 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/types"
 )
 
 func TestMarshalJSON(t *testing.T) {
 
-	alice := actor{
-		address:     common.HexToAddress(`0xD9995BAE12FEe327256FFec1e3184d492bD94C31`),
-		destination: types.AddressToDestination(common.HexToAddress(`0xD9995BAE12FEe327256FFec1e3184d492bD94C31`)),
-		privateKey:  common.Hex2Bytes(`7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8`),
-		role:        0,
-	}
-
-	p1 := actor{ // Aliases: The Hub, Irene
-		address:     common.HexToAddress(`0xd4Fa489Eacc52BA59438993f37Be9fcC20090E39`),
-		destination: types.AddressToDestination(common.HexToAddress(`0xd4Fa489Eacc52BA59438993f37Be9fcC20090E39`)),
-		privateKey:  common.Hex2Bytes(`2030b463177db2da82908ef90fa55ddfcef56e8183caf60db464bc398e736e6f`),
-		role:        1,
-	}
-
-	bob := actor{
-		address:     common.HexToAddress(`0x760bf27cd45036a6C486802D30B5D90CfFBE31FE`),
-		destination: types.AddressToDestination(common.HexToAddress(`0x760bf27cd45036a6C486802D30B5D90CfFBE31FE`)),
-		privateKey:  common.Hex2Bytes(`62ecd49c4ccb41a70ad46532aed63cf815de15864bc415c87d507afd6a5e8da2`),
-		role:        2,
-	}
+	alice, p1, bob := testactors.Actors.Alice, testactors.Actors.Irene, testactors.Actors.Bob
 
 	vPreFund := state.State{
 		ChainId:           big.NewInt(9001),
-		Participants:      []types.Address{alice.address, p1.address, bob.address}, // A single hop virtual channel
+		Participants:      []types.Address{alice.Address, p1.Address, bob.Address}, // A single hop virtual channel
 		ChannelNonce:      big.NewInt(0),
 		AppDefinition:     types.Address{},
 		ChallengeDuration: big.NewInt(45),
@@ -47,11 +28,11 @@ func TestMarshalJSON(t *testing.T) {
 		Outcome: outcome.Exit{outcome.SingleAssetExit{
 			Allocations: outcome.Allocations{
 				outcome.Allocation{
-					Destination: alice.destination,
+					Destination: alice.Destination(),
 					Amount:      big.NewInt(5),
 				},
 				outcome.Allocation{
-					Destination: bob.destination,
+					Destination: bob.Destination(),
 					Amount:      big.NewInt(5),
 				},
 			},
@@ -67,7 +48,7 @@ func TestMarshalJSON(t *testing.T) {
 	vfo, err := constructFromState(
 		false,
 		vPreFund,
-		alice.address,
+		alice.Address,
 		nil,
 		right,
 	)

--- a/protocols/virtualfund/virtualfund_test.go
+++ b/protocols/virtualfund/virtualfund_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestMarshalJSON(t *testing.T) {
 
-	alice, p1, bob := testactors.Actors.Alice, testactors.Actors.Irene, testactors.Actors.Bob
+	alice, p1, bob := testactors.Alice, testactors.Irene, testactors.Bob
 
 	vPreFund := state.State{
 		ChainId:           big.NewInt(9001),


### PR DESCRIPTION
Instead of having tests construct their own version of the `actor` struct it makes sense for tests to use the set of test actors.

This PR updates various tests to use a test actors instead of declaring it's own actor struct.

## Changes
### Actor struct is now exported
To let tests easily use the actor struct I've modified it to be public. This makes dealing with actors in a test much simpler.
### Actors moved to a new package
To prevent any import cycles the actors have been moved to their own package `testactors`.  Otherwise we'd get an import cycle when using actors in virtual funding tests due to `testdata` importing virtual and direct funding packages.
### Fields added to actor struct
A `Name` and `Role` have been added to the Actor struct to support the current virtual funding tests.
