### PR TITLE
waitTimeForCompletedObjectiveIds only waited for one objective id

### DIFF
--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -31,8 +31,8 @@ func waitTimeForCompletedObjectiveIds(t *testing.T, client *client.Client, timeo
 
 			// If all objectives are completed we can send the all done signal and return
 			isDone := true
-			for _, objectiveCompleted := range completed {
-				isDone = isDone && objectiveCompleted
+			for _, id := range ids {
+				isDone = isDone && completed[id]
 			}
 			if isDone {
 				allDone <- struct{}{}


### PR DESCRIPTION
`waitTimeForCompletedObjectiveIds` would iterate through the `completed` map to determine if it was all done or not. The problem is that the `completed` map only gets populated when an objective is complete. This means that `waitTimeForCompletedObjectiveIds` will return after one objective is completed, since the `isDone = isDone && completed[id]` will always return true.

This PR solves this by iterating through the `ids` passed into `waitTimeForCompletedObjectiveIds`. That way we're checking that all objectives are complete.

