### PR TITLE
refactor syncMap to its own package

### DIFF
--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -3,10 +3,10 @@ package store
 import (
 	"encoding/json"
 	"fmt"
-	"sync"
 
 	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/client/engine/store/safesync"
 	"github.com/statechannels/go-nitro/crypto"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/protocols/directdefund"
@@ -16,61 +16,13 @@ import (
 )
 
 type MemStore struct {
-	objectives         syncMap[[]byte]
-	channels           syncMap[[]byte]
-	consensusChannels  syncMap[[]byte]
-	channelToObjective syncMap[protocols.ObjectiveId]
+	objectives         safesync.Map[[]byte]
+	channels           safesync.Map[[]byte]
+	consensusChannels  safesync.Map[[]byte]
+	channelToObjective safesync.Map[protocols.ObjectiveId]
 
 	key     []byte        // the signing key of the store's engine
 	address types.Address // the (Ethereum) address associated to the signing key
-}
-
-// syncMap wraps sync.Map in order to provide type safety
-type syncMap[T any] struct {
-	m sync.Map
-}
-
-// Load returns the value stored in the map for a key, or nil if no
-// value is present.
-// The ok result indicates whether value was found in the map.
-func (o *syncMap[T]) Load(id string) (value T, ok bool) {
-	data, ok := o.m.Load(id)
-
-	if !ok {
-		var result T
-		return result, false
-	}
-
-	value = data.(T)
-
-	return value, ok
-}
-
-// Store sets the value for a key.
-func (o *syncMap[T]) Store(key string, data T) {
-	o.m.Store(key, data)
-}
-
-// Delete deletes the value for a key.
-func (o *syncMap[T]) Delete(key string) {
-	o.m.Delete(key)
-}
-
-// Range calls f sequentially for each key and value present in the map.
-// If f returns false, range stops the iteration.
-//
-// Range does not necessarily correspond to any consistent snapshot of the Map's
-// contents: no key will be visited more than once, but if the value for any key
-// is stored or deleted concurrently, Range may reflect any mapping for that key
-// from any point during the Range call.
-//
-// Range may be O(N) with the number of elements in the map even if f returns
-// false after a constant number of calls.
-func (o *syncMap[T]) Range(f func(key string, value T) bool) {
-	untypedF := func(key, value interface{}) bool {
-		return f(key.(string), value.(T))
-	}
-	o.m.Range(untypedF)
 }
 
 func NewMemStore(key []byte) Store {
@@ -78,10 +30,10 @@ func NewMemStore(key []byte) Store {
 	ms.key = key
 	ms.address = crypto.GetAddressFromSecretKeyBytes(key)
 
-	ms.objectives = syncMap[[]byte]{}
-	ms.channels = syncMap[[]byte]{}
-	ms.consensusChannels = syncMap[[]byte]{}
-	ms.channelToObjective = syncMap[protocols.ObjectiveId]{}
+	ms.objectives = safesync.Map[[]byte]{}
+	ms.channels = safesync.Map[[]byte]{}
+	ms.consensusChannels = safesync.Map[[]byte]{}
+	ms.channelToObjective = safesync.Map[protocols.ObjectiveId]{}
 
 	return &ms
 }

--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -321,5 +321,5 @@ func decodeObjective(id protocols.ObjectiveId, data []byte) (protocols.Objective
 }
 
 func (ms *MemStore) ReleaseChannelFromOwnership(channelId types.Destination) {
-	ms.channelToObjective.m.Delete(channelId.String())
+	ms.channelToObjective.Delete(channelId.String())
 }

--- a/client/engine/store/safesync/safesync.go
+++ b/client/engine/store/safesync/safesync.go
@@ -1,0 +1,51 @@
+package safesync
+
+import "sync"
+
+// Map wraps sync.Map in order to provide type safety
+type Map[T any] struct {
+	m sync.Map
+}
+
+// Load returns the value stored in the map for a key, or nil if no
+// value is present.
+// The ok result indicates whether value was found in the map.
+func (o *Map[T]) Load(id string) (value T, ok bool) {
+	data, ok := o.m.Load(id)
+
+	if !ok {
+		var result T
+		return result, false
+	}
+
+	value = data.(T)
+
+	return value, ok
+}
+
+// Store sets the value for a key.
+func (o *Map[T]) Store(key string, data T) {
+	o.m.Store(key, data)
+}
+
+// Delete deletes the value for a key.
+func (o *Map[T]) Delete(key string) {
+	o.m.Delete(key)
+}
+
+// Range calls f sequentially for each key and value present in the map.
+// If f returns false, range stops the iteration.
+//
+// Range does not necessarily correspond to any consistent snapshot of the Map's
+// contents: no key will be visited more than once, but if the value for any key
+// is stored or deleted concurrently, Range may reflect any mapping for that key
+// from any point during the Range call.
+//
+// Range may be O(N) with the number of elements in the map even if f returns
+// false after a constant number of calls.
+func (o *Map[T]) Range(f func(key string, value T) bool) {
+	untypedF := func(key, value interface{}) bool {
+		return f(key.(string), value.(T))
+	}
+	o.m.Range(untypedF)
+}

--- a/client/engine/store/safesync/safesync.go
+++ b/client/engine/store/safesync/safesync.go
@@ -1,3 +1,4 @@
+// package safesync provides a type-safe, concurrency-safe Map struct
 package safesync
 
 import "sync"


### PR DESCRIPTION
closes #616 

refactor PR to hide private field of the type-safe wrapping class `syncMap`.

As a bonus, this did in fact catch an accidental direct usage of the wrapped syncMap.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
