### PR TITLE
restrict ObjectiveEvent to single proposal/state

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -266,19 +266,6 @@ func (c *Channel) AddSignedState(ss state.SignedState) bool {
 	return true
 }
 
-// AddSignedStates adds each signed state in the passed slice. It returns true if all signed states were added successfully, false otherwise.
-// If one or more signed states fails to be added, this does not prevent other signed states from being added.
-func (c *Channel) AddSignedStates(sss []state.SignedState) bool {
-	allOk := true
-	for _, ss := range sss {
-		ok := c.AddSignedState(ss)
-		if !ok {
-			allOk = false
-		}
-	}
-	return allOk
-}
-
 // SignAndAddPrefund signs and adds the prefund state for the channel, returning a state.SignedState suitable for sending to peers.
 func (c *Channel) SignAndAddPrefund(sk *[]byte) (state.SignedState, error) {
 	return c.SignAndAddState(c.PreFundState(), sk)

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -188,51 +188,6 @@ func TestChannel(t *testing.T) {
 		}
 	}
 
-	testAddSignedStates := func(t *testing.T) {
-		myC, _ := New(s, 0)
-
-		ss := state.NewSignedState(s)
-		sigA, err := ss.State().Sign(alicePrivateKey)
-		if err != nil {
-			t.Error(err)
-		}
-		sigB, err := ss.State().Sign(bobPrivateKey)
-		if err != nil {
-			t.Error(err)
-		}
-		err = ss.AddSignature(sigA)
-		if err != nil {
-			t.Error(err)
-		}
-		err = ss.AddSignature(sigB)
-		if err != nil {
-			t.Error(err)
-		}
-		if ok := myC.AddSignedStates([]state.SignedState{ss}); !ok {
-			t.Error("AddSignedStates returned false")
-		}
-
-		// It should properly update the latestSupportedStateNum
-		got := myC.latestSupportedStateTurnNum
-		if got != s.TurnNum {
-			t.Fatalf("Expected latestSupportedStateTurnNum of %d but got %d", s.TurnNum, got)
-		}
-
-		// verify the signatures
-		expectedSigs := []state.Signature{sigA, sigB}
-		for i := range myC.Participants {
-			gotSig, err := myC.SignedStateForTurnNum[s.TurnNum].GetParticipantSignature(uint(i))
-			if err != nil {
-				panic(err)
-			}
-			wantSig := expectedSigs[i]
-			if !gotSig.Equal(wantSig) {
-				t.Fatalf("Expected to find signature %x at index 0, but got %x", wantSig, gotSig)
-			}
-		}
-
-	}
-
 	testAddStateWithSignature := func(t *testing.T) {
 		// Begin testing the cases that are NOOPs returning false
 		want := false
@@ -348,7 +303,6 @@ func TestChannel(t *testing.T) {
 	t.Run(`TestLatestSignedState`, testLatestSignedState)
 	t.Run(`TestTotal`, testTotal)
 	t.Run(`TestAddStateWithSignature`, testAddStateWithSignature)
-	t.Run(`TestAddSignedStates`, testAddSignedStates)
 	t.Run(`TestAddSignedState`, testAddSignedState)
 
 }

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -150,9 +150,9 @@ func (e *Engine) handleMessage(message protocols.Message) (ObjectiveChangeEvent,
 		}
 
 		event := protocols.ObjectiveEvent{
-			ObjectiveId:     entry.ObjectiveId,
-			SignedProposals: []consensus_channel.SignedProposal{},
-			SignedStates:    []state.SignedState{entry.Payload},
+			ObjectiveId:    entry.ObjectiveId,
+			SignedProposal: consensus_channel.SignedProposal{},
+			SignedState:    entry.Payload,
 		}
 		updatedObjective, err := objective.Update(event)
 		if err != nil {
@@ -176,9 +176,9 @@ func (e *Engine) handleMessage(message protocols.Message) (ObjectiveChangeEvent,
 		}
 
 		event := protocols.ObjectiveEvent{
-			ObjectiveId:     entry.ObjectiveId,
-			SignedProposals: []consensus_channel.SignedProposal{entry.Payload},
-			SignedStates:    []state.SignedState{},
+			ObjectiveId:    entry.ObjectiveId,
+			SignedProposal: entry.Payload,
+			SignedState:    state.SignedState{},
 		}
 		updatedObjective, err := objective.Update(event)
 		if err != nil {

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -107,7 +107,7 @@ func TestUpdate(t *testing.T) {
 	s.TurnNum = 3
 	e.ObjectiveId = o.Id()
 	ss, _ := signedTestState(s, []bool{true, false})
-	e.SignedStates = []state.SignedState{ss}
+	e.SignedState = ss
 
 	if _, err := o.Update(e); err.Error() != "direct defund objective can only be updated with final states" {
 		t.Error(err)
@@ -117,7 +117,7 @@ func TestUpdate(t *testing.T) {
 	s.TurnNum = 4
 	s.IsFinal = true
 	ss, _ = signedTestState(s, []bool{true, false})
-	e.SignedStates = []state.SignedState{ss}
+	e.SignedState = ss
 
 	if _, err := o.Update(e); err.Error() != "expected state with turn number 2, received turn number 4" {
 		t.Error(err)
@@ -169,7 +169,7 @@ func TestCrankAlice(t *testing.T) {
 
 	// The second update and crank. Alice is expected to create a withdrawAll transaction
 	finalStateSignedByAliceBob, _ := signedTestState(finalState, []bool{true, true})
-	e := protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedStates: []state.SignedState{finalStateSignedByAliceBob}}
+	e := protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedState: finalStateSignedByAliceBob}
 
 	updated, err = updated.Update(e)
 	if err != nil {
@@ -223,7 +223,7 @@ func TestCrankBob(t *testing.T) {
 	finalState.TurnNum = 2
 	finalState.IsFinal = true
 	finalStateSignedByAlice, _ := signedTestState(finalState, []bool{true, false})
-	e := protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedStates: []state.SignedState{finalStateSignedByAlice}}
+	e := protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedState: finalStateSignedByAlice}
 	updated, err := o.Update(e)
 	if err != nil {
 		t.Fatal(err)

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -202,7 +202,7 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 	}
 
 	updated := o.clone()
-	updated.C.AddSignedStates(event.SignedStates)
+	updated.C.AddSignedState(event.SignedState)
 
 	return &updated, nil
 }

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -105,7 +105,6 @@ func TestUpdate(t *testing.T) {
 	// and make a new Sigs map.
 	// This prepares us for the rest of the test. We will reuse the same event multiple times
 	e.ObjectiveId = s.Id()
-	e.SignedStates = make([]state.SignedState, 0)
 
 	// Next, attempt to update the objective with correct signature by a participant on a relevant state
 	// Assert that this results in an appropriate change in the extended state of the objective
@@ -114,7 +113,7 @@ func TestUpdate(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	e.SignedStates = append(e.SignedStates, ss)
+	e.SignedState = ss
 	updatedObjective, err := s.Update(e)
 	if err != nil {
 		t.Error(err)

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -48,9 +48,9 @@ type AdjudicationStatus struct {
 
 // ObjectiveEvent holds information used to update an Objective. Some fields may be nil.
 type ObjectiveEvent struct {
-	ObjectiveId     ObjectiveId
-	SignedStates    []state.SignedState
-	SignedProposals []consensus_channel.SignedProposal
+	ObjectiveId    ObjectiveId
+	SignedState    state.SignedState
+	SignedProposal consensus_channel.SignedProposal
 }
 
 // Storable is an object that can be stored by the store.

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -366,7 +366,7 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 
 	updated := o.clone()
 
-	for _, ss := range event.SignedStates {
+	if ss := event.SignedState; len(ss.Signatures()) != 0 {
 		incomingChannelId, _ := ss.State().ChannelId() // TODO handle error
 		vChannelId, _ := updated.VFixed.ChannelId()    // TODO handle error
 
@@ -411,7 +411,7 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 		toMyRightId = o.ToMyRight.Id
 	}
 
-	for _, sp := range event.SignedProposals {
+	if sp := event.SignedProposal; sp.ChannelId() == o.OwnsChannel() {
 		var err error
 		switch sp.Proposal.ChannelID {
 		case types.Destination{}:

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -43,7 +43,7 @@ func TestInvalidUpdate(t *testing.T) {
 	// Sign the final state by some other participant
 	signStateByOthers(alice, signedFinal)
 
-	e := protocols.ObjectiveEvent{ObjectiveId: virtualDefund.Id(), SignedStates: []state.SignedState{signedFinal}}
+	e := protocols.ObjectiveEvent{ObjectiveId: virtualDefund.Id(), SignedState: signedFinal}
 	_, err := virtualDefund.Update(e)
 	if err.Error() != "event channelId out of scope of objective" {
 		t.Errorf("Expected error for channelId being out of scope, got %v", err)
@@ -62,7 +62,7 @@ func testUpdateAs(my ta.Actor) func(t *testing.T) {
 		// Sign the final state by some other participant
 		signStateByOthers(my, signedFinal)
 
-		e := protocols.ObjectiveEvent{ObjectiveId: virtualDefund.Id(), SignedStates: []state.SignedState{signedFinal}}
+		e := protocols.ObjectiveEvent{ObjectiveId: virtualDefund.Id(), SignedState: signedFinal}
 
 		updatedObj, err := virtualDefund.Update(e)
 		updated := updatedObj.(*Objective)

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -314,8 +314,9 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 		toMyRightId = o.ToMyRight.Channel.Id // Avoid this if it is nil
 	}
 
-	for _, sp := range event.SignedProposals {
+	if sp := event.SignedProposal; sp.Proposal.Target() == o.V.Id {
 		var err error
+
 		switch sp.Proposal.ChannelID {
 		case types.Destination{}:
 			return &o, fmt.Errorf("signed proposal is for a zero-addressed ledger channel") // catch this case to avoid unspecified behaviour -- because if Alice or Bob we allow a null channel.
@@ -332,7 +333,7 @@ func (o Objective) Update(event protocols.ObjectiveEvent) (protocols.Objective, 
 		}
 	}
 
-	for _, ss := range event.SignedStates {
+	if ss := event.SignedState; len(ss.Signatures()) != 0 {
 		channelId, _ := ss.State().ChannelId() // TODO handle error
 		switch channelId {
 		case types.Destination{}:

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -246,7 +246,7 @@ func TestCrankAsAlice(t *testing.T) {
 
 	// Update the objective with prefund signatures
 	c := cloneAndSignSetupStateByPeers(*o.V, my.Role, true)
-	e := protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedStates: []state.SignedState{c.SignedPreFundState()}}
+	e := protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedState: c.SignedPreFundState()}
 	oObj, err = o.Update(e)
 	o = oObj.(*Objective)
 	Ok(t, err)
@@ -274,7 +274,7 @@ func TestCrankAsAlice(t *testing.T) {
 
 	// If Alice had received a signed counterproposal, she should proceed to postFundSetup
 	sp = consensus_channel.SignedProposal{Proposal: p, Signature: consensusStateSignatures(alice, p1, o.ToMyRight.getExpectedGuarantee())[1]}
-	e = protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedProposals: []consensus_channel.SignedProposal{sp}}
+	e = protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedProposal: sp}
 	oObj, err = o.Update(e)
 	o = oObj.(*Objective)
 	Ok(t, err)
@@ -325,7 +325,7 @@ func TestCrankAsBob(t *testing.T) {
 
 	// Update the objective with prefund signatures
 	c := cloneAndSignSetupStateByPeers(*o.V, my.Role, true)
-	e := protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedStates: []state.SignedState{c.SignedPreFundState()}}
+	e := protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedState: c.SignedPreFundState()}
 	oObj, err = o.Update(e)
 	o = oObj.(*Objective)
 	Ok(t, err)
@@ -352,7 +352,7 @@ func TestCrankAsBob(t *testing.T) {
 	// If Bob had received a signed counterproposal, he should proceed to postFundSetup
 	p := consensus_channel.NewAddProposal(o.ToMyLeft.Channel.Id, 2, o.ToMyLeft.getExpectedGuarantee(), big.NewInt(6))
 	sp := consensus_channel.SignedProposal{Proposal: p, Signature: consensusStateSignatures(p1, bob, o.ToMyLeft.getExpectedGuarantee())[0]}
-	e = protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedProposals: []consensus_channel.SignedProposal{sp}}
+	e = protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedProposal: sp}
 	oObj, err = o.Update(e)
 	o = oObj.(*Objective)
 	Ok(t, err)
@@ -406,7 +406,7 @@ func TestCrankAsP1(t *testing.T) {
 
 	// Update the objective with prefund signatures
 	c := cloneAndSignSetupStateByPeers(*o.V, my.Role, true)
-	e := protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedStates: []state.SignedState{c.SignedPreFundState()}}
+	e := protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedState: c.SignedPreFundState()}
 	oObj, err = o.Update(e)
 	o = oObj.(*Objective)
 	Ok(t, err)
@@ -434,7 +434,7 @@ func TestCrankAsP1(t *testing.T) {
 	// If P1 had received a signed counterproposal, she should proceed to postFundSetup
 	p = consensus_channel.NewAddProposal(o.ToMyLeft.Channel.Id, 2, o.ToMyLeft.getExpectedGuarantee(), big.NewInt(6))
 	sp = consensus_channel.SignedProposal{Proposal: p, Signature: consensusStateSignatures(p1, alice, o.ToMyLeft.getExpectedGuarantee())[1]}
-	e = protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedProposals: []consensus_channel.SignedProposal{sp}}
+	e = protocols.ObjectiveEvent{ObjectiveId: o.Id(), SignedProposal: sp}
 	oObj, err = o.Update(e)
 	o = oObj.(*Objective)
 	Ok(t, err)


### PR DESCRIPTION
This is an alternative to #597.



---

#### Code quality

- [ ] I have written clear commit messages
- [ ] I have performed a self-review of my own code
- [ ] This change does not have an unduly wide scope
- [ ] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [ ] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
- [ ] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [ ] I have assigned myself to this PR
- [ ] I have linked the appropriate github issue
- [ ] I have assigned this PR to the appropriate GitHub project
- [ ] I have assigned this PR to the appropriate GitHub Milestone
