### PR TITLE
Add Completed status for Objective and ignore completed objectives

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -148,7 +148,10 @@ func (e *Engine) handleMessage(message protocols.Message) (ObjectiveChangeEvent,
 		if err != nil {
 			return ObjectiveChangeEvent{}, err
 		}
-
+		if objective.GetStatus() == protocols.Completed {
+			e.logger.Printf("Ignoring payload for complected objective  %s", objective.Id())
+			continue
+		}
 		event := protocols.ObjectiveEvent{
 			ObjectiveId:     entry.ObjectiveId,
 			SignedProposals: []consensus_channel.SignedProposal{},
@@ -173,6 +176,10 @@ func (e *Engine) handleMessage(message protocols.Message) (ObjectiveChangeEvent,
 		objective, err := e.store.GetObjectiveById(entry.ObjectiveId)
 		if err != nil {
 			return ObjectiveChangeEvent{}, err
+		}
+		if objective.GetStatus() == protocols.Completed {
+			e.logger.Printf("Ignoring payload for complected objective  %s", objective.Id())
+			continue
 		}
 
 		event := protocols.ObjectiveEvent{

--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -98,7 +98,7 @@ func (ms *MemStore) SetObjective(obj protocols.Objective) error {
 
 	// Objective ownership can only be transferred if the channel is not owned by another objective
 	prevOwner, isOwned := ms.channelToObjective.Load(obj.OwnsChannel().String())
-	if status := obj.GetStatus(); status == protocols.Approved || status == protocols.Completed {
+	if status := obj.GetStatus(); status == protocols.Approved {
 		if !isOwned {
 			ms.channelToObjective.Store(obj.OwnsChannel().String(), obj.Id())
 		}

--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -98,7 +98,7 @@ func (ms *MemStore) SetObjective(obj protocols.Objective) error {
 
 	// Objective ownership can only be transferred if the channel is not owned by another objective
 	prevOwner, isOwned := ms.channelToObjective.Load(obj.OwnsChannel().String())
-	if obj.GetStatus() == protocols.Approved {
+	if status := obj.GetStatus(); status == protocols.Approved || status == protocols.Completed {
 		if !isOwned {
 			ms.channelToObjective.Store(obj.OwnsChannel().String(), obj.Id())
 		}

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -263,6 +263,7 @@ func (o Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Side
 		return &updated, sideEffects, WaitingForWithdraw, nil
 	}
 
+	updated.Status = protocols.Completed
 	return &updated, sideEffects, WaitingForNothing, nil
 }
 

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -287,6 +287,7 @@ func (o Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Side
 	}
 
 	// Completion
+	updated.Status = protocols.Completed
 	return &updated, sideEffects, WaitingForNothing, nil
 }
 

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -93,6 +93,7 @@ const (
 	Unapproved ObjectiveStatus = iota
 	Approved
 	Rejected
+	Completed
 )
 
 // ObjectiveRequest is a request to create a new objective.

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -230,6 +230,9 @@ func (o Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Side
 	if fullyDefunded := updated.isLeftDefunded() && updated.isRightDefunded(); !fullyDefunded {
 		return &updated, sideEffects, WaitingForCompleteLedgerDefunding, nil
 	}
+
+	// Mark the objective as done
+	updated.Status = protocols.Completed
 	return &updated, sideEffects, WaitingForNothing, nil
 
 }

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -413,6 +413,7 @@ func (o Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Side
 	}
 
 	// Completion
+	updated.Status = protocols.Completed
 	return &updated, sideEffects, WaitingForNothing, nil
 }
 


### PR DESCRIPTION
Towards #618 

Adds a completed status for objectives so we can ignore completed objectives instead of trying to process any messages for them.


`Crank` now updates the status to `Completed` once an objective is done.