### PR TITLE
rename left/right in CC helper to leader/follower

### DIFF
--- a/protocols/virtualfund/helpers_test.go
+++ b/protocols/virtualfund/helpers_test.go
@@ -10,42 +10,42 @@ import (
 )
 
 // prepareConsensusChannel prepares a consensus channel with a consensus outcome
-//  - allocating 6 to left
-//  - allocating 4 to right
+//  - allocating 6 to leader
+//  - allocating 4 to follower
 //  - including the given guarantees
-func prepareConsensusChannel(role uint, left, right testactors.Actor, guarantees ...consensus_channel.Guarantee) *consensus_channel.ConsensusChannel {
-	return prepareConsensusChannelHelper(role, left, right, 6, 4, 1, guarantees...)
+func prepareConsensusChannel(role uint, leader, follower testactors.Actor, guarantees ...consensus_channel.Guarantee) *consensus_channel.ConsensusChannel {
+	return prepareConsensusChannelHelper(role, leader, follower, 6, 4, 1, guarantees...)
 }
 
 // consensusStateSignatures prepares a consensus channel with a consensus outcome and returns the signatures on the consensus state
-func consensusStateSignatures(left, right testactors.Actor, guarantees ...consensus_channel.Guarantee) [2]state.Signature {
-	return prepareConsensusChannelHelper(0, left, right, 0, 0, 2, guarantees...).Signatures()
+func consensusStateSignatures(leader, follower testactors.Actor, guarantees ...consensus_channel.Guarantee) [2]state.Signature {
+	return prepareConsensusChannelHelper(0, leader, follower, 0, 0, 2, guarantees...).Signatures()
 }
 
-func prepareConsensusChannelHelper(role uint, left, right testactors.Actor, leftBalance, rightBalance, turnNum int, guarantees ...consensus_channel.Guarantee) *consensus_channel.ConsensusChannel {
+func prepareConsensusChannelHelper(role uint, leader, follower testactors.Actor, leftBalance, rightBalance, turnNum int, guarantees ...consensus_channel.Guarantee) *consensus_channel.ConsensusChannel {
 	fp := state.FixedPart{
 		ChainId:           big.NewInt(9001),
-		Participants:      []types.Address{left.Address, right.Address},
+		Participants:      []types.Address{leader.Address, follower.Address},
 		ChannelNonce:      big.NewInt(0),
 		AppDefinition:     types.Address{},
 		ChallengeDuration: big.NewInt(45),
 	}
 
-	leftBal := consensus_channel.NewBalance(left.Destination(), big.NewInt(int64(leftBalance)))
-	rightBal := consensus_channel.NewBalance(right.Destination(), big.NewInt(int64(rightBalance)))
+	leaderBal := consensus_channel.NewBalance(leader.Destination(), big.NewInt(int64(leftBalance)))
+	followerBal := consensus_channel.NewBalance(follower.Destination(), big.NewInt(int64(rightBalance)))
 
-	lo := *consensus_channel.NewLedgerOutcome(types.Address{}, leftBal, rightBal, guarantees)
+	lo := *consensus_channel.NewLedgerOutcome(types.Address{}, leaderBal, followerBal, guarantees)
 
 	signedVars := consensus_channel.SignedVars{Vars: consensus_channel.Vars{Outcome: lo, TurnNum: uint64(turnNum)}}
-	leftSig, err := signedVars.Vars.AsState(fp).Sign(left.PrivateKey)
+	leaderSig, err := signedVars.Vars.AsState(fp).Sign(leader.PrivateKey)
 	if err != nil {
 		panic(err)
 	}
-	rightSig, err := signedVars.Vars.AsState(fp).Sign(right.PrivateKey)
+	followerSig, err := signedVars.Vars.AsState(fp).Sign(follower.PrivateKey)
 	if err != nil {
 		panic(err)
 	}
-	sigs := [2]state.Signature{leftSig, rightSig}
+	sigs := [2]state.Signature{leaderSig, followerSig}
 
 	var cc consensus_channel.ConsensusChannel
 


### PR DESCRIPTION
closes #596

PR renames the participants in `prepareConsensusChannelHelper` (and associates) from `left`, `right` to `leader`, `follower`.

Clarifying: the leader and follower designations of a consensus ledger channel are a permanent characteristic of the channel. Left and right designations are contextual, and depend on the channel's role in a vfo.

```
// vf1 - alice is leader and left in the [a i] channel
alice -[a i]- irene -[i b]- bob 
// vf2 - alice is leader and right in the [a i] channel
bob -[i b]- irene -[a i]- alice
```

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] ~I have added tests that prove my fix is effective or that my feature works, if necessary~
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
