### PR TITLE
Round 2 of Virtual Defunding

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -310,6 +310,14 @@ func (lo *LedgerOutcome) Clone() LedgerOutcome {
 	}
 }
 
+func (l LedgerOutcome) Left() Balance {
+	return l.left
+}
+
+func (l LedgerOutcome) Right() Balance {
+	return l.right
+}
+
 // NewLedgerOutcome creates a new ledger outcome with the given asset address and balances and guarantees
 func NewLedgerOutcome(assetAddress types.Address, left, right Balance, guarantees []Guarantee) *LedgerOutcome {
 	guaranteeMap := make(map[types.Destination]Guarantee, len(guarantees))

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -83,6 +83,11 @@ func newConsensusChannel(
 
 }
 
+// FixedPart returns the fixed part of the channel
+func (c *ConsensusChannel) FixedPart() state.FixedPart {
+	return c.fp
+}
+
 // Receive accepts a proposal signed by the ConsensusChannel counterparty,
 // validates its signature, and performs updates the proposal queue and
 // consensus state

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -107,6 +107,24 @@ func (c *ConsensusChannel) Includes(g Guarantee) bool {
 	return c.current.Outcome.includes(g)
 }
 
+// IncludesTarget returns whether or not the consensus state includes a guarantee targeting the given channel
+func (c *ConsensusChannel) IncludesTarget(target types.Destination) bool {
+	return c.current.Outcome.includesTarget(target)
+}
+
+// RemoveProposedFor returns whether or not a proposal exists to remove the guaranatee for the target
+func (c *ConsensusChannel) RemoveProposedFor(target types.Destination) bool {
+	for _, p := range c.proposalQueue {
+		if p.Proposal.Type() == RemoveProposal {
+			remove := p.Proposal.ToRemove
+			if remove.Target == target {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // IsLeader returns true if the calling client is the leader of the channel,
 // and false otherwise
 func (c *ConsensusChannel) IsLeader() bool {
@@ -304,6 +322,12 @@ func NewLedgerOutcome(assetAddress types.Address, left, right Balance, guarantee
 		right:        right,
 		guarantees:   guaranteeMap,
 	}
+}
+
+// includesTarget returns true when the receiver includes a guarantee that targets the given destination
+func (o *LedgerOutcome) includesTarget(target types.Destination) bool {
+	_, found := o.guarantees[target]
+	return found
 }
 
 // includes returns true when the receiver includes g in its list of guarantees.

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -118,8 +118,8 @@ func (c *ConsensusChannel) IncludesTarget(target types.Destination) bool {
 	return c.current.Outcome.includesTarget(target)
 }
 
-// RemoveProposedFor returns whether or not a proposal exists to remove the guaranatee for the target
-func (c *ConsensusChannel) RemoveProposedFor(target types.Destination) bool {
+// HasRemovalBeenProposedFor returns whether or not a proposal exists to remove the guaranatee for the target
+func (c *ConsensusChannel) HasRemovalBeenProposedFor(target types.Destination) bool {
 	for _, p := range c.proposalQueue {
 		if p.Proposal.Type() == RemoveProposal {
 			remove := p.Proposal.ToRemove

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -2,6 +2,7 @@
 package consensus_channel
 
 import (
+	"bytes"
 	"fmt"
 	"math/big"
 	"sort"
@@ -540,7 +541,7 @@ func (p *Proposal) TurnNum() uint64 {
 
 // equal returns true if the supplied Proposal is deeply equal to the receiver, false otherwise.
 func (p *Proposal) equal(q *Proposal) bool {
-	return p.ToAdd.equal(q.ToAdd) && p.ToRemove == q.ToRemove
+	return p.ToAdd.equal(q.ToAdd) && p.ToRemove.equal(q.ToRemove)
 }
 
 // SignedProposal is a Proposal with a signature on it
@@ -614,6 +615,23 @@ func (a Add) equal(a2 Add) bool {
 		return false
 	}
 	return types.Equal(a.LeftDeposit, a2.LeftDeposit)
+}
+
+func (r Remove) equal(r2 Remove) bool {
+	if r.turnNum != r2.turnNum {
+		return false
+	}
+	if !bytes.Equal(r.Target.Bytes(), r2.Target.Bytes()) {
+
+		return false
+	}
+	if !types.Equal(r.LeftAmount, r2.LeftAmount) {
+		return false
+	}
+	if !types.Equal(r.RightAmount, r2.RightAmount) {
+		return false
+	}
+	return true
 }
 
 var ErrIncorrectTurnNum = fmt.Errorf("incorrect turn number")

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -316,14 +316,6 @@ func (lo *LedgerOutcome) Clone() LedgerOutcome {
 	}
 }
 
-func (l LedgerOutcome) Left() Balance {
-	return l.left
-}
-
-func (l LedgerOutcome) Right() Balance {
-	return l.right
-}
-
 // NewLedgerOutcome creates a new ledger outcome with the given asset address and balances and guarantees
 func NewLedgerOutcome(assetAddress types.Address, left, right Balance, guarantees []Guarantee) *LedgerOutcome {
 	guaranteeMap := make(map[types.Destination]Guarantee, len(guarantees))

--- a/protocols/virtualdefund/helpers_test.go
+++ b/protocols/virtualdefund/helpers_test.go
@@ -32,36 +32,23 @@ func assertProposalSent(t *testing.T, ses protocols.SideEffects, sp consensus_ch
 }
 
 // generateLedgers generates the left and right ledger channels based on myRole
-// The ledgers will contain a guarantee if vIsFunded==true otherwise a ledger will have no guarantees
-func generateLedgers(myRole uint, vId types.Destination, vIsFunded bool) (left, right *consensus_channel.ConsensusChannel) {
-	leftGuarantees := []consensus_channel.Guarantee{}
-	rightGuarantees := []consensus_channel.Guarantee{}
+func generateLedgers(myRole uint, vId types.Destination) (left, right *consensus_channel.ConsensusChannel) {
 	switch myRole {
 	case 0:
 		{
-
-			if vIsFunded {
-				rightGuarantees = append(rightGuarantees, generateGuarantee(testactors.Alice, testactors.Irene, vId))
-			}
-			return nil, prepareConsensusChannel(uint(consensus_channel.Leader), testactors.Alice, testactors.Irene, rightGuarantees...)
-
+			return nil, prepareConsensusChannel(uint(consensus_channel.Leader), testactors.Alice, testactors.Irene, generateGuarantee(testactors.Alice, testactors.Irene, vId))
 		}
 	case 1:
 		{
-			if vIsFunded {
-				leftGuarantees = append(leftGuarantees, generateGuarantee(testactors.Alice, testactors.Irene, vId))
-				rightGuarantees = append(rightGuarantees, generateGuarantee(testactors.Irene, testactors.Bob, vId))
-			}
-			return prepareConsensusChannel(uint(consensus_channel.Follower), testactors.Alice, testactors.Irene, leftGuarantees...),
-				prepareConsensusChannel(uint(consensus_channel.Leader), testactors.Irene, testactors.Bob, rightGuarantees...)
+
+			return prepareConsensusChannel(uint(consensus_channel.Follower), testactors.Alice, testactors.Irene, generateGuarantee(testactors.Alice, testactors.Irene, vId)),
+				prepareConsensusChannel(uint(consensus_channel.Leader), testactors.Irene, testactors.Bob, generateGuarantee(testactors.Irene, testactors.Bob, vId))
 
 		}
 	case 2:
 		{
-			if vIsFunded {
-				leftGuarantees = append(leftGuarantees, generateGuarantee(testactors.Irene, testactors.Bob, vId))
-			}
-			return prepareConsensusChannel(uint(consensus_channel.Follower), testactors.Irene, testactors.Bob, leftGuarantees...), nil
+
+			return prepareConsensusChannel(uint(consensus_channel.Follower), testactors.Irene, testactors.Bob, generateGuarantee(testactors.Irene, testactors.Bob, vId)), nil
 
 		}
 	default:

--- a/protocols/virtualdefund/helpers_test.go
+++ b/protocols/virtualdefund/helpers_test.go
@@ -192,7 +192,8 @@ func checkForLeaderProposals(t *testing.T, se protocols.SideEffects, o *Objectiv
 // signProposal signs a proposal with the given actor's private key
 func signProposal(me testactors.Actor, p consensus_channel.Proposal, c *consensus_channel.ConsensusChannel) (consensus_channel.SignedProposal, error) {
 
-	vars := c.ConsensusVars().Clone()
+	con := c.ConsensusVars()
+	vars := con.Clone()
 	err := vars.HandleProposal(p)
 	if err != nil {
 		return consensus_channel.SignedProposal{}, err

--- a/protocols/virtualdefund/helpers_test.go
+++ b/protocols/virtualdefund/helpers_test.go
@@ -138,25 +138,44 @@ func checkForFollowerProposals(t *testing.T, se protocols.SideEffects, o *Object
 	}
 }
 
-// generateLeaderProposals generates the signed proposals for the leader of the consensus channel
-func generateLeaderProposals(myRole uint, vId types.Destination, o *Objective) []consensus_channel.SignedProposal {
+// generateProposalsResponses generates the signed proposals that a participant should expect from the other participants
+func generateProposalsResponses(myRole uint, vId types.Destination, o *Objective) []consensus_channel.SignedProposal {
 	leftAmount := big.NewInt(6)
 	rightAmount := big.NewInt(4)
 	switch myRole {
-	case 1:
+	case 0:
 		{
-			// Irene should get a proposal from Alice
-			p := consensus_channel.NewRemoveProposal(o.ToMyLeft.Id, FinalTurnNum, vId, leftAmount, rightAmount)
-			sp, err := signProposal(alice, p, o.ToMyLeft)
+			// Alice expects Irene to accept her proposal
+			p := consensus_channel.NewRemoveProposal(o.ToMyRight.Id, FinalTurnNum, vId, leftAmount, rightAmount)
+			sp, err := signProposal(irene, p, o.ToMyRight)
 			if err != nil {
 				panic(err)
 			}
 
 			return []consensus_channel.SignedProposal{sp}
 		}
+
+	case 1:
+		{
+			// Irene expects Alice to send a proposal
+			p := consensus_channel.NewRemoveProposal(o.ToMyLeft.Id, FinalTurnNum, vId, leftAmount, rightAmount)
+			sp, err := signProposal(alice, p, o.ToMyLeft)
+			if err != nil {
+				panic(err)
+			}
+
+			// Irene expects Bob to accept her proposal
+			p2 := consensus_channel.NewRemoveProposal(o.ToMyRight.Id, FinalTurnNum, vId, leftAmount, rightAmount)
+			sp2, err := signProposal(bob, p2, o.ToMyRight)
+			if err != nil {
+				panic(err)
+			}
+
+			return []consensus_channel.SignedProposal{sp, sp2}
+		}
 	case 2:
 		{
-			// Bob should get a proposal from Irene
+			// Bob expects Irene to send a proposal
 			p := consensus_channel.NewRemoveProposal(o.ToMyLeft.Id, FinalTurnNum, vId, leftAmount, rightAmount)
 			sp, err := signProposal(irene, p, o.ToMyLeft)
 			if err != nil {

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -55,7 +55,7 @@ type Objective struct {
 const ObjectivePrefix = "VirtualDefund-"
 
 // newObjective constructs a new virtual defund objective
-func newObjective(preApprove bool, vFixed state.FixedPart, initialOutcome outcome.SingleAssetExit, paidToBob *big.Int, myRole uint) Objective {
+func newObjective(preApprove bool, vFixed state.FixedPart, initialOutcome outcome.SingleAssetExit, paidToBob *big.Int, toMyLeft, toMyRight *consensus_channel.ConsensusChannel, myRole uint) Objective {
 	var status protocols.ObjectiveStatus
 
 	if preApprove {
@@ -71,6 +71,8 @@ func newObjective(preApprove bool, vFixed state.FixedPart, initialOutcome outcom
 		VFixed:         vFixed,
 		Signatures:     [3]state.Signature{},
 		MyRole:         myRole,
+		ToMyLeft:       toMyLeft,
+		ToMyRight:      toMyRight,
 	}
 
 }

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -270,7 +270,7 @@ func (o *Objective) defundLedger(ledger *consensus_channel.ConsensusChannel, sk 
 
 	var sideEffects protocols.SideEffects
 
-	proposed := ledger.RemoveProposedFor(o.VId())
+	proposed := ledger.HasRemovalBeenProposedFor(o.VId())
 
 	if ledger.IsLeader() {
 		if proposed { // If we've already proposed a remove proposal we can return

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -321,7 +321,7 @@ func (o Objective) isRightDefunded() bool {
 		return true
 	}
 
-	included := o.ToMyLeft.IncludesTarget(o.VId())
+	included := o.ToMyRight.IncludesTarget(o.VId())
 	return !included
 }
 

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -19,7 +19,7 @@ const (
 )
 
 // The turn number used for the final state
-const FinalTurnNum = 3
+const FinalTurnNum = 2
 
 // errors
 var ErrNotApproved = errors.New("objective not approved")

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -215,7 +215,7 @@ func (o Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Side
 	}
 
 	if !updated.isAlice() && !updated.isLeftDefunded() {
-		ledgerSideEffects, err := updated.defundLedger(updated.ToMyLeft, secretKey)
+		ledgerSideEffects, err := updated.updateLedgerToRemoveGuarantee(updated.ToMyLeft, secretKey)
 		if err != nil {
 			return &o, protocols.SideEffects{}, WaitingForNothing, fmt.Errorf("error updating ledger funding: %w", err)
 		}
@@ -223,7 +223,7 @@ func (o Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Side
 	}
 
 	if !updated.isBob() && !updated.isRightDefunded() {
-		ledgerSideEffects, err := updated.defundLedger(updated.ToMyRight, secretKey)
+		ledgerSideEffects, err := updated.updateLedgerToRemoveGuarantee(updated.ToMyRight, secretKey)
 		if err != nil {
 			return &o, protocols.SideEffects{}, WaitingForNothing, fmt.Errorf("error updating ledger funding: %w", err)
 		}
@@ -265,8 +265,8 @@ func (o Objective) ledgerProposal(ledger *consensus_channel.ConsensusChannel) co
 	return consensus_channel.NewRemoveProposal(ledger.Id, FinalTurnNum, o.VId(), left, right)
 }
 
-// defundLedger updates the ledger channel to remove the guarantee that funds V.
-func (o *Objective) defundLedger(ledger *consensus_channel.ConsensusChannel, sk *[]byte) (protocols.SideEffects, error) {
+// updateLedgerToRemoveGuarantee updates the ledger channel to remove the guarantee that funds V.
+func (o *Objective) updateLedgerToRemoveGuarantee(ledger *consensus_channel.ConsensusChannel, sk *[]byte) (protocols.SideEffects, error) {
 
 	var sideEffects protocols.SideEffects
 

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -232,9 +232,8 @@ func (o Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Side
 
 	if fullyDefunded := updated.isLeftDefunded() && updated.isRightDefunded(); !fullyDefunded {
 		return &updated, sideEffects, WaitingForCompleteLedgerDefunding, nil
-	} else {
-		return &updated, sideEffects, WaitingForNothing, nil
 	}
+	return &updated, sideEffects, WaitingForNothing, nil
 
 }
 
@@ -297,9 +296,6 @@ func (o *Objective) defundLedger(ledger *consensus_channel.ConsensusChannel, sk 
 
 			message := o.createSignedProposalMessage(sp, ledger)
 			sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, message)
-
-		} else {
-
 		}
 	}
 

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -167,6 +167,14 @@ func (o *Objective) clone() Objective {
 	}
 	clone.MyRole = o.MyRole
 
+	// TODO: Properly clone the consensus channels
+	if o.ToMyLeft != nil {
+		clone.ToMyLeft = o.ToMyLeft
+	}
+	if o.ToMyRight != nil {
+		clone.ToMyRight = o.ToMyRight
+	}
+
 	return clone
 }
 

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -115,9 +115,9 @@ func testCrankAs(my ta.Actor) func(t *testing.T) {
 
 		testhelpers.Equals(t, WaitingForCompleteLedgerDefunding, waitingFor)
 
-		checkForLeaderProposals(t, se, updated)
+		checkForLeaderProposals(t, se, updated, data)
 
-		proposals := generateProposalsResponses(my.Role, vId, updated)
+		proposals := generateProposalsResponses(my.Role, vId, updated, data)
 		updateProposals(updated, proposals...)
 
 		updatedObj, se, waitingFor, err = updated.Crank(&my.PrivateKey)
@@ -125,7 +125,7 @@ func testCrankAs(my ta.Actor) func(t *testing.T) {
 		testhelpers.Ok(t, err)
 
 		testhelpers.Equals(t, waitingFor, WaitingForNothing)
-		checkForFollowerProposals(t, se, updated)
+		checkForFollowerProposals(t, se, updated, data)
 
 	}
 

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -205,7 +205,7 @@ func testCrankAs(my ta.Actor) func(t *testing.T) {
 		updated.ToMyLeft = defundedLeft
 		updated.ToMyRight = defundedRight
 
-		updatedObj, se, waitingFor, err = updated.Crank(&my.PrivateKey)
+		_, se, waitingFor, err = updated.Crank(&my.PrivateKey)
 		testhelpers.Ok(t, err)
 		testhelpers.Assert(t, len(se.MessagesToSend) == 0, "expected no messages to send")
 		testhelpers.Equals(t, waitingFor, WaitingForNothing)

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -137,7 +137,7 @@ func testUpdateAs(my ta.Actor) func(t *testing.T) {
 	return func(t *testing.T) {
 		data := generateTestData()
 		vId, _ := data.vFixed.ChannelId()
-		left, right := generateLedgers(my.Role, vId, true)
+		left, right := generateLedgers(my.Role, vId)
 
 		virtualDefund := newObjective(false, data.vFixed, data.initialOutcome, big.NewInt(int64(data.paid)), left, right, my.Role)
 		signedFinal := state.NewSignedState(data.vFinal)
@@ -164,7 +164,7 @@ func testCrankAs(my ta.Actor) func(t *testing.T) {
 	return func(t *testing.T) {
 		data := generateTestData()
 		vId, _ := data.vFixed.ChannelId()
-		left, right := generateLedgers(my.Role, vId, true)
+		left, right := generateLedgers(my.Role, vId)
 		virtualDefund := newObjective(true, data.vFixed, data.initialOutcome, big.NewInt(int64(data.paid)), left, right, my.Role)
 
 		updatedObj, se, waitingFor, err := virtualDefund.Crank(&my.PrivateKey)

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -33,7 +33,7 @@ func TestCrank(t *testing.T) {
 func TestInvalidUpdate(t *testing.T) {
 	data := generateTestData()
 
-	virtualDefund := newObjective(false, data.vFixed, data.initialOutcome, big.NewInt(int64(data.paid)), nil, nil, 0)
+	virtualDefund := newObjective(false, data.vFinal.FixedPart(), data.initialOutcome, big.NewInt(int64(data.paid)), nil, nil, 0)
 	invalidFinal := data.vFinal.Clone()
 	invalidFinal.ChannelNonce = big.NewInt(5)
 
@@ -53,10 +53,10 @@ func TestInvalidUpdate(t *testing.T) {
 func testUpdateAs(my ta.Actor) func(t *testing.T) {
 	return func(t *testing.T) {
 		data := generateTestData()
-		vId, _ := data.vFixed.ChannelId()
+		vId, _ := data.vFinal.ChannelId()
 		left, right := generateLedgers(my.Role, vId)
 
-		virtualDefund := newObjective(false, data.vFixed, data.initialOutcome, big.NewInt(int64(data.paid)), left, right, my.Role)
+		virtualDefund := newObjective(false, data.vFinal.FixedPart(), data.initialOutcome, big.NewInt(int64(data.paid)), left, right, my.Role)
 		signedFinal := state.NewSignedState(data.vFinal)
 		// Sign the final state by some other participant
 		signStateByOthers(my, signedFinal)
@@ -80,9 +80,9 @@ func testUpdateAs(my ta.Actor) func(t *testing.T) {
 func testCrankAs(my ta.Actor) func(t *testing.T) {
 	return func(t *testing.T) {
 		data := generateTestData()
-		vId, _ := data.vFixed.ChannelId()
+		vId, _ := data.vFinal.ChannelId()
 		left, right := generateLedgers(my.Role, vId)
-		virtualDefund := newObjective(true, data.vFixed, data.initialOutcome, big.NewInt(int64(data.paid)), left, right, my.Role)
+		virtualDefund := newObjective(true, data.vFinal.FixedPart(), data.initialOutcome, big.NewInt(int64(data.paid)), left, right, my.Role)
 
 		updatedObj, se, waitingFor, err := virtualDefund.Crank(&my.PrivateKey)
 		testhelpers.Ok(t, err)

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/statechannels/go-nitro/channel/state"
 	ta "github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/internal/testhelpers"
+	. "github.com/statechannels/go-nitro/internal/testhelpers"
 	"github.com/statechannels/go-nitro/protocols"
 )
 
@@ -99,7 +100,7 @@ func testCrankAs(my ta.Actor) func(t *testing.T) {
 		testhelpers.Equals(t, waitingFor, WaitingForCompleteFinal)
 		signedByMe := state.NewSignedState(data.vFinal)
 		_ = signedByMe.Sign(&my.PrivateKey)
-		assertStateSentToEveryone(t, se, signedByMe, my)
+		AssertStateSentToEveryone(t, se, signedByMe, my, allActors)
 
 		// Update the signatures on the objective so the final state is fully signed
 		signedByOthers := signStateByOthers(my, state.NewSignedState(data.vFinal))

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -39,8 +39,8 @@ func TestInvalidUpdate(t *testing.T) {
 
 	signedFinal := state.NewSignedState(invalidFinal)
 
-	// Sign the final state by other participant
-	signByOthers(alice, signedFinal)
+	// Sign the final state by some other participant
+	signStateByOthers(alice, signedFinal)
 
 	e := protocols.ObjectiveEvent{ObjectiveId: virtualDefund.Id(), SignedStates: []state.SignedState{signedFinal}}
 	_, err := virtualDefund.Update(e)
@@ -59,7 +59,7 @@ func testUpdateAs(my ta.Actor) func(t *testing.T) {
 		virtualDefund := newObjective(false, data.vFixed, data.initialOutcome, big.NewInt(int64(data.paid)), left, right, my.Role)
 		signedFinal := state.NewSignedState(data.vFinal)
 		// Sign the final state by some other participant
-		signByOthers(my, signedFinal)
+		signStateByOthers(my, signedFinal)
 
 		e := protocols.ObjectiveEvent{ObjectiveId: virtualDefund.Id(), SignedStates: []state.SignedState{signedFinal}}
 
@@ -102,7 +102,7 @@ func testCrankAs(my ta.Actor) func(t *testing.T) {
 		assertStateSentToEveryone(t, se, signedByMe, my)
 
 		// Update the signatures on the objective so the final state is fully signed
-		signedByOthers := signByOthers(my, state.NewSignedState(data.vFinal))
+		signedByOthers := signStateByOthers(my, state.NewSignedState(data.vFinal))
 		for i, sig := range signedByOthers.Signatures() {
 			if uint(i) != my.Role {
 				updated.Signatures[i] = sig

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -107,7 +107,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestCrank(t *testing.T) {
-	for _, my := range []testactors.Actor{bob} {
+	for _, my := range allActors {
 		msg := fmt.Sprintf("testing crank as %s", my.Name)
 		t.Run(msg, testCrankAs(my))
 	}
@@ -200,7 +200,7 @@ func testCrankAs(my ta.Actor) func(t *testing.T) {
 
 		checkForLeaderProposals(t, se, updated)
 
-		proposals := generateLeaderProposals(my.Role, vId, updated)
+		proposals := generateProposalsResponses(my.Role, vId, updated)
 		updateProposals(updated, proposals...)
 
 		updatedObj, se, waitingFor, err = updated.Crank(&my.PrivateKey)
@@ -208,7 +208,6 @@ func testCrankAs(my ta.Actor) func(t *testing.T) {
 		testhelpers.Ok(t, err)
 
 		testhelpers.Equals(t, waitingFor, WaitingForNothing)
-
 		checkForFollowerProposals(t, se, updated)
 
 	}

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -1,103 +1,20 @@
 package virtualdefund
 
 import (
-	"bytes"
 	"fmt"
 	"math/big"
 	"testing"
 
 	"github.com/statechannels/go-nitro/channel/state"
-	"github.com/statechannels/go-nitro/channel/state/outcome"
-	"github.com/statechannels/go-nitro/internal/testactors"
 	ta "github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/internal/testhelpers"
 	"github.com/statechannels/go-nitro/protocols"
-	"github.com/statechannels/go-nitro/types"
 )
 
 var alice = ta.Alice
 var bob = ta.Bob
 var irene = ta.Irene
 var allActors = []ta.Actor{alice, irene, bob}
-
-// makeOutcome creates an outcome allocating to alice and bob
-func makeOutcome(aliceAmount uint, bobAmount uint) outcome.SingleAssetExit {
-	return outcome.SingleAssetExit{
-		Allocations: outcome.Allocations{
-			outcome.Allocation{
-				Destination: alice.Destination(),
-				Amount:      big.NewInt(int64(aliceAmount)),
-			},
-			outcome.Allocation{
-				Destination: bob.Destination(),
-				Amount:      big.NewInt(int64(bobAmount)),
-			},
-		},
-	}
-}
-
-type testdata struct {
-	vFixed         state.FixedPart
-	vFinal         state.State
-	initialOutcome outcome.SingleAssetExit
-	finalOutcome   outcome.SingleAssetExit
-	paid           uint
-}
-
-// generateTestData generates some test data that can be used in a test
-func generateTestData() testdata {
-	vFixed := state.FixedPart{
-		ChainId:           big.NewInt(9001),
-		Participants:      []types.Address{alice.Address, irene.Address, bob.Address}, // A single hop virtual channel
-		ChannelNonce:      big.NewInt(0),
-		AppDefinition:     types.Address{},
-		ChallengeDuration: big.NewInt(45),
-	}
-
-	initialOutcome := makeOutcome(7, 3)
-	finalOutcome := makeOutcome(6, 4)
-	paid := uint(1)
-
-	vFinal := state.StateFromFixedAndVariablePart(vFixed, state.VariablePart{IsFinal: true, Outcome: outcome.Exit{finalOutcome}, TurnNum: FinalTurnNum})
-
-	return testdata{vFixed, vFinal, initialOutcome, finalOutcome, paid}
-}
-
-// signByOthers signs the state by every participant except my
-func signByOthers(my ta.Actor, signedState state.SignedState) state.SignedState {
-	if my.Role != 0 {
-		_ = signedState.Sign(&alice.PrivateKey)
-	}
-
-	if my.Role != 1 {
-		_ = signedState.Sign(&irene.PrivateKey)
-	}
-
-	if my.Role != 2 {
-		_ = signedState.Sign(&bob.PrivateKey)
-	}
-	return signedState
-}
-
-// assertStateSentToEveryone asserts that ses contains a message for every participant but from
-func assertStateSentToEveryone(t *testing.T, ses protocols.SideEffects, expected state.SignedState, from testactors.Actor) {
-	for _, a := range allActors {
-		if a.Role != from.Role {
-			assertStateSentTo(t, ses, expected, a)
-		}
-	}
-}
-
-// assertStateSentTo asserts that ses contains a message for the participant
-func assertStateSentTo(t *testing.T, ses protocols.SideEffects, expected state.SignedState, to testactors.Actor) {
-	for _, msg := range ses.MessagesToSend {
-		if bytes.Equal(msg.To[:], to.Address[:]) {
-			for _, ss := range msg.SignedStates {
-				testhelpers.Equals(t, ss, expected)
-			}
-		}
-	}
-}
 
 func TestUpdate(t *testing.T) {
 	for _, my := range allActors {


### PR DESCRIPTION
Fixes #480.

This PR extends the virtual defunding protocol to handle defunding the ledger channels. 

To help with organization test helpers have been moved to a separate file.

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
