### PR TITLE
Switch Actor Address from field to function

### DIFF
--- a/channel/consensus_channel/helpers_test.go
+++ b/channel/consensus_channel/helpers_test.go
@@ -19,7 +19,7 @@ var alice, bob, brian testactors.Actor = testactors.Alice, testactors.Bob, testa
 
 func fp() state.FixedPart {
 	participants := [2]types.Address{
-		alice.Address, bob.Address,
+		alice.Address(), bob.Address(),
 	}
 	return state.FixedPart{
 		Participants:      participants[:],

--- a/client/engine/store/memstore_test.go
+++ b/client/engine/store/memstore_test.go
@@ -137,14 +137,14 @@ func TestConsensusChannelStore(t *testing.T) {
 
 	ms := store.NewMemStore(sk)
 
-	got, ok := ms.GetConsensusChannel(ta.Alice.Address)
+	got, ok := ms.GetConsensusChannel(ta.Alice.Address())
 	if ok {
 		t.Fatalf("expected not to find the a consensus channel, but found %v", got)
 	}
 
 	fp := td.Objectives.Directfund.GenericDFO().C.FixedPart // TODO replace with testdata not nested under GenericDFO
-	fp.Participants[0] = ta.Alice.Address
-	fp.Participants[1] = ta.Bob.Address
+	fp.Participants[0] = ta.Alice.Address()
+	fp.Participants[1] = ta.Bob.Address()
 	asset := types.Address{}
 	left := cc.NewBalance(ta.Alice.Destination(), big.NewInt(6))
 	right := cc.NewBalance(ta.Bob.Destination(), big.NewInt(4))

--- a/client_test/virtual_fund_message_delay_test.go
+++ b/client_test/virtual_fund_message_delay_test.go
@@ -37,7 +37,7 @@ func TestVirtualFundWithMessageDelays(t *testing.T) {
 	directlyFundALedgerChannel(t, clientA, clientI)
 	directlyFundALedgerChannel(t, clientI, clientB)
 
-	ids := createVirtualChannels(clientA, bob.Address, irene.Address, 5)
+	ids := createVirtualChannels(clientA, bob.Address(), irene.Address(), 5)
 	waitTimeForCompletedObjectiveIds(t, &clientA, OBJECTIVE_TIMEOUT, ids...)
 	waitTimeForCompletedObjectiveIds(t, &clientB, OBJECTIVE_TIMEOUT, ids...)
 	waitTimeForCompletedObjectiveIds(t, &clientI, OBJECTIVE_TIMEOUT, ids...)

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -37,7 +37,7 @@ func TestBenchmark(t *testing.T) {
 
 	n := 1
 	for i := 0; i < n; i++ {
-		go benchmarkVirtualChannelCreation(t, clientAlice, clientBob, irene.Address, done)
+		go benchmarkVirtualChannelCreation(t, clientAlice, clientBob, irene.Address(), done)
 	}
 
 	expect(t, done, n, time.Second*1)

--- a/client_test/virtualfund_integration_test.go
+++ b/client_test/virtualfund_integration_test.go
@@ -29,11 +29,11 @@ func TestVirtualFundIntegration(t *testing.T) {
 	directlyFundALedgerChannel(t, clientA, clientI)
 	directlyFundALedgerChannel(t, clientI, clientB)
 
-	outcome := td.Outcomes.Create(alice.Address, bob.Address, 1, 1)
+	outcome := td.Outcomes.Create(alice.Address(), bob.Address(), 1, 1)
 	request := virtualfund.ObjectiveRequest{
-		MyAddress:         alice.Address,
-		CounterParty:      bob.Address,
-		Intermediary:      irene.Address,
+		MyAddress:         alice.Address(),
+		CounterParty:      bob.Address(),
+		Intermediary:      irene.Address(),
 		Outcome:           outcome,
 		AppDefinition:     types.Address{},
 		AppData:           types.Bytes{},

--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -31,12 +31,12 @@ func TestMultiPartyVirtualFundIntegration(t *testing.T) {
 	directlyFundALedgerChannel(t, clientIrene, clientBob)
 	directlyFundALedgerChannel(t, clientIrene, clientBrian)
 	withBobRequest := virtualfund.ObjectiveRequest{
-		MyAddress:    alice.Address,
-		CounterParty: bob.Address,
-		Intermediary: irene.Address,
+		MyAddress:    alice.Address(),
+		CounterParty: bob.Address(),
+		Intermediary: irene.Address(),
 		Outcome: td.Outcomes.Create(
-			alice.Address,
-			bob.Address,
+			alice.Address(),
+			bob.Address(),
 			1,
 			1,
 		),
@@ -46,12 +46,12 @@ func TestMultiPartyVirtualFundIntegration(t *testing.T) {
 		Nonce:             rand.Int63(),
 	}
 	withBrianRequest := virtualfund.ObjectiveRequest{
-		MyAddress:    alice.Address,
-		CounterParty: brian.Address,
-		Intermediary: irene.Address,
+		MyAddress:    alice.Address(),
+		CounterParty: brian.Address(),
+		Intermediary: irene.Address(),
 		Outcome: td.Outcomes.Create(
-			alice.Address,
-			brian.Address,
+			alice.Address(),
+			brian.Address(),
 			1,
 			1,
 		),

--- a/internal/testactors/actors.go
+++ b/internal/testactors/actors.go
@@ -3,40 +3,47 @@ package testactors
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/crypto"
 	"github.com/statechannels/go-nitro/types"
 )
 
 type Actor struct {
-	Address    types.Address
 	PrivateKey []byte
 	Role       uint
 	Name       string
 }
 
 func (a Actor) Destination() types.Destination {
-	return types.AddressToDestination(a.Address)
+	return types.AddressToDestination(a.Address())
 }
 
+func (a Actor) Address() types.Address {
+	return crypto.GetAddressFromSecretKeyBytes(a.PrivateKey)
+}
+
+// Alice has the address 0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE
 var Alice Actor = Actor{
-	common.HexToAddress(`0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE`),
 	common.Hex2Bytes(`2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d`),
 	0,
 	"alice",
 }
+
+// Bob has the address 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94
 var Bob Actor = Actor{
-	common.HexToAddress(`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`),
 	common.Hex2Bytes(`0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4`),
 	2,
 	"bob",
 }
+
+// Brian has the address 0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01
 var Brian Actor = Actor{
-	common.HexToAddress("0xB2B22ec3889d11f2ddb1A1Db11e80D20EF367c01"),
 	common.Hex2Bytes("0aca28ba64679f63d71e671ab4dbb32aaa212d4789988e6ca47da47601c18fe2"),
 	2,
 	"brian",
 }
+
+// Irene has the address 0x111A00868581f73AB42FEEF67D235Ca09ca1E8db
 var Irene Actor = Actor{
-	common.HexToAddress(`0x111A00868581f73AB42FEEF67D235Ca09ca1E8db`),
 	common.Hex2Bytes(`febb3b74b0b52d0976f6571d555f4ac8b91c308dfa25c7b58d1e6a7c3f50c781`),
 	1,
 	"irene",

--- a/internal/testdata/channels.go
+++ b/internal/testdata/channels.go
@@ -162,8 +162,8 @@ func createLedgerPath(actors []testactors.Actor) LedgerNetwork {
 
 func createTestLedger(leader, follower testactors.Actor) TestLedger {
 	fp := testState.Clone().FixedPart()
-	fp.Participants[0] = leader.Address
-	fp.Participants[1] = follower.Address
+	fp.Participants[0] = leader.Address()
+	fp.Participants[1] = follower.Address()
 
 	outcome := consensus_channel.NewLedgerOutcome(
 		types.Address{}, // the zero asset

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -61,9 +61,9 @@ func genericDFO() directfund.Objective {
 
 func genericVFO() virtualfund.Objective {
 	ts := testVirtualState.Clone()
-	ts.Participants[0] = testactors.Alice.Address
-	ts.Participants[1] = testactors.Irene.Address
-	ts.Participants[2] = testactors.Bob.Address
+	ts.Participants[0] = testactors.Alice.Address()
+	ts.Participants[1] = testactors.Irene.Address()
+	ts.Participants[2] = testactors.Bob.Address()
 
 	request := virtualfund.ObjectiveRequest{
 		ts.Participants[0],
@@ -81,7 +81,7 @@ func genericVFO() virtualfund.Objective {
 		testactors.Irene,
 		testactors.Bob,
 	})
-	lookup := ledgerPath.GetLedgerLookup(testactors.Alice.Address)
+	lookup := ledgerPath.GetLedgerLookup(testactors.Alice.Address())
 
 	testVFO, err := virtualfund.NewObjective(request, lookup)
 	if err != nil {

--- a/internal/testdata/states.go
+++ b/internal/testdata/states.go
@@ -42,9 +42,9 @@ var testOutcome = createLongOutcome(
 var testVirtualState = state.State{
 	ChainId: chainId,
 	Participants: []types.Address{
-		testactors.Alice.Address,
-		testactors.Irene.Address,
-		testactors.Bob.Address,
+		testactors.Alice.Address(),
+		testactors.Irene.Address(),
+		testactors.Bob.Address(),
 	},
 	ChannelNonce:      big.NewInt(1234789),
 	AppDefinition:     someAppDefinition,
@@ -61,8 +61,8 @@ var testVirtualState = state.State{
 var testState = state.State{
 	ChainId: chainId,
 	Participants: []types.Address{
-		testactors.Alice.Address,
-		testactors.Bob.Address,
+		testactors.Alice.Address(),
+		testactors.Bob.Address(),
 	},
 	ChannelNonce:      big.NewInt(37140676580),
 	AppDefinition:     someAppDefinition,

--- a/internal/testhelpers/testhelpers.go
+++ b/internal/testhelpers/testhelpers.go
@@ -66,7 +66,8 @@ func AssertStateSentToEveryone(t *testing.T, ses protocols.SideEffects, expected
 // AssertStateSentTo asserts that ses contains a message for the participant
 func AssertStateSentTo(t *testing.T, ses protocols.SideEffects, expected state.SignedState, to testactors.Actor) {
 	for _, msg := range ses.MessagesToSend {
-		if bytes.Equal(msg.To[:], to.Address[:]) {
+		toAddress := to.Address()
+		if bytes.Equal(msg.To[:], toAddress[:]) {
 			for _, ss := range msg.SignedStates() {
 				Equals(t, ss.Payload, expected)
 			}
@@ -84,7 +85,8 @@ func AssertProposalSent(t *testing.T, ses protocols.SideEffects, sp consensus_ch
 	for _, p := range msg.SignedProposals() {
 		found = found || p.Payload.Proposal.Equal(&sp.Proposal)
 	}
+	toAddress := to.Address()
 	Assert(t, found, "proposal %+v not found in signed proposals %+v", sp.Proposal, msg.SignedProposals())
-	Assert(t, bytes.Equal(msg.To[:], to.Address[:]), "exp: %+v\n\n\tgot%+v", msg.To.String(), to.Address.String())
+	Assert(t, bytes.Equal(msg.To[:], toAddress[:]), "exp: %+v\n\n\tgot%+v", msg.To.String(), to.Address().String())
 
 }

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -21,7 +21,7 @@ var alice, bob testactors.Actor = testactors.Alice, testactors.Bob
 
 var testState = state.State{
 	ChainId:           big.NewInt(9001),
-	Participants:      []types.Address{alice.Address, bob.Address},
+	Participants:      []types.Address{alice.Address(), bob.Address()},
 	ChannelNonce:      big.NewInt(37140676580),
 	AppDefinition:     common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),
 	ChallengeDuration: big.NewInt(60),
@@ -68,7 +68,7 @@ func signedTestState(s state.State, toSign []bool) (state.SignedState, error) {
 
 // newTestObjective returns a directdefund Objective constructed with a MockConsensusChannel.
 func newTestObjective() (Objective, error) {
-	cc, _ := testdata.Channels.MockConsensusChannel(alice.Address)
+	cc, _ := testdata.Channels.MockConsensusChannel(alice.Address())
 
 	getConsensusChannel := func(id types.Destination) (channel *consensus_channel.ConsensusChannel, err error) {
 		return cc, nil
@@ -156,7 +156,7 @@ func TestCrankAlice(t *testing.T) {
 
 	expectedSE := protocols.SideEffects{
 		MessagesToSend: []protocols.Message{{
-			To: bob.Address,
+			To: bob.Address(),
 			Payloads: []protocols.MessagePayload{{
 				ObjectiveId: o.Id(),
 				SignedState: finalStateSignedByAlice,
@@ -244,7 +244,7 @@ func TestCrankBob(t *testing.T) {
 	finalStateSignedByBob, _ := signedTestState(finalState, []bool{false, true})
 	expectedSE := protocols.SideEffects{
 		MessagesToSend: []protocols.Message{{
-			To: alice.Address,
+			To: alice.Address(),
 			Payloads: []protocols.MessagePayload{{ObjectiveId: updated.Id(),
 				SignedState: finalStateSignedByBob,
 			}}}}}

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -21,7 +21,7 @@ var alice, bob testactors.Actor = testactors.Alice, testactors.Bob
 
 var testState = state.State{
 	ChainId:           big.NewInt(9001),
-	Participants:      []types.Address{alice.Address, bob.Address},
+	Participants:      []types.Address{alice.Address(), bob.Address()},
 	ChannelNonce:      big.NewInt(37140676580),
 	AppDefinition:     common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),
 	ChallengeDuration: big.NewInt(60),
@@ -180,7 +180,7 @@ func TestCrank(t *testing.T) {
 	expectedPreFundSideEffects := protocols.SideEffects{
 		MessagesToSend: []protocols.Message{
 			{
-				To: bob.Address,
+				To: bob.Address(),
 				Payloads: []protocols.MessagePayload{{
 					ObjectiveId: s.Id(),
 					SignedState: preFundSS,
@@ -192,7 +192,7 @@ func TestCrank(t *testing.T) {
 	expectedPostFundSideEffects := protocols.SideEffects{
 		MessagesToSend: []protocols.Message{
 			{
-				To: bob.Address,
+				To: bob.Address(),
 				Payloads: []protocols.MessagePayload{{
 					ObjectiveId: s.Id(),
 					SignedState: postFundSS,

--- a/protocols/virtualdefund/helpers_test.go
+++ b/protocols/virtualdefund/helpers_test.go
@@ -54,7 +54,7 @@ func generateGuarantee(left, right testactors.Actor, vId types.Destination) cons
 func prepareConsensusChannel(role uint, left, right testactors.Actor, guarantees ...consensus_channel.Guarantee) *consensus_channel.ConsensusChannel {
 	fp := state.FixedPart{
 		ChainId:           big.NewInt(9001),
-		Participants:      []types.Address{left.Address, right.Address},
+		Participants:      []types.Address{left.Address(), right.Address()},
 		ChannelNonce:      big.NewInt(0),
 		AppDefinition:     types.Address{},
 		ChallengeDuration: big.NewInt(45),
@@ -246,7 +246,7 @@ func generateRemoveProposal(cId types.Destination, td testdata) consensus_channe
 func generateTestData() testdata {
 	vFixed := state.FixedPart{
 		ChainId:           big.NewInt(9001),
-		Participants:      []types.Address{alice.Address, irene.Address, bob.Address}, // A single hop virtual channel
+		Participants:      []types.Address{alice.Address(), irene.Address(), bob.Address()}, // A single hop virtual channel
 		ChannelNonce:      big.NewInt(0),
 		AppDefinition:     types.Address{},
 		ChallengeDuration: big.NewInt(45),

--- a/protocols/virtualfund/helpers_test.go
+++ b/protocols/virtualfund/helpers_test.go
@@ -25,7 +25,7 @@ func consensusStateSignatures(leader, follower testactors.Actor, guarantees ...c
 func prepareConsensusChannelHelper(role uint, leader, follower testactors.Actor, leftBalance, rightBalance, turnNum int, guarantees ...consensus_channel.Guarantee) *consensus_channel.ConsensusChannel {
 	fp := state.FixedPart{
 		ChainId:           big.NewInt(9001),
-		Participants:      []types.Address{leader.Address, follower.Address},
+		Participants:      []types.Address{leader.Address(), follower.Address()},
 		ChannelNonce:      big.NewInt(0),
 		AppDefinition:     types.Address{},
 		ChallengeDuration: big.NewInt(45),

--- a/protocols/virtualfund/virtualfund_test.go
+++ b/protocols/virtualfund/virtualfund_test.go
@@ -20,7 +20,7 @@ func TestMarshalJSON(t *testing.T) {
 
 	vPreFund := state.State{
 		ChainId:           big.NewInt(9001),
-		Participants:      []types.Address{alice.Address, p1.Address, bob.Address}, // A single hop virtual channel
+		Participants:      []types.Address{alice.Address(), p1.Address(), bob.Address()}, // A single hop virtual channel
 		ChannelNonce:      big.NewInt(0),
 		AppDefinition:     types.Address{},
 		ChallengeDuration: big.NewInt(45),
@@ -48,7 +48,7 @@ func TestMarshalJSON(t *testing.T) {
 	vfo, err := constructFromState(
 		false,
 		vPreFund,
-		alice.Address,
+		alice.Address(),
 		nil,
 		right,
 	)


### PR DESCRIPTION
An actor's address is determined by the private key. Switching to a function has the following benefits:
- Since the address is calculated, we avoid the possibility of an actor where the private key and the address do not match.
- Simplifies adding a new actor.

