### PR TITLE
Ensure logs get written out on failure

### DIFF
--- a/client_test/directdefund_integration_test.go
+++ b/client_test/directdefund_integration_test.go
@@ -2,7 +2,6 @@
 package client_test // import "github.com/statechannels/go-nitro/client_test"
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/statechannels/go-nitro/client"
@@ -22,8 +21,9 @@ func directlyDefundALedgerChannel(t *testing.T, alpha client.Client, beta client
 func TestDirectDefundIntegration(t *testing.T) {
 
 	// Setup logging
-	logDestination := &bytes.Buffer{}
-	t.Cleanup(flushToFileCleanupFn(logDestination, "directdefund_client_test.log"))
+	logFile := "directdefund_client_test.log"
+	truncateLog(logFile)
+	logDestination := newLogWriter(logFile)
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()

--- a/client_test/directfund_integration_test.go
+++ b/client_test/directfund_integration_test.go
@@ -2,7 +2,6 @@
 package client_test // import "github.com/statechannels/go-nitro/client_test"
 
 import (
-	"bytes"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -40,8 +39,9 @@ func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.C
 func TestDirectFundIntegration(t *testing.T) {
 
 	// Setup logging
-	logDestination := &bytes.Buffer{}
-	t.Cleanup(flushToFileCleanupFn(logDestination, "directfund_client_test.log"))
+	logFile := "directfund_client_test.log"
+	truncateLog(logFile)
+	logDestination := newLogWriter(logFile)
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -74,14 +74,6 @@ func setupClient(pk []byte, chain chainservice.MockChain, msgBroker messageservi
 	return client.New(messageservice, chainservice, storeA, logDestination), storeA
 }
 
-func flushToFileCleanupFn(w io.Reader, fileName string) func() {
-	return func() {
-		truncateLog(fileName)
-		ld := newLogWriter(fileName)
-		_, _ = ld.ReadFrom(w)
-		ld.Close()
-	}
-}
 func truncateLog(logFile string) {
 	logDestination := newLogWriter(logFile)
 

--- a/client_test/virtual_fund_message_delay_test.go
+++ b/client_test/virtual_fund_message_delay_test.go
@@ -1,7 +1,6 @@
 package client_test
 
 import (
-	"bytes"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -24,8 +23,9 @@ func TestVirtualFundWithMessageDelays(t *testing.T) {
 	const OBJECTIVE_TIMEOUT = time.Second * 2
 
 	// Setup logging
-	logDestination := &bytes.Buffer{}
-	t.Cleanup(flushToFileCleanupFn(logDestination, "virtual_fund_message_delay_test.log"))
+	logFile := "virtual_fund_message_delay_test.log"
+	truncateLog(logFile)
+	logDestination := newLogWriter(logFile)
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -1,7 +1,6 @@
 package client_test
 
 import (
-	"bytes"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -20,8 +19,9 @@ import (
 func TestBenchmark(t *testing.T) {
 
 	// Setup logging
-	logDestination := &bytes.Buffer{}
-	t.Cleanup(flushToFileCleanupFn(logDestination, "virtualfund_benchmark_test.log"))
+	logFile := "virtualfund_benchmark_test.log"
+	truncateLog(logFile)
+	logDestination := newLogWriter(logFile)
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()

--- a/client_test/virtualfund_integration_test.go
+++ b/client_test/virtualfund_integration_test.go
@@ -1,7 +1,6 @@
 package client_test
 
 import (
-	"bytes"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -16,8 +15,9 @@ import (
 func TestVirtualFundIntegration(t *testing.T) {
 
 	// Setup logging
-	logDestination := &bytes.Buffer{}
-	t.Cleanup(flushToFileCleanupFn(logDestination, "virtualfund_client_test.log"))
+	logFile := "virtualfund_client_test.log"
+	truncateLog(logFile)
+	logDestination := newLogWriter(logFile)
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()

--- a/client_test/virtualfund_multiparty_integration_test.go
+++ b/client_test/virtualfund_multiparty_integration_test.go
@@ -1,7 +1,6 @@
 package client_test
 
 import (
-	"bytes"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -16,8 +15,9 @@ import (
 // TestMultiPartyVirtualFundIntegration tests the scenario where Alice creates virtual channels with Bob and Brian using Irene as the intermediary.
 func TestMultiPartyVirtualFundIntegration(t *testing.T) {
 
-	logDestination := &bytes.Buffer{}
-	t.Cleanup(flushToFileCleanupFn(logDestination, "virtualfund_multiparty_client_test.log"))
+	logFile := "virtualfund_multiparty_client_test.log"
+	truncateLog(logFile)
+	logDestination := newLogWriter(logFile)
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()


### PR DESCRIPTION
Fixes https://github.com/statechannels/go-nitro/issues/568

We made some changes in https://github.com/statechannels/go-nitro/pull/404 to allow for more concurrent tests to run and log out to the log files.  We a keep a buffer in memory that we write to and we flush that out in `t.Cleanup`

However if a `panic` happens (like for the current `engine` error handling) the clean up function does not get triggered and the log doesn't get written out. This means that when an error occurs we won't get the log files to aid in debugging 😢 
(Here's an [example](https://github.com/statechannels/go-nitro/actions/runs/2259743068))

To resolve this I've just reverted the client tests to write directly to the file instead of writing to a buffer. This means that less client tests can run concurrently (using the `go test -count` flag) but it does mean that we will always generate log files.