### PR TITLE
Experiment with breaking up the store

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -7,7 +7,7 @@ import (
 	"github.com/statechannels/go-nitro/client/engine"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
-	"github.com/statechannels/go-nitro/client/engine/store"
+	"github.com/statechannels/go-nitro/client/engine/store/store_interface"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/protocols/directdefund"
 	"github.com/statechannels/go-nitro/protocols/directfund"
@@ -23,7 +23,7 @@ type Client struct {
 }
 
 // New is the constructor for a Client. It accepts a messaging service, a chain service, and a store as injected dependencies.
-func New(messageService messageservice.MessageService, chainservice chainservice.ChainService, store store.Store, logDestination io.Writer) Client {
+func New(messageService messageservice.MessageService, chainservice chainservice.ChainService, store store_interface.Store, logDestination io.Writer) Client {
 	c := Client{}
 	c.Address = store.GetAddress()
 	c.engine = engine.New(messageService, chainservice, store, logDestination)

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -286,7 +286,7 @@ func (ms *MockStore) GetObjectiveByChannelId(channelId types.Destination) (proto
 	// todo: locking
 	id, found := ms.channelToObjective.Load(channelId.String())
 	if !found {
-		return &directfund.Objective{}, false
+		return nil, false
 	}
 
 	objective, err := ms.GetObjectiveById(protocols.ObjectiveId(id))

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -7,11 +7,13 @@ import (
 
 	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/client/engine/store/store_interface"
 	"github.com/statechannels/go-nitro/crypto"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/protocols/directdefund"
 	"github.com/statechannels/go-nitro/protocols/directfund"
 	"github.com/statechannels/go-nitro/protocols/virtualfund"
+
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -68,7 +70,7 @@ func (o *syncMap[T]) Range(f func(key string, value T) bool) {
 	o.m.Range(untypedF)
 }
 
-func NewMockStore(key []byte) Store {
+func NewMockStore(key []byte) store_interface.Store {
 	ms := MockStore{}
 	ms.key = key
 	ms.address = crypto.GetAddressFromSecretKeyBytes(key)

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -3,55 +3,7 @@ package store // import "github.com/statechannels/go-nitro/client/engine/store"
 
 import (
 	"errors"
-
-	"github.com/statechannels/go-nitro/channel"
-	"github.com/statechannels/go-nitro/channel/consensus_channel"
-	"github.com/statechannels/go-nitro/protocols"
-	"github.com/statechannels/go-nitro/types"
 )
 
 var ErrNoSuchObjective error = errors.New("store: no such objective")
 var ErrNoSuchChannel error = errors.New("store: failed to find required channel data")
-
-// Store is responsible for persisting objectives, objective metadata, states, signatures, private keys and blockchain data
-type Store interface {
-	GetChannelSecretKey() *[]byte // Get a pointer to a secret key for signing channel updates
-	GetAddress() *types.Address   // Get the (Ethereum) address associated with the ChannelSecretKey
-
-	ObjectiveGetter
-	ObjectiveSetter
-
-	ChannelGetter
-	ChannelSetter
-	ReleaseChannelFromOwnership(types.Destination) // Release channel from being owned by any objective
-
-	ConsensusChannelGetter
-	ConsensusChannelSetter
-	GetTwoPartyLedger(firstParty types.Address, secondParty types.Address) (channel *channel.TwoPartyLedger, ok bool) // deprecated
-
-}
-
-type ObjectiveGetter interface {
-	GetObjectiveById(protocols.ObjectiveId) (protocols.Objective, error)          // Read an existing objective
-	GetObjectiveByChannelId(types.Destination) (obj protocols.Objective, ok bool) // Get the objective that currently owns the channel with the supplied ChannelId
-
-}
-
-type ObjectiveSetter interface {
-	SetObjective(protocols.Objective) error // Write an objective
-}
-
-type ChannelGetter interface {
-	GetChannelById(id types.Destination) (c *channel.Channel, ok bool)
-}
-
-type ChannelSetter interface {
-	SetChannel(*channel.Channel) error
-}
-
-type ConsensusChannelGetter interface {
-	GetConsensusChannel(counterparty types.Address) (channel *consensus_channel.ConsensusChannel, ok bool)
-}
-type ConsensusChannelSetter interface {
-	SetConsensusChannel(*consensus_channel.ConsensusChannel) error
-}

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -18,19 +18,40 @@ type Store interface {
 	GetChannelSecretKey() *[]byte // Get a pointer to a secret key for signing channel updates
 	GetAddress() *types.Address   // Get the (Ethereum) address associated with the ChannelSecretKey
 
-	GetObjectiveById(protocols.ObjectiveId) (protocols.Objective, error)          // Read an existing objective
-	GetObjectiveByChannelId(types.Destination) (obj protocols.Objective, ok bool) // Get the objective that currently owns the channel with the supplied ChannelId
-	SetObjective(protocols.Objective) error                                       // Write an objective
-	GetTwoPartyLedger(firstParty types.Address, secondParty types.Address) (channel *channel.TwoPartyLedger, ok bool)
-	GetChannelById(id types.Destination) (c *channel.Channel, ok bool)
-	SetChannel(*channel.Channel) error
+	ObjectiveGetter
+	ObjectiveSetter
 
+	ChannelGetter
+	ChannelSetter
 	ReleaseChannelFromOwnership(types.Destination) // Release channel from being owned by any objective
 
-	ConsensusChannelStore
+	ConsensusChannelGetter
+	ConsensusChannelSetter
+	GetTwoPartyLedger(firstParty types.Address, secondParty types.Address) (channel *channel.TwoPartyLedger, ok bool) // deprecated
+
 }
 
-type ConsensusChannelStore interface {
+type ObjectiveGetter interface {
+	GetObjectiveById(protocols.ObjectiveId) (protocols.Objective, error)          // Read an existing objective
+	GetObjectiveByChannelId(types.Destination) (obj protocols.Objective, ok bool) // Get the objective that currently owns the channel with the supplied ChannelId
+
+}
+
+type ObjectiveSetter interface {
+	SetObjective(protocols.Objective) error // Write an objective
+}
+
+type ChannelGetter interface {
+	GetChannelById(id types.Destination) (c *channel.Channel, ok bool)
+}
+
+type ChannelSetter interface {
+	SetChannel(*channel.Channel) error
+}
+
+type ConsensusChannelGetter interface {
 	GetConsensusChannel(counterparty types.Address) (channel *consensus_channel.ConsensusChannel, ok bool)
+}
+type ConsensusChannelSetter interface {
 	SetConsensusChannel(*consensus_channel.ConsensusChannel) error
 }

--- a/client/engine/store/store_interface/store_interface.go
+++ b/client/engine/store/store_interface/store_interface.go
@@ -1,0 +1,51 @@
+package store_interface
+
+import (
+	"github.com/statechannels/go-nitro/channel"
+	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/types"
+)
+
+// Store is responsible for persisting objectives, objective metadata, states, signatures, private keys and blockchain data
+type Store interface {
+	GetChannelSecretKey() *[]byte // Get a pointer to a secret key for signing channel updates
+	GetAddress() *types.Address   // Get the (Ethereum) address associated with the ChannelSecretKey
+
+	ObjectiveGetter
+	ObjectiveSetter
+
+	ChannelGetter
+	ChannelSetter
+	ReleaseChannelFromOwnership(types.Destination) // Release channel from being owned by any objective
+
+	ConsensusChannelGetter
+	ConsensusChannelSetter
+	GetTwoPartyLedger(firstParty types.Address, secondParty types.Address) (channel *channel.TwoPartyLedger, ok bool) // deprecated
+
+}
+
+type ObjectiveGetter interface {
+	GetObjectiveById(protocols.ObjectiveId) (protocols.Objective, error)          // Read an existing objective
+	GetObjectiveByChannelId(types.Destination) (obj protocols.Objective, ok bool) // Get the objective that currently owns the channel with the supplied ChannelId
+
+}
+
+type ObjectiveSetter interface {
+	SetObjective(protocols.Objective) error // Write an objective
+}
+
+type ChannelGetter interface {
+	GetChannelById(id types.Destination) (c *channel.Channel, ok bool)
+}
+
+type ChannelSetter interface {
+	SetChannel(*channel.Channel) error
+}
+
+type ConsensusChannelGetter interface {
+	GetConsensusChannel(counterparty types.Address) (channel *consensus_channel.ConsensusChannel, ok bool)
+}
+type ConsensusChannelSetter interface {
+	SetConsensusChannel(*consensus_channel.ConsensusChannel) error
+}

--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
-	"github.com/statechannels/go-nitro/client/engine/store"
+	"github.com/statechannels/go-nitro/client/engine/store/store_interface"
 	"github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols/directfund"
 	"github.com/statechannels/go-nitro/types"
@@ -53,7 +53,7 @@ func TestDirectFundIntegration(t *testing.T) {
 
 	want := testdata.Outcomes.Create(*clientA.Address, *clientB.Address, 5, 5)
 	// Ensure that we create a consensus channel in the store
-	for _, store := range []store.Store{storeA, storeB} {
+	for _, store := range []store_interface.Store{storeA, storeB} {
 		var con *consensus_channel.ConsensusChannel
 		var ok bool
 

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	"github.com/statechannels/go-nitro/client/engine/store"
+	"github.com/statechannels/go-nitro/client/engine/store/store_interface"
 	"github.com/statechannels/go-nitro/crypto"
 	"github.com/statechannels/go-nitro/protocols"
 )
@@ -65,7 +66,7 @@ func waitTimeForCompletedObjectiveIds(t *testing.T, client *client.Client, timeo
 }
 
 // setupClient is a helper function that contructs a client and returns the new client and message service.
-func setupClient(pk []byte, chain chainservice.MockChain, msgBroker messageservice.Broker, logDestination io.Writer, meanMessageDelay time.Duration) (client.Client, store.Store) {
+func setupClient(pk []byte, chain chainservice.MockChain, msgBroker messageservice.Broker, logDestination io.Writer, meanMessageDelay time.Duration) (client.Client, store_interface.Store) {
 	myAddress := crypto.GetAddressFromSecretKeyBytes(pk)
 	chain.Subscribe(myAddress)
 	chainservice := chainservice.NewSimpleChainService(chain, myAddress)

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -83,7 +83,7 @@ func genericVFO() virtualfund.Objective {
 	})
 	lookup := ledgerPath.GetLedgerLookup(testactors.Alice.Address)
 
-	testVFO, err := virtualfund.NewObjective(request, Channels.MockTwoPartyLedger, lookup)
+	testVFO, err := virtualfund.NewObjective(request, lookup)
 	if err != nil {
 		panic(fmt.Errorf("error constructing genericVFO: %w", err))
 	}


### PR DESCRIPTION
This is quite far from being mergable, but I wanted to share some experimentation I have done towards #574.

I had to put the store interface in its own package to avoid import cycles. 

Quite a lot of our (test in particular) code is tightly coupled to the use of **function types** rather than **interfaces**. This has made the work a bit painful and it no longer seems worth the effort to me. 