### PR TITLE
Use objective Update in virtualfund_single_hop_test.go

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -135,6 +135,11 @@ func (c Channel) PreFundState() state.State {
 	return c.SignedStateForTurnNum[PreFundTurnNum].State()
 }
 
+// SignedPreFundState returns the signed pre fund setup state for the channel.
+func (c Channel) SignedPreFundState() state.SignedState {
+	return c.SignedStateForTurnNum[PreFundTurnNum]
+}
+
 // PostFundState() returns the post fund setup state for the channel.
 func (c Channel) PostFundState() state.State {
 	return c.SignedStateForTurnNum[PostFundTurnNum].State()
@@ -144,7 +149,6 @@ func (c Channel) PostFundState() state.State {
 // SignedPostFundState() returns the SIGNED post fund setup state for the channel.
 func (c Channel) SignedPostFundState() state.SignedState {
 	return c.SignedStateForTurnNum[PostFundTurnNum]
-
 }
 
 // PreFundSignedByMe() returns true if I have signed the pre fund setup state, false otherwise.

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -182,6 +182,10 @@ func (c *ConsensusChannel) ConsensusVars() Vars {
 	return c.current.Vars
 }
 
+func (c *ConsensusChannel) Signatures() [2]state.Signature {
+	return c.current.Signatures
+}
+
 // latestProposedVars returns the latest proposed vars in a consensus channel
 // by cloning its current vars and applying each proposal in the queue
 func (c *ConsensusChannel) latestProposedVars() (Vars, error) {

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -182,6 +182,7 @@ func (c *ConsensusChannel) ConsensusVars() Vars {
 	return c.current.Vars
 }
 
+// Signatures returns the signatures on the currently supported state
 func (c *ConsensusChannel) Signatures() [2]state.Signature {
 	return c.current.Signatures
 }

--- a/protocols/virtualfund/helpers_test.go
+++ b/protocols/virtualfund/helpers_test.go
@@ -9,29 +9,33 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-func fixedPart(left, right testactors.Actor) state.FixedPart {
-	return state.FixedPart{
+// prepareConsensusChannel prepares a consensus channel with a consensus outcome
+//  - allocating 6 to left
+//  - allocating 4 to right
+//  - including the given guarantees
+func prepareConsensusChannel(role uint, left, right testactors.Actor, guarantees ...consensus_channel.Guarantee) *consensus_channel.ConsensusChannel {
+	return prepareConsensusChannelHelper(role, left, right, 6, 4, 1, guarantees...)
+}
+
+func consensusStateSignatures(left, right testactors.Actor, guarantees ...consensus_channel.Guarantee) [2]state.Signature {
+	return prepareConsensusChannelHelper(0, left, right, 0, 0, 2, guarantees...).Signatures()
+}
+
+func prepareConsensusChannelHelper(role uint, left, right testactors.Actor, leftBalance, rightBalance, turnNum int, guarantees ...consensus_channel.Guarantee) *consensus_channel.ConsensusChannel {
+	fp := state.FixedPart{
 		ChainId:           big.NewInt(9001),
 		Participants:      []types.Address{left.Address, right.Address},
 		ChannelNonce:      big.NewInt(0),
 		AppDefinition:     types.Address{},
 		ChallengeDuration: big.NewInt(45),
 	}
-}
 
-// prepareConsensusChannel prepares a consensus channel with a consensus outcome
-//  - allocating 6 to left
-//  - allocating 4 to right
-//  - including the given guarantees
-func prepareConsensusChannel(role uint, left, right testactors.Actor, guarantees ...consensus_channel.Guarantee) *consensus_channel.ConsensusChannel {
-	fp := fixedPart(left, right)
-
-	leftBal := consensus_channel.NewBalance(left.Destination(), big.NewInt(6))
-	rightBal := consensus_channel.NewBalance(right.Destination(), big.NewInt(4))
+	leftBal := consensus_channel.NewBalance(left.Destination(), big.NewInt(int64(leftBalance)))
+	rightBal := consensus_channel.NewBalance(right.Destination(), big.NewInt(int64(rightBalance)))
 
 	lo := *consensus_channel.NewLedgerOutcome(types.Address{}, leftBal, rightBal, guarantees)
 
-	signedVars := consensus_channel.SignedVars{Vars: consensus_channel.Vars{Outcome: lo, TurnNum: 1}}
+	signedVars := consensus_channel.SignedVars{Vars: consensus_channel.Vars{Outcome: lo, TurnNum: uint64(turnNum)}}
 	leftSig, err := signedVars.Vars.AsState(fp).Sign(left.PrivateKey)
 	if err != nil {
 		panic(err)
@@ -45,37 +49,13 @@ func prepareConsensusChannel(role uint, left, right testactors.Actor, guarantees
 	var cc consensus_channel.ConsensusChannel
 
 	if role == 0 {
-		cc, err = consensus_channel.NewLeaderChannel(fp, 1, lo, sigs)
+		cc, err = consensus_channel.NewLeaderChannel(fp, uint64(turnNum), lo, sigs)
 	} else {
-		cc, err = consensus_channel.NewFollowerChannel(fp, 1, lo, sigs)
+		cc, err = consensus_channel.NewFollowerChannel(fp, uint64(turnNum), lo, sigs)
 	}
 	if err != nil {
 		panic(err)
 	}
 
 	return &cc
-}
-
-func consensusStateSignatures(left, right testactors.Actor, guarantees ...consensus_channel.Guarantee) [2]state.Signature {
-	fp := fixedPart(left, right)
-
-	leftBal := consensus_channel.NewBalance(left.Destination(), big.NewInt(0))
-	rightBal := consensus_channel.NewBalance(right.Destination(), big.NewInt(0))
-
-	lo := *consensus_channel.NewLedgerOutcome(types.Address{}, leftBal, rightBal, guarantees)
-
-	signedVars := consensus_channel.SignedVars{Vars: consensus_channel.Vars{Outcome: lo, TurnNum: 2}}
-
-	st := signedVars.Vars.AsState(fp)
-
-	leftSig, err := st.Sign(left.PrivateKey)
-	if err != nil {
-		panic(err)
-	}
-	rightSig, err := st.Sign(right.PrivateKey)
-	if err != nil {
-		panic(err)
-	}
-
-	return [2]state.Signature{leftSig, rightSig}
 }

--- a/protocols/virtualfund/helpers_test.go
+++ b/protocols/virtualfund/helpers_test.go
@@ -9,18 +9,22 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-// prepareConsensusChannel prepares a consensus channel with a consensus outcome
-//  - allocating 6 to left
-//  - allocating 4 to right
-//  - including the given guarantees
-func prepareConsensusChannel(role uint, left, right testactors.Actor, guarantees ...consensus_channel.Guarantee) *consensus_channel.ConsensusChannel {
-	fp := state.FixedPart{
+func fixedPart(left, right testactors.Actor) state.FixedPart {
+	return state.FixedPart{
 		ChainId:           big.NewInt(9001),
 		Participants:      []types.Address{left.Address, right.Address},
 		ChannelNonce:      big.NewInt(0),
 		AppDefinition:     types.Address{},
 		ChallengeDuration: big.NewInt(45),
 	}
+}
+
+// prepareConsensusChannel prepares a consensus channel with a consensus outcome
+//  - allocating 6 to left
+//  - allocating 4 to right
+//  - including the given guarantees
+func prepareConsensusChannel(role uint, left, right testactors.Actor, guarantees ...consensus_channel.Guarantee) *consensus_channel.ConsensusChannel {
+	fp := fixedPart(left, right)
 
 	leftBal := consensus_channel.NewBalance(left.Destination(), big.NewInt(6))
 	rightBal := consensus_channel.NewBalance(right.Destination(), big.NewInt(4))
@@ -50,4 +54,28 @@ func prepareConsensusChannel(role uint, left, right testactors.Actor, guarantees
 	}
 
 	return &cc
+}
+
+func consensusStateSignatures(left, right testactors.Actor, guarantees ...consensus_channel.Guarantee) [2]state.Signature {
+	fp := fixedPart(left, right)
+
+	leftBal := consensus_channel.NewBalance(left.Destination(), big.NewInt(0))
+	rightBal := consensus_channel.NewBalance(right.Destination(), big.NewInt(0))
+
+	lo := *consensus_channel.NewLedgerOutcome(types.Address{}, leftBal, rightBal, guarantees)
+
+	signedVars := consensus_channel.SignedVars{Vars: consensus_channel.Vars{Outcome: lo, TurnNum: 2}}
+
+	st := signedVars.Vars.AsState(fp)
+
+	leftSig, err := st.Sign(left.PrivateKey)
+	if err != nil {
+		panic(err)
+	}
+	rightSig, err := st.Sign(right.PrivateKey)
+	if err != nil {
+		panic(err)
+	}
+
+	return [2]state.Signature{leftSig, rightSig}
 }

--- a/protocols/virtualfund/helpers_test.go
+++ b/protocols/virtualfund/helpers_test.go
@@ -17,6 +17,7 @@ func prepareConsensusChannel(role uint, left, right testactors.Actor, guarantees
 	return prepareConsensusChannelHelper(role, left, right, 6, 4, 1, guarantees...)
 }
 
+// consensusStateSignatures prepares a consensus channel with a consensus outcome and returns the signatures on the consensus state
 func consensusStateSignatures(left, right testactors.Actor, guarantees ...consensus_channel.Guarantee) [2]state.Signature {
 	return prepareConsensusChannelHelper(0, left, right, 0, 0, 2, guarantees...).Signatures()
 }

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -563,8 +563,8 @@ func (c *Connection) expectedProposal() consensus_channel.Proposal {
 		leftAmount = val
 		break
 	}
-	currentTurn := c.Channel.ConsensusVars().TurnNum
-	proposal := consensus_channel.NewAddProposal(c.Channel.Id, currentTurn+1, g, leftAmount)
+	proposalTurnNum := c.Channel.ConsensusTurnNum() + 1
+	proposal := consensus_channel.NewAddProposal(c.Channel.Id, proposalTurnNum, g, leftAmount)
 
 	return proposal
 }

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -172,7 +172,7 @@ func TestClone(t *testing.T) {
 	}
 }
 
-func collectPeerSignaturesOnSetupState(v *channel.SingleHopVirtualChannel, myRole uint, prefund bool) *channel.SingleHopVirtualChannel {
+func cloneAndSignSetupStateByPeers(v *channel.SingleHopVirtualChannel, myRole uint, prefund bool) *channel.SingleHopVirtualChannel {
 	var state state.State
 	if prefund {
 		state = v.PreFundState()
@@ -230,7 +230,7 @@ func TestCrankAsAlice(t *testing.T) {
 	assertStateSentTo(t, effects, expectedSignedState, p1)
 
 	// Update the objective with prefund signatures
-	c := collectPeerSignaturesOnSetupState(o.V, my.Role, true)
+	c := cloneAndSignSetupStateByPeers(o.V, my.Role, true)
 	e := protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedStates: []state.SignedState{c.SignedPreFundState()}}
 	oObj, err = o.Update(e)
 	o = oObj.(*Objective)
@@ -307,7 +307,7 @@ func TestCrankAsBob(t *testing.T) {
 	assertStateSentTo(t, effects, expectedSignedState, p1)
 
 	// Update the objective with prefund signatures
-	c := collectPeerSignaturesOnSetupState(o.V, my.Role, true)
+	c := cloneAndSignSetupStateByPeers(o.V, my.Role, true)
 	e := protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedStates: []state.SignedState{c.SignedPreFundState()}}
 	oObj, err = o.Update(e)
 	o = oObj.(*Objective)
@@ -386,7 +386,7 @@ func TestCrankAsP1(t *testing.T) {
 	assertStateSentTo(t, effects, expectedSignedState, bob)
 
 	// Update the objective with prefund signatures
-	c := collectPeerSignaturesOnSetupState(o.V, my.Role, true)
+	c := cloneAndSignSetupStateByPeers(o.V, my.Role, true)
 	e := protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedStates: []state.SignedState{c.SignedPreFundState()}}
 	oObj, err = o.Update(e)
 	o = oObj.(*Objective)

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -173,28 +173,28 @@ func TestClone(t *testing.T) {
 }
 
 func cloneAndSignSetupStateByPeers(v channel.SingleHopVirtualChannel, myRole uint, prefund bool) *channel.SingleHopVirtualChannel {
+	withSigs := v.Clone()
+
 	var state state.State
 	if prefund {
-		state = v.PreFundState()
+		state = withSigs.PreFundState()
 	} else {
-		state = v.PostFundState()
+		state = withSigs.PostFundState()
 	}
-
-	updated := v.Clone()
 
 	if myRole != alice.Role {
 		aliceSig, _ := state.Sign(alice.PrivateKey)
-		updated.AddStateWithSignature(state, aliceSig)
+		withSigs.AddStateWithSignature(state, aliceSig)
 	}
 	if myRole != p1.Role {
 		p1Sig, _ := state.Sign(p1.PrivateKey)
-		updated.AddStateWithSignature(state, p1Sig)
+		withSigs.AddStateWithSignature(state, p1Sig)
 	}
 	if myRole != bob.Role {
 		bobSig, _ := state.Sign(bob.PrivateKey)
-		updated.AddStateWithSignature(state, bobSig)
+		withSigs.AddStateWithSignature(state, bobSig)
 	}
-	return updated
+	return withSigs
 }
 
 // TestCrankAsAlice tests the behaviour from a end-user's point of view when they are a leader in the ledger channel

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -172,7 +172,7 @@ func TestClone(t *testing.T) {
 	}
 }
 
-func cloneAndSignSetupStateByPeers(v *channel.SingleHopVirtualChannel, myRole uint, prefund bool) *channel.SingleHopVirtualChannel {
+func cloneAndSignSetupStateByPeers(v channel.SingleHopVirtualChannel, myRole uint, prefund bool) *channel.SingleHopVirtualChannel {
 	var state state.State
 	if prefund {
 		state = v.PreFundState()
@@ -230,7 +230,7 @@ func TestCrankAsAlice(t *testing.T) {
 	assertStateSentTo(t, effects, expectedSignedState, p1)
 
 	// Update the objective with prefund signatures
-	c := cloneAndSignSetupStateByPeers(o.V, my.Role, true)
+	c := cloneAndSignSetupStateByPeers(*o.V, my.Role, true)
 	e := protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedStates: []state.SignedState{c.SignedPreFundState()}}
 	oObj, err = o.Update(e)
 	o = oObj.(*Objective)
@@ -307,7 +307,7 @@ func TestCrankAsBob(t *testing.T) {
 	assertStateSentTo(t, effects, expectedSignedState, p1)
 
 	// Update the objective with prefund signatures
-	c := cloneAndSignSetupStateByPeers(o.V, my.Role, true)
+	c := cloneAndSignSetupStateByPeers(*o.V, my.Role, true)
 	e := protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedStates: []state.SignedState{c.SignedPreFundState()}}
 	oObj, err = o.Update(e)
 	o = oObj.(*Objective)
@@ -386,7 +386,7 @@ func TestCrankAsP1(t *testing.T) {
 	assertStateSentTo(t, effects, expectedSignedState, bob)
 
 	// Update the objective with prefund signatures
-	c := cloneAndSignSetupStateByPeers(o.V, my.Role, true)
+	c := cloneAndSignSetupStateByPeers(*o.V, my.Role, true)
 	e := protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedStates: []state.SignedState{c.SignedPreFundState()}}
 	oObj, err = o.Update(e)
 	o = oObj.(*Objective)


### PR DESCRIPTION
Prior to this PR, `virtualfund_single_hop_test` would manipulate internal objective data structures to progress the objective. This PR removes the manipulations and instead uses the public `Update` api.