### PR TITLE
Separate chainservice.Event from ObjectiveEvent 

### DIFF
--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -9,7 +9,6 @@ import (
 // Event dictates which methods all chain events must implement
 type Event interface {
 	ChannelID() types.Destination
-	GetBlockNum() uint64
 }
 
 // CommonEvent declares fields shared by all chain events
@@ -29,10 +28,6 @@ func (de DepositedEvent) ChannelID() types.Destination {
 	return de.channelID
 }
 
-func (de DepositedEvent) GetBlockNum() uint64 {
-	return de.BlockNum
-}
-
 // AllocationUpdated is an internal representation of the AllocatonUpdated blockchain event
 type AllocationUpdatedEvent struct {
 	CommonEvent
@@ -41,10 +36,6 @@ type AllocationUpdatedEvent struct {
 
 func (de AllocationUpdatedEvent) ChannelID() types.Destination {
 	return de.channelID
-}
-
-func (de AllocationUpdatedEvent) GetBlockNum() uint64 {
-	return de.BlockNum
 }
 
 // todo implement other event types

--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -6,13 +6,27 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-// ChainEvent is an internal representation of a blockchain event
-type Event struct {
-	ChannelId          types.Destination
+type Event interface {
+	ChannelId() types.Destination
+}
+
+// DepositedEvent is an internal representation of the deposited blockchain event
+type DepositedEvent struct {
+	IntoChannel        types.Destination
 	Holdings           types.Funds // indexed by asset
 	AdjudicationStatus protocols.AdjudicationStatus
 	BlockNum           uint64
 }
+
+func (de DepositedEvent) ChannelId() types.Destination {
+	return de.IntoChannel
+}
+
+// todo implement other event types
+// AllocationUpdated
+// Concluded
+// ChallengeRegistered
+// ChallengeCleared
 
 type ChainService interface {
 	Out() <-chan Event

--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -28,6 +28,10 @@ func (de DepositedEvent) ChannelId() types.Destination {
 // ChallengeRegistered
 // ChallengeCleared
 
+type ChainEventHandler interface {
+	UpdateWithChainEvent(event Event) (protocols.Objective, error)
+}
+
 type ChainService interface {
 	Out() <-chan Event
 	In() chan<- protocols.ChainTransaction

--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -11,12 +11,16 @@ type Event interface {
 	GetBlockNum() uint64
 }
 
-// DepositedEvent is an internal representation of the deposited blockchain event
-type DepositedEvent struct {
+type CommonEvent struct {
 	ChannelId          types.Destination
-	Holdings           types.Funds // indexed by asset
 	AdjudicationStatus protocols.AdjudicationStatus
 	BlockNum           uint64
+}
+
+// DepositedEvent is an internal representation of the deposited blockchain event
+type DepositedEvent struct {
+	CommonEvent
+	Holdings types.Funds // indexed by asset
 }
 
 func (de DepositedEvent) GetChannelId() types.Destination {
@@ -27,12 +31,10 @@ func (de DepositedEvent) GetBlockNum() uint64 {
 	return de.BlockNum
 }
 
-// DepositedEvent is an internal representation of the deposited blockchain event
+// AllocationUpdated is an internal representation of the AllocatonUpdated blockchain event
 type AllocationUpdatedEvent struct {
-	ChannelId          types.Destination
-	Holdings           types.Funds // indexed by asset
-	AdjudicationStatus protocols.AdjudicationStatus
-	BlockNum           uint64
+	CommonEvent
+	Holdings types.Funds // indexed by asset
 }
 
 func (de AllocationUpdatedEvent) GetChannelId() types.Destination {

--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -27,6 +27,22 @@ func (de DepositedEvent) GetBlockNum() uint64 {
 	return de.BlockNum
 }
 
+// DepositedEvent is an internal representation of the deposited blockchain event
+type AllocationUpdatedEvent struct {
+	ChannelId          types.Destination
+	Holdings           types.Funds // indexed by asset
+	AdjudicationStatus protocols.AdjudicationStatus
+	BlockNum           uint64
+}
+
+func (de AllocationUpdatedEvent) GetChannelId() types.Destination {
+	return de.ChannelId
+}
+
+func (de AllocationUpdatedEvent) GetBlockNum() uint64 {
+	return de.BlockNum
+}
+
 // todo implement other event types
 // AllocationUpdated
 // Concluded

--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -8,6 +8,7 @@ import (
 
 type Event interface {
 	GetChannelId() types.Destination
+	GetBlockNum() uint64
 }
 
 // DepositedEvent is an internal representation of the deposited blockchain event
@@ -20,6 +21,10 @@ type DepositedEvent struct {
 
 func (de DepositedEvent) GetChannelId() types.Destination {
 	return de.ChannelId
+}
+
+func (de DepositedEvent) GetBlockNum() uint64 {
+	return de.BlockNum
 }
 
 // todo implement other event types

--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -7,19 +7,19 @@ import (
 )
 
 type Event interface {
-	ChannelId() types.Destination
+	GetChannelId() types.Destination
 }
 
 // DepositedEvent is an internal representation of the deposited blockchain event
 type DepositedEvent struct {
-	IntoChannel        types.Destination
+	ChannelId          types.Destination
 	Holdings           types.Funds // indexed by asset
 	AdjudicationStatus protocols.AdjudicationStatus
 	BlockNum           uint64
 }
 
-func (de DepositedEvent) ChannelId() types.Destination {
-	return de.IntoChannel
+func (de DepositedEvent) GetChannelId() types.Destination {
+	return de.ChannelId
 }
 
 // todo implement other event types

--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -6,11 +6,13 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
+// Event dictates which methods all chain events must implement
 type Event interface {
 	GetChannelId() types.Destination
 	GetBlockNum() uint64
 }
 
+// CommonEvent declares fields shared by all chain events
 type CommonEvent struct {
 	ChannelId          types.Destination
 	AdjudicationStatus protocols.AdjudicationStatus
@@ -46,11 +48,11 @@ func (de AllocationUpdatedEvent) GetBlockNum() uint64 {
 }
 
 // todo implement other event types
-// AllocationUpdated
 // Concluded
 // ChallengeRegistered
 // ChallengeCleared
 
+// ChainEventHandler describes an objective that can handle chain events
 type ChainEventHandler interface {
 	UpdateWithChainEvent(event Event) (protocols.Objective, error)
 }

--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -8,13 +8,13 @@ import (
 
 // Event dictates which methods all chain events must implement
 type Event interface {
-	GetChannelId() types.Destination
+	ChannelID() types.Destination
 	GetBlockNum() uint64
 }
 
 // CommonEvent declares fields shared by all chain events
 type CommonEvent struct {
-	ChannelId          types.Destination
+	channelID          types.Destination
 	AdjudicationStatus protocols.AdjudicationStatus
 	BlockNum           uint64
 }
@@ -25,8 +25,8 @@ type DepositedEvent struct {
 	Holdings types.Funds // indexed by asset
 }
 
-func (de DepositedEvent) GetChannelId() types.Destination {
-	return de.ChannelId
+func (de DepositedEvent) ChannelID() types.Destination {
+	return de.channelID
 }
 
 func (de DepositedEvent) GetBlockNum() uint64 {
@@ -39,8 +39,8 @@ type AllocationUpdatedEvent struct {
 	Holdings types.Funds // indexed by asset
 }
 
-func (de AllocationUpdatedEvent) GetChannelId() types.Destination {
-	return de.ChannelId
+func (de AllocationUpdatedEvent) ChannelID() types.Destination {
+	return de.channelID
 }
 
 func (de AllocationUpdatedEvent) GetBlockNum() uint64 {

--- a/client/engine/chainservice/mockchain.go
+++ b/client/engine/chainservice/mockchain.go
@@ -63,7 +63,7 @@ func (mc MockChain) handleTx(tx protocols.ChainTransaction) {
 	case protocols.DepositTransactionType:
 		event = DepositedEvent{
 			CommonEvent: CommonEvent{
-				ChannelId:          tx.ChannelId,
+				channelID:          tx.ChannelId,
 				AdjudicationStatus: protocols.AdjudicationStatus{TurnNumRecord: 0},
 				BlockNum:           mc.blockNum},
 
@@ -72,7 +72,7 @@ func (mc MockChain) handleTx(tx protocols.ChainTransaction) {
 	case protocols.WithdrawAllTransactionType:
 		event = AllocationUpdatedEvent{
 			CommonEvent: CommonEvent{
-				ChannelId:          tx.ChannelId,
+				channelID:          tx.ChannelId,
 				AdjudicationStatus: protocols.AdjudicationStatus{TurnNumRecord: 0},
 				BlockNum:           mc.blockNum},
 

--- a/client/engine/chainservice/mockchain.go
+++ b/client/engine/chainservice/mockchain.go
@@ -58,8 +58,8 @@ func (mc MockChain) handleTx(tx protocols.ChainTransaction) {
 	if tx.Deposit.IsNonZero() {
 		mc.holdings[tx.ChannelId] = mc.holdings[tx.ChannelId].Add(tx.Deposit)
 	}
-	event := Event{
-		ChannelId:          tx.ChannelId,
+	event := DepositedEvent{
+		IntoChannel:        tx.ChannelId,
 		Holdings:           mc.holdings[tx.ChannelId],
 		AdjudicationStatus: protocols.AdjudicationStatus{TurnNumRecord: 0},
 		BlockNum:           mc.blockNum,

--- a/client/engine/chainservice/mockchain.go
+++ b/client/engine/chainservice/mockchain.go
@@ -59,7 +59,7 @@ func (mc MockChain) handleTx(tx protocols.ChainTransaction) {
 		mc.holdings[tx.ChannelId] = mc.holdings[tx.ChannelId].Add(tx.Deposit)
 	}
 	event := DepositedEvent{
-		IntoChannel:        tx.ChannelId,
+		ChannelId:          tx.ChannelId,
 		Holdings:           mc.holdings[tx.ChannelId],
 		AdjudicationStatus: protocols.AdjudicationStatus{TurnNumRecord: 0},
 		BlockNum:           mc.blockNum,

--- a/client/engine/chainservice/mockchain_test.go
+++ b/client/engine/chainservice/mockchain_test.go
@@ -42,11 +42,11 @@ func TestDeposit(t *testing.T) {
 	inA <- testTx
 	event := <-outA
 
-	if event.ChannelId != testTx.ChannelId {
-		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, event.ChannelId)
+	if event.ChannelId() != testTx.ChannelId {
+		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, event.ChannelId())
 	}
-	if !event.Holdings.Equal(testTx.Deposit) {
-		t.Fatalf(`holdings mismatch: expected %v but got %v`, testTx.Deposit, event.Holdings)
+	if !event.(DepositedEvent).Holdings.Equal(testTx.Deposit) {
+		t.Fatalf(`holdings mismatch: expected %v but got %v`, testTx.Deposit, event.(DepositedEvent).Holdings)
 	}
 
 	// Send the transaction again and recieve another event
@@ -56,31 +56,31 @@ func TestDeposit(t *testing.T) {
 	// The expectation is that the MockChainService remembered the previous deposit and added this one to it:
 	expectedHoldings := testTx.Deposit.Add(testTx.Deposit)
 
-	if event.ChannelId != testTx.ChannelId {
-		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, event.ChannelId)
+	if event.ChannelId() != testTx.ChannelId {
+		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, event.ChannelId())
 	}
-	if !event.Holdings.Equal(expectedHoldings) {
-		t.Fatalf(`holdings mismatch: expected %v but got %v`, expectedHoldings, event.Holdings)
+	if !event.(DepositedEvent).Holdings.Equal(expectedHoldings) {
+		t.Fatalf(`holdings mismatch: expected %v but got %v`, expectedHoldings, event.(DepositedEvent).Holdings)
 	}
 
 	// Pull an event out of the other mock chain service and check that
 	eventB := <-mcsB.Out()
 
-	if eventB.ChannelId != testTx.ChannelId {
-		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, eventB.ChannelId)
+	if eventB.ChannelId() != testTx.ChannelId {
+		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, eventB.ChannelId())
 	}
-	if !eventB.Holdings.Equal(testTx.Deposit) {
-		t.Fatalf(`holdings mismatch: expected %v but got %v`, testTx.Deposit, eventB.Holdings)
+	if !eventB.(DepositedEvent).Holdings.Equal(testTx.Deposit) {
+		t.Fatalf(`holdings mismatch: expected %v but got %v`, testTx.Deposit, eventB.(DepositedEvent).Holdings)
 	}
 
 	// Pull another event out of the other mock chain service and check that
 	eventB = <-mcsB.Out()
 
-	if eventB.ChannelId != testTx.ChannelId {
-		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, eventB.ChannelId)
+	if eventB.ChannelId() != testTx.ChannelId {
+		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, eventB.ChannelId())
 	}
-	if !eventB.Holdings.Equal(expectedHoldings) {
-		t.Fatalf(`holdings mismatch: expected %v but got %v`, expectedHoldings, eventB.Holdings)
+	if !eventB.(DepositedEvent).Holdings.Equal(expectedHoldings) {
+		t.Fatalf(`holdings mismatch: expected %v but got %v`, expectedHoldings, eventB.(DepositedEvent).Holdings)
 	}
 
 }

--- a/client/engine/chainservice/mockchain_test.go
+++ b/client/engine/chainservice/mockchain_test.go
@@ -42,8 +42,8 @@ func TestDeposit(t *testing.T) {
 	inA <- testTx
 	event := <-outA
 
-	if event.ChannelId() != testTx.ChannelId {
-		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, event.ChannelId())
+	if event.GetChannelId() != testTx.ChannelId {
+		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, event.GetChannelId())
 	}
 	if !event.(DepositedEvent).Holdings.Equal(testTx.Deposit) {
 		t.Fatalf(`holdings mismatch: expected %v but got %v`, testTx.Deposit, event.(DepositedEvent).Holdings)
@@ -56,8 +56,8 @@ func TestDeposit(t *testing.T) {
 	// The expectation is that the MockChainService remembered the previous deposit and added this one to it:
 	expectedHoldings := testTx.Deposit.Add(testTx.Deposit)
 
-	if event.ChannelId() != testTx.ChannelId {
-		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, event.ChannelId())
+	if event.GetChannelId() != testTx.ChannelId {
+		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, event.GetChannelId())
 	}
 	if !event.(DepositedEvent).Holdings.Equal(expectedHoldings) {
 		t.Fatalf(`holdings mismatch: expected %v but got %v`, expectedHoldings, event.(DepositedEvent).Holdings)
@@ -66,8 +66,8 @@ func TestDeposit(t *testing.T) {
 	// Pull an event out of the other mock chain service and check that
 	eventB := <-mcsB.Out()
 
-	if eventB.ChannelId() != testTx.ChannelId {
-		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, eventB.ChannelId())
+	if eventB.GetChannelId() != testTx.ChannelId {
+		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, eventB.GetChannelId())
 	}
 	if !eventB.(DepositedEvent).Holdings.Equal(testTx.Deposit) {
 		t.Fatalf(`holdings mismatch: expected %v but got %v`, testTx.Deposit, eventB.(DepositedEvent).Holdings)
@@ -76,8 +76,8 @@ func TestDeposit(t *testing.T) {
 	// Pull another event out of the other mock chain service and check that
 	eventB = <-mcsB.Out()
 
-	if eventB.ChannelId() != testTx.ChannelId {
-		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, eventB.ChannelId())
+	if eventB.GetChannelId() != testTx.ChannelId {
+		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, eventB.GetChannelId())
 	}
 	if !eventB.(DepositedEvent).Holdings.Equal(expectedHoldings) {
 		t.Fatalf(`holdings mismatch: expected %v but got %v`, expectedHoldings, eventB.(DepositedEvent).Holdings)

--- a/client/engine/chainservice/mockchain_test.go
+++ b/client/engine/chainservice/mockchain_test.go
@@ -43,8 +43,8 @@ func TestDeposit(t *testing.T) {
 	inA <- testTx
 	event := <-outA
 
-	if event.GetChannelId() != testTx.ChannelId {
-		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, event.GetChannelId())
+	if event.ChannelID() != testTx.ChannelId {
+		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, event.ChannelID())
 	}
 	if !event.(DepositedEvent).Holdings.Equal(testTx.Deposit) {
 		t.Fatalf(`holdings mismatch: expected %v but got %v`, testTx.Deposit, event.(DepositedEvent).Holdings)
@@ -57,8 +57,8 @@ func TestDeposit(t *testing.T) {
 	// The expectation is that the MockChainService remembered the previous deposit and added this one to it:
 	expectedHoldings := testTx.Deposit.Add(testTx.Deposit)
 
-	if event.GetChannelId() != testTx.ChannelId {
-		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, event.GetChannelId())
+	if event.ChannelID() != testTx.ChannelId {
+		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, event.ChannelID())
 	}
 	if !event.(DepositedEvent).Holdings.Equal(expectedHoldings) {
 		t.Fatalf(`holdings mismatch: expected %v but got %v`, expectedHoldings, event.(DepositedEvent).Holdings)
@@ -67,8 +67,8 @@ func TestDeposit(t *testing.T) {
 	// Pull an event out of the other mock chain service and check that
 	eventB := <-mcsB.Out()
 
-	if eventB.GetChannelId() != testTx.ChannelId {
-		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, eventB.GetChannelId())
+	if eventB.ChannelID() != testTx.ChannelId {
+		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, eventB.ChannelID())
 	}
 	if !eventB.(DepositedEvent).Holdings.Equal(testTx.Deposit) {
 		t.Fatalf(`holdings mismatch: expected %v but got %v`, testTx.Deposit, eventB.(DepositedEvent).Holdings)
@@ -77,8 +77,8 @@ func TestDeposit(t *testing.T) {
 	// Pull another event out of the other mock chain service and check that
 	eventB = <-mcsB.Out()
 
-	if eventB.GetChannelId() != testTx.ChannelId {
-		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, eventB.GetChannelId())
+	if eventB.ChannelID() != testTx.ChannelId {
+		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, eventB.ChannelID())
 	}
 	if !eventB.(DepositedEvent).Holdings.Equal(expectedHoldings) {
 		t.Fatalf(`holdings mismatch: expected %v but got %v`, expectedHoldings, eventB.(DepositedEvent).Holdings)

--- a/client/engine/chainservice/mockchain_test.go
+++ b/client/engine/chainservice/mockchain_test.go
@@ -36,6 +36,7 @@ func TestDeposit(t *testing.T) {
 	testTx := protocols.ChainTransaction{
 		ChannelId: types.Destination(common.HexToHash(`4ebd366d014a173765ba1e50f284c179ade31f20441bec41664712aac6cc461d`)),
 		Deposit:   testDeposit,
+		Type:      protocols.DepositTransactionType,
 	}
 
 	// Send one transaction into one of the SimpleChainServices and recieve one event from it.

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -163,7 +163,7 @@ func (e *Engine) handleMessage(message protocols.Message) (ObjectiveChangeEvent,
 // attempts progress.
 func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (ObjectiveChangeEvent, error) {
 	e.logger.Printf("handling chain event %v", chainEvent)
-	objective, ok := e.store.GetObjectiveByChannelId(chainEvent.GetChannelId())
+	objective, ok := e.store.GetObjectiveByChannelId(chainEvent.ChannelID())
 	if !ok {
 		return ObjectiveChangeEvent{}, &ErrUnhandledChainEvent{event: chainEvent, objective: objective, reason: "no objective for channel"}
 	}

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -22,7 +22,7 @@ type ErrUnhandledChainEvent struct {
 }
 
 func (uce *ErrUnhandledChainEvent) Error() string {
-	return fmt.Sprintf("chain event could not be handled %#v by objective %#v", uce.event, uce.objective)
+	return fmt.Sprintf("chain event %#v could not be handled by objective %#v", uce.event, uce.objective)
 }
 
 // Engine is the imperative part of the core business logic of a go-nitro Client

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -160,7 +160,7 @@ func (e *Engine) handleMessage(message protocols.Message) (ObjectiveChangeEvent,
 // attempts progress.
 func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (ObjectiveChangeEvent, error) {
 	e.logger.Printf("handling chain event %v", chainEvent)
-	objective, ok := e.store.GetObjectiveByChannelId(chainEvent.ChannelId())
+	objective, ok := e.store.GetObjectiveByChannelId(chainEvent.GetChannelId())
 	if !ok {
 		return ObjectiveChangeEvent{}, &UnhandledChainEvent{event: chainEvent}
 	}

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -165,21 +165,15 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (ObjectiveChang
 		return ObjectiveChangeEvent{}, &UnhandledChainEvent{event: chainEvent}
 	}
 
-	switch event := chainEvent.(type) {
-	case chainservice.DepositedEvent:
-		o, ok := objective.(*directfund.Objective)
-		if !ok {
-			return ObjectiveChangeEvent{}, &UnhandledChainEvent{event: chainEvent}
-		}
-		updatedObjective, err := o.UpdateWithChainEvent(event)
-		if err != nil {
-			return ObjectiveChangeEvent{}, err
-		}
-		return e.attemptProgress(updatedObjective)
-	default:
+	eventHandler, ok := objective.(chainservice.ChainEventHandler)
+	if !ok {
 		return ObjectiveChangeEvent{}, &UnhandledChainEvent{event: chainEvent}
 	}
-
+	updatedEventHandler, err := eventHandler.UpdateWithChainEvent(chainEvent)
+	if err != nil {
+		return ObjectiveChangeEvent{}, err
+	}
+	return e.attemptProgress(updatedEventHandler)
 }
 
 // handleAPIEvent handles an API Event (triggered by an API call)

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -15,12 +15,14 @@ import (
 	"github.com/statechannels/go-nitro/protocols/virtualfund"
 )
 
+// UnhandledChainEvent is an engine error when the the engine cannot process a chain event
 type UnhandledChainEvent struct {
-	event chainservice.Event
+	event     chainservice.Event
+	objective protocols.Objective
 }
 
 func (uce *UnhandledChainEvent) Error() string {
-	return fmt.Sprintf("chain event could not be handled: %#v", uce.event)
+	return fmt.Sprintf("chain event could not be handled %#v by objective %#v", uce.event, uce.objective)
 }
 
 // Engine is the imperative part of the core business logic of a go-nitro Client
@@ -162,12 +164,12 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (ObjectiveChang
 	e.logger.Printf("handling chain event %v", chainEvent)
 	objective, ok := e.store.GetObjectiveByChannelId(chainEvent.GetChannelId())
 	if !ok {
-		return ObjectiveChangeEvent{}, &UnhandledChainEvent{event: chainEvent}
+		return ObjectiveChangeEvent{}, &UnhandledChainEvent{event: chainEvent, objective: objective}
 	}
 
 	eventHandler, ok := objective.(chainservice.ChainEventHandler)
 	if !ok {
-		return ObjectiveChangeEvent{}, &UnhandledChainEvent{event: chainEvent}
+		return ObjectiveChangeEvent{}, &UnhandledChainEvent{event: chainEvent, objective: objective}
 	}
 	updatedEventHandler, err := eventHandler.UpdateWithChainEvent(chainEvent)
 	if err != nil {

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -15,13 +15,13 @@ import (
 	"github.com/statechannels/go-nitro/protocols/virtualfund"
 )
 
-// UnhandledChainEvent is an engine error when the the engine cannot process a chain event
-type UnhandledChainEvent struct {
+// ErrUnhandledChainEvent is an engine error when the the engine cannot process a chain event
+type ErrUnhandledChainEvent struct {
 	event     chainservice.Event
 	objective protocols.Objective
 }
 
-func (uce *UnhandledChainEvent) Error() string {
+func (uce *ErrUnhandledChainEvent) Error() string {
 	return fmt.Sprintf("chain event could not be handled %#v by objective %#v", uce.event, uce.objective)
 }
 
@@ -164,12 +164,12 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (ObjectiveChang
 	e.logger.Printf("handling chain event %v", chainEvent)
 	objective, ok := e.store.GetObjectiveByChannelId(chainEvent.GetChannelId())
 	if !ok {
-		return ObjectiveChangeEvent{}, &UnhandledChainEvent{event: chainEvent, objective: objective}
+		return ObjectiveChangeEvent{}, &ErrUnhandledChainEvent{event: chainEvent, objective: objective}
 	}
 
 	eventHandler, ok := objective.(chainservice.ChainEventHandler)
 	if !ok {
-		return ObjectiveChangeEvent{}, &UnhandledChainEvent{event: chainEvent, objective: objective}
+		return ObjectiveChangeEvent{}, &ErrUnhandledChainEvent{event: chainEvent, objective: objective}
 	}
 	updatedEventHandler, err := eventHandler.UpdateWithChainEvent(chainEvent)
 	if err != nil {

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/statechannels/go-nitro/channel"
+	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/protocols"
 )
 
@@ -131,11 +132,20 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (Objective, error) {
 
 	updated := o.clone()
 	updated.C.AddSignedStates(event.SignedStates)
+
+	return updated, nil
+}
+
+// todo this should not be a deposited event
+func (o Objective) UpdateWithChainEvent(event chainservice.DepositedEvent) (Objective, error) {
+	updated := o.clone()
+	// todo: check block number
 	if event.Holdings != nil {
-		updated.C.OnChainFunding = event.Holdings
+		updated.C.OnChainFunding = event.Holdings.Clone()
 	}
 
 	return updated, nil
+
 }
 
 // Crank inspects the extended state and declares a list of Effects to be executed

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -114,12 +114,12 @@ func (o Objective) Reject() protocols.Objective {
 }
 
 // OwnsChannel returns the channel that the objective is funding.
-func (ddo *Objective) OwnsChannel() types.Destination {
+func (ddo Objective) OwnsChannel() types.Destination {
 	return ddo.C.Id
 }
 
 // GetStatus returns the status of the objective.
-func (ddo *Objective) GetStatus() protocols.ObjectiveStatus {
+func (ddo Objective) GetStatus() protocols.ObjectiveStatus {
 	return ddo.Status
 }
 

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -151,7 +151,6 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 	return &updated, nil
 }
 
-// todo this should not be a deposited event
 func (o Objective) UpdateWithChainEvent(event chainservice.Event) (protocols.Objective, error) {
 	updated := o.clone()
 	de, ok := event.(chainservice.AllocationUpdatedEvent)

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -151,6 +151,9 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 	return &updated, nil
 }
 
+// UpdateWithChainEvent updates the objective with observed on-chain data.
+//
+// Only Allocation Updated events are currently handled.
 func (o Objective) UpdateWithChainEvent(event chainservice.Event) (protocols.Objective, error) {
 	updated := o.clone()
 	de, ok := event.(chainservice.AllocationUpdatedEvent)

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -154,7 +154,7 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 // todo this should not be a deposited event
 func (o Objective) UpdateWithChainEvent(event chainservice.Event) (protocols.Objective, error) {
 	updated := o.clone()
-	de, ok := event.(chainservice.DepositedEvent)
+	de, ok := event.(chainservice.AllocationUpdatedEvent)
 	if !ok {
 		return &updated, fmt.Errorf("objective %+v cannot handle event %+v", updated, event)
 	}

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -310,7 +310,7 @@ func TestCrankBob(t *testing.T) {
 	}
 
 	// The third crank. Bob is expected to enter the terminal state of the defunding protocol.
-	updated, err = updated.(*Objective).UpdateWithChainEvent(chainservice.DepositedEvent{Holdings: types.Funds{}})
+	updated, err = updated.(*Objective).UpdateWithChainEvent(chainservice.AllocationUpdatedEvent{Holdings: types.Funds{}})
 
 	if err != nil {
 		t.Error(err)

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -227,7 +227,7 @@ func TestCrankAlice(t *testing.T) {
 	}
 
 	// The third crank. Alice is expected to enter the terminal state of the defunding protocol.
-	updated.C.OnChainFunding = types.Funds{}
+	updated.(*Objective).C.OnChainFunding = types.Funds{}
 	_, se, wf, err = updated.Crank(&alice.PrivateKey)
 	if err != nil {
 		t.Error(err)
@@ -256,13 +256,13 @@ func TestCrankBob(t *testing.T) {
 	finalState.IsFinal = true
 	finalStateSignedByAlice, _ := signedTestState(finalState, []bool{true, false})
 	e := protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedStates: []state.SignedState{finalStateSignedByAlice}}
-	o, err := o.Update(e)
+	updated, err := o.Update(e)
 	if err != nil {
 		t.Error(err)
 	}
 
 	// The first crank. Bob is expected to create and sign a final state
-	o, se, wf, err := o.Crank(&bob.PrivateKey)
+	updated, se, wf, err := updated.Crank(&bob.PrivateKey)
 
 	if err != nil {
 		t.Error(err)
@@ -277,7 +277,7 @@ func TestCrankBob(t *testing.T) {
 	expectedSE := protocols.SideEffects{
 		MessagesToSend: []protocols.Message{{
 			To:          alice.Address,
-			ObjectiveId: o.Id(),
+			ObjectiveId: updated.Id(),
 			SignedStates: []state.SignedState{
 				finalStateSignedByBob,
 			},
@@ -290,11 +290,11 @@ func TestCrankBob(t *testing.T) {
 	}
 
 	// The second update and crank. Bob is expected to NOT create any transactions or side effects
-	o, err = o.Update(e)
+	updated, err = updated.Update(e)
 	if err != nil {
 		t.Error(err)
 	}
-	_, se, wf, err = o.Crank(&bob.PrivateKey)
+	_, se, wf, err = updated.Crank(&bob.PrivateKey)
 	if err != nil {
 		t.Error(err)
 	}
@@ -310,13 +310,13 @@ func TestCrankBob(t *testing.T) {
 	}
 
 	// The third crank. Bob is expected to enter the terminal state of the defunding protocol.
-	o, err = o.UpdateWithChainEvent(chainservice.DepositedEvent{Holdings: types.Funds{}})
+	updated, err = updated.(*Objective).UpdateWithChainEvent(chainservice.DepositedEvent{Holdings: types.Funds{}})
 
 	if err != nil {
 		t.Error(err)
 	}
 
-	_, se, wf, err = o.Crank(&bob.PrivateKey)
+	_, se, wf, err = updated.Crank(&bob.PrivateKey)
 	if err != nil {
 		t.Error(err)
 	}

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
@@ -309,8 +310,8 @@ func TestCrankBob(t *testing.T) {
 	}
 
 	// The third crank. Bob is expected to enter the terminal state of the defunding protocol.
-	e = protocols.ObjectiveEvent{ObjectiveId: o.Id(), Holdings: types.Funds{}}
-	o, err = o.Update(e)
+	o, err = o.UpdateWithChainEvent(chainservice.DepositedEvent{Holdings: types.Funds{}})
+
 	if err != nil {
 		t.Error(err)
 	}

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -215,9 +215,9 @@ func (o Objective) UpdateWithChainEvent(event chainservice.Event) (protocols.Obj
 	if !ok {
 		return &updated, fmt.Errorf("objective %+v cannot handle event %+v", updated, event)
 	}
-	if de.Holdings != nil && de.GetBlockNum() > updated.latestBlockNumber {
+	if de.Holdings != nil && de.BlockNum > updated.latestBlockNumber {
 		updated.C.OnChainFunding = de.Holdings.Clone()
-		updated.latestBlockNumber = de.GetBlockNum()
+		updated.latestBlockNumber = de.BlockNum
 	}
 
 	return &updated, nil

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -208,11 +208,16 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 	return &updated, nil
 }
 
-func (o Objective) UpdateWithChainEvent(event chainservice.DepositedEvent) (protocols.Objective, error) {
+func (o Objective) UpdateWithChainEvent(event chainservice.Event) (protocols.Objective, error) {
 	updated := o.clone()
-	if event.Holdings != nil && event.BlockNum > updated.latestBlockNumber {
-		updated.C.OnChainFunding = event.Holdings.Clone()
-		updated.latestBlockNumber = event.BlockNum
+
+	de, ok := event.(chainservice.DepositedEvent)
+	if !ok {
+		return &updated, fmt.Errorf("objective %+v cannot handle event %+v", updated, event)
+	}
+	if de.Holdings != nil && de.BlockNum > updated.latestBlockNumber {
+		updated.C.OnChainFunding = de.Holdings.Clone()
+		updated.latestBlockNumber = de.BlockNum
 	}
 
 	return &updated, nil

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -260,7 +260,7 @@ func (o Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Side
 	}
 
 	if !fundingComplete && safeToDeposit && amountToDeposit.IsNonZero() {
-		deposit := protocols.ChainTransaction{ChannelId: updated.C.Id, Deposit: amountToDeposit}
+		deposit := protocols.ChainTransaction{Type: protocols.DepositTransactionType, ChannelId: updated.C.Id, Deposit: amountToDeposit}
 		sideEffects.TransactionsToSubmit = append(sideEffects.TransactionsToSubmit, deposit)
 	}
 

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -11,6 +11,7 @@ import (
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -203,12 +204,19 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 
 	updated := o.clone()
 	updated.C.AddSignedStates(event.SignedStates)
+
+	return &updated, nil
+}
+
+func (o Objective) UpdateWithChainEvent(event chainservice.DepositedEvent) (protocols.Objective, error) {
+	updated := o.clone()
 	if event.Holdings != nil && event.BlockNum > updated.latestBlockNumber {
 		updated.C.OnChainFunding = event.Holdings.Clone()
 		updated.latestBlockNumber = event.BlockNum
 	}
 
 	return &updated, nil
+
 }
 
 // Crank inspects the extended state and declares a list of Effects to be executed

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -208,6 +208,9 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 	return &updated, nil
 }
 
+// UpdateWithChainEvent updates the objective with observed on-chain data.
+//
+// Only Channel Deposit events are currently handled.
 func (o Objective) UpdateWithChainEvent(event chainservice.Event) (protocols.Objective, error) {
 	updated := o.clone()
 

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -124,12 +124,12 @@ func constructFromState(
 }
 
 // OwnsChannel returns the channel that the objective is funding.
-func (dfo *Objective) OwnsChannel() types.Destination {
+func (dfo Objective) OwnsChannel() types.Destination {
 	return dfo.C.Id
 }
 
 // GetStatus returns the status of the objective.
-func (dfo *Objective) GetStatus() protocols.ObjectiveStatus {
+func (dfo Objective) GetStatus() protocols.ObjectiveStatus {
 	return dfo.Status
 }
 

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -215,9 +215,9 @@ func (o Objective) UpdateWithChainEvent(event chainservice.Event) (protocols.Obj
 	if !ok {
 		return &updated, fmt.Errorf("objective %+v cannot handle event %+v", updated, event)
 	}
-	if de.Holdings != nil && de.BlockNum > updated.latestBlockNumber {
+	if de.Holdings != nil && de.GetBlockNum() > updated.latestBlockNumber {
 		updated.C.OnChainFunding = de.Holdings.Clone()
-		updated.latestBlockNumber = de.BlockNum
+		updated.latestBlockNumber = de.GetBlockNum()
 	}
 
 	return &updated, nil

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
@@ -129,13 +130,13 @@ func TestUpdate(t *testing.T) {
 		common.Address{}: big.NewInt(3),
 	}
 	highBlockNum := uint64(200)
-	updatedObjective, err = s.Update(protocols.ObjectiveEvent{ObjectiveId: s.Id(), Holdings: newFunding, BlockNum: highBlockNum})
+	updatedObjective, err = s.UpdateWithChainEvent(chainservice.DepositedEvent{Holdings: newFunding, BlockNum: highBlockNum})
 	if err != nil {
 		t.Error(err)
 	}
 	updated = updatedObjective.(*Objective)
 	if !updated.C.OnChainFunding.Equal(newFunding) {
-		t.Error(`Objective data not updated as expected`, updated.C.OnChainFunding, e.Holdings)
+		t.Error(`Objective data not updated as expected`, updated.C.OnChainFunding, newFunding)
 	}
 	if updated.latestBlockNumber != uint64(highBlockNum) {
 		t.Error("Latest block number not updated as expected", updated.latestBlockNumber, highBlockNum)
@@ -146,7 +147,8 @@ func TestUpdate(t *testing.T) {
 	staleFunding[common.Address{}] = big.NewInt(2)
 	lowBlockNum := uint64(100)
 
-	updatedObjective, _ = updated.Update(protocols.ObjectiveEvent{ObjectiveId: s.Id(), Holdings: staleFunding, BlockNum: uint64(lowBlockNum)})
+	updatedObjective, _ = updated.UpdateWithChainEvent(chainservice.DepositedEvent{Holdings: staleFunding, BlockNum: uint64(lowBlockNum)})
+
 	updated = updatedObjective.(*Objective)
 
 	if updated.C.OnChainFunding.Equal(staleFunding) {

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -130,7 +130,7 @@ func TestUpdate(t *testing.T) {
 		common.Address{}: big.NewInt(3),
 	}
 	highBlockNum := uint64(200)
-	updatedObjective, err = s.UpdateWithChainEvent(chainservice.DepositedEvent{Holdings: newFunding, BlockNum: highBlockNum})
+	updatedObjective, err = s.UpdateWithChainEvent(chainservice.DepositedEvent{Holdings: newFunding, CommonEvent: chainservice.CommonEvent{BlockNum: highBlockNum}})
 	if err != nil {
 		t.Error(err)
 	}
@@ -147,7 +147,7 @@ func TestUpdate(t *testing.T) {
 	staleFunding[common.Address{}] = big.NewInt(2)
 	lowBlockNum := uint64(100)
 
-	updatedObjective, _ = updated.UpdateWithChainEvent(chainservice.DepositedEvent{Holdings: staleFunding, BlockNum: uint64(lowBlockNum)})
+	updatedObjective, _ = updated.UpdateWithChainEvent(chainservice.DepositedEvent{Holdings: staleFunding, CommonEvent: chainservice.CommonEvent{BlockNum: uint64(lowBlockNum)}})
 
 	updated = updatedObjective.(*Objective)
 
@@ -204,6 +204,7 @@ func TestCrank(t *testing.T) {
 		}}
 	expectedFundingSideEffects := protocols.SideEffects{
 		TransactionsToSubmit: []protocols.ChainTransaction{{
+			Type:      protocols.DepositTransactionType,
 			ChannelId: s.C.Id,
 			Deposit: types.Funds{
 				testState.Outcome[0].Asset: testState.Outcome[0].Allocations[0].Amount,

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -43,12 +43,9 @@ type AdjudicationStatus struct {
 
 // ObjectiveEvent holds information used to update an Objective. Some fields may be nil.
 type ObjectiveEvent struct {
-	ObjectiveId        ObjectiveId
-	SignedStates       []state.SignedState
-	SignedProposals    []consensus_channel.SignedProposal
-	Holdings           types.Funds // mapping from asset identifier to amount
-	AdjudicationStatus AdjudicationStatus
-	BlockNum           uint64
+	ObjectiveId     ObjectiveId
+	SignedStates    []state.SignedState
+	SignedProposals []consensus_channel.SignedProposal
 }
 
 // Storable is an object that can be stored by the store.


### PR DESCRIPTION
Fixes https://github.com/statechannels/go-nitro/issues/490.

This PR separates the logic for handling chain events. When the engine processes a chain event:
1. There must be an active objective for the channel targeted by the chain event.
2. The objective must be able to handle chain events.

Every objective decides whether it handles chain events. If an objective handles chain events but receives an unexpected chain event type, the objective returns an error. 