### PR TITLE
Tidy 420 todos

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -182,17 +182,6 @@ func (c *ConsensusChannel) ConsensusVars() Vars {
 	return c.current.Vars
 }
 
-// LatestProposedVars is TEMPORARY CODE used for external assertions
-// todo 420: delete this
-func (c *ConsensusChannel) LatestProposedVars() Vars {
-	vars, err := c.latestProposedVars()
-	if err != nil {
-		panic(err)
-	}
-
-	return vars
-}
-
 // latestProposedVars returns the latest proposed vars in a consensus channel
 // by cloning its current vars and applying each proposal in the queue
 func (c *ConsensusChannel) latestProposedVars() (Vars, error) {

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -18,8 +18,6 @@ import (
 // TestBenchmark sets up three clients, then runs a virtual funding benchmark, printing the duration
 // to the screen.
 func TestBenchmark(t *testing.T) {
-	// todo: #420 unskip
-	t.Skip()
 
 	// Setup logging
 	logDestination := &bytes.Buffer{}

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -1,3 +1,4 @@
+// todo: #420 delete this file
 package virtualfund
 
 import (
@@ -100,7 +101,6 @@ func compareGuarantees(a, b consensus_channel.Guarantee) string {
 // }
 
 func TestSingleHopVirtualFund(t *testing.T) {
-	// todo: #420 unskip
 	t.Skip()
 
 	// assertSideEffectsContainsMessageWith fails the test instantly if the supplied side effects does not contain a message for the supplied actor with the supplied expected signed state.

--- a/protocols/virtualfund/virtualfund-single-hop_test.go
+++ b/protocols/virtualfund/virtualfund-single-hop_test.go
@@ -203,7 +203,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 			ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareConsensusChannels(my.Role)
 
 			// Assert that a valid set of constructor args does not result in an error
-			o, err := constructFromState(false, vPreFund, my.Address, ledgerChannelToMyLeft, ledgerChannelToMyRight) // todo: #420 deprecate TwoPartyLedgers
+			o, err := constructFromState(false, vPreFund, my.Address, ledgerChannelToMyLeft, ledgerChannelToMyRight)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -252,7 +252,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 		testclone := func(t *testing.T) {
 			// ledgerChannelToMyLeft, ledgerChannelToMyRight := prepareLedgerChannels(my.Role)
 
-			o, _ := constructFromState(false, vPreFund, my.Address, nil, nil) // todo: #420 deprecate TwoPartyLedgers
+			o, _ := constructFromState(false, vPreFund, my.Address, nil, nil)
 
 			clone := o.clone()
 
@@ -263,7 +263,7 @@ func TestSingleHopVirtualFund(t *testing.T) {
 
 		testCrank := func(t *testing.T) {
 			leftCC, rightCC := prepareConsensusChannels(my.Role)
-			var s, _ = constructFromState(false, vPreFund, my.Address, leftCC, rightCC) // todo: #420 deprecate TwoPartyLedgers
+			var s, _ = constructFromState(false, vPreFund, my.Address, leftCC, rightCC)
 			// Assert that cranking an unapproved objective returns an error
 			if _, _, _, err := s.Crank(&my.PrivateKey); err == nil {
 				t.Fatal(`Expected error when cranking unapproved objective, but got nil`)

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -307,10 +307,10 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 	var toMyRightId types.Destination
 
 	if !o.isAlice() {
-		toMyLeftId = o.ToMyLeft.Channel.Id // Avoid this if it is nil // todo: #420 deprecate
+		toMyLeftId = o.ToMyLeft.Channel.Id // Avoid this if it is nil
 	}
 	if !o.isBob() {
-		toMyRightId = o.ToMyRight.Channel.Id // Avoid this if it is nil // todo: #420 deprecate
+		toMyRightId = o.ToMyRight.Channel.Id // Avoid this if it is nil
 	}
 
 	for _, sp := range event.SignedProposals {
@@ -571,7 +571,7 @@ func (c *Connection) expectedProposal() consensus_channel.Proposal {
 
 // proposeLedgerUpdate will propose a ledger update to the channel by crafting a new state
 func (o *Objective) proposeLedgerUpdate(connection Connection, sk *[]byte) (protocols.SideEffects, error) {
-	ledger := connection.Channel // todo: #420 deprecate - replace with LeaderChannel.Propose workflow
+	ledger := connection.Channel
 
 	if !ledger.IsLeader() {
 		return protocols.SideEffects{}, errors.New("only the proposer can propose a ledger update")
@@ -623,7 +623,7 @@ func (o *Objective) createSignedProposalMessage(sp consensus_channel.SignedPropo
 // If the user is the follower then they will sign a ledger state proposal if it satisfies their expected guarantees.
 func (o *Objective) updateLedgerWithGuarantee(ledgerConnection Connection, sk *[]byte) (protocols.SideEffects, error) {
 
-	ledger := ledgerConnection.Channel // todo: #420 deprecate
+	ledger := ledgerConnection.Channel
 
 	var sideEffects protocols.SideEffects
 	g := ledgerConnection.getExpectedGuarantee()


### PR DESCRIPTION
This PR prunes out a number of stale todos respecting #420. Recommend a per-commit read, as some context is added where todos are removed with no accompanying code changes.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
