### PR TITLE
Only sign proposal if it is next in the queue in virtual defunding

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -133,8 +133,8 @@ func (c *ConsensusChannel) IncludesTarget(target types.Destination) bool {
 	return c.current.Outcome.includesTarget(target)
 }
 
-// HasRemovalBeenProposedFor returns whether or not a proposal exists to remove the guaranatee for the target.
-func (c *ConsensusChannel) HasRemovalBeenProposedFor(target types.Destination) bool {
+// HasRemovalBeenProposed returns whether or not a proposal exists to remove the guaranatee for the target.
+func (c *ConsensusChannel) HasRemovalBeenProposed(target types.Destination) bool {
 	for _, p := range c.proposalQueue {
 		if p.Proposal.Type() == RemoveProposal {
 			remove := p.Proposal.ToRemove
@@ -144,6 +144,18 @@ func (c *ConsensusChannel) HasRemovalBeenProposedFor(target types.Destination) b
 		}
 	}
 	return false
+}
+
+// HasRemovalBeenProposedNext returns whether or not the next proposal in the queue is a remove proposal for the given target
+func (c *ConsensusChannel) HasRemovalBeenProposedNext(target types.Destination) bool {
+
+	if len(c.proposalQueue) == 0 {
+		return false
+	}
+
+	p := c.proposalQueue[0]
+	return p.Proposal.Type() == RemoveProposal && p.Proposal.ToRemove.Target == target
+
 }
 
 // IsLeader returns true if the calling client is the leader of the channel,

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -267,7 +267,7 @@ func (o *Objective) updateLedgerToRemoveGuarantee(ledger *consensus_channel.Cons
 
 	var sideEffects protocols.SideEffects
 
-	proposed := ledger.HasRemovalBeenProposedFor(o.VId())
+	proposed := ledger.HasRemovalBeenProposed(o.VId())
 
 	if ledger.IsLeader() {
 		if proposed { // If we've already proposed a remove proposal we can return
@@ -283,8 +283,9 @@ func (o *Objective) updateLedgerToRemoveGuarantee(ledger *consensus_channel.Cons
 		sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, message)
 
 	} else {
-
-		if proposed {
+		// If the proposal is next in the queue we accept it
+		proposedNext := ledger.HasRemovalBeenProposedNext(o.VId())
+		if proposedNext {
 			sp, err := ledger.SignNextProposal(o.ledgerProposal(ledger), *sk)
 
 			if err != nil {


### PR DESCRIPTION
Towards #618.

Fixes #639.

Updated virtual defunding to follower a similar pattern as virtual funding and only call `signNextProposal` if the proposal next in the queue is what we want.