### PR TITLE
Add testLedgers helper functions

### DIFF
--- a/internal/testdata/channels.go
+++ b/internal/testdata/channels.go
@@ -182,7 +182,7 @@ func createTestLedger(leader, follower testactors.Actor) TestLedger {
 		sigs,
 	)
 	if err != nil {
-		panic(fmt.Sprintf("error creating leader channel in testLedger: %v", err)
+		panic(fmt.Sprintf("error creating leader channel in testLedger: %v", err))
 	}
 	followCh, err := consensus_channel.NewFollowerChannel(
 		fp,
@@ -191,7 +191,7 @@ func createTestLedger(leader, follower testactors.Actor) TestLedger {
 		sigs,
 	)
 	if err != nil {
-		panic(fmt.Sprintf("error creating follwer channel in testLedger: %v", err)
+		panic(fmt.Sprintf("error creating follwer channel in testLedger: %v", err))
 	}
 
 	return TestLedger{leaderCh, followCh}

--- a/internal/testdata/channels.go
+++ b/internal/testdata/channels.go
@@ -99,7 +99,7 @@ func (l LedgerNetwork) GetLedgerLookup(seeker types.Address) virtualfund.GetTwoP
 // createLedgerNetwork returns active, funded consensus_channels connecting the supplied
 // actors according the the supplied edge list.
 //
-// Edges specify actors via their indeces in the actors slice,
+// Edges specify actors via their indices in the actors slice,
 // and each edge is ordered [leader, follower].
 func createLedgerNetwork(actors []testactors.Actor, edges [][2]int) LedgerNetwork {
 	if len(edges) == 0 {

--- a/internal/testdata/channels.go
+++ b/internal/testdata/channels.go
@@ -102,10 +102,6 @@ func (l LedgerNetwork) GetLedgerLookup(seeker types.Address) virtualfund.GetTwoP
 // Edges specify actors via their indices in the actors slice,
 // and each edge is ordered [leader, follower].
 func createLedgerNetwork(actors []testactors.Actor, edges [][2]int) LedgerNetwork {
-	if len(edges) == 0 {
-		return createLedgerPath(actors)
-	}
-
 	// naive connectedness check: does not detect, eg
 	// a--b  c--d (no path from a to c or d, etc)
 	for i, a := range actors {

--- a/internal/testdata/channels.go
+++ b/internal/testdata/channels.go
@@ -49,3 +49,150 @@ func mockConsensusChannel(counterparty types.Address) (ledger *consensus_channel
 	cc, _ := testObj.CreateConsensusChannel()
 	return cc, true
 }
+
+// LedgerNetwork is a collection of in-memory consensus_channel ledgers
+// which expose both the leader and follower perspective on the ledger
+type LedgerNetwork struct {
+	ledgers []TestLedger
+}
+
+// TestLedger wraps the leader and follower views of a consensus_channel
+type TestLedger struct {
+	LeaderView   consensus_channel.ConsensusChannel
+	FollowerView consensus_channel.ConsensusChannel
+}
+
+// GetLedgerLookup returns a ledger-lookup function for the given ledger seeker.
+//
+// The returned function inspects the ledgers from the ledger set, and returns
+// the ledger between the seeker and given counterparty from the seeker's perspective.
+func (l LedgerNetwork) GetLedgerLookup(seeker types.Address) virtualfund.GetTwoPartyConsensusLedgerFunction {
+	var myLedgers []TestLedger
+
+	// package all of seeker's ledgers for the closure
+	for _, ledger := range l.ledgers {
+		if ledger.FollowerView.Leader() == seeker ||
+			ledger.FollowerView.Follower() == seeker {
+			myLedgers = append(myLedgers, ledger)
+		}
+	}
+
+	return func(counterparty types.Address) (ledger *consensus_channel.ConsensusChannel, ok bool) {
+		for _, ledger := range myLedgers {
+			if ledger.FollowerView.Follower() == seeker &&
+				ledger.FollowerView.Leader() == counterparty {
+				return &ledger.FollowerView, true
+			}
+
+			if ledger.LeaderView.Leader() == seeker &&
+				ledger.LeaderView.Follower() == counterparty {
+				return &ledger.LeaderView, true
+			}
+		}
+		return nil, false
+	}
+}
+
+// createLedgerNetwork returns active, funded consensus_channels connecting the supplied
+// actors according the the supplied edge list.
+//
+// Edges specify actors via their indeces in the actors slice,
+// and each edge is ordered [leader, follower].
+func createLedgerNetwork(actors []testactors.Actor, edges [][2]int) LedgerNetwork {
+	if len(edges) == 0 {
+		return createLedgerPath(actors)
+	}
+
+	// naive connectedness check: does not detect, eg
+	// a--b  c--d (no path from a to c or d, etc)
+	for i, a := range actors {
+		connected := false
+		for _, edge := range edges {
+			if edge[0] == i || edge[1] == i {
+				connected = true
+			}
+		}
+		if !connected {
+			panic(fmt.Sprintf("actor %v is not connected in the test network", a))
+		}
+	}
+
+	var ret LedgerNetwork
+
+	for _, edge := range edges {
+		if edge[0] > len(actors)-1 ||
+			edge[1] > len(actors)-1 ||
+			edge[0] == edge[1] {
+			panic(fmt.Sprintf("malformed ledger network edge list: %v", edge))
+		}
+		leader := actors[edge[0]]
+		follower := actors[edge[1]]
+
+		testLedger := createTestLedger(leader, follower)
+
+		ret.ledgers = append(ret.ledgers, testLedger)
+	}
+
+	return ret
+}
+
+// createLedgerPath returns active, funded consensus_channels connecting the supplied
+// actors in left-to-right fashion from actors[0] to actors[len(actors)-1]. The
+// leftmost actor in each consensuschannel is the channel's leader.
+//
+// Constructed and returned channels can be accessed from either "perspective"
+// of leader or follower
+func createLedgerPath(actors []testactors.Actor) LedgerNetwork {
+	var ret LedgerNetwork
+
+	for i, leader := range actors {
+		if i+1 >= len(actors) {
+			break
+		}
+		follower := actors[i+1]
+		testLedger := createTestLedger(leader, follower)
+
+		ret.ledgers = append(ret.ledgers, testLedger)
+	}
+	return ret
+}
+
+func createTestLedger(leader, follower testactors.Actor) TestLedger {
+	fp := testState.Clone().FixedPart()
+	fp.Participants[0] = leader.Address
+	fp.Participants[1] = follower.Address
+
+	outcome := consensus_channel.NewLedgerOutcome(
+		types.Address{}, // the zero asset
+		consensus_channel.NewBalance(leader.Destination(), big.NewInt(100)),
+		consensus_channel.NewBalance(follower.Destination(), big.NewInt(200)),
+		[]consensus_channel.Guarantee{},
+	)
+
+	initVars := consensus_channel.Vars{Outcome: *outcome, TurnNum: 0}
+	leaderSig, _ := initVars.AsState(fp).Sign(leader.PrivateKey)
+	followSig, _ := initVars.AsState(fp).Sign(follower.PrivateKey)
+
+	sigs := [2]state.Signature{leaderSig, followSig}
+
+	leaderCh, err := consensus_channel.NewLeaderChannel(
+		fp,
+		0,
+		*outcome,
+		sigs,
+	)
+	if err != nil {
+		panic(fmt.Sprintf("error creating leader channel in testLedger: %v", err)
+	}
+	followCh, err := consensus_channel.NewFollowerChannel(
+		fp,
+		0,
+		*outcome,
+		sigs,
+	)
+	if err != nil {
+		panic(fmt.Sprintf("error creating follwer channel in testLedger: %v", err)
+	}
+
+	return TestLedger{leaderCh, followCh}
+}

--- a/internal/testdata/channels.go
+++ b/internal/testdata/channels.go
@@ -2,9 +2,12 @@ package testdata
 
 import (
 	"fmt"
+	"math/big"
 
 	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/protocols/directfund"
 	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/types"

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -76,11 +76,11 @@ func genericVFO() virtualfund.Objective {
 		ts.ChannelNonce.Int64(),
 	}
 
-	ledgerPath := createLedgerNetwork([]testactors.Actor{
+	ledgerPath := createLedgerPath([]testactors.Actor{
 		testactors.Alice,
 		testactors.Irene,
 		testactors.Bob,
-	}, nil)
+	})
 	lookup := ledgerPath.GetLedgerLookup(testactors.Alice.Address)
 
 	testVFO, err := virtualfund.NewObjective(request, Channels.MockTwoPartyLedger, lookup)

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -3,6 +3,7 @@ package testdata
 import (
 	"fmt"
 
+	"github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/protocols/directfund"
 	"github.com/statechannels/go-nitro/protocols/virtualfund"
 )
@@ -60,6 +61,10 @@ func genericDFO() directfund.Objective {
 
 func genericVFO() virtualfund.Objective {
 	ts := testVirtualState.Clone()
+	ts.Participants[0] = testactors.Alice.Address
+	ts.Participants[1] = testactors.Irene.Address
+	ts.Participants[2] = testactors.Bob.Address
+
 	request := virtualfund.ObjectiveRequest{
 		ts.Participants[0],
 		ts.Participants[1],
@@ -70,7 +75,15 @@ func genericVFO() virtualfund.Objective {
 		ts.Outcome,
 		ts.ChannelNonce.Int64(),
 	}
-	testVFO, err := virtualfund.NewObjective(request, Channels.MockTwoPartyLedger, Channels.MockConsensusChannel)
+
+	ledgerPath := createLedgerNetwork([]testactors.Actor{
+		testactors.Alice,
+		testactors.Irene,
+		testactors.Bob,
+	}, nil)
+	lookup := ledgerPath.GetLedgerLookup(testactors.Alice.Address)
+
+	testVFO, err := virtualfund.NewObjective(request, Channels.MockTwoPartyLedger, lookup)
 	if err != nil {
 		panic(fmt.Errorf("error constructing genericVFO: %w", err))
 	}

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -224,7 +224,6 @@ func constructFromState(
 	if !init.isAlice() { // everyone other than Alice has a left-channel
 		init.ToMyLeft = &Connection{}
 
-		// todo: #420
 		if consensusChannelToMyLeft == nil {
 			return Objective{}, fmt.Errorf("non-alice virtualfund objective requires non-nil left ledger channel")
 		}

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -226,7 +226,7 @@ func constructFromState(
 
 		// todo: #420
 		if consensusChannelToMyLeft == nil {
-			return Objective{}, fmt.Errorf("non-alice virtualfund objective requires non-nil ledger channel")
+			return Objective{}, fmt.Errorf("non-alice virtualfund objective requires non-nil left ledger channel")
 		}
 
 		init.ToMyLeft.Channel = consensusChannelToMyLeft
@@ -246,7 +246,7 @@ func constructFromState(
 		init.ToMyRight = &Connection{}
 
 		if consensusChannelToMyRight == nil {
-			return Objective{}, fmt.Errorf("non-bob virtualfund objective requires non-nil ledger channel")
+			return Objective{}, fmt.Errorf("non-bob virtualfund objective requires non-nil right ledger channel")
 		}
 
 		init.ToMyRight.Channel = consensusChannelToMyRight


### PR DESCRIPTION
This PR adds ledger-network generation functions which connect a list of `testactors.Actor`s via `consensus_channel`s.

In the immediate, it is a replacement part for now-broken generation of test VFOs (as consumed by the mockstore test). (Incremental toward #420 - reinstating mockstore test of setting/retrieving VFOs)

Going forward, these are potentially useful for stress-testing networks. IE, generating a large number of actors and connecting them in a synthetic network.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
