### PR TITLE
rename consensus channel to ledger channel

### DIFF
--- a/channel/ledger/clone_test.go
+++ b/channel/ledger/clone_test.go
@@ -1,4 +1,4 @@
-package consensus_channel
+package ledger
 
 import (
 	"math/big"
@@ -22,7 +22,7 @@ func TestClone(t *testing.T) {
 	bobsSig, _ := initialVars.AsState(fp()).Sign(bob.PrivateKey)
 	sigs := [2]state.Signature{aliceSig, bobsSig}
 
-	cc, err := newConsensusChannel(fp(), Leader, 0, outcome, sigs)
+	cc, err := newLedgerChannel(fp(), Leader, 0, outcome, sigs)
 
 	if err != nil {
 		t.Fatal(err)
@@ -30,10 +30,10 @@ func TestClone(t *testing.T) {
 
 	clone := cc.Clone()
 
-	compareConsensusChannels := func(a, b ConsensusChannel) string {
+	compareLedgerChannels := func(a, b LedgerChannel) string {
 		return cmp.Diff(&a, &b,
 			cmp.AllowUnexported(
-				ConsensusChannel{},
+				LedgerChannel{},
 				Vars{},
 				LedgerOutcome{},
 				Guarantee{},
@@ -42,7 +42,7 @@ func TestClone(t *testing.T) {
 				state.SignedState{}))
 	}
 
-	if diff := compareConsensusChannels(cc, *clone); diff != "" {
+	if diff := compareLedgerChannels(cc, *clone); diff != "" {
 		t.Errorf("Clone: mismatch (-want +got):\n%s", diff)
 	}
 

--- a/channel/ledger/follower_channel.go
+++ b/channel/ledger/follower_channel.go
@@ -1,4 +1,4 @@
-package consensus_channel
+package ledger
 
 import (
 	"fmt"
@@ -15,14 +15,14 @@ var ErrInvalidProposalSignature = fmt.Errorf("invalid signature for proposal")
 var ErrInvalidTurnNum = fmt.Errorf("the proposal turn number is not the next turn number")
 
 // NewFollowerChannel constructs a new FollowerChannel
-func NewFollowerChannel(fp state.FixedPart, turnNum uint64, outcome LedgerOutcome, signatures [2]state.Signature) (ConsensusChannel, error) {
-	return newConsensusChannel(fp, Follower, turnNum, outcome, signatures)
+func NewFollowerChannel(fp state.FixedPart, turnNum uint64, outcome LedgerOutcome, signatures [2]state.Signature) (LedgerChannel, error) {
+	return newLedgerChannel(fp, Follower, turnNum, outcome, signatures)
 }
 
 // SignNextProposal is called by the follower and inspects whether the
 // expected proposal matches the first proposal in the queue. If so,
 // the proposal is removed from the queue and integrated into the channel state.
-func (c *ConsensusChannel) SignNextProposal(expectedProposal Proposal, sk []byte) (SignedProposal, error) {
+func (c *LedgerChannel) SignNextProposal(expectedProposal Proposal, sk []byte) (SignedProposal, error) {
 	if c.MyIndex != Follower {
 		return SignedProposal{}, ErrNotFollower
 	}
@@ -67,7 +67,7 @@ func (c *ConsensusChannel) SignNextProposal(expectedProposal Proposal, sk []byte
 }
 
 // followerReceive is called by the follower to validate a proposal from the leader and add it to the proposal queue
-func (c *ConsensusChannel) followerReceive(p SignedProposal) error {
+func (c *LedgerChannel) followerReceive(p SignedProposal) error {
 	if c.MyIndex != Follower {
 		return ErrNotFollower
 	}

--- a/channel/ledger/follower_channel_test.go
+++ b/channel/ledger/follower_channel_test.go
@@ -1,4 +1,4 @@
-package consensus_channel
+package ledger
 
 import (
 	"errors"

--- a/channel/ledger/helpers_test.go
+++ b/channel/ledger/helpers_test.go
@@ -1,4 +1,4 @@
-package consensus_channel
+package ledger
 
 import (
 	"math/big"

--- a/channel/ledger/leader_channel.go
+++ b/channel/ledger/leader_channel.go
@@ -1,4 +1,4 @@
-package consensus_channel
+package ledger
 
 import (
 	"fmt"
@@ -9,14 +9,14 @@ import (
 var ErrNotLeader = fmt.Errorf("method may only be called by the channel leader")
 
 // NewLeaderChannel constructs a new LeaderChannel
-func NewLeaderChannel(fp state.FixedPart, turnNum uint64, outcome LedgerOutcome, signatures [2]state.Signature) (ConsensusChannel, error) {
-	return newConsensusChannel(fp, Leader, turnNum, outcome, signatures)
+func NewLeaderChannel(fp state.FixedPart, turnNum uint64, outcome LedgerOutcome, signatures [2]state.Signature) (LedgerChannel, error) {
+	return newLedgerChannel(fp, Leader, turnNum, outcome, signatures)
 }
 
 // IsProposed returns true if a proposal in the queue would lead to g being included in the receiver's outcome, and false otherwise.
 //
 // Specific clarification: If the current outcome already includes g, IsProposed returns false.
-func (c *ConsensusChannel) IsProposed(g Guarantee) (bool, error) {
+func (c *LedgerChannel) IsProposed(g Guarantee) (bool, error) {
 	latest, err := c.latestProposedVars()
 	if err != nil {
 		return false, err
@@ -27,7 +27,7 @@ func (c *ConsensusChannel) IsProposed(g Guarantee) (bool, error) {
 }
 
 // IsProposedNext returns if the next proposal in the queue would lead to g being included in the receiver's outcome, and false otherwise.
-func (c *ConsensusChannel) IsProposedNext(g Guarantee) (bool, error) {
+func (c *LedgerChannel) IsProposedNext(g Guarantee) (bool, error) {
 	vars := Vars{TurnNum: c.current.TurnNum, Outcome: c.current.Outcome.clone()}
 
 	if len(c.proposalQueue) == 0 {
@@ -49,7 +49,7 @@ func (c *ConsensusChannel) IsProposedNext(g Guarantee) (bool, error) {
 //
 // Note: the TurnNum on add is ignored; the correct turn number is computed
 // and applied by c
-func (c *ConsensusChannel) Propose(proposal Proposal, sk []byte) (SignedProposal, error) {
+func (c *LedgerChannel) Propose(proposal Proposal, sk []byte) (SignedProposal, error) {
 	if c.MyIndex != Leader {
 		return SignedProposal{}, ErrNotLeader
 	}
@@ -95,7 +95,7 @@ func (c *ConsensusChannel) Propose(proposal Proposal, sk []byte) (SignedProposal
 // An error is returned if:
 //  - the countersupplied proposal is not found
 //  - or if it is found but not correctly signed by the Follower
-func (c *ConsensusChannel) leaderReceive(countersigned SignedProposal) error {
+func (c *LedgerChannel) leaderReceive(countersigned SignedProposal) error {
 	if c.MyIndex != Leader {
 		return ErrNotLeader
 	}

--- a/channel/ledger/leader_channel_test.go
+++ b/channel/ledger/leader_channel_test.go
@@ -1,4 +1,4 @@
-package consensus_channel
+package ledger
 
 import (
 	"errors"
@@ -63,7 +63,7 @@ func TestLeaderChannel(t *testing.T) {
 	}
 
 	cId, _ := fp().ChannelId()
-	testChannel := func(lo LedgerOutcome, testProposalQueue []SignedProposalVars) ConsensusChannel {
+	testChannel := func(lo LedgerOutcome, testProposalQueue []SignedProposalVars) LedgerChannel {
 		vars := Vars{TurnNum: 0, Outcome: lo}
 		aliceSig, _ := vars.AsState(fp()).Sign(alice.PrivateKey)
 		bobsSig, _ := vars.AsState(fp()).Sign(bob.PrivateKey)
@@ -77,7 +77,7 @@ func TestLeaderChannel(t *testing.T) {
 			proposalQueue = append(proposalQueue, p.SignedProposal)
 		}
 
-		return ConsensusChannel{
+		return LedgerChannel{
 			fp:            fp(),
 			Id:            cId,
 			MyIndex:       Leader,
@@ -112,7 +112,7 @@ func TestLeaderChannel(t *testing.T) {
 	// ******* //
 
 	testPropose := func(
-		channel ConsensusChannel,
+		channel LedgerChannel,
 		proposal Proposal,
 		expectedSp SignedProposal,
 		expectedErr error,

--- a/channel/ledger/ledger_channel_test.go
+++ b/channel/ledger/ledger_channel_test.go
@@ -1,4 +1,4 @@
-package consensus_channel
+package ledger
 
 import (
 	"errors"
@@ -11,7 +11,7 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-func TestConsensusChannel(t *testing.T) {
+func TestLedgerChannel(t *testing.T) {
 	existingChannel := types.Destination{1}
 
 	proposal := add(10, vAmount, targetChannel, alice, bob)
@@ -174,11 +174,11 @@ func TestConsensusChannel(t *testing.T) {
 	bobsSig, _ := initialVars.AsState(fp()).Sign(bob.PrivateKey)
 	sigs := [2]state.Signature{aliceSig, bobsSig}
 
-	testConsensusChannelFunctionality := func(t *testing.T) {
-		channel, err := newConsensusChannel(fp(), Leader, 0, outcome(), sigs)
+	testLedgerChannelFunctionality := func(t *testing.T) {
+		channel, err := newLedgerChannel(fp(), Leader, 0, outcome(), sigs)
 
 		if err != nil {
-			t.Fatalf("unable to construct a new consensus channel: %v", err)
+			t.Fatalf("unable to construct a new ledger channel: %v", err)
 		}
 
 		_, err = channel.sign(initialVars, bob.PrivateKey)
@@ -200,7 +200,7 @@ func TestConsensusChannel(t *testing.T) {
 
 		briansSig, _ := initialVars.AsState(fp()).Sign(brian.PrivateKey)
 		wrongSigs := [2]state.Signature{sigs[1], briansSig}
-		_, err = newConsensusChannel(fp(), Leader, 0, outcome(), wrongSigs)
+		_, err = newLedgerChannel(fp(), Leader, 0, outcome(), wrongSigs)
 		if err == nil {
 			t.Fatalf("channel should check that signers are participants")
 		}
@@ -208,5 +208,5 @@ func TestConsensusChannel(t *testing.T) {
 
 	t.Run(`TestApplyingAddProposalToVars`, testApplyingAddProposalToVars)
 	t.Run(`TestApplyingRemoveProposalToVars`, testApplyingRemoveProposalToVars)
-	t.Run(`TestConsensusChannelFunctionality`, testConsensusChannelFunctionality)
+	t.Run(`TestLedgerChannelFunctionality`, testLedgerChannelFunctionality)
 }

--- a/channel/ledger/readme.md
+++ b/channel/ledger/readme.md
@@ -1,0 +1,5 @@
+# Ledger Funding
+
+The ledger funding protocol uses a leader/follower approach.
+
+Every ledger channel has

--- a/channel/ledger/serde.go
+++ b/channel/ledger/serde.go
@@ -1,4 +1,4 @@
-package consensus_channel
+package ledger
 
 import (
 	"encoding/json"
@@ -174,9 +174,9 @@ func (l *LedgerOutcome) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// jsonConsensusChannel replaces ConsensusChannel's private fields with public ones,
+// jsonLedgerChannel replaces LedgerChannel's private fields with public ones,
 // making it suitable for serialization
-type jsonConsensusChannel struct {
+type jsonLedgerChannel struct {
 	Id             types.Destination
 	OnChainFunding types.Funds
 	MyIndex        ledgerIndex
@@ -185,9 +185,9 @@ type jsonConsensusChannel struct {
 	ProposalQueue  []SignedProposal
 }
 
-// MarshalJSON returns a JSON representation of the ConsensusChannel
-func (c ConsensusChannel) MarshalJSON() ([]byte, error) {
-	jsonCh := jsonConsensusChannel{
+// MarshalJSON returns a JSON representation of the LedgerChannel
+func (c LedgerChannel) MarshalJSON() ([]byte, error) {
+	jsonCh := jsonLedgerChannel{
 		MyIndex:        c.MyIndex,
 		FP:             c.fp,
 		Id:             c.Id,
@@ -200,8 +200,8 @@ func (c ConsensusChannel) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON populates the receiver with the
 // json-encoded data
-func (c *ConsensusChannel) UnmarshalJSON(data []byte) error {
-	var jsonCh jsonConsensusChannel
+func (c *LedgerChannel) UnmarshalJSON(data []byte) error {
+	var jsonCh jsonLedgerChannel
 	err := json.Unmarshal(data, &jsonCh)
 	if err != nil {
 		return fmt.Errorf("error unmarshaling channel data: %w", err)

--- a/channel/ledger/serde_test.go
+++ b/channel/ledger/serde_test.go
@@ -1,4 +1,4 @@
-package consensus_channel
+package ledger
 
 import (
 	"encoding/json"
@@ -34,7 +34,7 @@ func TestSerde(t *testing.T) {
 		someGuarantee)
 	someOutcomeJSON := `{"AssetAddress":"0x0000000000000000000000000000000000000000","Left":{"Destination":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce","Amount":2},"Right":{"Destination":"0x000000000000000000000000bbb676f9cff8d242e9eac39d063848807d3d1d94","Amount":7},"Guarantees":{"0x6300000000000000000000000000000000000000000000000000000000000000":{"Amount":1,"Target":"0x6300000000000000000000000000000000000000000000000000000000000000","Left":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce","Right":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce"}}}`
 
-	someConsensusChannel := ConsensusChannel{
+	someLedgerChannel := LedgerChannel{
 		MyIndex: Leader,
 		fp:      fp(),
 		Id:      types.Destination{1},
@@ -65,7 +65,7 @@ func TestSerde(t *testing.T) {
 			Proposal: Proposal{ToAdd: add(1, 2, types.Destination{3}, alice, bob)},
 		}},
 	}
-	someConsensusChannelJSON := `{"Id":"0x0100000000000000000000000000000000000000000000000000000000000000","OnChainFunding":{"0x0000000000000000000000000000000000000000":9},"MyIndex":0,"FP":{"ChainId":9001,"Participants":["0xaaa6628ec44a8a742987ef3a114ddfe2d4f7adce","0xbbb676f9cff8d242e9eac39d063848807d3d1d94"],"ChannelNonce":9001,"AppDefinition":"0x0000000000000000000000000000000000000000","ChallengeDuration":100},"Current":{"TurnNum":0,"Outcome":{"AssetAddress":"0x0000000000000000000000000000000000000000","Left":{"Destination":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce","Amount":2},"Right":{"Destination":"0x000000000000000000000000bbb676f9cff8d242e9eac39d063848807d3d1d94","Amount":7},"Guarantees":{"0x6300000000000000000000000000000000000000000000000000000000000000":{"Amount":1,"Target":"0x6300000000000000000000000000000000000000000000000000000000000000","Left":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce","Right":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce"}}},"Signatures":[{"R":"cEs6/MbnAhAsoa8/c887N/MAfzaMQOi4HKgjpldAoFM=","S":"FAQK1MWY27BVpQQwFCoTUY4TMLedJO7Yb8vf8aepVYk=","V":0},{"R":"FAQK1MWY27BVpQQwFCoTUY4TMLedJO7Yb8vf8aepVYk=","S":"cEs6/MbnAhAsoa8/c887N/MAfzaMQOi4HKgjpldAoFM=","V":0}]},"ProposalQueue":[{"R":"FAQK1MWY27BVpQQwFCoTUY4TMLedJO7Yb8vf8aepVYk=","S":"cEs6/MbnAhAsoa8/c887N/MAfzaMQOi4HKgjpldAoFM=","V":0,"Proposal":{"ChannelID":"0x0000000000000000000000000000000000000000000000000000000000000000","ToAdd":{"TurnNum":1,"Guarantee":{"Amount":2,"Target":"0x0300000000000000000000000000000000000000000000000000000000000000","Left":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce","Right":"0x000000000000000000000000bbb676f9cff8d242e9eac39d063848807d3d1d94"},"LeftDeposit":2},"ToRemove":{"Target":"0x0000000000000000000000000000000000000000000000000000000000000000","LeftAmount":null,"RightAmount":null}}}]}`
+	someLedgerChannelJSON := `{"Id":"0x0100000000000000000000000000000000000000000000000000000000000000","OnChainFunding":{"0x0000000000000000000000000000000000000000":9},"MyIndex":0,"FP":{"ChainId":9001,"Participants":["0xaaa6628ec44a8a742987ef3a114ddfe2d4f7adce","0xbbb676f9cff8d242e9eac39d063848807d3d1d94"],"ChannelNonce":9001,"AppDefinition":"0x0000000000000000000000000000000000000000","ChallengeDuration":100},"Current":{"TurnNum":0,"Outcome":{"AssetAddress":"0x0000000000000000000000000000000000000000","Left":{"Destination":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce","Amount":2},"Right":{"Destination":"0x000000000000000000000000bbb676f9cff8d242e9eac39d063848807d3d1d94","Amount":7},"Guarantees":{"0x6300000000000000000000000000000000000000000000000000000000000000":{"Amount":1,"Target":"0x6300000000000000000000000000000000000000000000000000000000000000","Left":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce","Right":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce"}}},"Signatures":[{"R":"cEs6/MbnAhAsoa8/c887N/MAfzaMQOi4HKgjpldAoFM=","S":"FAQK1MWY27BVpQQwFCoTUY4TMLedJO7Yb8vf8aepVYk=","V":0},{"R":"FAQK1MWY27BVpQQwFCoTUY4TMLedJO7Yb8vf8aepVYk=","S":"cEs6/MbnAhAsoa8/c887N/MAfzaMQOi4HKgjpldAoFM=","V":0}]},"ProposalQueue":[{"R":"FAQK1MWY27BVpQQwFCoTUY4TMLedJO7Yb8vf8aepVYk=","S":"cEs6/MbnAhAsoa8/c887N/MAfzaMQOi4HKgjpldAoFM=","V":0,"Proposal":{"ChannelID":"0x0000000000000000000000000000000000000000000000000000000000000000","ToAdd":{"TurnNum":1,"Guarantee":{"Amount":2,"Target":"0x0300000000000000000000000000000000000000000000000000000000000000","Left":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce","Right":"0x000000000000000000000000bbb676f9cff8d242e9eac39d063848807d3d1d94"},"LeftDeposit":2},"ToRemove":{"Target":"0x0000000000000000000000000000000000000000000000000000000000000000","LeftAmount":null,"RightAmount":null}}}]}`
 
 	type testCase struct {
 		name string
@@ -90,9 +90,9 @@ func TestSerde(t *testing.T) {
 			someOutcomeJSON,
 		},
 		{
-			"ConsensusChannel",
-			someConsensusChannel,
-			someConsensusChannelJSON,
+			"LedgerChannel",
+			someLedgerChannel,
+			someLedgerChannelJSON,
 		},
 	}
 
@@ -122,8 +122,8 @@ func TestSerde(t *testing.T) {
 				lo := LedgerOutcome{}
 				err = json.Unmarshal([]byte(c.json), &lo)
 				got = lo
-			case ConsensusChannel:
-				cc := ConsensusChannel{}
+			case LedgerChannel:
+				cc := LedgerChannel{}
 				err = json.Unmarshal([]byte(c.json), &cc)
 				got = cc
 			case Add:

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	"github.com/statechannels/go-nitro/channel"
-	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/channel/ledger"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -27,11 +27,11 @@ type Store interface {
 
 	ReleaseChannelFromOwnership(types.Destination) // Release channel from being owned by any objective
 
-	ConsensusChannelStore
+	LedgerChannelStore
 }
 
-type ConsensusChannelStore interface {
-	GetConsensusChannel(counterparty types.Address) (channel *consensus_channel.ConsensusChannel, ok bool)
-	GetConsensusChannelById(id types.Destination) (channel *consensus_channel.ConsensusChannel, err error)
-	SetConsensusChannel(*consensus_channel.ConsensusChannel) error
+type LedgerChannelStore interface {
+	GetLedgerChannel(counterparty types.Address) (channel *ledger.LedgerChannel, ok bool)
+	GetLedgerChannelById(id types.Destination) (channel *ledger.LedgerChannel, err error)
+	SetLedgerChannel(*ledger.LedgerChannel) error
 }

--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/channel/ledger"
 	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
@@ -52,20 +52,20 @@ func TestDirectFundIntegration(t *testing.T) {
 	directlyFundALedgerChannel(t, clientA, clientB)
 
 	want := testdata.Outcomes.Create(*clientA.Address, *clientB.Address, 5, 5)
-	// Ensure that we create a consensus channel in the store
+	// Ensure that we create a ledger channel in the store
 	for _, store := range []store.Store{storeA, storeB} {
-		var con *consensus_channel.ConsensusChannel
+		var con *ledger.LedgerChannel
 		var ok bool
 
-		// each client fetches the ConsensusChannel by reference to their counterparty
+		// each client fetches the LedgerChannel by reference to their counterparty
 		if store.GetChannelSecretKey() == &alice.PrivateKey {
-			con, ok = store.GetConsensusChannel(*clientB.Address)
+			con, ok = store.GetLedgerChannel(*clientB.Address)
 		} else {
-			con, ok = store.GetConsensusChannel(*clientA.Address)
+			con, ok = store.GetLedgerChannel(*clientA.Address)
 		}
 
 		if !ok {
-			t.Fatalf("expected a consensus channel to have been created")
+			t.Fatalf("expected a ledger channel to have been created")
 		}
 		vars := con.ConsensusVars()
 		got := vars.Outcome.AsOutcome()

--- a/internal/testhelpers/testhelpers.go
+++ b/internal/testhelpers/testhelpers.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/channel/ledger"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/protocols"
@@ -74,7 +74,7 @@ func AssertStateSentTo(t *testing.T, ses protocols.SideEffects, expected state.S
 	}
 }
 
-func AssertProposalSent(t *testing.T, ses protocols.SideEffects, sp consensus_channel.SignedProposal, to testactors.Actor) {
+func AssertProposalSent(t *testing.T, ses protocols.SideEffects, sp ledger.SignedProposal, to testactors.Actor) {
 
 	Assert(t, len(ses.MessagesToSend) == 1, "expected one message")
 

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/go-cmp/cmp"
-	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/channel/ledger"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
@@ -66,16 +66,16 @@ func signedTestState(s state.State, toSign []bool) (state.SignedState, error) {
 	return ss, nil
 }
 
-// newTestObjective returns a directdefund Objective constructed with a MockConsensusChannel.
+// newTestObjective returns a directdefund Objective constructed with a MockLedgerChannel.
 func newTestObjective() (Objective, error) {
-	cc, _ := testdata.Channels.MockConsensusChannel(alice.Address)
+	cc, _ := testdata.Channels.MockLedgerChannel(alice.Address)
 
-	getConsensusChannel := func(id types.Destination) (channel *consensus_channel.ConsensusChannel, err error) {
+	getLedgerChannel := func(id types.Destination) (channel *ledger.LedgerChannel, err error) {
 		return cc, nil
 	}
 
 	// Assert that valid constructor args do not result in error
-	o, err := NewObjective(true, cc.Id, getConsensusChannel)
+	o, err := NewObjective(true, cc.Id, getLedgerChannel)
 	if err != nil {
 		return Objective{}, err
 	}
@@ -125,7 +125,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func compareSideEffect(a, b protocols.SideEffects) string {
-	return cmp.Diff(a, b, cmp.AllowUnexported(a, state.SignedState{}, consensus_channel.Add{}, consensus_channel.Remove{}, consensus_channel.Guarantee{}))
+	return cmp.Diff(a, b, cmp.AllowUnexported(a, state.SignedState{}, ledger.Add{}, ledger.Remove{}, ledger.Guarantee{}))
 }
 
 func TestCrankAlice(t *testing.T) {

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/statechannels/go-nitro/channel"
-	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	. "github.com/statechannels/go-nitro/channel/ledger"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
@@ -133,44 +133,44 @@ func (dfo Objective) GetStatus() protocols.ObjectiveStatus {
 	return dfo.Status
 }
 
-// CreateConsensusChannel creates a ConsensusChannel from the Objective by extracting signatures and a single asset outcome from the post fund state.
-func (dfo *Objective) CreateConsensusChannel() (*consensus_channel.ConsensusChannel, error) {
+// CreateLedgerChannel creates a LedgerChannel from the Objective by extracting signatures and a single asset outcome from the post fund state.
+func (dfo *Objective) CreateLedgerChannel() (*LedgerChannel, error) {
 	ledger := dfo.C
 
 	if !ledger.PostFundComplete() {
 		return nil, fmt.Errorf("expected funding for channel %s to be complete", dfo.C.Id)
 	}
 	signedPostFund := ledger.SignedPostFundState()
-	leaderSig, err := signedPostFund.GetParticipantSignature(uint(consensus_channel.Leader))
+	leaderSig, err := signedPostFund.GetParticipantSignature(uint(Leader))
 	if err != nil {
 		return nil, fmt.Errorf("could not get leader signature: %w", err)
 	}
-	followerSig, err := signedPostFund.GetParticipantSignature(uint(consensus_channel.Follower))
+	followerSig, err := signedPostFund.GetParticipantSignature(uint(Follower))
 	if err != nil {
 		return nil, fmt.Errorf("could not get follower signature: %w", err)
 	}
 	signatures := [2]state.Signature{leaderSig, followerSig}
 
 	if len(signedPostFund.State().Outcome) != 1 {
-		return nil, fmt.Errorf("a consensus channel only supports a single asset")
+		return nil, fmt.Errorf("a ledger channel only supports a single asset")
 	}
 	assetExit := signedPostFund.State().Outcome[0]
 	turnNum := signedPostFund.State().TurnNum
-	outcome := consensus_channel.FromExit(assetExit)
+	outcome := FromExit(assetExit)
 
-	if ledger.MyIndex == uint(consensus_channel.Leader) {
-		con, err := consensus_channel.NewLeaderChannel(ledger.FixedPart, turnNum, outcome, signatures)
+	if ledger.MyIndex == uint(Leader) {
+		con, err := NewLeaderChannel(ledger.FixedPart, turnNum, outcome, signatures)
 		con.OnChainFunding = ledger.OnChainFunding.Clone() // Copy OnChainFunding so we don't lose this information
 		if err != nil {
-			return nil, fmt.Errorf("could not create consensus channel as leader: %w", err)
+			return nil, fmt.Errorf("could not create ledger channel as leader: %w", err)
 		}
 		return &con, nil
 
 	} else {
-		con, err := consensus_channel.NewFollowerChannel(ledger.FixedPart, turnNum, outcome, signatures)
+		con, err := NewFollowerChannel(ledger.FixedPart, turnNum, outcome, signatures)
 		con.OnChainFunding = ledger.OnChainFunding.Clone() // Copy OnChainFunding so we don't lose this information
 		if err != nil {
-			return nil, fmt.Errorf("could not create consensus channel as follower: %w", err)
+			return nil, fmt.Errorf("could not create ledger channel as follower: %w", err)
 		}
 		return &con, nil
 	}

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/go-cmp/cmp"
 	"github.com/statechannels/go-nitro/channel"
-	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/channel/ledger"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
@@ -161,7 +161,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func compareSideEffect(a, b protocols.SideEffects) string {
-	return cmp.Diff(a, b, cmp.AllowUnexported(a, state.SignedState{}, consensus_channel.Add{}, consensus_channel.Guarantee{}, consensus_channel.Remove{}))
+	return cmp.Diff(a, b, cmp.AllowUnexported(a, state.SignedState{}, ledger.Add{}, ledger.Guarantee{}, ledger.Remove{}))
 }
 
 func TestCrank(t *testing.T) {

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -3,7 +3,7 @@ package protocols
 import (
 	"encoding/json"
 
-	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/channel/ledger"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -45,7 +45,7 @@ type AdjudicationStatus struct {
 type ObjectiveEvent struct {
 	ObjectiveId     ObjectiveId
 	SignedStates    []state.SignedState
-	SignedProposals []consensus_channel.SignedProposal
+	SignedProposals []ledger.SignedProposal
 }
 
 // Storable is an object that can be stored by the store.

--- a/protocols/messages_test.go
+++ b/protocols/messages_test.go
@@ -5,14 +5,14 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/channel/ledger"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/types"
 )
 
-func addProposal() consensus_channel.SignedProposal {
+func addProposal() ledger.SignedProposal {
 	amount := big.NewInt(1)
-	add := consensus_channel.NewAddProposal(types.Destination{'l'}, 1, consensus_channel.NewGuarantee(
+	add := ledger.NewAddProposal(types.Destination{'l'}, 1, ledger.NewGuarantee(
 		amount,
 		types.Destination{'a'},
 		types.Destination{'b'},
@@ -21,7 +21,7 @@ func addProposal() consensus_channel.SignedProposal {
 		amount,
 	)
 
-	return consensus_channel.SignedProposal{Proposal: add, Signature: state.Signature{}}
+	return ledger.SignedProposal{Proposal: add, Signature: state.Signature{}}
 }
 
 func TestMessage(t *testing.T) {

--- a/protocols/virtualdefund/serde.go
+++ b/protocols/virtualdefund/serde.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/channel/ledger"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/protocols"
@@ -76,8 +76,8 @@ func (o *Objective) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("failed to unmarshal the VirtualDefundObjective: %w", err)
 	}
 
-	o.ToMyLeft = &consensus_channel.ConsensusChannel{}
-	o.ToMyRight = &consensus_channel.ConsensusChannel{}
+	o.ToMyLeft = &ledger.LedgerChannel{}
+	o.ToMyRight = &ledger.LedgerChannel{}
 	if err := o.ToMyLeft.UnmarshalJSON(jsonVFO.ToMyLeft); err != nil {
 		return fmt.Errorf("failed to unmarshal left ledger channel: %w", err)
 	}

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/channel/ledger"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/protocols"
@@ -42,8 +42,8 @@ type Objective struct {
 	// Signatures gets updated as participants sign and send states to each other.
 	Signatures [3]state.Signature
 
-	ToMyLeft  *consensus_channel.ConsensusChannel
-	ToMyRight *consensus_channel.ConsensusChannel
+	ToMyLeft  *ledger.LedgerChannel
+	ToMyRight *ledger.LedgerChannel
 
 	// MyRole is the index of the participant in the participants list
 	// 0 is Alice
@@ -55,7 +55,7 @@ type Objective struct {
 const ObjectivePrefix = "VirtualDefund-"
 
 // newObjective constructs a new virtual defund objective
-func newObjective(preApprove bool, vFixed state.FixedPart, initialOutcome outcome.SingleAssetExit, paidToBob *big.Int, toMyLeft, toMyRight *consensus_channel.ConsensusChannel, myRole uint) Objective {
+func newObjective(preApprove bool, vFixed state.FixedPart, initialOutcome outcome.SingleAssetExit, paidToBob *big.Int, toMyLeft, toMyRight *ledger.LedgerChannel, myRole uint) Objective {
 	var status protocols.ObjectiveStatus
 
 	if preApprove {
@@ -169,7 +169,7 @@ func (o *Objective) clone() Objective {
 	}
 	clone.MyRole = o.MyRole
 
-	// TODO: Properly clone the consensus channels
+	// TODO: Properly clone the ledger channels
 	if o.ToMyLeft != nil {
 		clone.ToMyLeft = o.ToMyLeft
 	}
@@ -258,15 +258,15 @@ func (o Objective) isBob() bool {
 }
 
 // ledgerProposal generates a ledger proposal to remove the guarantee for V for ledger
-func (o Objective) ledgerProposal(ledger *consensus_channel.ConsensusChannel) consensus_channel.Proposal {
+func (o Objective) ledgerProposal(l *ledger.LedgerChannel) ledger.Proposal {
 	left := o.finalOutcome().Allocations[0].Amount
 	right := o.finalOutcome().Allocations[1].Amount
 
-	return consensus_channel.NewRemoveProposal(ledger.Id, FinalTurnNum, o.VId(), left, right)
+	return ledger.NewRemoveProposal(l.Id, FinalTurnNum, o.VId(), left, right)
 }
 
 // updateLedgerToRemoveGuarantee updates the ledger channel to remove the guarantee that funds V.
-func (o *Objective) updateLedgerToRemoveGuarantee(ledger *consensus_channel.ConsensusChannel, sk *[]byte) (protocols.SideEffects, error) {
+func (o *Objective) updateLedgerToRemoveGuarantee(ledger *ledger.LedgerChannel, sk *[]byte) (protocols.SideEffects, error) {
 
 	var sideEffects protocols.SideEffects
 

--- a/protocols/virtualfund/serde.go
+++ b/protocols/virtualfund/serde.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/statechannels/go-nitro/channel"
-	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/channel/ledger"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -38,7 +38,7 @@ func (c Connection) MarshalJSON() ([]byte, error) {
 // NOTE: Marshal -> Unmarshal is a lossy process. All channel data from
 //       (other than Id) is discarded
 func (c *Connection) UnmarshalJSON(data []byte) error {
-	c.Channel = &consensus_channel.ConsensusChannel{}
+	c.Channel = &ledger.LedgerChannel{}
 
 	if string(data) == "null" {
 		// populate a well-formed but blank-addressed Connection

--- a/protocols/virtualfund/virtualfund_test.go
+++ b/protocols/virtualfund/virtualfund_test.go
@@ -44,7 +44,7 @@ func TestMarshalJSON(t *testing.T) {
 	ts := state.TestState
 	ts.TurnNum = channel.PreFundTurnNum
 
-	right := prepareConsensusChannel(1, alice, bob)
+	right := prepareLedgerChannel(1, alice, bob)
 	vfo, err := constructFromState(
 		false,
 		vPreFund,

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ The following roadmap gives an idea of the various packages that compose the `go
 ```bash
 ├── abi ✅                     # types for abi encoding and decoding.
 ├── channel ✅                 # query the latest supported state of a channel
-│   ├── consensus_channel 🚧   # manage a running ledger channel.
+│   ├── ledger 🚧              # manage a running ledger channel.
 │   └── state ✅               # generate and recover signatures on state updates
 │       ├── outcome ✅         # define how funds are dispersed when a channel closes
 ├── client 🚧                  # exposes an API to the consuming application


### PR DESCRIPTION
Originally I think we chose the name of `consensus_channel` because we already had a `TwoPartyLedgerChannel`. Now that `TwoPartyLedgerChannel`s are removed we can rename `consensus_channel` to `ledger`.

Ledger is the term we use in the paper and in our discussions so I think it makes sense for the code to reflect that.