### PR TITLE
fix: ledger defund directs funds according to guarantee

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -757,8 +757,13 @@ func (vars *Vars) Remove(p Remove) error {
 	vars.TurnNum += 1
 
 	// Adjust balances
-	o.leader.amount.Add(o.leader.amount, p.LeftAmount)
-	o.follower.amount.Add(o.follower.amount, p.RightAmount)
+	if o.leader.destination == guarantee.left {
+		o.leader.amount.Add(o.leader.amount, p.LeftAmount)
+		o.follower.amount.Add(o.follower.amount, p.RightAmount)
+	} else {
+		o.leader.amount.Add(o.leader.amount, p.RightAmount)
+		o.follower.amount.Add(o.follower.amount, p.LeftAmount)
+	}
 
 	// Remove the guarantee
 	delete(o.guarantees, p.Target)


### PR DESCRIPTION
following #645, this bug became much more obvious.

Previously, `vars.Remove` assigned `LeftAmount` to the leader (who was named Left) and the `RightAmount` to the follower (who was named Right).

Now, it checks the address of the leader against the guarantee's left address, and assigns accordingly.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] ~I have added tests that prove my fix is effective or that my feature works, if necessary~ pending integration tests w/ assertions by clients on their final states
- [ ] ~I have added comprehensive [godoc](https://go.dev/blog/godoc) comments~ no new identifiers

#### Project management

- [x] I have assigned myself to this PR
- [ ] ~I have linked the appropriate github issue~
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
