### PR TITLE
Remove GetTwoPartyLedgerFunction type

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -194,7 +194,7 @@ func (e *Engine) handleAPIEvent(apiEvent APIEvent) (ObjectiveChangeEvent, error)
 		switch request := (apiEvent.ObjectiveToSpawn).(type) {
 
 		case virtualfund.ObjectiveRequest:
-			vfo, err := virtualfund.NewObjective(request, e.store.GetTwoPartyLedger, e.store.GetConsensusChannel)
+			vfo, err := virtualfund.NewObjective(request, e.store.GetConsensusChannel)
 			if err != nil {
 				return ObjectiveChangeEvent{}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 			}
@@ -344,7 +344,7 @@ func (e *Engine) constructObjectiveFromMessage(message protocols.Message) (proto
 
 		return &dfo, err
 	case virtualfund.IsVirtualFundObjective(message.ObjectiveId):
-		vfo, err := virtualfund.ConstructObjectiveFromMessage(message, *e.store.GetAddress(), e.store.GetTwoPartyLedger, e.store.GetConsensusChannel)
+		vfo, err := virtualfund.ConstructObjectiveFromMessage(message, *e.store.GetAddress(), e.store.GetConsensusChannel)
 		if err != nil {
 			return &virtualfund.Objective{}, fmt.Errorf("could not create virtual fund objective from message: %w", err)
 		}

--- a/client/engine/store/mockstore.go
+++ b/client/engine/store/mockstore.go
@@ -206,35 +206,6 @@ func (ms *MockStore) getChannelById(id types.Destination) (channel.Channel, erro
 	return ch, nil
 }
 
-// GetTwoPartyLedger returns a ledger channel between the two parties if it exists.
-func (ms *MockStore) GetTwoPartyLedger(firstParty types.Address, secondParty types.Address) (*channel.TwoPartyLedger, bool) {
-	var ledger *channel.TwoPartyLedger
-	var ok bool
-
-	ms.channels.Range(func(key string, chJSON []byte) bool {
-
-		var ch channel.Channel
-		err := json.Unmarshal(chJSON, &ch)
-
-		if err != nil {
-			return true // channel not found, continue looking
-		}
-
-		if len(ch.Participants) == 2 {
-			// TODO: Should order matter?
-			if ch.Participants[0] == firstParty && ch.Participants[1] == secondParty {
-				ledger = &channel.TwoPartyLedger{Channel: ch}
-				ok = true
-				return false // we have found the target channel: break the Range loop
-			}
-		}
-
-		return true // channel not found: continue looking
-	})
-
-	return ledger, ok
-}
-
 // GetConsensusChannelById returns a ConsensusChannel with the given channel id
 func (ms *MockStore) GetConsensusChannelById(id types.Destination) (channel *consensus_channel.ConsensusChannel, err error) {
 

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -21,7 +21,7 @@ type Store interface {
 	GetObjectiveById(protocols.ObjectiveId) (protocols.Objective, error)          // Read an existing objective
 	GetObjectiveByChannelId(types.Destination) (obj protocols.Objective, ok bool) // Get the objective that currently owns the channel with the supplied ChannelId
 	SetObjective(protocols.Objective) error                                       // Write an objective
-	GetTwoPartyLedger(firstParty types.Address, secondParty types.Address) (channel *channel.TwoPartyLedger, ok bool)
+
 	GetChannelById(id types.Destination) (c *channel.Channel, ok bool)
 	SetChannel(*channel.Channel) error
 

--- a/internal/testdata/channels.go
+++ b/internal/testdata/channels.go
@@ -14,13 +14,11 @@ import (
 )
 
 type channelCollection struct {
-	// MockTwoPartyLedger constructs and returns a ledger channel
-	MockTwoPartyLedger   virtualfund.GetTwoPartyLedgerFunction
+	// MockConsensusChannel constructs and returns a ledger channel
 	MockConsensusChannel virtualfund.GetTwoPartyConsensusLedgerFunction
 }
 
 var Channels channelCollection = channelCollection{
-	MockTwoPartyLedger:   mockTwoPartyLedger,
 	MockConsensusChannel: mockConsensusChannel,
 }
 

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -83,7 +83,7 @@ func genericVFO() virtualfund.Objective {
 	})
 	lookup := ledgerPath.GetLedgerLookup(testactors.Alice.Address)
 
-	testVFO, err := virtualfund.NewObjective(request, Channels.MockTwoPartyLedger, lookup)
+	testVFO, err := virtualfund.NewObjective(request, lookup)
 	if err != nil {
 		panic(fmt.Errorf("error constructing genericVFO: %w", err))
 	}

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -490,7 +490,8 @@ func (o *Objective) isBob() bool {
 	return o.MyRole == o.n+1
 }
 
-// todo: #420 assume name and godoc from GetTwoPartyLedgerFunction
+// GetTwoPartyConsensusLedgerFuncion describes functions which return a ConsensusChannel ledger channel between
+// the calling client and the given counterparty, if such a channel exists.
 type GetTwoPartyConsensusLedgerFunction func(counterparty types.Address) (ledger *consensus_channel.ConsensusChannel, ok bool)
 
 // ConstructObjectiveFromMessage takes in a message and constructs an objective from it.

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -128,7 +128,7 @@ type Objective struct {
 }
 
 // NewObjective creates a new virtual funding objective from a given request.
-func NewObjective(request ObjectiveRequest, getTwoPartyLedger GetTwoPartyLedgerFunction, getTwoPartyConsensusLedger GetTwoPartyConsensusLedgerFunction) (Objective, error) {
+func NewObjective(request ObjectiveRequest, getTwoPartyConsensusLedger GetTwoPartyConsensusLedgerFunction) (Objective, error) {
 	rightCC, ok := getTwoPartyConsensusLedger(request.Intermediary)
 
 	if !ok {
@@ -490,9 +490,6 @@ func (o *Objective) isBob() bool {
 	return o.MyRole == o.n+1
 }
 
-// GetTwoPartyLedgerFunction specifies a function that can be used to retreive ledgers from a store.
-type GetTwoPartyLedgerFunction func(firstParty types.Address, secondParty types.Address) (ledger *channel.TwoPartyLedger, ok bool)
-
 // todo: #420 assume name and godoc from GetTwoPartyLedgerFunction
 type GetTwoPartyConsensusLedgerFunction func(counterparty types.Address) (ledger *consensus_channel.ConsensusChannel, ok bool)
 
@@ -501,7 +498,6 @@ type GetTwoPartyConsensusLedgerFunction func(counterparty types.Address) (ledger
 func ConstructObjectiveFromMessage(
 	m protocols.Message,
 	myAddress types.Address,
-	getTwoPartyLedger GetTwoPartyLedgerFunction,
 	getTwoPartyConsensusLedger GetTwoPartyConsensusLedgerFunction,
 ) (Objective, error) {
 	if len(m.SignedStates) != 1 {


### PR DESCRIPTION
closes https://github.com/statechannels/go-nitro/issues/573, toward https://github.com/statechannels/go-nitro/issues/420

PR:

- removes the unused GetTwoPartyConsensusLedger from virtualfund.ConstructObjectiveFromMessage
- removes the (now) unused function type GetTwoPartyLedger

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] ~I have added tests that prove my fix is effective or that my feature works, if necessary~
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
