### PR TITLE
Cmk.420 remove tpl getter

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -194,7 +194,7 @@ func (e *Engine) handleAPIEvent(apiEvent APIEvent) (ObjectiveChangeEvent, error)
 		switch request := (apiEvent.ObjectiveToSpawn).(type) {
 
 		case virtualfund.ObjectiveRequest:
-			vfo, err := virtualfund.NewObjective(request, e.store.GetConsensusChannel)
+			vfo, err := virtualfund.NewObjective(request, e.store.GetLedgerChannel)
 			if err != nil {
 				return ObjectiveChangeEvent{}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 			}
@@ -300,7 +300,7 @@ func (e Engine) SpawnConsensusChannelIfDirectFundObjective(crankedObjective prot
 		if err != nil {
 			return fmt.Errorf("could not create consensus channel for objective %s: %w", crankedObjective.Id(), err)
 		}
-		err = e.store.SetConsensusChannel(c)
+		err = e.store.SetLedgerChannel(c)
 		if err != nil {
 			return fmt.Errorf("could not store consensus channel for objective %s: %w", crankedObjective.Id(), err)
 		}
@@ -344,7 +344,7 @@ func (e *Engine) constructObjectiveFromMessage(message protocols.Message) (proto
 
 		return &dfo, err
 	case virtualfund.IsVirtualFundObjective(message.ObjectiveId):
-		vfo, err := virtualfund.ConstructObjectiveFromMessage(message, *e.store.GetAddress(), e.store.GetConsensusChannel)
+		vfo, err := virtualfund.ConstructObjectiveFromMessage(message, *e.store.GetAddress(), e.store.GetLedgerChannel)
 		if err != nil {
 			return &virtualfund.Objective{}, fmt.Errorf("could not create virtual fund objective from message: %w", err)
 		}

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -194,7 +194,7 @@ func (e *Engine) handleAPIEvent(apiEvent APIEvent) (ObjectiveChangeEvent, error)
 		switch request := (apiEvent.ObjectiveToSpawn).(type) {
 
 		case virtualfund.ObjectiveRequest:
-			vfo, err := virtualfund.NewObjective(request, e.store.GetTwoPartyLedger, e.store.GetConsensusChannel)
+			vfo, err := virtualfund.NewObjective(request, e.store.GetConsensusChannel)
 			if err != nil {
 				return ObjectiveChangeEvent{}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 			}
@@ -344,7 +344,7 @@ func (e *Engine) constructObjectiveFromMessage(message protocols.Message) (proto
 
 		return &dfo, err
 	case virtualfund.IsVirtualFundObjective(message.ObjectiveId):
-		vfo, err := virtualfund.ConstructObjectiveFromMessage(message, *e.store.GetAddress(), e.store.GetTwoPartyLedger, e.store.GetConsensusChannel)
+		vfo, err := virtualfund.ConstructObjectiveFromMessage(message, *e.store.GetAddress(), e.store.GetConsensusChannel)
 		if err != nil {
 			return &virtualfund.Objective{}, fmt.Errorf("could not create virtual fund objective from message: %w", err)
 		}

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -284,7 +284,7 @@ func (e *Engine) attemptProgress(objective protocols.Objective) (outgoing Object
 	if waitingFor == "WaitingForNothing" {
 		outgoing.CompletedObjectives = append(outgoing.CompletedObjectives, crankedObjective)
 		e.store.ReleaseChannelFromOwnership(crankedObjective.OwnsChannel())
-		err = e.SpawnConsensusChannelIfDirectFundObjective(crankedObjective) // Here we assume that every directfund.Objective is for a ledger channel.
+		err = e.SpawnLedgerChannelIfDirectFundObjective(crankedObjective) // Here we assume that every directfund.Objective is for a ledger channel.
 		if err != nil {
 			return
 		}
@@ -293,10 +293,10 @@ func (e *Engine) attemptProgress(objective protocols.Objective) (outgoing Object
 	return
 }
 
-// SpawnConsensusChannelIfDirectFundObjective will attempt to create and store a ConsensusChannel derived from the supplied Objective iff it is a directfund.Objective.
-func (e Engine) SpawnConsensusChannelIfDirectFundObjective(crankedObjective protocols.Objective) error {
+// SpawnLedgerChannelIfDirectFundObjective will attempt to create and store a ConsensusChannel derived from the supplied Objective iff it is a directfund.Objective.
+func (e Engine) SpawnLedgerChannelIfDirectFundObjective(crankedObjective protocols.Objective) error {
 	if dfo, isDfo := crankedObjective.(*directfund.Objective); isDfo {
-		c, err := dfo.CreateConsensusChannel()
+		c, err := dfo.CreateLedgerChannel()
 		if err != nil {
 			return fmt.Errorf("could not create consensus channel for objective %s: %w", crankedObjective.Id(), err)
 		}

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -130,7 +130,7 @@ func (ms *MockStore) SetObjective(obj protocols.Objective) error {
 				return fmt.Errorf("error setting channel %s from objective %s: %w", ch.Id, obj.Id(), err)
 			}
 		case *consensus_channel.ConsensusChannel:
-			err := ms.SetConsensusChannel(ch)
+			err := ms.SetLedgerChannel(ch)
 			if err != nil {
 				return fmt.Errorf("error setting consensus channel %s from objective %s: %w", ch.Id, obj.Id(), err)
 			}
@@ -165,8 +165,8 @@ func (ms *MockStore) SetChannel(ch *channel.Channel) error {
 	return nil
 }
 
-// SetConsensusChannel sets the channel in the store.
-func (ms *MockStore) SetConsensusChannel(ch *consensus_channel.ConsensusChannel) error {
+// SetLedgerChannel sets the channel in the store.
+func (ms *MockStore) SetLedgerChannel(ch *consensus_channel.ConsensusChannel) error {
 	chJSON, err := ch.MarshalJSON()
 
 	if err != nil {
@@ -254,9 +254,9 @@ func (ms *MockStore) GetConsensusChannelById(id types.Destination) (channel *con
 	return ch, nil
 }
 
-// GetConsensusChannel returns a ConsensusChannel between the calling client and
+// GetLedgerChannel returns a ConsensusChannel between the calling client and
 // the supplied counterparty, if such channel exists
-func (ms *MockStore) GetConsensusChannel(counterparty types.Address) (channel *consensus_channel.ConsensusChannel, ok bool) {
+func (ms *MockStore) GetLedgerChannel(counterparty types.Address) (channel *consensus_channel.ConsensusChannel, ok bool) {
 
 	ms.consensusChannels.Range(func(key string, chJSON []byte) bool {
 

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -196,4 +196,3 @@ func TestConsensusChannelStore(t *testing.T) {
 		t.Fatalf("fetched result different than expected %s", diff)
 	}
 }
-2

--- a/client/engine/store/mockstore_test.go
+++ b/client/engine/store/mockstore_test.go
@@ -137,7 +137,7 @@ func TestConsensusChannelStore(t *testing.T) {
 
 	ms := store.NewMockStore(sk)
 
-	got, ok := ms.GetConsensusChannel(ta.Alice.Address)
+	got, ok := ms.GetLedgerChannel(ta.Alice.Address)
 	if ok {
 		t.Fatalf("expected not to find the a consensus channel, but found %v", got)
 	}
@@ -178,11 +178,11 @@ func TestConsensusChannelStore(t *testing.T) {
 	// The store only deals with ConsensusChannels
 	want := leader
 
-	if err := ms.SetConsensusChannel(&want); err != nil {
+	if err := ms.SetLedgerChannel(&want); err != nil {
 		t.Fatalf("error setting consensus channel %v: %s", want, err.Error())
 	}
 
-	got, ok = ms.GetConsensusChannel(fp.Participants[1])
+	got, ok = ms.GetLedgerChannel(fp.Participants[1])
 
 	if !ok {
 		t.Fatalf("expected to find the inserted consensus channel, but didn't")
@@ -196,3 +196,4 @@ func TestConsensusChannelStore(t *testing.T) {
 		t.Fatalf("fetched result different than expected %s", diff)
 	}
 }
+2

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -21,7 +21,7 @@ type Store interface {
 	GetObjectiveById(protocols.ObjectiveId) (protocols.Objective, error)          // Read an existing objective
 	GetObjectiveByChannelId(types.Destination) (obj protocols.Objective, ok bool) // Get the objective that currently owns the channel with the supplied ChannelId
 	SetObjective(protocols.Objective) error                                       // Write an objective
-	GetTwoPartyLedger(firstParty types.Address, secondParty types.Address) (channel *channel.TwoPartyLedger, ok bool)
+
 	GetChannelById(id types.Destination) (c *channel.Channel, ok bool)
 	SetChannel(*channel.Channel) error
 

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -27,10 +27,10 @@ type Store interface {
 
 	ReleaseChannelFromOwnership(types.Destination) // Release channel from being owned by any objective
 
-	ConsensusChannelStore
+	LedgerChannelStore
 }
 
-type ConsensusChannelStore interface {
-	GetConsensusChannel(counterparty types.Address) (channel *consensus_channel.ConsensusChannel, ok bool)
-	SetConsensusChannel(*consensus_channel.ConsensusChannel) error
+type LedgerChannelStore interface {
+	GetLedgerChannel(counterparty types.Address) (channel *consensus_channel.ConsensusChannel, ok bool)
+	SetLedgerChannel(*consensus_channel.ConsensusChannel) error
 }

--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -59,9 +59,9 @@ func TestDirectFundIntegration(t *testing.T) {
 
 		// each client fetches the ConsensusChannel by reference to their counterparty
 		if store.GetChannelSecretKey() == &alice.PrivateKey {
-			con, ok = store.GetConsensusChannel(*clientB.Address)
+			con, ok = store.GetLedgerChannel(*clientB.Address)
 		} else {
-			con, ok = store.GetConsensusChannel(*clientA.Address)
+			con, ok = store.GetLedgerChannel(*clientA.Address)
 		}
 
 		if !ok {

--- a/internal/testdata/channels.go
+++ b/internal/testdata/channels.go
@@ -47,7 +47,7 @@ func mockConsensusChannel(counterparty types.Address) (ledger *consensus_channel
 		Outcome:           ts.Outcome,
 	}
 	testObj, _ := directfund.NewObjective(request, false)
-	cc, _ := testObj.CreateConsensusChannel()
+	cc, _ := testObj.CreateLedgerChannel()
 	return cc, true
 }
 

--- a/internal/testdata/channels.go
+++ b/internal/testdata/channels.go
@@ -14,13 +14,11 @@ import (
 )
 
 type channelCollection struct {
-	// MockTwoPartyLedger constructs and returns a ledger channel
-	MockTwoPartyLedger   virtualfund.GetTwoPartyLedgerFunction
+	// MockConsensusChannel constructs and returns a ledger channel
 	MockConsensusChannel virtualfund.GetTwoPartyConsensusLedgerFunction
 }
 
 var Channels channelCollection = channelCollection{
-	MockTwoPartyLedger:   mockTwoPartyLedger,
 	MockConsensusChannel: mockConsensusChannel,
 }
 

--- a/internal/testdata/channels.go
+++ b/internal/testdata/channels.go
@@ -15,7 +15,7 @@ import (
 
 type channelCollection struct {
 	// MockConsensusChannel constructs and returns a ledger channel
-	MockConsensusChannel virtualfund.GetTwoPartyConsensusLedgerFunction
+	MockConsensusChannel virtualfund.GetLedgerFunction
 }
 
 var Channels channelCollection = channelCollection{
@@ -67,7 +67,7 @@ type TestLedger struct {
 //
 // The returned function inspects the ledgers from the ledger set, and returns
 // the ledger between the seeker and given counterparty from the seeker's perspective.
-func (l LedgerNetwork) GetLedgerLookup(seeker types.Address) virtualfund.GetTwoPartyConsensusLedgerFunction {
+func (l LedgerNetwork) GetLedgerLookup(seeker types.Address) virtualfund.GetLedgerFunction {
 	var myLedgers []TestLedger
 
 	// package all of seeker's ledgers for the closure

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -83,7 +83,7 @@ func genericVFO() virtualfund.Objective {
 	})
 	lookup := ledgerPath.GetLedgerLookup(testactors.Alice.Address)
 
-	testVFO, err := virtualfund.NewObjective(request, Channels.MockTwoPartyLedger, lookup)
+	testVFO, err := virtualfund.NewObjective(request, lookup)
 	if err != nil {
 		panic(fmt.Errorf("error constructing genericVFO: %w", err))
 	}

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -133,8 +133,8 @@ func (dfo Objective) GetStatus() protocols.ObjectiveStatus {
 	return dfo.Status
 }
 
-// CreateConsensusChannel creates a ConsensusChannel from the Objective by extracting signatures and a single asset outcome from the post fund state.
-func (dfo *Objective) CreateConsensusChannel() (*consensus_channel.ConsensusChannel, error) {
+// CreateLedgerChannel creates a ConsensusChannel from the Objective by extracting signatures and a single asset outcome from the post fund state.
+func (dfo *Objective) CreateLedgerChannel() (*consensus_channel.ConsensusChannel, error) {
 	ledger := dfo.C
 
 	if !ledger.PostFundComplete() {

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -128,7 +128,7 @@ type Objective struct {
 }
 
 // NewObjective creates a new virtual funding objective from a given request.
-func NewObjective(request ObjectiveRequest, getTwoPartyLedger GetTwoPartyLedgerFunction, getTwoPartyConsensusLedger GetTwoPartyConsensusLedgerFunction) (Objective, error) {
+func NewObjective(request ObjectiveRequest, getTwoPartyConsensusLedger GetTwoPartyConsensusLedgerFunction) (Objective, error) {
 	rightCC, ok := getTwoPartyConsensusLedger(request.Intermediary)
 
 	if !ok {
@@ -490,9 +490,6 @@ func (o *Objective) isBob() bool {
 	return o.MyRole == o.n+1
 }
 
-// GetTwoPartyLedgerFunction specifies a function that can be used to retreive ledgers from a store.
-type GetTwoPartyLedgerFunction func(firstParty types.Address, secondParty types.Address) (ledger *channel.TwoPartyLedger, ok bool)
-
 // todo: #420 assume name and godoc from GetTwoPartyLedgerFunction
 type GetTwoPartyConsensusLedgerFunction func(counterparty types.Address) (ledger *consensus_channel.ConsensusChannel, ok bool)
 
@@ -501,7 +498,6 @@ type GetTwoPartyConsensusLedgerFunction func(counterparty types.Address) (ledger
 func ConstructObjectiveFromMessage(
 	m protocols.Message,
 	myAddress types.Address,
-	getTwoPartyLedger GetTwoPartyLedgerFunction,
 	getTwoPartyConsensusLedger GetTwoPartyConsensusLedgerFunction,
 ) (Objective, error) {
 	if len(m.SignedStates) != 1 {


### PR DESCRIPTION
closes #573, toward #420, #429

PR: 
- removes the unused `GetTwoPartyConsensusLedger` from `virtualfund.ConstructObjectiveFromMessage`
- removes the (now) unused function type `GetTwoPartyLedger`
- shortens the name `GetTwoPartyConsensusLedgerFunction` to `GetLedgerFunction`
- refactors a number of overly specified references to ConsensusChannels to read as references to LedgerChannels

---

#### Code quality

- [x] I have written clear commit messages
- [ ] I have performed a self-review of my own code
- [ ] This change does not have an unduly wide scope
  - bled into a couple of separate issues accidentally
  - still a straightforward refactor PR: zero functional changes
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] ~I have added tests that prove my fix is effective or that my feature works, if necessary~
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
