### PR TITLE
Handle messages out of order

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -189,6 +189,11 @@ func (c *ConsensusChannel) Signatures() [2]state.Signature {
 	return c.current.Signatures
 }
 
+// ProposalQueue returns the current queue of proposals
+func (c *ConsensusChannel) ProposalQueue() []SignedProposal {
+	return c.proposalQueue
+}
+
 // latestProposedVars returns the latest proposed vars in a consensus channel
 // by cloning its current vars and applying each proposal in the queue
 func (c *ConsensusChannel) latestProposedVars() (Vars, error) {
@@ -261,6 +266,11 @@ func (g *Guarantee) Clone() Guarantee {
 		left:   g.left,
 		right:  g.right,
 	}
+}
+
+// Target returns the target of the guarantee
+func (g Guarantee) Target() types.Destination {
+	return g.target
 }
 
 // NewGuarantee constructs a new guarantee
@@ -532,7 +542,35 @@ func (p *Proposal) equal(q *Proposal) bool {
 	return p.ToAdd.equal(q.ToAdd) && p.ToRemove.equal(q.ToRemove)
 }
 
-// SignedProposal is a Proposal with a signature on it
+// ChannelId returns the channel id of the proposal.
+func (p SignedProposal) ChannelId() types.Destination {
+	return p.Proposal.ChannelID
+}
+
+// TurnNum returns the turn number of the proposal.
+func (p SignedProposal) TurnNum() uint64 {
+	return p.Proposal.TurnNum()
+}
+
+// Target returns the target channel of the proposal
+func (p *Proposal) Target() types.Destination {
+	switch p.Type() {
+	case "AddProposal":
+		{
+			return p.ToAdd.Target()
+		}
+	case "RemoveProposal":
+		{
+			return p.ToRemove.Target
+		}
+	default:
+		{
+			panic("invalid proposal type")
+		}
+	}
+}
+
+// SignedProposal is a Proposall with a signature on it
 type SignedProposal struct {
 	state.Signature
 	Proposal Proposal
@@ -627,6 +665,7 @@ var ErrIncorrectTurnNum = fmt.Errorf("incorrect turn number")
 // HandleProposal handles a proposal to add or remove a guarantee
 // It will mutate Vars by calling Add or Remove for the proposal
 func (vars *Vars) HandleProposal(p Proposal) error {
+
 	switch p.Type() {
 	case AddProposal:
 		{

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -537,8 +537,8 @@ func (p *Proposal) TurnNum() uint64 {
 	}
 }
 
-// equal returns true if the supplied Proposal is deeply equal to the receiver, false otherwise.
-func (p *Proposal) equal(q *Proposal) bool {
+// Equal returns true if the supplied Proposal is deeply Equal to the receiver, false otherwise.
+func (p *Proposal) Equal(q *Proposal) bool {
 	return p.ToAdd.equal(q.ToAdd) && p.ToRemove.equal(q.ToRemove)
 }
 

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -570,7 +570,7 @@ func (p *Proposal) Target() types.Destination {
 	}
 }
 
-// SignedProposal is a Proposall with a signature on it
+// SignedProposal is a Proposal with a signature on it
 type SignedProposal struct {
 	state.Signature
 	Proposal Proposal

--- a/channel/consensus_channel/follower_channel.go
+++ b/channel/consensus_channel/follower_channel.go
@@ -37,7 +37,7 @@ func (c *ConsensusChannel) SignNextProposal(expectedProposal Proposal, sk []byte
 
 	p := c.proposalQueue[0].Proposal
 
-	if !p.equal(&expectedProposal) {
+	if !p.Equal(&expectedProposal) {
 		return SignedProposal{}, ErrNonMatchingProposals
 	}
 

--- a/channel/consensus_channel/leader_channel.go
+++ b/channel/consensus_channel/leader_channel.go
@@ -23,6 +23,24 @@ func (c *ConsensusChannel) IsProposed(g Guarantee) (bool, error) {
 	}
 
 	return latest.Outcome.includes(g) && !c.Includes(g), nil
+
+}
+
+// IsProposedNext returns if the next proposal in the queue would lead to g being included in the receiver's outcome, and false otherwise.
+func (c *ConsensusChannel) IsProposedNext(g Guarantee) (bool, error) {
+	vars := Vars{TurnNum: c.current.TurnNum, Outcome: c.current.Outcome.clone()}
+
+	if len(c.proposalQueue) == 0 {
+		return false, nil
+	}
+
+	p := c.proposalQueue[0]
+	err := vars.HandleProposal(p.Proposal)
+	if err != nil {
+		return false, err
+	}
+
+	return vars.Outcome.includes(g) && !c.Includes(g), nil
 }
 
 // Propose is called by the Leader and receives a proposal to add a guarantee,

--- a/channel/consensus_channel/leader_channel_test.go
+++ b/channel/consensus_channel/leader_channel_test.go
@@ -353,13 +353,13 @@ func TestLeaderChannel(t *testing.T) {
 		p1 := createAdd(cId, vars.TurnNum+1, t1)
 		sp1 := aliceSignedProposal(vars, p1)
 
-		p2 := createAdd(cId, sp1.TurnNum+1, t2)
+		p2 := createAdd(cId, sp1.Vars.TurnNum+1, t2)
 		sp2 := aliceSignedProposal(sp1.Vars, p2)
 
-		p3 := createAdd(cId, sp2.TurnNum+1, t3)
+		p3 := createAdd(cId, sp2.Vars.TurnNum+1, t3)
 		sp3 := aliceSignedProposal(sp2.Vars, p3)
 
-		p4 := createRemove(cId, sp3.TurnNum+1, t3)
+		p4 := createRemove(cId, sp3.Vars.TurnNum+1, t3)
 		sp4 := aliceSignedProposal(sp3.Vars, p4)
 
 		return []SignedProposalVars{sp1, sp2, sp3, sp4}
@@ -479,7 +479,7 @@ func TestLeaderChannel(t *testing.T) {
 	{
 		msg := "err:unexpected proposal"
 		p := populatedQueue()[2]
-		p4 := createAdd(cId, p.TurnNum+10, types.Destination{11})
+		p4 := createAdd(cId, p.Vars.TurnNum+10, types.Destination{11})
 		counterP := bobSignedProposal(p.Vars, p4)
 		t.Run(msg, testUpdateConsensusErr(counterP, ErrProposalQueueExhausted))
 	}
@@ -487,7 +487,7 @@ func TestLeaderChannel(t *testing.T) {
 	{
 		msg := "err:wrong channel"
 		p := populatedQueue()[2]
-		p4 := createAdd(types.Destination{}, p.TurnNum+10, types.Destination{11}) // blank ChannelID intentionally different than precomputed cId
+		p4 := createAdd(types.Destination{}, p.Vars.TurnNum+10, types.Destination{11}) // blank ChannelID intentionally different than precomputed cId
 		counterP := bobSignedProposal(p.Vars, p4)
 		t.Run(msg, testUpdateConsensusErr(counterP, ErrIncorrectChannelID))
 	}

--- a/channel/state/signedstate.go
+++ b/channel/state/signedstate.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/statechannels/go-nitro/crypto"
+	"github.com/statechannels/go-nitro/types"
 )
 
 type SignedState struct {
@@ -162,4 +163,15 @@ func (ss *SignedState) UnmarshalJSON(j []byte) error {
 	ss.sigs = rr.Sigs
 	return err
 
+}
+
+// ChannelId returns the channel id of the state.
+func (ss SignedState) ChannelId() types.Destination {
+	cId, _ := ss.state.ChannelId()
+	return cId
+}
+
+// TurnNum returns the turn number of the state.
+func (ss SignedState) TurnNum() uint64 {
+	return ss.state.TurnNum
 }

--- a/channel/state/state.go
+++ b/channel/state/state.go
@@ -180,11 +180,11 @@ func equalParticipants(p []types.Address, q []types.Address) bool {
 
 // Equal returns true if the given State is deeply equal to the receiever.
 func (s State) Equal(r State) bool {
-	return s.ChainId.Cmp(r.ChainId) == 0 &&
+	return types.Equal(s.ChainId, r.ChainId) &&
 		equalParticipants(s.Participants, r.Participants) &&
-		s.ChannelNonce.Cmp(r.ChannelNonce) == 0 &&
+		types.Equal(s.ChannelNonce, r.ChannelNonce) &&
 		bytes.Equal(s.AppDefinition.Bytes(), r.AppDefinition.Bytes()) &&
-		s.ChallengeDuration.Cmp(r.ChallengeDuration) == 0 &&
+		types.Equal(s.ChallengeDuration, r.ChallengeDuration) &&
 		bytes.Equal(s.AppData, r.AppData) &&
 		s.Outcome.Equal(r.Outcome) &&
 		s.TurnNum == r.TurnNum &&

--- a/client/engine/messageservice/test-messageservice_test.go
+++ b/client/engine/messageservice/test-messageservice_test.go
@@ -3,7 +3,6 @@ package messageservice
 import (
 	"testing"
 
-	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -15,9 +14,10 @@ var bobMS = NewTestMessageService(types.Address{'b'}, broker, 0)
 var testId protocols.ObjectiveId = "testObjectiveID"
 
 var aToB protocols.Message = protocols.Message{
-	To:           bobMS.address,
-	ObjectiveId:  testId,
-	SignedStates: []state.SignedState{},
+	To: bobMS.address,
+	Payloads: []protocols.MessagePayload{{
+		ObjectiveId: testId,
+	}},
 }
 
 func TestConnect(t *testing.T) {
@@ -27,8 +27,8 @@ func TestConnect(t *testing.T) {
 
 	got := <-bobOut
 
-	if got.ObjectiveId != testId {
+	if got.Payloads[0].ObjectiveId != testId {
 		t.Fatalf("expected bob to recieve ObjectiveId %v, but recieved %v",
-			testId, got.ObjectiveId)
+			testId, got.Payloads[0].ObjectiveId)
 	}
 }

--- a/client_test/virtual_fund_message_delay_test.go
+++ b/client_test/virtual_fund_message_delay_test.go
@@ -23,9 +23,6 @@ func TestVirtualFundWithMessageDelays(t *testing.T) {
 	// Since we are delaying messages we allow for enough time to complete the objective
 	const OBJECTIVE_TIMEOUT = time.Second * 2
 
-	// This test fails due to https://github.com/statechannels/go-nitro/issues/366
-	t.Skip()
-
 	// Setup logging
 	logDestination := &bytes.Buffer{}
 	t.Cleanup(flushToFileCleanupFn(logDestination, "virtual_fund_message_delay_test.log"))

--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -15,7 +15,7 @@ import (
 
 // TestMultiPartyVirtualFundIntegration tests the scenario where Alice creates virtual channels with Bob and Brian using Irene as the intermediary.
 func TestMultiPartyVirtualFundIntegration(t *testing.T) {
-	t.Skip()
+
 	logDestination := &bytes.Buffer{}
 	t.Cleanup(flushToFileCleanupFn(logDestination, "virtualfund_multiparty_client_test.log"))
 

--- a/internal/testhelpers/testhelpers.go
+++ b/internal/testhelpers/testhelpers.go
@@ -67,8 +67,8 @@ func AssertStateSentToEveryone(t *testing.T, ses protocols.SideEffects, expected
 func AssertStateSentTo(t *testing.T, ses protocols.SideEffects, expected state.SignedState, to testactors.Actor) {
 	for _, msg := range ses.MessagesToSend {
 		if bytes.Equal(msg.To[:], to.Address[:]) {
-			for _, ss := range msg.SignedStates {
-				Equals(t, ss, expected)
+			for _, ss := range msg.SignedStates() {
+				Equals(t, ss.Payload, expected)
 			}
 		}
 	}
@@ -78,12 +78,12 @@ func AssertProposalSent(t *testing.T, ses protocols.SideEffects, sp consensus_ch
 
 	Assert(t, len(ses.MessagesToSend) == 1, "expected one message")
 
-	Assert(t, len(ses.MessagesToSend[0].SignedProposals) == 1, "expected one signed proposal")
+	Assert(t, len(ses.MessagesToSend[0].SignedProposals()) == 1, "expected one signed proposal")
 
 	msg := ses.MessagesToSend[0]
-	sent := msg.SignedProposals[0]
+	sent := msg.SignedProposals()[0].Payload
 
-	Assert(t, len(ses.MessagesToSend[0].SignedProposals) == 1, "exp: %+v\n\n\tgot%+v", sent.Proposal, sp.Proposal)
+	Assert(t, len(ses.MessagesToSend[0].SignedProposals()) == 1, "exp: %+v\n\n\tgot%+v", sent.Proposal, sp.Proposal)
 
 	Assert(t, bytes.Equal(msg.To[:], to.Address[:]), "exp: %+v\n\n\tgot%+v", msg.To.String(), to.Address.String())
 

--- a/internal/testhelpers/testhelpers.go
+++ b/internal/testhelpers/testhelpers.go
@@ -78,13 +78,13 @@ func AssertProposalSent(t *testing.T, ses protocols.SideEffects, sp consensus_ch
 
 	Assert(t, len(ses.MessagesToSend) == 1, "expected one message")
 
-	Assert(t, len(ses.MessagesToSend[0].SignedProposals()) == 1, "expected one signed proposal")
+	found := false
 
 	msg := ses.MessagesToSend[0]
-	sent := msg.SignedProposals()[0].Payload
-
-	Assert(t, len(ses.MessagesToSend[0].SignedProposals()) == 1, "exp: %+v\n\n\tgot%+v", sent.Proposal, sp.Proposal)
-
+	for _, p := range msg.SignedProposals() {
+		found = found || p.Payload.Proposal.Equal(&sp.Proposal)
+	}
+	Assert(t, found, "proposal %+v not found in signed proposals %+v", sp.Proposal, msg.SignedProposals())
 	Assert(t, bytes.Equal(msg.To[:], to.Address[:]), "exp: %+v\n\n\tgot%+v", msg.To.String(), to.Address.String())
 
 }

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/statechannels/go-nitro/channel"
+	"github.com/statechannels/go-nitro/channel/state"
+
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
@@ -102,9 +104,9 @@ func NewObjective(
 
 var ErrNoFinalState = errors.New("Cannot spawn direct defund objective without a final state")
 
-// ConstructObjectiveFromMessage takes in a message and constructs an objective from it.
-func ConstructObjectiveFromMessage(
-	m protocols.Message,
+// ConstructObjectiveFromState takes in a message and constructs an objective from it.
+func ConstructObjectiveFromState(
+	s state.State,
 	getChannel GetChannelByIdFunction,
 ) (Objective, error) {
 	preApprove := true
@@ -114,11 +116,11 @@ func ConstructObjectiveFromMessage(
 	// Implicit in the wire protocol is that the message signalling
 	// closure of a channel includes an isFinal state (in the 0 slot of the message)
 	//
-	if !m.SignedStates[0].State().IsFinal {
+	if !s.IsFinal {
 		return Objective{}, ErrNoFinalState
 	}
 
-	cId, err := m.SignedStates[0].State().ChannelId()
+	cId, err := s.ChannelId()
 	if err != nil {
 		return Objective{}, err
 	}

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -162,7 +162,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func compareSideEffect(a, b protocols.SideEffects) string {
-	return cmp.Diff(a, b, cmp.AllowUnexported(a, state.SignedState{}))
+	return cmp.Diff(a, b, cmp.AllowUnexported(a, state.SignedState{}, consensus_channel.Add{}, consensus_channel.Remove{}, consensus_channel.Guarantee{}))
 }
 
 func TestCrankAlice(t *testing.T) {
@@ -190,14 +190,12 @@ func TestCrankAlice(t *testing.T) {
 
 	expectedSE := protocols.SideEffects{
 		MessagesToSend: []protocols.Message{{
-			To:          bob.Address,
-			ObjectiveId: o.Id(),
-			SignedStates: []state.SignedState{
-				finalStateSignedByAlice,
-			},
-			SignedProposals: []consensus_channel.SignedProposal{},
-		},
-		}}
+			To: bob.Address,
+			Payloads: []protocols.MessagePayload{{
+				ObjectiveId: o.Id(),
+				SignedState: finalStateSignedByAlice,
+			}},
+		}}}
 
 	if diff := compareSideEffect(expectedSE, se); diff != "" {
 		t.Errorf("Side effects mismatch (-want +got):\n%s", diff)
@@ -280,14 +278,10 @@ func TestCrankBob(t *testing.T) {
 	finalStateSignedByBob, _ := signedTestState(finalState, []bool{false, true})
 	expectedSE := protocols.SideEffects{
 		MessagesToSend: []protocols.Message{{
-			To:          alice.Address,
-			ObjectiveId: updated.Id(),
-			SignedStates: []state.SignedState{
-				finalStateSignedByBob,
-			},
-			SignedProposals: []consensus_channel.SignedProposal{},
-		},
-		}}
+			To: alice.Address,
+			Payloads: []protocols.MessagePayload{{ObjectiveId: updated.Id(),
+				SignedState: finalStateSignedByBob,
+			}}}}}
 
 	if diff := compareSideEffect(expectedSE, se); diff != "" {
 		t.Errorf("Side effects mismatch (-want +got):\n%s", diff)

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -47,7 +47,7 @@ type Objective struct {
 // NewObjective creates a new direct funding objective from a given request.
 func NewObjective(request ObjectiveRequest, preApprove bool) (Objective, error) {
 
-	objective, err := constructFromState(preApprove,
+	objective, err := ConstructFromState(preApprove,
 		state.State{
 			ChainId:           big.NewInt(0), // TODO
 			Participants:      []types.Address{request.MyAddress, request.CounterParty},
@@ -67,9 +67,9 @@ func NewObjective(request ObjectiveRequest, preApprove bool) (Objective, error) 
 	return objective, nil
 }
 
-// constructFromState initiates a Objective with data calculated from
+// ConstructFromState initiates a Objective with data calculated from
 // the supplied initialState and client address
-func constructFromState(
+func ConstructFromState(
 	preApprove bool,
 	initialState state.State,
 	myAddress types.Address,
@@ -367,25 +367,6 @@ func (o Objective) clone() Objective {
 // IsDirectFundObjective inspects a objective id and returns true if the objective id is for a direct fund objective.
 func IsDirectFundObjective(id protocols.ObjectiveId) bool {
 	return strings.HasPrefix(string(id), ObjectivePrefix)
-}
-
-// ConstructObjectiveFromMessage takes in a message and constructs a direct funding objective from it.
-func ConstructObjectiveFromMessage(m protocols.Message, myAddress types.Address) (Objective, error) {
-
-	if len(m.SignedStates) == 0 {
-		return Objective{}, errors.New("expected at least one signed state in the message")
-	}
-	initialState := m.SignedStates[0].State()
-
-	objective, err := constructFromState(
-		true, // TODO ensure objective in only approved if the application has given permission somehow
-		initialState,
-		myAddress,
-	)
-	if err != nil {
-		return Objective{}, fmt.Errorf("could not create new objective: %w", err)
-	}
-	return objective, nil
 }
 
 // ObjectiveRequest represents a request to create a new direct funding objective.

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -48,7 +48,7 @@ var testState = state.State{
 // TestNew tests the constructor using a TestState fixture
 func TestNew(t *testing.T) {
 	// Assert that valid constructor args do not result in error
-	if _, err := constructFromState(false, testState, testState.Participants[0]); err != nil {
+	if _, err := ConstructFromState(false, testState, testState.Participants[0]); err != nil {
 		t.Error(err)
 	}
 
@@ -56,19 +56,19 @@ func TestNew(t *testing.T) {
 	finalState := testState.Clone()
 	finalState.IsFinal = true
 
-	if _, err := constructFromState(false, finalState, testState.Participants[0]); err == nil {
+	if _, err := ConstructFromState(false, finalState, testState.Participants[0]); err == nil {
 		t.Error("expected an error when constructing with an intial state marked final, but got nil")
 	}
 
 	nonParticipant := common.HexToAddress("0x5b53f71453aeCb03D837bfe170570d40aE736CB4")
-	if _, err := constructFromState(false, testState, nonParticipant); err == nil {
+	if _, err := ConstructFromState(false, testState, nonParticipant); err == nil {
 		t.Error("expected an error when constructing with a participant not in the channel, but got nil")
 	}
 }
 
 func TestConstructFromState(t *testing.T) {
 	// Assert that valid constructor args do not result in error
-	if _, err := constructFromState(false, testState, testState.Participants[0]); err != nil {
+	if _, err := ConstructFromState(false, testState, testState.Participants[0]); err != nil {
 		t.Error(err)
 	}
 
@@ -76,18 +76,18 @@ func TestConstructFromState(t *testing.T) {
 	finalState := testState.Clone()
 	finalState.IsFinal = true
 
-	if _, err := constructFromState(false, finalState, testState.Participants[0]); err == nil {
+	if _, err := ConstructFromState(false, finalState, testState.Participants[0]); err == nil {
 		t.Error("expected an error when constructing with an intial state marked final, but got nil")
 	}
 
 	nonParticipant := common.HexToAddress("0x5b53f71453aeCb03D837bfe170570d40aE736CB4")
-	if _, err := constructFromState(false, testState, nonParticipant); err == nil {
+	if _, err := ConstructFromState(false, testState, nonParticipant); err == nil {
 		t.Error("expected an error when constructing with a participant not in the channel, but got nil")
 	}
 }
 func TestUpdate(t *testing.T) {
 	// Construct various variables for use in TestUpdate
-	var s, _ = constructFromState(false, testState, testState.Participants[0])
+	var s, _ = ConstructFromState(false, testState, testState.Participants[0])
 
 	var stateToSign state.State = s.C.PreFundState()
 	var correctSignatureByParticipant, _ = stateToSign.Sign(alice.PrivateKey)
@@ -161,13 +161,13 @@ func TestUpdate(t *testing.T) {
 }
 
 func compareSideEffect(a, b protocols.SideEffects) string {
-	return cmp.Diff(a, b, cmp.AllowUnexported(a, state.SignedState{}))
+	return cmp.Diff(a, b, cmp.AllowUnexported(a, state.SignedState{}, consensus_channel.Add{}, consensus_channel.Guarantee{}, consensus_channel.Remove{}))
 }
 
 func TestCrank(t *testing.T) {
 
 	// BEGIN test data preparation
-	var s, _ = constructFromState(false, testState, testState.Participants[0])
+	var s, _ = ConstructFromState(false, testState, testState.Participants[0])
 	var correctSignatureByAliceOnPreFund, _ = s.C.PreFundState().Sign(alice.PrivateKey)
 	var correctSignatureByBobOnPreFund, _ = s.C.PreFundState().Sign(bob.PrivateKey)
 
@@ -180,26 +180,23 @@ func TestCrank(t *testing.T) {
 	expectedPreFundSideEffects := protocols.SideEffects{
 		MessagesToSend: []protocols.Message{
 			{
-				To:          bob.Address,
-				ObjectiveId: s.Id(),
-				SignedStates: []state.SignedState{
-					preFundSS,
-				},
-				SignedProposals: []consensus_channel.SignedProposal{},
-			},
-		}}
+				To: bob.Address,
+				Payloads: []protocols.MessagePayload{{
+					ObjectiveId: s.Id(),
+					SignedState: preFundSS,
+				}},
+			}}}
 
 	postFundSS := state.NewSignedState(s.C.PostFundState())
 	_ = postFundSS.AddSignature(correctSignatureByAliceOnPostFund)
 	expectedPostFundSideEffects := protocols.SideEffects{
 		MessagesToSend: []protocols.Message{
 			{
-				To:          bob.Address,
-				ObjectiveId: s.Id(),
-				SignedStates: []state.SignedState{
-					postFundSS,
-				},
-				SignedProposals: []consensus_channel.SignedProposal{},
+				To: bob.Address,
+				Payloads: []protocols.MessagePayload{{
+					ObjectiveId: s.Id(),
+					SignedState: postFundSS,
+				}},
 			},
 		}}
 	expectedFundingSideEffects := protocols.SideEffects{
@@ -300,7 +297,7 @@ func TestClone(t *testing.T) {
 		return cmp.Diff(&a, &b, cmp.AllowUnexported(Objective{}, channel.Channel{}, big.Int{}, state.SignedState{}))
 	}
 
-	var s, _ = constructFromState(false, testState, testState.Participants[0])
+	var s, _ = ConstructFromState(false, testState, testState.Participants[0])
 
 	clone := s.clone()
 
@@ -310,7 +307,7 @@ func TestClone(t *testing.T) {
 }
 
 func TestMarshalJSON(t *testing.T) {
-	dfo, _ := constructFromState(false, testState, testState.Participants[0])
+	dfo, _ := ConstructFromState(false, testState, testState.Participants[0])
 
 	encodedDfo, err := json.Marshal(dfo)
 

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"sort"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/types"
@@ -33,12 +32,7 @@ type MessagePayload struct {
 
 // hasState returns true if the payload contains a signed state.
 func (p MessagePayload) hasState() bool {
-	stateHash, err := p.SignedState.State().Hash()
-	if err != nil {
-		return false
-	}
-
-	return bytes.Compare(stateHash.Bytes(), common.Hash{}.Bytes()) != 0
+	return !p.SignedState.State().Equal(state.State{})
 }
 
 // hasProposal returns true if the payload contains a signed proposal.

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -57,7 +57,7 @@ func (p MessagePayload) Type() PayloadType {
 	panic("payload has both state and proposal")
 }
 
-// ObjectivePayload is a struct that contains an objectiveId and EITHER.
+// ObjectivePayload is a struct that contains an objectiveId and EITHER a Signed State or Signed Proposal.
 type ObjectivePayload[T PayloadValue] struct {
 	Payload     T
 	ObjectiveId ObjectiveId

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -42,13 +42,16 @@ func (p MessagePayload) hasProposal() bool {
 
 // Type returns the type of the payload, either a SignedProposal or SignedState.
 func (p MessagePayload) Type() PayloadType {
-
-	if p.hasProposal() && !p.hasState() {
+	switch {
+	case p.hasProposal() && !p.hasState():
 		return SignedProposalPayload
-	} else if p.hasState() && !p.hasProposal() {
+	case !p.hasProposal() && p.hasState():
 		return SignedStatePayload
+	case p.hasProposal() && p.hasState():
+		panic("payload has both state and proposal %v")
+	default:
+		panic("payload has neither state nor proposal")
 	}
-	panic("payload has both state and proposal")
 }
 
 // ObjectivePayload is a struct that contains an objectiveId and EITHER a Signed State or Signed Proposal.

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -1,19 +1,98 @@
 package protocols
 
 import (
+	"bytes"
 	"encoding/json"
+	"sort"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/types"
 )
 
+const (
+	SignedStatePayload    PayloadType = "SignedStatePayload"
+	SignedProposalPayload PayloadType = "SignedProposalPayload"
+)
+
+type PayloadType string
+
 // Message is an object to be sent across the wire. It can contain a proposal and signed states, and is addressed to a counterparty.
 type Message struct {
-	To              types.Address
-	ObjectiveId     ObjectiveId
-	SignedStates    []state.SignedState
-	SignedProposals []consensus_channel.SignedProposal
+	To       types.Address
+	Payloads []MessagePayload
+}
+
+// MessagePayload is an objective id and EITHER a SignedState or SignedProposal.
+type MessagePayload struct {
+	ObjectiveId    ObjectiveId
+	SignedState    state.SignedState
+	SignedProposal consensus_channel.SignedProposal
+}
+
+// hasState returns true if the payload contains a signed state.
+func (p MessagePayload) hasState() bool {
+	stateHash, err := p.SignedState.State().Hash()
+	if err != nil {
+		return false
+	}
+
+	return bytes.Compare(stateHash.Bytes(), common.Hash{}.Bytes()) != 0
+}
+
+// hasProposal returns true if the payload contains a signed proposal.
+func (p MessagePayload) hasProposal() bool {
+	return p.SignedProposal.Proposal != consensus_channel.Proposal{}
+}
+
+// Type returns the type of the payload, either a SignedProposal or SignedState.
+func (p MessagePayload) Type() PayloadType {
+
+	if p.hasProposal() && !p.hasState() {
+		return SignedProposalPayload
+	} else if p.hasState() && !p.hasProposal() {
+		return SignedStatePayload
+	}
+	panic("payload has both state and proposal")
+}
+
+// ObjectivePayload is a struct that contains an objectiveId and EITHER.
+type ObjectivePayload[T PayloadValue] struct {
+	Payload     T
+	ObjectiveId ObjectiveId
+}
+
+// SignedStates returns a slice of signed states with their objectiveId that were contained in the message.
+// The states are sorted by channel id then turnNum.
+func (m Message) SignedStates() []ObjectivePayload[state.SignedState] {
+	signedStates := make([]ObjectivePayload[state.SignedState], 0)
+	for _, p := range m.Payloads {
+		if p.Type() == SignedStatePayload {
+			entry := ObjectivePayload[state.SignedState]{p.SignedState, p.ObjectiveId}
+			signedStates = append(signedStates, entry)
+		}
+	}
+
+	sortPayloads(signedStates)
+
+	return signedStates
+}
+
+// SignedProposals returns a slice of signed proposals with their objectiveId that were contained in the message.
+// The proposals are sorted by ledger id then turnNum.
+func (m Message) SignedProposals() []ObjectivePayload[consensus_channel.SignedProposal] {
+	signedProposals := make([]ObjectivePayload[consensus_channel.SignedProposal], 0)
+	for _, p := range m.Payloads {
+		if p.Type() == SignedProposalPayload {
+			entry := ObjectivePayload[consensus_channel.SignedProposal]{p.SignedProposal, p.ObjectiveId}
+			signedProposals = append(signedProposals, entry)
+		}
+	}
+
+	sortPayloads(signedProposals)
+
+	return signedProposals
 }
 
 // Serialize serializes the message into a string.
@@ -40,9 +119,12 @@ func CreateSignedStateMessages(id ObjectiveId, ss state.SignedState, myIndex uin
 		if uint(i) == myIndex {
 			continue
 		}
-		signedStates := []state.SignedState{}
-		signedStates = append(signedStates, ss)
-		message := Message{To: participant, ObjectiveId: id, SignedStates: signedStates, SignedProposals: []consensus_channel.SignedProposal{}}
+		payload := MessagePayload{
+			ObjectiveId: id,
+			SignedState: ss,
+		}
+
+		message := Message{To: participant, Payloads: []MessagePayload{payload}}
 		messages = append(messages, message)
 	}
 	return messages
@@ -54,4 +136,80 @@ func (se *SideEffects) Merge(other SideEffects) {
 	se.MessagesToSend = append(se.MessagesToSend, other.MessagesToSend...)
 	se.TransactionsToSubmit = append(se.TransactionsToSubmit, other.TransactionsToSubmit...)
 
+}
+
+// PayloadValue is a type constraint that specifies a payload is either a SignedProposal or SignedState.
+// It includes functions to get basic info to allow sorting.
+type PayloadValue interface {
+	state.SignedState | consensus_channel.SignedProposal
+	ChannelId() types.Destination
+	TurnNum() uint64
+}
+
+// sortPayloads sorts the objective payloads by channel id then turnNum.
+// This is used to ensure that the payloads can be processed in a deterministic order.
+func sortPayloads[T PayloadValue](payloads []ObjectivePayload[T]) {
+	sort.Slice(payloads, func(i, j int) bool {
+		p1, p2 := payloads[i], payloads[j]
+
+		cId1 := p1.Payload.ChannelId()
+		cId2 := p2.Payload.ChannelId()
+		cIdCompare := bytes.Compare(cId1.Bytes(), cId2.Bytes())
+
+		if sameChannel := cIdCompare == 0; sameChannel {
+			return p1.Payload.TurnNum() < p2.Payload.TurnNum()
+		} else {
+			return cIdCompare < 0
+		}
+	})
+}
+
+// ProposalSummary contains some basic info about a proposal for logging.
+type ProposalSummary struct {
+	ObjectiveId string
+	LedgerId    string
+	Target      string
+	Type        string
+	TurnNum     uint64
+}
+
+// StateSummary contains some basic info about a state for logging.
+type StateSummary struct {
+	ObjectiveId string
+	ChannelId   string
+	TurnNum     uint64
+}
+
+// MessagarSummary contains some basic info about a message for logging.
+type MessageSummary struct {
+	To        string
+	Proposals []ProposalSummary
+	States    []StateSummary
+}
+
+// SummarizeMessage returns a MessageSummary for the provided message.
+func SummarizeMessage(m Message) MessageSummary {
+	proposals := make([]ProposalSummary, len(m.SignedProposals()))
+	for i, p := range m.SignedProposals() {
+
+		proposals[i] = ProposalSummary{
+			LedgerId:    p.Payload.Proposal.ChannelID.String(),
+			ObjectiveId: string(p.ObjectiveId),
+			Target:      p.Payload.Proposal.Target().String(),
+			TurnNum:     p.Payload.Proposal.TurnNum(),
+			Type:        string(p.Payload.Proposal.Type()),
+		}
+	}
+
+	states := make([]StateSummary, len(m.SignedStates()))
+	for i, s := range m.SignedStates() {
+		channelId, _ := s.Payload.State().ChannelId()
+		states[i] = StateSummary{
+			ObjectiveId: string(s.ObjectiveId),
+			ChannelId:   channelId.String(),
+			TurnNum:     s.Payload.State().TurnNum,
+		}
+	}
+
+	return MessageSummary{To: m.To.String(), Proposals: proposals, States: states}
 }

--- a/protocols/messages_test.go
+++ b/protocols/messages_test.go
@@ -26,37 +26,46 @@ func addProposal() consensus_channel.SignedProposal {
 
 func TestMessage(t *testing.T) {
 
-	msg := Message{
-		To:          types.Address{'a'},
-		ObjectiveId: `say-hello-to-my-little-friend`,
-		SignedStates: []state.SignedState{
-			state.NewSignedState(state.TestState),
-		},
-		SignedProposals: []consensus_channel.SignedProposal{addProposal()},
+	msgs := []Message{{
+		To: types.Address{'a'},
+
+		Payloads: []MessagePayload{{
+			ObjectiveId: `say-hello-to-my-little-friend`,
+			SignedState: state.NewSignedState(state.TestState),
+		}}}, {
+		To: types.Address{'a'},
+
+		Payloads: []MessagePayload{{
+			ObjectiveId:    `say-hello-to-my-little-friend2`,
+			SignedProposal: addProposal(),
+		}}}}
+
+	msgStrings := []string{
+		`{"To":"0x6100000000000000000000000000000000000000","Payloads":[{"ObjectiveId":"say-hello-to-my-little-friend","SignedState":{"State":{"ChainId":9001,"Participants":["0xf5a1bb5607c9d079e46d1b3dc33f257d937b43bd","0x760bf27cd45036a6c486802d30b5d90cffbe31fe"],"ChannelNonce":37140676580,"AppDefinition":"0x5e29e5ab8ef33f050c7cc10b5a0456d975c5f88d","ChallengeDuration":60,"AppData":"","Outcome":[{"Asset":"0x0000000000000000000000000000000000000000","Metadata":null,"Allocations":[{"Destination":"0x000000000000000000000000f5a1bb5607c9d079e46d1b3dc33f257d937b43bd","Amount":5,"AllocationType":0,"Metadata":null},{"Destination":"0x000000000000000000000000ee18ff1575055691009aa246ae608132c57a422c","Amount":5,"AllocationType":0,"Metadata":null}]}],"TurnNum":5,"IsFinal":false},"Sigs":{}},"SignedProposal":{"R":null,"S":null,"V":0,"Proposal":{"ChannelID":"0x0000000000000000000000000000000000000000000000000000000000000000","ToAdd":{"TurnNum":0,"Guarantee":{"Amount":null,"Target":"0x0000000000000000000000000000000000000000000000000000000000000000","Left":"0x0000000000000000000000000000000000000000000000000000000000000000","Right":"0x0000000000000000000000000000000000000000000000000000000000000000"},"LeftDeposit":null},"ToRemove":{"Target":"0x0000000000000000000000000000000000000000000000000000000000000000","LeftAmount":null,"RightAmount":null}}}}]}`,
+		`{"To":"0x6100000000000000000000000000000000000000","Payloads":[{"ObjectiveId":"say-hello-to-my-little-friend2","SignedState":{"State":{"ChainId":null,"Participants":null,"ChannelNonce":null,"AppDefinition":"0x0000000000000000000000000000000000000000","ChallengeDuration":null,"AppData":null,"Outcome":null,"TurnNum":0,"IsFinal":false},"Sigs":null},"SignedProposal":{"R":null,"S":null,"V":0,"Proposal":{"ChannelID":"0x6c00000000000000000000000000000000000000000000000000000000000000","ToAdd":{"TurnNum":1,"Guarantee":{"Amount":1,"Target":"0x6100000000000000000000000000000000000000000000000000000000000000","Left":"0x6200000000000000000000000000000000000000000000000000000000000000","Right":"0x6300000000000000000000000000000000000000000000000000000000000000"},"LeftDeposit":1},"ToRemove":{"Target":"0x0000000000000000000000000000000000000000000000000000000000000000","LeftAmount":null,"RightAmount":null}}}}]}`,
 	}
 
-	msgString := `{"To":"0x6100000000000000000000000000000000000000","ObjectiveId":"say-hello-to-my-little-friend","SignedStates":[{"State":{"ChainId":9001,"Participants":["0xf5a1bb5607c9d079e46d1b3dc33f257d937b43bd","0x760bf27cd45036a6c486802d30b5d90cffbe31fe"],"ChannelNonce":37140676580,"AppDefinition":"0x5e29e5ab8ef33f050c7cc10b5a0456d975c5f88d","ChallengeDuration":60,"AppData":"","Outcome":[{"Asset":"0x0000000000000000000000000000000000000000","Metadata":null,"Allocations":[{"Destination":"0x000000000000000000000000f5a1bb5607c9d079e46d1b3dc33f257d937b43bd","Amount":5,"AllocationType":0,"Metadata":null},{"Destination":"0x000000000000000000000000ee18ff1575055691009aa246ae608132c57a422c","Amount":5,"AllocationType":0,"Metadata":null}]}],"TurnNum":5,"IsFinal":false},"Sigs":{}}],"SignedProposals":[{"R":null,"S":null,"V":0,"Proposal":{"ChannelID":"0x6c00000000000000000000000000000000000000000000000000000000000000","ToAdd":{"TurnNum":1,"Guarantee":{"Amount":1,"Target":"0x6100000000000000000000000000000000000000000000000000000000000000","Left":"0x6200000000000000000000000000000000000000000000000000000000000000","Right":"0x6300000000000000000000000000000000000000000000000000000000000000"},"LeftDeposit":1},"ToRemove":{"Target":"0x0000000000000000000000000000000000000000000000000000000000000000","LeftAmount":null,"RightAmount":null}}}]}`
+	for i, msg := range msgs {
+		t.Run(`serialize`, func(t *testing.T) {
+			got, err := msg.Serialize()
+			if err != nil {
+				t.Error(err)
+			}
+			want := msgStrings[i]
+			if got != want {
+				t.Fatalf("incorrect serialization: got:\n%v\nwanted:\n%v", got, want)
+			}
+		})
 
-	t.Run(`serialize`, func(t *testing.T) {
-		got, err := msg.Serialize()
-		if err != nil {
-			t.Error(err)
-		}
-		want := msgString
-		if got != want {
-			t.Fatalf("incorrect serialization: got:\n%v\nwanted:\n%v", got, want)
-		}
-	})
-
-	t.Run(`deserialize`, func(t *testing.T) {
-		got, err := DeserializeMessage(msgString)
-		want := msg
-		if err != nil {
-			t.Error(err)
-		}
-		if !reflect.DeepEqual(got, want) {
-			t.Errorf("incorrect deserialization: got:\n%v\nwanted:\n%v", got, want)
-		}
-	})
-
+		t.Run(`deserialize`, func(t *testing.T) {
+			got, err := DeserializeMessage(msgStrings[i])
+			want := msg
+			if err != nil {
+				t.Error(err)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("incorrect deserialization: got:\n%v\nwanted:\n%v", got, want)
+			}
+		})
+	}
 }

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -349,9 +349,12 @@ func (o *Objective) createSignedProposalMessage(sp consensus_channel.SignedPropo
 		recipient = ledger.Follower()
 	}
 	return protocols.Message{
-		To:              recipient,
-		ObjectiveId:     o.Id(),
-		SignedProposals: []consensus_channel.SignedProposal{sp},
+		To: recipient,
+		Payloads: []protocols.MessagePayload{{
+			ObjectiveId:    o.Id(),
+			SignedProposal: sp,
+		},
+		},
 	}
 }
 

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -277,12 +277,12 @@ func (o *Objective) updateLedgerToRemoveGuarantee(ledger *consensus_channel.Cons
 			return protocols.SideEffects{}, nil
 		}
 
-		signedProposal, err := ledger.Propose(o.ledgerProposal(ledger), *sk)
+		sp, err := ledger.Propose(o.ledgerProposal(ledger), *sk)
 		if err != nil {
 			return protocols.SideEffects{}, fmt.Errorf("error proposing ledger update: %w", err)
 		}
 
-		message := o.createSignedProposalMessage(signedProposal, ledger)
+		message := protocols.CreateSignedProposalMessage(ledger, sp)
 		sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, message)
 
 	} else {
@@ -294,7 +294,7 @@ func (o *Objective) updateLedgerToRemoveGuarantee(ledger *consensus_channel.Cons
 				return protocols.SideEffects{}, fmt.Errorf("could not sign proposal: %w", err)
 			}
 
-			message := o.createSignedProposalMessage(sp, ledger)
+			message := protocols.CreateSignedProposalMessage(ledger, sp)
 			sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, message)
 		}
 	}
@@ -340,22 +340,6 @@ func (o Objective) isLeftDefunded() bool {
 
 	included := o.ToMyLeft.IncludesTarget(o.VId())
 	return !included
-}
-
-// createSignedProposalMessage returns a signed proposal message addressed to the counterparty in the given ledger
-func (o *Objective) createSignedProposalMessage(sp consensus_channel.SignedProposal, ledger *consensus_channel.ConsensusChannel) protocols.Message {
-	recipient := ledger.Leader()
-	if ledger.IsLeader() {
-		recipient = ledger.Follower()
-	}
-	return protocols.Message{
-		To: recipient,
-		Payloads: []protocols.MessagePayload{{
-			ObjectiveId:    o.Id(),
-			SignedProposal: sp,
-		},
-		},
-	}
 }
 
 // validateSignature returns whether the given signature is valid for the given participant

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -649,7 +649,10 @@ func (o *Objective) updateLedgerWithGuarantee(ledgerConnection Connection, sk *[
 		if err != nil {
 			return protocols.SideEffects{}, err
 		}
-		if proposed {
+		// If the proposal is next in the queue we accept it
+		proposedNext, _ := ledger.IsProposedNext(g)
+		if proposedNext {
+
 			se, err := o.acceptLedgerUpdate(ledgerConnection, sk)
 			if err != nil {
 				return protocols.SideEffects{}, fmt.Errorf("error proposing ledger update: %w", err)

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -78,7 +78,11 @@ func (c *Connection) handleProposal(sp consensus_channel.SignedProposal) error {
 	}
 
 	if c.Channel != nil {
-		return c.Channel.Receive(sp)
+		err := c.Channel.Receive(sp)
+		// Ignore stale or future proposals
+		if errors.Is(err, consensus_channel.ErrInvalidTurnNum) {
+			return nil
+		}
 	}
 
 	return nil

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -471,12 +471,12 @@ func assertSupportedPrefund(o *Objective, t *testing.T) {
 func assertOneProposalSent(t *testing.T, ses protocols.SideEffects, sp consensus_channel.SignedProposal, to actors.Actor) {
 	numProposals := 0
 	for _, msg := range ses.MessagesToSend {
-		if len(msg.SignedProposals) > 0 {
+		if len(msg.SignedProposals()) > 0 {
 
 			msg := ses.MessagesToSend[0]
-			sent := msg.SignedProposals[0]
+			sent := msg.SignedProposals()[0].Payload
 
-			Assert(t, len(ses.MessagesToSend[0].SignedProposals) == 1, "exp: %+v\n\n\tgot%+v", sent.Proposal, sp.Proposal)
+			Assert(t, len(ses.MessagesToSend[0].SignedProposals()) == 1, "exp: %+v\n\n\tgot%+v", sent.Proposal, sp.Proposal)
 			Assert(t, bytes.Equal(msg.To[:], to.Address[:]), "exp: %+v\n\n\tgot%+v", msg.To.String(), to.Address.String())
 			Assert(t, compareSignedProposals(sp, sent), "exp: %+v\n\n\tgot%+v", sp, sent)
 			numProposals++
@@ -489,11 +489,10 @@ func assertOneProposalSent(t *testing.T, ses protocols.SideEffects, sp consensus
 func assertStateSentTo(t *testing.T, ses protocols.SideEffects, expected state.SignedState, to testactors.Actor) {
 	found := false
 	for _, msg := range ses.MessagesToSend {
-		for _, ss := range msg.SignedStates {
-			correctAddress := bytes.Equal(msg.To[:], to.Address[:])
-
-			if correctAddress {
-				diff := compareStates(ss, expected)
+		correctAddress := bytes.Equal(msg.To[:], to.Address[:])
+		if correctAddress {
+			for _, ss := range msg.SignedStates() {
+				diff := compareStates(ss.Payload, expected)
 				Assert(t, diff == "", "incorrect state\n\ndiff: %v", diff)
 				found = true
 				break

--- a/types/bigutils.go
+++ b/types/bigutils.go
@@ -17,6 +17,12 @@ func Lt(a *big.Int, b *big.Int) bool {
 }
 
 func Equal(a *big.Int, b *big.Int) bool {
+	if a == nil {
+		return b == nil
+	}
+	if b == nil {
+		return a == nil
+	}
 	return a.Cmp(b) == 0
 }
 


### PR DESCRIPTION
Fixes #366 
Fixes #588 

This PR makes changes to the message format and how we handle messages so we can support handling messages out of order.

# Changes
## Message Format Refactor
A message now contains a `To` and a collection of `MessagePayloads`.
```
// Message is an object to be sent across the wire. It can contain a proposal and signed states, and is addressed to a counterparty.
type Message struct {
	To       types.Address
	Payloads []MessagePayload
}
```

A message payload is an objective id and either a signed proposal **or** a signed state. 
```
// MessagePayload is an objective id and EITHER a SignedState or SignedProposal.
type MessagePayload struct {
	ObjectiveId    ObjectiveId
	SignedState    state.SignedState
	SignedProposal consensus_channel.SignedProposal
}
```

## New Message Functions
The message struct now has two new functions: `SignedStates` and `SignedProposals`. These return a sorted slice of the states/proposals in a message. These slices are sorted by `ChannelI`d then `TurnNum` to make sure the engine can easily process them in the correct order.

I've tried out using generics to share some of the sorting code between `SignedStates` and `SignedProposals`. They both return an `ObjectivePayload`. This lets us share some sorting code between these two functions.
```
// ObjectivePayload is a struct that contains an objectiveId and EITHER.
type ObjectivePayload[T PayloadValue] struct {
	Payload     T
	ObjectiveId ObjectiveId
}
```
The PayloadValue is a type constraint enforcing an the payload value is a Signed Proposal or a Signed State. It also enforces a `ChannelId` and `TurnNum` function so we can easily sort the payloads.
```
// PayloadValue is a type constraint that specifies a payload is either a SignedProposal or SignedState.
// It includes functions to get basic info to allow sorting.
type PayloadValue interface {
	state.SignedState | consensus_channel.SignedProposal
	ChannelId() types.Destination
	TurnNum() uint64
}
```

## Signed Proposal Messages include all proposals
When creating a message for a signed proposal we now also include all proposals in the proposal queue in the message.
This allows us to handle messages out of order and not get stalled out by a missing message.

## Testing
The multi party and message delay integration test has been re-enabled to test this functionality.