### PR TITLE
Re-enable virtual funding integration test

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -165,7 +165,10 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (ObjectiveChang
 	e.logger.Printf("handling chain event %v", chainEvent)
 	objective, ok := e.store.GetObjectiveByChannelId(chainEvent.ChannelID())
 	if !ok {
-		return ObjectiveChangeEvent{}, &ErrUnhandledChainEvent{event: chainEvent, objective: objective, reason: "no objective for channel"}
+		// TODO: Right now the chain service returns chain events for ALL channels even those we aren't involved in
+		// for now we can ignore channels we aren't involved in
+		// in the future the chain service should allow us to register for specific channels
+		return ObjectiveChangeEvent{}, nil
 	}
 
 	eventHandler, ok := objective.(chainservice.ChainEventHandler)

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -129,7 +129,12 @@ func (ms *MockStore) SetObjective(obj protocols.Objective) error {
 			if err != nil {
 				return fmt.Errorf("error setting channel %s from objective %s: %w", ch.Id, obj.Id(), err)
 			}
-
+		case *consensus_channel.ConsensusChannel:
+			ch := rel.(*consensus_channel.ConsensusChannel)
+			err := ms.SetConsensusChannel(ch)
+			if err != nil {
+				return fmt.Errorf("error setting consensus channel %s from objective %s: %w", ch.Id, obj.Id(), err)
+			}
 		default:
 			return fmt.Errorf("unexpected type: %T", rel)
 		}

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -235,8 +235,7 @@ func (ms *MockStore) GetConsensusChannelById(id types.Destination) (channel *con
 		return &consensus_channel.ConsensusChannel{}, ErrNoSuchChannel
 	}
 
-	var ch *consensus_channel.ConsensusChannel
-
+	ch := &consensus_channel.ConsensusChannel{}
 	err = ch.UnmarshalJSON(chJSON)
 
 	if err != nil {

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -122,15 +122,13 @@ func (ms *MockStore) SetObjective(obj protocols.Objective) error {
 	ms.objectives.Store(string(obj.Id()), objJSON)
 
 	for _, rel := range obj.Related() {
-		switch rel.(type) {
+		switch ch := rel.(type) {
 		case *channel.Channel:
-			ch := rel.(*channel.Channel)
 			err := ms.SetChannel(ch)
 			if err != nil {
 				return fmt.Errorf("error setting channel %s from objective %s: %w", ch.Id, obj.Id(), err)
 			}
 		case *consensus_channel.ConsensusChannel:
-			ch := rel.(*consensus_channel.ConsensusChannel)
 			err := ms.SetConsensusChannel(ch)
 			if err != nil {
 				return fmt.Errorf("error setting consensus channel %s from objective %s: %w", ch.Id, obj.Id(), err)

--- a/client_test/virtualfund_integration_test.go
+++ b/client_test/virtualfund_integration_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestVirtualFundIntegration(t *testing.T) {
-	// todo: #420 unskip
-	t.Skip()
 
 	// Setup logging
 	logDestination := &bytes.Buffer{}

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -567,7 +567,8 @@ func (c *Connection) expectedProposal() consensus_channel.Proposal {
 		leftAmount = val
 		break
 	}
-	proposal := consensus_channel.NewAddProposal(c.Channel.Id, 0, g, leftAmount)
+	currentTurn := c.Channel.ConsensusVars().TurnNum
+	proposal := consensus_channel.NewAddProposal(c.Channel.Id, currentTurn+1, g, leftAmount)
 
 	return proposal
 }

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -525,18 +525,18 @@ func ConstructObjectiveFromMessage(
 	if myAddress == alice {
 		return Objective{}, errors.New("participant[0] should not construct objectives from peer messages")
 	} else if myAddress == bob {
-		leftC, _ = getTwoPartyConsensusLedger(intermediary)
+		leftC, ok = getTwoPartyConsensusLedger(intermediary)
 		if !ok {
 			return Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", intermediary, bob)
 		}
 
 	} else if myAddress == intermediary {
-		leftC, _ = getTwoPartyConsensusLedger(alice)
+		leftC, ok = getTwoPartyConsensusLedger(alice)
 		if !ok {
 			return Objective{}, fmt.Errorf("could not find a left ledger channel between %v and %v", alice, intermediary)
 		}
 
-		rightC, _ = getTwoPartyConsensusLedger(bob)
+		rightC, ok = getTwoPartyConsensusLedger(bob)
 		if !ok {
 			return Objective{}, fmt.Errorf("could not find a right ledger channel between %v and %v", intermediary, bob)
 		}


### PR DESCRIPTION
This PR re-enables the virtual funding integration test. It also makes a collection of small fixes to get the virtual funding integration test passing.

## Changes
- https://github.com/statechannels/go-nitro/pull/566/commits/ea2c1a769279d97dce9a4516205997459b0aff0d Ignore chain events if we don't have the channel. Right now the chain service returns chain events to every client, even if they're not interested in that channel. 
- https://github.com/statechannels/go-nitro/pull/566/commits/0e76ea9e1a48d13a5a8d6637a0ca5748cbecae7b Properly store the consensus channel when storing an objective.
- [619cc5b](https://github.com/statechannels/go-nitro/pull/566/commits/619cc5bc0df8d58a982f6de70bd735aa75d8c5c2) Previously we just declared an `ok` var and never set it. This updates `ok` based on the result of `getTwoPartyConsensusLedger`
- [0c27489](https://github.com/statechannels/go-nitro/pull/566/commits/0c2748904a73f7dad8064f9dd9deb34c40f892b2) Initialize a consensus channel before calling `UnmarshalJSON`. Previously we were just passing a nil pointer receiver.
- [f9e1057](https://github.com/statechannels/go-nitro/pull/566/commits/f9e10579507cf423153259019adaa4db46494966) get the turn number for the expected proposal based on the current consensus turn number. Previously we were just using 0.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [ ] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
