### PR TITLE
Refactor Update on Objective interface

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log"
 
-	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
@@ -149,12 +148,7 @@ func (e *Engine) handleMessage(message protocols.Message) (ObjectiveChangeEvent,
 			return ObjectiveChangeEvent{}, err
 		}
 
-		event := protocols.ObjectiveEvent{
-			ObjectiveId:     entry.ObjectiveId,
-			SignedProposals: []consensus_channel.SignedProposal{},
-			SignedStates:    []state.SignedState{entry.Payload},
-		}
-		updatedObjective, err := objective.Update(event)
+		updatedObjective, err := objective.UpdateWithState(entry.Payload)
 		if err != nil {
 			return ObjectiveChangeEvent{}, err
 		}
@@ -175,12 +169,7 @@ func (e *Engine) handleMessage(message protocols.Message) (ObjectiveChangeEvent,
 			return ObjectiveChangeEvent{}, err
 		}
 
-		event := protocols.ObjectiveEvent{
-			ObjectiveId:     entry.ObjectiveId,
-			SignedProposals: []consensus_channel.SignedProposal{entry.Payload},
-			SignedStates:    []state.SignedState{},
-		}
-		updatedObjective, err := objective.Update(event)
+		updatedObjective, err := objective.UpdateWithProposal(entry.Payload)
 		if err != nil {
 			return ObjectiveChangeEvent{}, err
 		}

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -91,21 +91,6 @@ func TestUpdate(t *testing.T) {
 
 	var stateToSign state.State = s.C.PreFundState()
 	var correctSignatureByParticipant, _ = stateToSign.Sign(alice.PrivateKey)
-	// Prepare an event with a mismatched channelId
-	e := protocols.ObjectiveEvent{
-		ObjectiveId: "some-id",
-	}
-	// Assert that Updating the objective with such an event returns an error
-	// TODO is this the behaviour we want? Below with the signatures, we prefer a log + NOOP (no error)
-	if _, err := s.Update(e); err == nil {
-		t.Error(`ChannelId mismatch -- expected an error but did not get one`)
-	}
-
-	// Now modify the event to give it the "correct" objective id,
-	// and make a new Sigs map.
-	// This prepares us for the rest of the test. We will reuse the same event multiple times
-	e.ObjectiveId = s.Id()
-	e.SignedStates = make([]state.SignedState, 0)
 
 	// Next, attempt to update the objective with correct signature by a participant on a relevant state
 	// Assert that this results in an appropriate change in the extended state of the objective
@@ -114,8 +99,8 @@ func TestUpdate(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	e.SignedStates = append(e.SignedStates, ss)
-	updatedObjective, err := s.Update(e)
+
+	updatedObjective, err := s.UpdateWithState(ss)
 	if err != nil {
 		t.Error(err)
 	}

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -64,10 +64,11 @@ type Storable interface {
 type Objective interface {
 	Id() ObjectiveId
 
-	Approve() Objective                                                  // returns an updated Objective (a copy, no mutation allowed), does not declare effects
-	Reject() Objective                                                   // returns an updated Objective (a copy, no mutation allowed), does not declare effects
-	Update(event ObjectiveEvent) (Objective, error)                      // returns an updated Objective (a copy, no mutation allowed), does not declare effects
-	Crank(secretKey *[]byte) (Objective, SideEffects, WaitingFor, error) // does *not* accept an event, but *does* accept a pointer to a signing key; declare side effects; return an updated Objective
+	Approve() Objective                                                       // returns an updated Objective (a copy, no mutation allowed), does not declare effects
+	Reject() Objective                                                        // returns an updated Objective (a copy, no mutation allowed), does not declare effects
+	UpdateWithState(ss state.SignedState) (Objective, error)                  // returns an updated Objective (a copy, no mutation allowed), does not declare effects
+	UpdateWithProposal(p consensus_channel.SignedProposal) (Objective, error) // returns an updated Objective (a copy, no mutation allowed), does not declare effects
+	Crank(secretKey *[]byte) (Objective, SideEffects, WaitingFor, error)      // does *not* accept an event, but *does* accept a pointer to a signing key; declare side effects; return an updated Objective
 
 	// Related returns a slice of related objects that need to be stored along with the objective
 	Related() []Storable

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -41,13 +41,6 @@ type AdjudicationStatus struct {
 	// TODO eventually this struct will contain the other fields stored in (or committed to by) the adjudicator
 }
 
-// ObjectiveEvent holds information used to update an Objective. Some fields may be nil.
-type ObjectiveEvent struct {
-	ObjectiveId     ObjectiveId
-	SignedStates    []state.SignedState
-	SignedProposals []consensus_channel.SignedProposal
-}
-
 // Storable is an object that can be stored by the store.
 type Storable interface {
 	json.Marshaler

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -9,7 +9,6 @@ import (
 	ta "github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/internal/testhelpers"
 	. "github.com/statechannels/go-nitro/internal/testhelpers"
-	"github.com/statechannels/go-nitro/protocols"
 )
 
 var alice = ta.Alice
@@ -43,8 +42,7 @@ func TestInvalidUpdate(t *testing.T) {
 	// Sign the final state by some other participant
 	signStateByOthers(alice, signedFinal)
 
-	e := protocols.ObjectiveEvent{ObjectiveId: virtualDefund.Id(), SignedStates: []state.SignedState{signedFinal}}
-	_, err := virtualDefund.Update(e)
+	_, err := virtualDefund.UpdateWithState(signedFinal)
 	if err.Error() != "event channelId out of scope of objective" {
 		t.Errorf("Expected error for channelId being out of scope, got %v", err)
 	}
@@ -62,9 +60,7 @@ func testUpdateAs(my ta.Actor) func(t *testing.T) {
 		// Sign the final state by some other participant
 		signStateByOthers(my, signedFinal)
 
-		e := protocols.ObjectiveEvent{ObjectiveId: virtualDefund.Id(), SignedStates: []state.SignedState{signedFinal}}
-
-		updatedObj, err := virtualDefund.Update(e)
+		updatedObj, err := virtualDefund.UpdateWithState(signedFinal)
 		updated := updatedObj.(*Objective)
 		for _, a := range allActors {
 			if a.Role != my.Role {


### PR DESCRIPTION
Now that the engine is responsible for making sure proposals and states are handled in a specific order, it makes sense to simplify `Update` to only deal with one value at a time.

To accomplish this I've split `Update` into `UpdateWithState` and `UpdateWithProposal`.  We no longer deal with an `ObjectiveUpdateEvent`. This simplifies the code slightly.