### PR TITLE
Crank related objectives

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -169,11 +169,11 @@ func (e *Engine) handleMessage(message protocols.Message) (ObjectiveChangeEvent,
 		}
 		allCompleted.CompletedObjectives = append(allCompleted.CompletedObjectives, progressEvent.CompletedObjectives...)
 
-		relatedProgressEvent, err := e.attemptProgressForRelatedObjectives(&updatedObjective)
+		relatedObjectiveCompletions, err := e.attemptProgressForRelatedObjectives(&updatedObjective)
 		if err != nil {
 			return ObjectiveChangeEvent{}, err
 		}
-		allCompleted.CompletedObjectives = append(allCompleted.CompletedObjectives, relatedProgressEvent.CompletedObjectives...)
+		allCompleted.CompletedObjectives = append(allCompleted.CompletedObjectives, relatedObjectiveCompletions.CompletedObjectives...)
 
 	}
 

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -167,8 +167,13 @@ func (e *Engine) handleMessage(message protocols.Message) (ObjectiveChangeEvent,
 		if err != nil {
 			return ObjectiveChangeEvent{}, err
 		}
-
 		allCompleted.CompletedObjectives = append(allCompleted.CompletedObjectives, progressEvent.CompletedObjectives...)
+
+		relatedProgressEvent, err := e.attemptProgressForRelatedObjectives(&updatedObjective)
+		if err != nil {
+			return ObjectiveChangeEvent{}, err
+		}
+		allCompleted.CompletedObjectives = append(allCompleted.CompletedObjectives, relatedProgressEvent.CompletedObjectives...)
 
 	}
 
@@ -200,10 +205,56 @@ func (e *Engine) handleMessage(message protocols.Message) (ObjectiveChangeEvent,
 		}
 
 		allCompleted.CompletedObjectives = append(allCompleted.CompletedObjectives, progressEvent.CompletedObjectives...)
-	}
 
+		relatedProgressEvent, err := e.attemptProgressForRelatedObjectives(&updatedObjective)
+		if err != nil {
+			return ObjectiveChangeEvent{}, err
+		}
+		allCompleted.CompletedObjectives = append(allCompleted.CompletedObjectives, relatedProgressEvent.CompletedObjectives...)
+
+	}
 	return allCompleted, nil
 
+}
+
+// attemptProgressForRelatedObjectives attempts to progress any objectives that may be related to the objective that was just updated
+// An objective is related when it shares a ledger channel with the provided objective.
+// This allows progress to made on other objectives that may be unblocked after processing the updatedObjective.
+func (e *Engine) attemptProgressForRelatedObjectives(updatedObjective *protocols.Objective) (ObjectiveChangeEvent, error) {
+	allCompleted := ObjectiveChangeEvent{}
+	relatedIds, err := e.findRelatedObjectives(*updatedObjective)
+	if err != nil {
+		return ObjectiveChangeEvent{}, err
+	}
+	for _, id := range relatedIds {
+		related, err := e.store.GetObjectiveById(id)
+		if err != nil {
+			return ObjectiveChangeEvent{}, err
+		}
+		progressEvent, err := e.attemptProgress(related)
+		if err != nil {
+			return ObjectiveChangeEvent{}, err
+		}
+		allCompleted.CompletedObjectives = append(allCompleted.CompletedObjectives, progressEvent.CompletedObjectives...)
+	}
+	return allCompleted, nil
+}
+
+// findRelatedObjectives finds all objectives that are related to provided objective.
+// An objective is related when it shares a ledger channel with the provided objective.
+func (e *Engine) findRelatedObjectives(o protocols.Objective) ([]protocols.ObjectiveId, error) {
+	relatedIds := []protocols.ObjectiveId{}
+	for _, rel := range o.Related() {
+		c, ok := rel.(*consensus_channel.ConsensusChannel)
+		if ok {
+			for _, p := range c.ProposalQueue() {
+				id := getProposalObjectiveId(p.Proposal)
+
+				relatedIds = append(relatedIds, id)
+			}
+		}
+	}
+	return relatedIds, nil
 }
 
 // handleChainEvent handles a Chain Event from the blockchain.
@@ -429,4 +480,28 @@ func (e *Engine) constructObjectiveFromMessage(id protocols.ObjectiveId, ss stat
 		return &directfund.Objective{}, errors.New("cannot handle unimplemented objective type")
 	}
 
+}
+
+// getProposalObjectiveId returns the objectiveId for a proposal.
+func getProposalObjectiveId(p consensus_channel.Proposal) protocols.ObjectiveId {
+	switch p.Type() {
+	case "AddProposal":
+		{
+			const prefix = "VirtualFund-"
+			channelId := p.ToAdd.Guarantee.Target().String()
+			return protocols.ObjectiveId(prefix + channelId)
+
+		}
+	case "RemoveProposal":
+		{
+			const prefix = "VirtualDefund-"
+			channelId := p.ToRemove.Target.String()
+			return protocols.ObjectiveId(prefix + channelId)
+
+		}
+	default:
+		{
+			panic("invalid proposal type")
+		}
+	}
 }

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -485,16 +485,16 @@ func (e *Engine) constructObjectiveFromMessage(id protocols.ObjectiveId, ss stat
 // getProposalObjectiveId returns the objectiveId for a proposal.
 func getProposalObjectiveId(p consensus_channel.Proposal) protocols.ObjectiveId {
 	switch p.Type() {
-	case "AddProposal":
+	case consensus_channel.AddProposal:
 		{
-			const prefix = "VirtualFund-"
+			const prefix = virtualfund.ObjectivePrefix
 			channelId := p.ToAdd.Guarantee.Target().String()
 			return protocols.ObjectiveId(prefix + channelId)
 
 		}
-	case "RemoveProposal":
+	case consensus_channel.RemoveProposal:
 		{
-			const prefix = "VirtualDefund-"
+			const prefix = virtualdefund.ObjectivePrefix
 			channelId := p.ToRemove.Target.String()
 			return protocols.ObjectiveId(prefix + channelId)
 

--- a/client_test/virtualdefund_test.go
+++ b/client_test/virtualdefund_test.go
@@ -30,7 +30,7 @@ func TestVirtualDefundIntegration(t *testing.T) {
 	clientB, storeB := setupClient(bob.PrivateKey, chain, broker, logDestination, 0)
 	clientI, storeI := setupClient(irene.PrivateKey, chain, broker, logDestination, 0)
 
-	numOfVirtualChannels := uint(1)
+	numOfVirtualChannels := uint(5)
 	paidToBob := uint(1)
 	totalPaidToBob := paidToBob * numOfVirtualChannels
 


### PR DESCRIPTION
Based on #618 

This fixes #637 by attempting to crank any related objectives after we crank an objective.

We consider an objective related to another if they share a ledger channel.
