### PR TITLE
refactor / doc: tidying public API godocs for publish

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -148,7 +148,7 @@ func (c Channel) SignedPostFundState() state.SignedState {
 	return c.SignedStateForTurnNum[PostFundTurnNum]
 }
 
-// PreFundSignedByMe() returns true if the calling client has signed the pre fund setup state, false otherwise.
+// PreFundSignedByMe returns true if the calling client has signed the pre fund setup state, false otherwise.
 func (c Channel) PreFundSignedByMe() bool {
 	if _, ok := c.SignedStateForTurnNum[PreFundTurnNum]; ok {
 		if c.SignedStateForTurnNum[PreFundTurnNum].HasSignatureForParticipant(c.MyIndex) {

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -12,7 +12,7 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-// Class containing states and metadata, and exposing convenience methods.
+// Channel contains states and metadata, and exposes convenience methods.
 type Channel struct {
 	Id      types.Destination
 	MyIndex uint
@@ -23,10 +23,10 @@ type Channel struct {
 	// Support []uint64 // TODO: this property will be important, and allow the Channel to store the necessary data to close out the channel on chain
 	// It could be an array of turnNums, which can be used to slice into Channel.SignedStateForTurnNum
 
-	latestSupportedStateTurnNum uint64 // largest uint64 value reserved for "no supported state"
-
-	SignedStateForTurnNum map[uint64]state.SignedState // this stores up to 1 state per turn number.
+	SignedStateForTurnNum map[uint64]state.SignedState
 	// Longer term, we should have a more efficient and smart mechanism to store states https://github.com/statechannels/go-nitro/issues/106
+
+	latestSupportedStateTurnNum uint64 // largest uint64 value reserved for "no supported state"
 }
 
 // New constructs a new Channel from the supplied state.
@@ -148,7 +148,7 @@ func (c Channel) SignedPostFundState() state.SignedState {
 	return c.SignedStateForTurnNum[PostFundTurnNum]
 }
 
-// PreFundSignedByMe() returns true if I have signed the pre fund setup state, false otherwise.
+// PreFundSignedByMe() returns true if the calling client has signed the pre fund setup state, false otherwise.
 func (c Channel) PreFundSignedByMe() bool {
 	if _, ok := c.SignedStateForTurnNum[PreFundTurnNum]; ok {
 		if c.SignedStateForTurnNum[PreFundTurnNum].HasSignatureForParticipant(c.MyIndex) {
@@ -158,7 +158,7 @@ func (c Channel) PreFundSignedByMe() bool {
 	return false
 }
 
-// PostFundSignedByMe() returns true if I have signed the post fund setup state, false otherwise.
+// PostFundSignedByMe() returns true if the calling client has signed the post fund setup state, false otherwise.
 func (c Channel) PostFundSignedByMe() bool {
 	if _, ok := c.SignedStateForTurnNum[PostFundTurnNum]; ok {
 		if c.SignedStateForTurnNum[PostFundTurnNum].HasSignatureForParticipant(c.MyIndex) {
@@ -178,7 +178,8 @@ func (c Channel) PostFundComplete() bool {
 	return c.SignedStateForTurnNum[PostFundTurnNum].HasAllSignatures()
 }
 
-// LatestSupportedState returns the latest supported state.
+// LatestSupportedState returns the latest supported state. A state is supported if it is signed
+// by all participants.
 func (c Channel) LatestSupportedState() (state.State, error) {
 	if c.latestSupportedStateTurnNum == MaxTurnNum {
 		return state.State{}, errors.New(`no state is yet supported`)
@@ -186,7 +187,7 @@ func (c Channel) LatestSupportedState() (state.State, error) {
 	return c.SignedStateForTurnNum[c.latestSupportedStateTurnNum].State(), nil
 }
 
-// LatestSignedState fetches the state with the largest turn number signed by any participant
+// LatestSignedState fetches the state with the largest turn number signed by at least one participant.
 func (c Channel) LatestSignedState() (state.SignedState, error) {
 	if len(c.SignedStateForTurnNum) == 0 {
 		return state.SignedState{}, errors.New("No states are signed")

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -158,7 +158,7 @@ func (c Channel) PreFundSignedByMe() bool {
 	return false
 }
 
-// PostFundSignedByMe() returns true if the calling client has signed the post fund setup state, false otherwise.
+// PostFundSignedByMe returns true if the calling client has signed the post fund setup state, false otherwise.
 func (c Channel) PostFundSignedByMe() bool {
 	if _, ok := c.SignedStateForTurnNum[PostFundTurnNum]; ok {
 		if c.SignedStateForTurnNum[PostFundTurnNum].HasSignatureForParticipant(c.MyIndex) {

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -12,7 +12,7 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-// Channel contains states and metadata, and exposes convenience methods.
+// Channel contains states and metadata and exposes convenience methods.
 type Channel struct {
 	Id      types.Destination
 	MyIndex uint

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -243,7 +243,7 @@ func NewBalance(destination types.Destination, amount *big.Int) Balance {
 
 }
 
-// Balance is a convenient ergonomic representation of a single-asset Allocation
+// Balance is a convenient, ergonomic representation of a single-asset Allocation
 // of type 0, ie. a simple allocation.
 type Balance struct {
 	destination types.Destination

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -264,7 +264,7 @@ func (b Balance) AsAllocation() outcome.Allocation {
 	return outcome.Allocation{Destination: b.destination, Amount: amount, AllocationType: outcome.NormalAllocationType}
 }
 
-// Guarantee is a convenient, ergonomic representation a
+// Guarantee is a convenient, ergonomic representation of a
 // single-asset Allocation of type 1, ie. a guarantee.
 type Guarantee struct {
 	amount *big.Int

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -32,7 +32,7 @@ const (
 	Follower ledgerIndex = 1
 )
 
-// ConsensusChannel is used to manage states in a running ledger channel
+// ConsensusChannel is used to manage states in a running ledger channel.
 type ConsensusChannel struct {
 	// constants
 
@@ -50,7 +50,8 @@ type ConsensusChannel struct {
 	proposalQueue []SignedProposal
 }
 
-// newConsensusChannel constructs a new consensus channel, validating its input by checking that the signatures are as expected for the given fp, initialTurnNum and outcome]
+// newConsensusChannel constructs a new consensus channel, validating its input by
+// checking that the signatures are as expected for the given fp, initialTurnNum and outcome.
 func newConsensusChannel(
 	fp state.FixedPart,
 	myIndex ledgerIndex,
@@ -97,14 +98,14 @@ func newConsensusChannel(
 
 }
 
-// FixedPart returns the fixed part of the channel
+// FixedPart returns the fixed part of the channel.
 func (c *ConsensusChannel) FixedPart() state.FixedPart {
 	return c.fp
 }
 
 // Receive accepts a proposal signed by the ConsensusChannel counterparty,
-// validates its signature, and performs updates the proposal queue and
-// consensus state
+// validates its signature, and performs updates to the proposal queue and
+// consensus state.
 func (c *ConsensusChannel) Receive(sp SignedProposal) error {
 	if c.IsFollower() {
 		return c.followerReceive(sp)
@@ -116,22 +117,23 @@ func (c *ConsensusChannel) Receive(sp SignedProposal) error {
 	return fmt.Errorf("ConsensusChannel is malformed")
 }
 
-// ConsensusTurnNum returns the turn number of the current consensus state
+// ConsensusTurnNum returns the turn number of the current consensus state.
 func (c *ConsensusChannel) ConsensusTurnNum() uint64 {
 	return c.current.TurnNum
 }
 
-// Includes returns whether or not the consensus state includes the given guarantee
+// Includes returns whether or not the consensus state includes the given guarantee.
 func (c *ConsensusChannel) Includes(g Guarantee) bool {
 	return c.current.Outcome.includes(g)
 }
 
-// IncludesTarget returns whether or not the consensus state includes a guarantee targeting the given channel
+// IncludesTarget returns whether or not the consensus state includes a guarantee
+// addressed to the given target.
 func (c *ConsensusChannel) IncludesTarget(target types.Destination) bool {
 	return c.current.Outcome.includesTarget(target)
 }
 
-// HasRemovalBeenProposedFor returns whether or not a proposal exists to remove the guaranatee for the target
+// HasRemovalBeenProposedFor returns whether or not a proposal exists to remove the guaranatee for the target.
 func (c *ConsensusChannel) HasRemovalBeenProposedFor(target types.Destination) bool {
 	for _, p := range c.proposalQueue {
 		if p.Proposal.Type() == RemoveProposal {
@@ -145,24 +147,24 @@ func (c *ConsensusChannel) HasRemovalBeenProposedFor(target types.Destination) b
 }
 
 // IsLeader returns true if the calling client is the leader of the channel,
-// and false otherwise
+// and false otherwise.
 func (c *ConsensusChannel) IsLeader() bool {
 	return c.MyIndex == Leader
 }
 
 // IsFollower returns true if the calling client is the follower of the channel,
-// and false otherwise
+// and false otherwise.
 func (c *ConsensusChannel) IsFollower() bool {
 	return c.MyIndex == Follower
 }
 
-// Leader returns the address of the participant responsible for proposing
+// Leader returns the address of the participant responsible for proposing.
 func (c *ConsensusChannel) Leader() common.Address {
 	return c.fp.Participants[Leader]
 }
 
 // Follower returns the address of the participant who recieves and contersigns
-// proposals
+// proposals.
 func (c *ConsensusChannel) Follower() common.Address {
 	return c.fp.Participants[Follower]
 }
@@ -183,30 +185,30 @@ func (c *ConsensusChannel) sign(vars Vars, sk []byte) (state.Signature, error) {
 	return state.Sign(sk)
 }
 
-// recoverSigner returns the signer of the vars using the given signature
+// recoverSigner returns the signer of the vars using the given signature.
 func (c *ConsensusChannel) recoverSigner(vars Vars, sig state.Signature) (common.Address, error) {
 	state := vars.AsState(c.fp)
 	return state.RecoverSigner(sig)
 }
 
 // ConsensusVars returns the vars of the consensus state
-// The consensus state is the latest state that has been signed by both parties
+// The consensus state is the latest state that has been signed by both parties.
 func (c *ConsensusChannel) ConsensusVars() Vars {
 	return c.current.Vars
 }
 
-// Signatures returns the signatures on the currently supported state
+// Signatures returns the signatures on the currently supported state.
 func (c *ConsensusChannel) Signatures() [2]state.Signature {
 	return c.current.Signatures
 }
 
-// ProposalQueue returns the current queue of proposals
+// ProposalQueue returns the current queue of proposals.
 func (c *ConsensusChannel) ProposalQueue() []SignedProposal {
 	return c.proposalQueue
 }
 
 // latestProposedVars returns the latest proposed vars in a consensus channel
-// by cloning its current vars and applying each proposal in the queue
+// by cloning its current vars and applying each proposal in the queue.
 func (c *ConsensusChannel) latestProposedVars() (Vars, error) {
 	vars := Vars{TurnNum: c.current.TurnNum, Outcome: c.current.Outcome.clone()}
 
@@ -222,7 +224,7 @@ func (c *ConsensusChannel) latestProposedVars() (Vars, error) {
 }
 
 // validateProposalID checks that the given proposal's ID matches
-// the channel's ID
+// the channel's ID.
 func (c *ConsensusChannel) validateProposalID(propsal Proposal) error {
 	if propsal.ChannelID != c.Id {
 		return ErrIncorrectChannelID
@@ -231,7 +233,7 @@ func (c *ConsensusChannel) validateProposalID(propsal Proposal) error {
 	return nil
 }
 
-// NewBalance returns a new Balance struct with the given amount and destination
+// NewBalance returns a new Balance struct with the given destination and amount.
 func NewBalance(destination types.Destination, amount *big.Int) Balance {
 	balanceAmount := big.NewInt(0).Set(amount)
 	return Balance{
@@ -241,13 +243,14 @@ func NewBalance(destination types.Destination, amount *big.Int) Balance {
 
 }
 
-// Balance represents an Allocation of type 0, ie. a simple allocation.
+// Balance is a convenient ergonomic representation of a single-asset Allocation
+// of type 0, ie. a simple allocation.
 type Balance struct {
 	destination types.Destination
 	amount      *big.Int
 }
 
-// Clone returns a deep copy of the recievr
+// Clone returns a deep copy of the receiver.
 func (b *Balance) Clone() Balance {
 	return Balance{
 		destination: b.destination,
@@ -255,13 +258,14 @@ func (b *Balance) Clone() Balance {
 	}
 }
 
-// AsAllocation converts a Balance struct into the on-chain outcome.Allocation type
+// AsAllocation converts a Balance struct into the on-chain outcome.Allocation type.
 func (b Balance) AsAllocation() outcome.Allocation {
 	amount := big.NewInt(0).Set(b.amount)
-	return outcome.Allocation{Destination: b.destination, Amount: amount, AllocationType: 0}
+	return outcome.Allocation{Destination: b.destination, Amount: amount, AllocationType: outcome.NormalAllocationType}
 }
 
-// Guarantee represents an Allocation of type 1, ie. a guarantee.
+// Guarantee is a convenient, ergonomic representation a
+// single-asset Allocation of type 1, ie. a guarantee.
 type Guarantee struct {
 	amount *big.Int
 	target types.Destination
@@ -269,7 +273,7 @@ type Guarantee struct {
 	right  types.Destination
 }
 
-// Clone returns a deep copy of the receiver
+// Clone returns a deep copy of the receiver.
 func (g *Guarantee) Clone() Guarantee {
 	return Guarantee{
 		amount: big.NewInt(0).Set(g.amount),
@@ -279,12 +283,12 @@ func (g *Guarantee) Clone() Guarantee {
 	}
 }
 
-// Target returns the target of the guarantee
+// Target returns the target of the guarantee.
 func (g Guarantee) Target() types.Destination {
 	return g.target
 }
 
-// NewGuarantee constructs a new guarantee
+// NewGuarantee constructs a new guarantee.
 func NewGuarantee(amount *big.Int, target types.Destination, left types.Destination, right types.Destination) Guarantee {
 	return Guarantee{amount, target, left, right}
 }
@@ -319,7 +323,7 @@ type LedgerOutcome struct {
 	guarantees   map[types.Destination]Guarantee
 }
 
-// Clone returns a deep copy of the receiver
+// Clone returns a deep copy of the receiver.
 func (lo *LedgerOutcome) Clone() LedgerOutcome {
 	clonedGuarantees := make(map[types.Destination]Guarantee)
 	for key, g := range lo.guarantees {
@@ -333,7 +337,7 @@ func (lo *LedgerOutcome) Clone() LedgerOutcome {
 	}
 }
 
-// NewLedgerOutcome creates a new ledger outcome with the given asset address and balances and guarantees
+// NewLedgerOutcome creates a new ledger outcome with the given asset address, balances, and guarantees.
 func NewLedgerOutcome(assetAddress types.Address, left, right Balance, guarantees []Guarantee) *LedgerOutcome {
 	guaranteeMap := make(map[types.Destination]Guarantee, len(guarantees))
 	for _, g := range guarantees {
@@ -347,7 +351,7 @@ func NewLedgerOutcome(assetAddress types.Address, left, right Balance, guarantee
 	}
 }
 
-// includesTarget returns true when the receiver includes a guarantee that targets the given destination
+// includesTarget returns true when the receiver includes a guarantee that targets the given destination.
 func (o *LedgerOutcome) includesTarget(target types.Destination) bool {
 	_, found := o.guarantees[target]
 	return found
@@ -367,6 +371,7 @@ func (o *LedgerOutcome) includes(g Guarantee) bool {
 }
 
 // FromExit creates a new LedgerOutcome from the given SingleAssetExit.
+//
 // It makes some assumptions about the exit:
 //  - The first alloction entry is for left
 //  - The second alloction entry is for right
@@ -395,7 +400,7 @@ func FromExit(sae outcome.SingleAssetExit) LedgerOutcome {
 // AsOutcome converts a LedgerOutcome to an on-chain exit according to the following convention:
 //  - the "left" balance is first
 //  - the "right" balance is second
-//  - following [left, right] comes the guarantees in sorted order
+//  - following [left, right] comes the guarantees sorted according to their target destination
 func (o *LedgerOutcome) AsOutcome() outcome.Exit {
 	// The first items are [left, right] balances
 	allocations := outcome.Allocations{o.left.AsAllocation(), o.right.AsAllocation()}
@@ -422,13 +427,13 @@ func (o *LedgerOutcome) AsOutcome() outcome.Exit {
 	}
 }
 
-// Vars stores the turn number and outcome for a state in a consensus channel
+// Vars stores the turn number and outcome for a state in a consensus channel.
 type Vars struct {
 	TurnNum uint64
 	Outcome LedgerOutcome
 }
 
-// Clone returns a deep copy of the receiver
+// Clone returns a deep copy of the receiver.
 func (v *Vars) Clone() Vars {
 	return Vars{
 		v.TurnNum,
@@ -436,7 +441,7 @@ func (v *Vars) Clone() Vars {
 	}
 }
 
-// clone returns a deep clone of v
+// clone returns a deep clone of v.
 func (o *LedgerOutcome) clone() LedgerOutcome {
 	assetAddress := o.assetAddress
 
@@ -465,13 +470,13 @@ func (o *LedgerOutcome) clone() LedgerOutcome {
 	}
 }
 
-// SignedVars stores 0-2 signatures for some vars in a consensus channel
+// SignedVars stores 0-2 signatures for some vars in a consensus channel.
 type SignedVars struct {
 	Vars
 	Signatures [2]state.Signature
 }
 
-// clone returns a deep copy of the reciever
+// clone returns a deep copy of the reciever.
 func (sv *SignedVars) clone() SignedVars {
 	clonedSignatures := [2]state.Signature{
 		sv.Signatures[0],
@@ -485,8 +490,11 @@ func (sv *SignedVars) clone() SignedVars {
 
 // Proposal is a proposal either to add or to remove a guarantee.
 //
-// Exactly one of {toAdd, toRemove} should be non nil
+// Exactly one of {toAdd, toRemove} should be non nil.
 type Proposal struct {
+	// ChannelID of the ConsensusChannel which should recieve the proposal.
+	//
+	// The target virtual channel ID is contained in the Add / Remove struct.
 	ChannelID types.Destination
 	ToAdd     Add
 	ToRemove  Remove
@@ -518,7 +526,7 @@ func (p *Proposal) Type() ProposalType {
 	}
 }
 
-// Updates the turn number on the Add or Remove proposal
+// SetTurnNum updates the turn number on the Add or Remove proposal.
 func (p *Proposal) SetTurnNum(turnNum uint64) {
 	switch p.Type() {
 	case AddProposal:
@@ -533,7 +541,7 @@ func (p *Proposal) SetTurnNum(turnNum uint64) {
 
 }
 
-// Returns the turn number on the Add or Remove proposal
+// TurnNum returns the turn number on the Add or Remove proposal.
 func (p *Proposal) TurnNum() uint64 {
 	if p.Type() == AddProposal {
 		return p.ToAdd.turnNum
@@ -542,12 +550,12 @@ func (p *Proposal) TurnNum() uint64 {
 	}
 }
 
-// Equal returns true if the supplied Proposal is deeply Equal to the receiver, false otherwise.
+// Equal returns true if the supplied Proposal is deeply equal to the receiver, false otherwise.
 func (p *Proposal) Equal(q *Proposal) bool {
 	return p.ToAdd.equal(q.ToAdd) && p.ToRemove.equal(q.ToRemove)
 }
 
-// ChannelId returns the channel id of the proposal.
+// ChannelId returns the id of the ConsensusChannel which receive the proposal.
 func (p SignedProposal) ChannelId() types.Destination {
 	return p.Proposal.ChannelID
 }
@@ -557,7 +565,7 @@ func (p SignedProposal) TurnNum() uint64 {
 	return p.Proposal.TurnNum()
 }
 
-// Target returns the target channel of the proposal
+// Target returns the target channel of the proposal.
 func (p *Proposal) Target() types.Destination {
 	switch p.Type() {
 	case "AddProposal":
@@ -575,27 +583,28 @@ func (p *Proposal) Target() types.Destination {
 	}
 }
 
-// SignedProposal is a Proposal with a signature on it
+// SignedProposal is a Proposal with a signature on it.
 type SignedProposal struct {
 	state.Signature
 	Proposal Proposal
 }
 
-// clone returns a deep copy of the reciever
+// clone returns a deep copy of the reciever.
 func (sp *SignedProposal) Clone() SignedProposal {
 	sp2 := SignedProposal{sp.Signature, sp.Proposal.Clone()}
 	return sp2
 }
 
-// Add is a proposal to add a guarantee for the given virtual channel
-// amount is to be deducted from left
+// Add encodes a proposal to add a guarantee to a ConsensusChannel.
+//
+// The balance of the guarantee is to be deducted from left.
 type Add struct {
 	turnNum uint64
 	Guarantee
 	LeftDeposit *big.Int
 }
 
-// Clone returns a deep copy of the receiver
+// Clone returns a deep copy of the receiver.
 func (a *Add) Clone() Add {
 	if a == nil {
 		return Add{}
@@ -607,7 +616,7 @@ func (a *Add) Clone() Add {
 	}
 }
 
-// NewAdd constructs a new Add proposal
+// NewAdd constructs a new Add proposal.
 func NewAdd(turnNum uint64, g Guarantee, leftDeposit *big.Int) Add {
 	return Add{
 		turnNum:     turnNum,
@@ -616,21 +625,23 @@ func NewAdd(turnNum uint64, g Guarantee, leftDeposit *big.Int) Add {
 	}
 }
 
-// NewAddProposal constucts a proposal with a valid Add proposal and empty remove proposal
+// NewAddProposal constucts a proposal with a valid Add proposal and empty remove proposal.
 func NewAddProposal(channelId types.Destination, turnNum uint64, g Guarantee, leftDeposit *big.Int) Proposal {
 	return Proposal{ToAdd: NewAdd(turnNum, g, leftDeposit), ChannelID: channelId}
 }
 
-// NewRemove constructs a new Remove proposal
+// NewRemove constructs a new Remove proposal.
 func NewRemove(turnNum uint64, target types.Destination, leftAmount, rightAmount *big.Int) Remove {
 	return Remove{turnNum: turnNum, Target: target, LeftAmount: leftAmount, RightAmount: rightAmount}
 }
 
-// NewRemoveProposal constucts a proposal with a valid Remove proposal and empty Add proposal
+// NewRemoveProposal constucts a proposal with a valid Remove proposal and empty Add proposal.
 func NewRemoveProposal(channelId types.Destination, turnNum uint64, target types.Destination, leftAmount, rightAmount *big.Int) Proposal {
 	return Proposal{ToRemove: NewRemove(turnNum, target, leftAmount, rightAmount), ChannelID: channelId}
 }
 
+// RightDeposit computes the deposit from the right participant such that
+// a.LeftDeposit + a.RightDeposit() fully funds a's guarantee.
 func (a Add) RightDeposit() *big.Int {
 	result := big.NewInt(0)
 	result.Sub(a.amount, a.LeftDeposit)
@@ -665,8 +676,8 @@ func (r Remove) equal(r2 Remove) bool {
 	return true
 }
 
-// HandleProposal handles a proposal to add or remove a guarantee
-// It will mutate Vars by calling Add or Remove for the proposal
+// HandleProposal handles a proposal to add or remove a guarantee.
+// It will mutate Vars by calling Add or Remove for the proposal.
 func (vars *Vars) HandleProposal(p Proposal) error {
 
 	switch p.Type() {
@@ -695,7 +706,7 @@ func (vars *Vars) HandleProposal(p Proposal) error {
 //  - the balances are incorrectly adjusted, or the deposits are too large
 //  - the guarantee is already included in vars.Outcome
 //
-// If an error is returned, the original vars is not mutated
+// If an error is returned, the original vars is not mutated.
 func (vars *Vars) Add(p Add) error {
 	// CHECKS
 	if p.turnNum != vars.TurnNum+1 {
@@ -747,7 +758,7 @@ func (vars *Vars) Add(p Add) error {
 //  - a guarantee is not found for the target
 //  - the amounts are too large for the guarantee amount
 //
-// If an error is returned, the original vars is not mutated
+// If an error is returned, the original vars is not mutated.
 func (vars *Vars) Remove(p Remove) error {
 	// CHECKS
 
@@ -781,7 +792,7 @@ func (vars *Vars) Remove(p Remove) error {
 	return nil
 }
 
-// Remove is a proposal to remover a guarantee for the given virtual channel
+// Remove is a proposal to remover a guarantee for the given virtual channel.
 type Remove struct {
 	turnNum uint64
 	Target  types.Destination

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -17,7 +17,15 @@ import (
 
 type ledgerIndex uint
 
-var ErrIncorrectChannelID = fmt.Errorf("proposal ID and channel ID do not match")
+var (
+	ErrIncorrectChannelID = fmt.Errorf("proposal ID and channel ID do not match")
+	ErrIncorrectTurnNum   = fmt.Errorf("incorrect turn number")
+	ErrInvalidDeposit     = fmt.Errorf("unable to divert to guarantee: invalid deposit")
+	ErrInsufficientFunds  = fmt.Errorf("insufficient funds")
+	ErrDuplicateGuarantee = fmt.Errorf("duplicate guarantee detected")
+	ErrGuaranteeNotFound  = fmt.Errorf("guarantee not found")
+	ErrInvalidAmounts     = fmt.Errorf("left and right amounts do not add up to the guarantee amount")
+)
 
 const (
 	Leader   ledgerIndex = 0
@@ -411,12 +419,6 @@ func (o *LedgerOutcome) AsOutcome() outcome.Exit {
 	}
 }
 
-var ErrInvalidDeposit = fmt.Errorf("unable to divert to guarantee: invalid deposit")
-var ErrInsufficientFunds = fmt.Errorf("insufficient funds")
-var ErrDuplicateGuarantee = fmt.Errorf("duplicate guarantee detected")
-var ErrGuaranteeNotFound = fmt.Errorf("guarantee not found")
-var ErrInvalidAmounts = fmt.Errorf("left and right amounts do not add up to the guarantee amount")
-
 // Vars stores the turn number and outcome for a state in a consensus channel
 type Vars struct {
 	TurnNum uint64
@@ -659,8 +661,6 @@ func (r Remove) equal(r2 Remove) bool {
 	}
 	return true
 }
-
-var ErrIncorrectTurnNum = fmt.Errorf("incorrect turn number")
 
 // HandleProposal handles a proposal to add or remove a guarantee
 // It will mutate Vars by calling Add or Remove for the proposal

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -589,7 +589,7 @@ type SignedProposal struct {
 	Proposal Proposal
 }
 
-// clone returns a deep copy of the reciever.
+// Clone returns a deep copy of the reciever.
 func (sp *SignedProposal) Clone() SignedProposal {
 	sp2 := SignedProposal{sp.Signature, sp.Proposal.Clone()}
 	return sp2

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -35,16 +35,19 @@ const (
 // ConsensusChannel is used to manage states in a running ledger channel
 type ConsensusChannel struct {
 	// constants
-	MyIndex ledgerIndex
-	fp      state.FixedPart
 
-	Id types.Destination
-
+	MyIndex        ledgerIndex
+	fp             state.FixedPart
+	Id             types.Destination
 	OnChainFunding types.Funds
 
 	// variables
-	current       SignedVars       // The "consensus state", signed by both parties
-	proposalQueue []SignedProposal // A queue of proposed changes, starting from the consensus state
+
+	// current represents the "consensus state", signed by both parties
+	current SignedVars
+
+	// a queue of proposed changes which can be applied to the current state
+	proposalQueue []SignedProposal
 }
 
 // newConsensusChannel constructs a new consensus channel, validating its input by checking that the signatures are as expected for the given fp, initialTurnNum and outcome]

--- a/channel/consensus_channel/follower_channel.go
+++ b/channel/consensus_channel/follower_channel.go
@@ -6,13 +6,15 @@ import (
 	"github.com/statechannels/go-nitro/channel/state"
 )
 
-var ErrNotFollower = fmt.Errorf("method may only be called by channel follower")
-var ErrNoProposals = fmt.Errorf("no proposals in the queue")
-var ErrUnsupportedQueuedProposal = fmt.Errorf("only Add proposal is supported for queued proposals")
-var ErrUnsupportedExpectedProposal = fmt.Errorf("only Add proposal is supported for expected update")
-var ErrNonMatchingProposals = fmt.Errorf("expected proposal does not match first proposal in the queue")
-var ErrInvalidProposalSignature = fmt.Errorf("invalid signature for proposal")
-var ErrInvalidTurnNum = fmt.Errorf("the proposal turn number is not the next turn number")
+var (
+	ErrNotFollower                 = fmt.Errorf("method may only be called by channel follower")
+	ErrNoProposals                 = fmt.Errorf("no proposals in the queue")
+	ErrUnsupportedQueuedProposal   = fmt.Errorf("only Add proposal is supported for queued proposals")
+	ErrUnsupportedExpectedProposal = fmt.Errorf("only Add proposal is supported for expected update")
+	ErrNonMatchingProposals        = fmt.Errorf("expected proposal does not match first proposal in the queue")
+	ErrInvalidProposalSignature    = fmt.Errorf("invalid signature for proposal")
+	ErrInvalidTurnNum              = fmt.Errorf("the proposal turn number is not the next turn number")
+)
 
 // NewFollowerChannel constructs a new FollowerChannel
 func NewFollowerChannel(fp state.FixedPart, turnNum uint64, outcome LedgerOutcome, signatures [2]state.Signature) (ConsensusChannel, error) {

--- a/channel/consensus_channel/leader_channel.go
+++ b/channel/consensus_channel/leader_channel.go
@@ -6,7 +6,11 @@ import (
 	"github.com/statechannels/go-nitro/channel/state"
 )
 
-var ErrNotLeader = fmt.Errorf("method may only be called by the channel leader")
+var (
+	ErrNotLeader              = fmt.Errorf("method may only be called by the channel leader")
+	ErrProposalQueueExhausted = fmt.Errorf("proposal queue exhausted")
+	ErrWrongSigner            = fmt.Errorf("proposal incorrectly signed")
+)
 
 // NewLeaderChannel constructs a new LeaderChannel
 func NewLeaderChannel(fp state.FixedPart, turnNum uint64, outcome LedgerOutcome, signatures [2]state.Signature) (ConsensusChannel, error) {
@@ -148,6 +152,3 @@ func (c *ConsensusChannel) leaderReceive(countersigned SignedProposal) error {
 
 	return ErrProposalQueueExhausted
 }
-
-var ErrProposalQueueExhausted = fmt.Errorf("proposal queue exhausted")
-var ErrWrongSigner = fmt.Errorf("proposal incorrectly signed")

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -10,8 +10,10 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-var ErrNoSuchObjective error = errors.New("store: no such objective")
-var ErrNoSuchChannel error = errors.New("store: failed to find required channel data")
+var (
+	ErrNoSuchObjective error = errors.New("store: no such objective")
+	ErrNoSuchChannel   error = errors.New("store: failed to find required channel data")
+)
 
 // Store is responsible for persisting objectives, objective metadata, states, signatures, private keys and blockchain data
 type Store interface {

--- a/internal/testdata/states.go
+++ b/internal/testdata/states.go
@@ -81,7 +81,7 @@ func createLedgerState(client, hub types.Address, clientBalance, hubBalance uint
 	}
 	state.Outcome = Outcomes.Create(client, hub, clientBalance, hubBalance)
 	state.AppDefinition = types.Address{} // ledger channel running the consensus app
-	state.TurnNum = 0                     // a requirement for channel.NewTwoPartyLedger
+	state.TurnNum = 0
 
 	return state
 }

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -23,9 +23,11 @@ const (
 
 const ObjectivePrefix = "DirectDefunding-"
 
-// errors
-var ErrNotApproved = errors.New("objective not approved")
-var ErrChannelUpdateInProgress = errors.New("can only defund a channel when the latest state is supported or when the channel has a final state")
+var (
+	ErrNotApproved             = errors.New("objective not approved")
+	ErrChannelUpdateInProgress = errors.New("can only defund a channel when the latest state is supported or when the channel has a final state")
+	ErrNoFinalState            = errors.New("Cannot spawn direct defund objective without a final state")
+)
 
 // Objective is a cache of data computed by reading from the store. It stores (potentially) infinite data
 type Objective struct {
@@ -109,8 +111,6 @@ func NewObjective(
 
 	return init, nil
 }
-
-var ErrNoFinalState = errors.New("Cannot spawn direct defund objective without a final state")
 
 // ConstructObjectiveFromState takes in a state and constructs an objective from it.
 func ConstructObjectiveFromState(

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -30,9 +30,6 @@ func FundOnChainEffect(cId types.Destination, asset string, amount types.Funds) 
 	return "deposit" + amount.String() + "into" + cId.String()
 }
 
-// errors
-var ErrNotApproved = errors.New("objective not approved")
-
 // Objective is a cache of data computed by reading from the store. It stores (potentially) infinite data
 type Objective struct {
 	Status protocols.ObjectiveStatus
@@ -238,7 +235,7 @@ func (o Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Side
 	sideEffects := protocols.SideEffects{}
 	// Input validation
 	if updated.Status != protocols.Approved {
-		return &updated, protocols.SideEffects{}, WaitingForNothing, ErrNotApproved
+		return &updated, protocols.SideEffects{}, WaitingForNothing, protocols.ErrNotApproved
 	}
 
 	// Prefunding

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -2,6 +2,7 @@ package protocols
 
 import (
 	"encoding/json"
+	"errors"
 
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
@@ -14,6 +15,10 @@ type TransactionType string
 const (
 	DepositTransactionType     TransactionType = "Deposit"
 	WithdrawAllTransactionType TransactionType = "Withdraw"
+)
+
+var (
+	ErrNotApproved = errors.New("objective not approved")
 )
 
 // ChainTransaction is an object to be sent to a blockchain provider.

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -21,9 +21,6 @@ const (
 // The turn number used for the final state
 const FinalTurnNum = 2
 
-// errors
-var ErrNotApproved = errors.New("objective not approved")
-
 // Objective contains relevent information for the defund objective
 type Objective struct {
 	Status protocols.ObjectiveStatus
@@ -187,7 +184,7 @@ func (o Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Side
 
 	// Input validation
 	if updated.Status != protocols.Approved {
-		return &updated, sideEffects, WaitingForNothing, ErrNotApproved
+		return &updated, sideEffects, WaitingForNothing, protocols.ErrNotApproved
 	}
 
 	// Signing of the final state

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -26,9 +26,6 @@ const (
 
 const ObjectivePrefix = "VirtualFund-"
 
-// errors
-var ErrNotApproved = errors.New("objective not approved")
-
 // GuaranteeInfo contains the information used to generate the expected guarantees.
 type GuaranteeInfo struct {
 	Left                 types.Destination
@@ -360,7 +357,7 @@ func (o Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Side
 	sideEffects := protocols.SideEffects{}
 	// Input validation
 	if updated.Status != protocols.Approved {
-		return &updated, sideEffects, WaitingForNothing, ErrNotApproved
+		return &updated, sideEffects, WaitingForNothing, protocols.ErrNotApproved
 	}
 
 	// Prefunding

--- a/types/bigutils.go
+++ b/types/bigutils.go
@@ -6,16 +6,18 @@ import "math/big"
 // bigutils.go is a parking spot for small, reusable utility functions extending the big package
 //////////
 
-// Gt return true if a > b, false otherwise
+// Gt returns true if a > b, false otherwise
 func Gt(a *big.Int, b *big.Int) bool {
 	return a.Cmp(b) > 0
 }
 
-// Lt return true if a < b, false otherwise
+// Lt returns true if a < b, false otherwise
 func Lt(a *big.Int, b *big.Int) bool {
 	return a.Cmp(b) < 0
 }
 
+// Equal returns true if a == b or if both of
+// a and b are nil, and false otherwise.
 func Equal(a *big.Int, b *big.Int) bool {
 	if a == nil {
 		return b == nil
@@ -26,7 +28,7 @@ func Equal(a *big.Int, b *big.Int) bool {
 	return a.Cmp(b) == 0
 }
 
-// Lt return true if a==0, false otherwise
+// IsZero returns true if a is zero, false otherwise
 func IsZero(a *big.Int) bool {
 	return a.Cmp(big.NewInt(0)) == 0
 }

--- a/types/destination.go
+++ b/types/destination.go
@@ -4,7 +4,8 @@ import (
 	"errors"
 )
 
-// IsExternal returns true if the destination has the 12 leading bytes as zero, false otherwise
+// IsExternal returns true if the destination is a blockchain address, and false
+// if it is a state channel ID.
 func (d Destination) IsExternal() bool {
 	for _, b := range d[0:12] {
 		if b != 0 {
@@ -36,6 +37,7 @@ func (d Destination) Bytes() []byte {
 	return Bytes32(d).Bytes()
 }
 
+// AddressToDestinaion left-pads the blockchain address with zeros.
 func AddressToDestination(a Address) Destination {
 	d := Destination{0}
 	for i := range a {

--- a/types/funds.go
+++ b/types/funds.go
@@ -55,15 +55,15 @@ func Sum(a ...Funds) Funds {
 	return sum
 }
 
-// Equal returns true if receiver `f` and input `g` are identical in value.
+// Equal returns true if receiver and input g are identical in monetary value, and false otherwise.
 //
 // Note that a zero-balance equals a non-balance: {[0x0a,0x00],[0x0b,0x01]} == {[0x0b,0x01]}
 func (f Funds) Equal(g Funds) bool {
 	return f.canAfford(g) && g.canAfford(f)
 }
 
-// canAfford returns true if each of `g`'s non-zero asset balances is matched
-// or exceeded by the same asset-balance in `f`
+// canAfford returns true if each of g's non-zero asset balances is matched
+// or exceeded by the same asset-balance in the receiver
 func (f Funds) canAfford(g Funds) bool {
 	zero := big.NewInt(0)
 

--- a/types/funds.go
+++ b/types/funds.go
@@ -63,7 +63,7 @@ func (f Funds) Equal(g Funds) bool {
 }
 
 // canAfford returns true if each of g's non-zero asset balances is matched
-// or exceeded by the same asset-balance in the receiver
+// or exceeded by the same asset-balance in the receiver.
 func (f Funds) canAfford(g Funds) bool {
 	zero := big.NewInt(0)
 

--- a/types/types.go
+++ b/types/types.go
@@ -13,7 +13,9 @@ type Address = common.Address
 // An ethereum hash (32 bytes)
 type Bytes32 = common.Hash
 
-// A nitro destination - either a left-zero-padded ethereum address or an application specific identifier
+// Destination represents a payable address in go-nitro, which is either:
+//  - a blockchain account address left-padded with 0s, or
+//  - a 32-byte nitro channel address
 type Destination Bytes32
 
 // An arbitrary length byte slice

--- a/types/types.go
+++ b/types/types.go
@@ -13,9 +13,10 @@ type Address = common.Address
 // An ethereum hash (32 bytes)
 type Bytes32 = common.Hash
 
-// Destination represents a payable address in go-nitro, which is either:
-//  - a blockchain account address left-padded with 0s, or
-//  - a 32-byte nitro channel address
+// Destination represents a payable address in go-nitro. In a state channel network,
+// payable address are either:
+//  - Internal: a 32-byte nitro channel ID, or
+//  - External: a blockchain account or contract address, left-padded with 0s
 type Destination Bytes32
 
 // An arbitrary length byte slice


### PR DESCRIPTION
toward #609

PR represents work-in-progress toward tidying the godoc of go-nitro's packages' public APIs.

Aiming for:
- [complete sentences](https://github.com/golang/go/wiki/CodeReviewComments#comment-sentences) 
- descriptive godoc that doesn't assume a great deal of reader expertise

In general, it is the norm in go to have long-winded godoc. See, eg:
- https://pkg.go.dev/html/template@go1.18.1#ErrorCode - long docstrings for individual errors
- https://pkg.go.dev/os/exec@go1.18.1#Cmd - long docstrings on struct fields
- https://pkg.go.dev/encoding/json@go1.18.1#Marshal - long docstring on a method

As things firm up, I think we should not be shy about adding thorough documentation to things like `FixedPart`, `VariablePart`, `LedgerChannel` (when that name comes back into focus), `Objective`, etc.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] ~I have added tests that prove my fix is effective or that my feature works, if necessary~
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments __(I hope so!)__

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
