### PR TITLE
Finish testing crank (part 2)

### DIFF
--- a/protocols/virtualfund/helpers_test.go
+++ b/protocols/virtualfund/helpers_test.go
@@ -3,7 +3,7 @@ package virtualfund
 import (
 	"math/big"
 
-	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	con_chan "github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/types"
@@ -13,7 +13,7 @@ import (
 //  - allocating 6 to left
 //  - allocating 4 to right
 //  - including the given guarantees
-func prepareConsensusChannel(role uint, left, right testactors.Actor, guarantees ...consensus_channel.Guarantee) *consensus_channel.ConsensusChannel {
+func prepareConsensusChannel(role uint, left, right testactors.Actor, guarantees ...con_chan.Guarantee) *con_chan.ConsensusChannel {
 	fp := state.FixedPart{
 		ChainId:           big.NewInt(9001),
 		Participants:      []types.Address{left.Address, right.Address},
@@ -22,12 +22,12 @@ func prepareConsensusChannel(role uint, left, right testactors.Actor, guarantees
 		ChallengeDuration: big.NewInt(45),
 	}
 
-	leftBal := consensus_channel.NewBalance(left.Destination(), big.NewInt(6))
-	rightBal := consensus_channel.NewBalance(right.Destination(), big.NewInt(4))
+	leftBal := con_chan.NewBalance(left.Destination(), big.NewInt(6))
+	rightBal := con_chan.NewBalance(right.Destination(), big.NewInt(4))
 
-	lo := *consensus_channel.NewLedgerOutcome(types.Address{}, leftBal, rightBal, guarantees)
+	lo := *con_chan.NewLedgerOutcome(types.Address{}, leftBal, rightBal, guarantees)
 
-	signedVars := consensus_channel.SignedVars{Vars: consensus_channel.Vars{Outcome: lo, TurnNum: 1}}
+	signedVars := con_chan.SignedVars{Vars: con_chan.Vars{Outcome: lo, TurnNum: 1}}
 	leftSig, err := signedVars.Vars.AsState(fp).Sign(left.PrivateKey)
 	if err != nil {
 		panic(err)
@@ -38,12 +38,12 @@ func prepareConsensusChannel(role uint, left, right testactors.Actor, guarantees
 	}
 	sigs := [2]state.Signature{leftSig, rightSig}
 
-	var cc consensus_channel.ConsensusChannel
+	var cc con_chan.ConsensusChannel
 
 	if role == 0 {
-		cc, err = consensus_channel.NewLeaderChannel(fp, 1, lo, sigs)
+		cc, err = con_chan.NewLeaderChannel(fp, 1, lo, sigs)
 	} else {
-		cc, err = consensus_channel.NewFollowerChannel(fp, 1, lo, sigs)
+		cc, err = con_chan.NewFollowerChannel(fp, 1, lo, sigs)
 	}
 	if err != nil {
 		panic(err)

--- a/protocols/virtualfund/helpers_test.go
+++ b/protocols/virtualfund/helpers_test.go
@@ -25,6 +25,9 @@ type CChanConfig struct {
 //  - allocating a default amount of 4 to cfg.right
 //  - including the given guarantees
 //  - ensuring that the props are signed and stored by the consensus channel
+// Note: The props that are passed in cfg don't need to be set up correctly!
+// The correct turn number and channelId will be set in order to ensure that
+// the resulting queue is in a valid state
 func prepareConsensusChannel(cfg CChanConfig) *con_chan.ConsensusChannel {
 	leftBal := cfg.leftBal
 	if leftBal == 0 {

--- a/protocols/virtualfund/helpers_test.go
+++ b/protocols/virtualfund/helpers_test.go
@@ -104,7 +104,6 @@ func prepareConsensusChannel(cfg CChanConfig) *con_chan.ConsensusChannel {
 			}
 			sp := con_chan.SignedProposal{Proposal: correctedProp, Signature: sig}
 
-
 			// Receive the signed prop
 			err = c.Receive(sp)
 			if err != nil {

--- a/protocols/virtualfund/helpers_test.go
+++ b/protocols/virtualfund/helpers_test.go
@@ -30,13 +30,13 @@ type CChanConfig struct {
 // The correct turn number and channelId will be set in order to ensure that
 // the resulting queue is in a valid state
 func prepareConsensusChannel(cfg CChanConfig) *con_chan.ConsensusChannel {
-	leftBal := cfg.leaderBal
-	if leftBal == 0 {
-		leftBal = 6
+	leaderBal := cfg.leaderBal
+	if leaderBal == 0 {
+		leaderBal = 6
 	}
-	rightBal := cfg.followerBal
-	if rightBal == 0 {
-		rightBal = 4
+	followerBal := cfg.followerBal
+	if followerBal == 0 {
+		followerBal = 4
 	}
 
 	var (
@@ -52,8 +52,8 @@ func prepareConsensusChannel(cfg CChanConfig) *con_chan.ConsensusChannel {
 		initialOutcome = func() con_chan.LedgerOutcome {
 			return *con_chan.NewLedgerOutcome(
 				types.Address{},
-				con_chan.NewBalance(cfg.leader.Destination(), big.NewInt(leftBal)),
-				con_chan.NewBalance(cfg.follower.Destination(), big.NewInt(rightBal)),
+				con_chan.NewBalance(cfg.leader.Destination(), big.NewInt(leaderBal)),
+				con_chan.NewBalance(cfg.follower.Destination(), big.NewInt(followerBal)),
 				cfg.guarantees,
 			)
 

--- a/protocols/virtualfund/helpers_test.go
+++ b/protocols/virtualfund/helpers_test.go
@@ -25,6 +25,7 @@ type CChanConfig struct {
 //  - allocating a default amount of 4 to cfg.right
 //  - including the given guarantees
 //  - ensuring that the props are signed and stored by the consensus channel
+//
 // Note: The props that are passed in cfg don't need to be set up correctly!
 // The correct turn number and channelId will be set in order to ensure that
 // the resulting queue is in a valid state

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -183,20 +183,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 	TestAs := func(my testactors.Actor, t *testing.T) {
 
 		prepareConsensusChannels := func(role uint) (*consensus_channel.ConsensusChannel, *consensus_channel.ConsensusChannel) {
-			var left *consensus_channel.ConsensusChannel
-			var right *consensus_channel.ConsensusChannel
-
-			switch role {
-			case 0:
-				right = prepareConsensusChannel(uint(consensus_channel.Leader), alice, p1)
-			case 1:
-				left = prepareConsensusChannel(uint(consensus_channel.Leader), alice, p1)
-				right = prepareConsensusChannel(uint(consensus_channel.Follower), p1, bob)
-			case 2:
-				left = prepareConsensusChannel(uint(consensus_channel.Leader), p1, bob)
-			}
-
-			return left, right
+			panic("to be removed")
 		}
 
 		testNew := func(t *testing.T) {

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -568,14 +568,15 @@ func (c *Connection) expectedProposal() consensus_channel.Proposal {
 		break
 	}
 
-	// this awkward step is required because Channel.SignNextProposal accepts as input the
-	// proposal expected in the queue, and validates that the next proposal in the queue
-	// matches exactly. I am not sure if validating the turn number is critical!
-	turnNum := c.Channel.ConsensusTurnNum() + 1
-
-	proposal := consensus_channel.NewAddProposal(c.Channel.Id, turnNum, g, leftAmount)
-
-	return proposal
+	return consensus_channel.NewAddProposal(
+		c.Channel.Id,
+		// this awkward step is required because Channel.SignNextProposal accepts as input the
+		// proposal expected in the queue, and validates that the next proposal in the queue
+		// matches exactly. I am not sure if validating the turn number is critical!
+		c.Channel.ConsensusTurnNum()+1,
+		g,
+		leftAmount,
+	)
 }
 
 // proposeLedgerUpdate will propose a ledger update to the channel by crafting a new state

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -567,7 +567,13 @@ func (c *Connection) expectedProposal() consensus_channel.Proposal {
 		leftAmount = val
 		break
 	}
-	proposal := consensus_channel.NewAddProposal(c.Channel.Id, 0, g, leftAmount)
+
+	// this awkward step is required because Channel.SignNextProposal accepts as input the
+	// proposal expected in the queue, and validates that the next proposal in the queue
+	// matches exactly. I am not sure if validating the turn number is critical!
+	turnNum := c.Channel.ConsensusTurnNum() + 1
+
+	proposal := consensus_channel.NewAddProposal(c.Channel.Id, turnNum, g, leftAmount)
 
 	return proposal
 }

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -413,7 +413,6 @@ func TestCrankAsP1(t *testing.T) {
 	oObj, effects, waitingFor, err = o.Crank(&my.PrivateKey)
 	o = oObj.(*Objective)
 
-
 	ok(t, err)
 	// We need to receive a proposal from Bob before funding is completed!
 	equals(t, waitingFor, WaitingForCompletePostFund)

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -64,26 +64,26 @@ func newTestData() testData {
 
 	leaderLedgers := make(map[types.Destination]actorLedgers)
 	leaderLedgers[alice.Destination()] = actorLedgers{
-		right: prepareConsensusChannel(uint(consensus_channel.Leader), alice, p1),
+		right: prepareConsensusChannel(CChanConfig{leader: true, left: alice, right: p1}),
 	}
 	leaderLedgers[p1.Destination()] = actorLedgers{
-		left:  prepareConsensusChannel(uint(consensus_channel.Leader), p1, alice),
-		right: prepareConsensusChannel(uint(consensus_channel.Leader), p1, bob),
+		left:  prepareConsensusChannel(CChanConfig{left: p1, right: alice, leader: true}),
+		right: prepareConsensusChannel(CChanConfig{left: p1, right: bob, leader: true}),
 	}
 	leaderLedgers[bob.Destination()] = actorLedgers{
-		left: prepareConsensusChannel(uint(consensus_channel.Leader), bob, p1),
+		left: prepareConsensusChannel(CChanConfig{left: bob, right: p1, leader: true}),
 	}
 
 	followerLedgers := make(map[types.Destination]actorLedgers)
 	followerLedgers[alice.Destination()] = actorLedgers{
-		right: prepareConsensusChannel(uint(consensus_channel.Follower), alice, p1),
+		right: prepareConsensusChannel(CChanConfig{left: alice, right: p1}),
 	}
 	followerLedgers[p1.Destination()] = actorLedgers{
-		left:  prepareConsensusChannel(uint(consensus_channel.Follower), alice, p1),
-		right: prepareConsensusChannel(uint(consensus_channel.Follower), p1, bob),
+		left:  prepareConsensusChannel(CChanConfig{left: alice, right: p1}),
+		right: prepareConsensusChannel(CChanConfig{left: p1, right: bob}),
 	}
 	followerLedgers[bob.Destination()] = actorLedgers{
-		left: prepareConsensusChannel(uint(consensus_channel.Follower), p1, bob),
+		left: prepareConsensusChannel(CChanConfig{left: p1, right: bob}),
 	}
 
 	return testData{vPreFund, vPostFund, leaderLedgers, followerLedgers}
@@ -252,7 +252,7 @@ func TestCrankAsAlice(t *testing.T) {
 
 	// If Alice had received a signed counterproposal, she should proceed to postFundSetup
 	guaranteeFundingV := consensus_channel.NewGuarantee(big.NewInt(10), o.V.Id, alice.Destination(), p1.Destination())
-	o.ToMyRight.Channel = prepareConsensusChannel(my.Role, alice, p1, guaranteeFundingV)
+	o.ToMyRight.Channel = prepareConsensusChannel(CChanConfig{left: alice, right: p1, guarantees: []consensus_channel.Guarantee{guaranteeFundingV}})
 
 	oObj, effects, waitingFor, err = o.Crank(&my.PrivateKey)
 	o = oObj.(*Objective)
@@ -320,7 +320,8 @@ func TestCrankAsBob(t *testing.T) {
 
 	// If Bob had received a signed counterproposal, he should proceed to postFundSetup
 	guaranteeFundingV := consensus_channel.NewGuarantee(big.NewInt(10), o.V.Id, p1.Destination(), bob.Destination())
-	o.ToMyLeft.Channel = prepareConsensusChannel(uint(consensus_channel.Leader), bob, p1, guaranteeFundingV)
+	guarantees := []consensus_channel.Guarantee{guaranteeFundingV}
+	o.ToMyLeft.Channel = prepareConsensusChannel(CChanConfig{leader: true, left: bob, right: p1, guarantees: guarantees})
 
 	oObj, effects, waitingFor, err = o.Crank(&my.PrivateKey)
 	o = oObj.(*Objective)
@@ -390,7 +391,8 @@ func TestCrankAsP1(t *testing.T) {
 
 	// If P1 had received a signed counterproposal, she should proceed to postFundSetup
 	guaranteeFundingV := consensus_channel.NewGuarantee(big.NewInt(10), o.V.Id, alice.Destination(), p1.Destination())
-	o.ToMyLeft.Channel = prepareConsensusChannel(uint(consensus_channel.Leader), alice, p1, guaranteeFundingV)
+	guarantees := []consensus_channel.Guarantee{guaranteeFundingV}
+	o.ToMyLeft.Channel = prepareConsensusChannel(CChanConfig{leader: true, left: alice, right: p1, guarantees: guarantees})
 
 	oObj, effects, waitingFor, err = o.Crank(&my.PrivateKey)
 	o = oObj.(*Objective)

--- a/protocols/virtualfund/virtualfund_test.go
+++ b/protocols/virtualfund/virtualfund_test.go
@@ -44,7 +44,7 @@ func TestMarshalJSON(t *testing.T) {
 	ts := state.TestState
 	ts.TurnNum = channel.PreFundTurnNum
 
-	right := prepareConsensusChannel(1, alice, bob)
+	right := prepareConsensusChannel(CChanConfig{left: alice, right: bob})
 	vfo, err := constructFromState(
 		false,
 		vPreFund,

--- a/protocols/virtualfund/virtualfund_test.go
+++ b/protocols/virtualfund/virtualfund_test.go
@@ -44,7 +44,7 @@ func TestMarshalJSON(t *testing.T) {
 	ts := state.TestState
 	ts.TurnNum = channel.PreFundTurnNum
 
-	right := prepareConsensusChannel(CChanConfig{left: alice, right: bob})
+	right := prepareConsensusChannel(CChanConfig{leader: alice, follower: bob})
 	vfo, err := constructFromState(
 		false,
 		vPreFund,


### PR DESCRIPTION
This PR tests finishes testing crank in three scenarios:
- Alice is the leader in her one connection
- P1 is the leader in their left connection and follower in their right connection
- Bob is the follower in his one connection

`Crank` is tested throughout the entire lifecycle of the objective in the three scenarios.

To facilitate this work, `prepareConsensusChannel` now receives a rich config, with sensible default values chosen (so you don't have to fill out the whole config). The caller can provide the state they want the channel to be in:
- what the consensus out come is
- (roughly) which proposals are in the queue -- the function will sign and add "corrected" proposals (making sure the turn number and channel id is correct)

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
