### PR TITLE
Git ignore artifacts directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
-# Logs
-*.log
+# The artifacts contains only logs, for now
+artifacts
+
+# OSX specific files
+.DS_Store


### PR DESCRIPTION
Do not ignore `.log` files. This helps developers notice if tests are sprinkling log files outside of the artifacts directory.