### PR TITLE
Stop follower from sending proposals signed by leader

### DIFF
--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -211,13 +211,8 @@ func SummarizeMessage(m Message) MessageSummary {
 
 // CreateSignedProposalMessage returns a signed proposal message addressed to the counterparty in the given ledger
 // It contains the provided signed proposals and any proposals in the proposal queue.
-func CreateSignedProposalMessage(ledger *consensus_channel.ConsensusChannel, sp ...consensus_channel.SignedProposal) Message {
-	recipient := ledger.Leader()
-	if ledger.IsLeader() {
-		recipient = ledger.Follower()
-	}
-	// Append the proposals to any existing proposals in the queue
-	proposals := append(ledger.ProposalQueue(), sp...)
+func CreateSignedProposalMessage(recipient types.Address, proposals ...consensus_channel.SignedProposal) Message {
+
 	payloads := make([]MessagePayload, len(proposals))
 	for i, sp := range proposals {
 		id := getProposalObjectiveId(sp.Proposal)

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -274,12 +274,12 @@ func (o *Objective) updateLedgerToRemoveGuarantee(ledger *consensus_channel.Cons
 			return protocols.SideEffects{}, nil
 		}
 
-		sp, err := ledger.Propose(o.ledgerProposal(ledger), *sk)
+		_, err := ledger.Propose(o.ledgerProposal(ledger), *sk)
 		if err != nil {
 			return protocols.SideEffects{}, fmt.Errorf("error proposing ledger update: %w", err)
 		}
-
-		message := protocols.CreateSignedProposalMessage(ledger, sp)
+		recipient := ledger.Follower()
+		message := protocols.CreateSignedProposalMessage(recipient, ledger.ProposalQueue()...)
 		sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, message)
 
 	} else {
@@ -290,8 +290,8 @@ func (o *Objective) updateLedgerToRemoveGuarantee(ledger *consensus_channel.Cons
 			if err != nil {
 				return protocols.SideEffects{}, fmt.Errorf("could not sign proposal: %w", err)
 			}
-
-			message := protocols.CreateSignedProposalMessage(ledger, sp)
+			recipient := ledger.Leader()
+			message := protocols.CreateSignedProposalMessage(recipient, sp)
 			sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, message)
 		}
 	}

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -580,7 +580,8 @@ func (o *Objective) proposeLedgerUpdate(connection Connection, sk *[]byte) (prot
 		return protocols.SideEffects{}, err
 	}
 
-	message := protocols.CreateSignedProposalMessage(connection.Channel)
+	recipient := ledger.Follower()
+	message := protocols.CreateSignedProposalMessage(recipient, connection.Channel.ProposalQueue()...)
 	sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, message)
 
 	return sideEffects, nil
@@ -596,7 +597,8 @@ func (o *Objective) acceptLedgerUpdate(c Connection, sk *[]byte) (protocols.Side
 	}
 
 	sideEffects := protocols.SideEffects{}
-	message := protocols.CreateSignedProposalMessage(c.Channel, sp)
+	recipient := ledger.Leader()
+	message := protocols.CreateSignedProposalMessage(recipient, sp)
 	sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, message)
 	return sideEffects, nil
 }

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -570,7 +570,7 @@ func (o *Objective) proposeLedgerUpdate(connection Connection, sk *[]byte) (prot
 	ledger := connection.Channel
 
 	if !ledger.IsLeader() {
-		return protocols.SideEffects{}, errors.New("only the proposer can propose a ledger update")
+		return protocols.SideEffects{}, errors.New("only the leader can propose a ledger update")
 	}
 
 	sideEffects := protocols.SideEffects{}


### PR DESCRIPTION
Towards #618.

Fixes #635.

Previously `CreateSignedProposalMessage` would include the `ProposalQueue` when sending out signed proposals. However since the `ProposalQueue` only contains the leader signatures this means that the follower could send out signed proposals with the leader's signatures.

This PR fixes this by only including the proposal queue when the leader is sending messages. The follower just sends individual signed proposals.

