### PR TITLE
Add a "vector clock" instrumented test message service and use in a retrieval-market-like test run

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.18.0'
+          go-version: "^1.18.0"
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.1.0
 
@@ -29,11 +29,7 @@ jobs:
 
       - name: Test
         timeout-minutes: 1
-        run: |
-        echo $(go env GOPATH) >> $GITHUB_PATH
-        go test -v ./... -count=2 -shuffle=on
-        
-
+        run: go test -v ./... -count=2 -shuffle=on
 
       - name: Archive logs
         if: always()

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,13 +16,24 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.1.0
 
+      - name: make bin folder
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/bin
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+
+      - name: install GoVector
+        run: GOPATH=$($GITHUB_WORKSPACE/bin) go install github.com/DistributedClocks/GoVector@latest
+
       - name: Build
         run: go build -v ./...
 
       - name: Test
-        run: echo $(go env GOPATH) >> $GITHUB_PATH
-        run: go test -v ./... -count=2 -shuffle=on
         timeout-minutes: 1
+        run: |
+        echo $(go env GOPATH) >> $GITHUB_PATH
+        go test -v ./... -count=2 -shuffle=on
+        
+
 
       - name: Archive logs
         if: always()

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,6 +20,7 @@ jobs:
         run: go build -v ./...
 
       - name: Test
+        run: echo $(go env GOPATH) >> $GITHUB_PATH
         run: go test -v ./... -count=2 -shuffle=on
         timeout-minutes: 1
 

--- a/client/engine/messageservice/test-messageservice.go
+++ b/client/engine/messageservice/test-messageservice.go
@@ -60,7 +60,7 @@ func NewTestMessageService(address types.Address, broker Broker, maxDelay time.D
 		fromPeers: make(chan []byte, 5),
 	}
 
-	tms.goveclogger = govec.InitGoVector(address.String(), "../artifacts/vectorclock", govec.GetDefaultConfig())
+	tms.goveclogger = govec.InitGoVector(address.String(), "../artifacts/vectorclock/"+address.String(), govec.GetDefaultConfig())
 
 	tms.connect(broker)
 	go tms.routeFromPeers()

--- a/client/engine/messageservice/vectorclock_testmessageservice.go
+++ b/client/engine/messageservice/vectorclock_testmessageservice.go
@@ -71,6 +71,12 @@ func (t VectorClockTestMessageService) dispatchMessage(message protocols.Message
 // It may be used to make logs more readable.
 func summarizeMessageSend(msg protocols.Message) string {
 	summary := ""
+	for _, entry := range msg.SignedProposals() {
+		summary += `propose `
+		summary += fmt.Sprint(entry.Payload.Proposal.ChannelID)[1:8]
+		summary += ` funds `
+		summary += fmt.Sprint(entry.Payload.Proposal.ToAdd.Target())[1:8]
+	}
 	for _, entry := range msg.SignedStates() {
 		summary += `send `
 		if len(entry.Payload.State().Participants) == 3 {
@@ -83,12 +89,6 @@ func summarizeMessageSend(msg protocols.Message) string {
 		summary += ` @turn `
 		summary += fmt.Sprint(entry.Payload.TurnNum())
 
-	}
-	for _, entry := range msg.SignedProposals() {
-		summary += `propose `
-		summary += fmt.Sprint(entry.Payload.Proposal.ChannelID)[1:8]
-		summary += ` funds `
-		summary += fmt.Sprint(entry.Payload.Proposal.ToAdd.Target())[1:8]
 	}
 	return summary
 }

--- a/client/engine/messageservice/vectorclock_testmessageservice.go
+++ b/client/engine/messageservice/vectorclock_testmessageservice.go
@@ -73,7 +73,20 @@ func (t VectorClockTestMessageService) dispatchMessage(message protocols.Message
 }
 
 func summarizeMessageSend(msg protocols.Message) string {
-	return "Send: " + string(msg.Payloads[0].ObjectiveId)
+	summary := ""
+	for _, entry := range msg.SignedStates() {
+		summary += `send `
+		summary += fmt.Sprint(entry.Payload.ChannelId())[0:8]
+		summary += ` @turn `
+		summary += fmt.Sprint(entry.Payload.TurnNum())
+	}
+	for _, entry := range msg.SignedProposals() {
+		summary += `propose `
+		summary += fmt.Sprint(entry.Payload.Proposal.ChannelID)[0:8]
+		summary += ` funds `
+		summary += fmt.Sprint(entry.Payload.Proposal.ToAdd.Target())[0:8]
+	}
+	return summary
 }
 
 // routeToPeers listens for messages from the engine, and dispatches them

--- a/client/engine/messageservice/vectorclock_testmessageservice.go
+++ b/client/engine/messageservice/vectorclock_testmessageservice.go
@@ -76,15 +76,22 @@ func summarizeMessageSend(msg protocols.Message) string {
 	summary := ""
 	for _, entry := range msg.SignedStates() {
 		summary += `send `
-		summary += fmt.Sprint(entry.Payload.ChannelId())[0:8]
+		if len(entry.Payload.State().Participants) == 3 {
+			summary += `V`
+		} else {
+			summary += `L`
+		}
+		summary += fmt.Sprint(entry.Payload.ChannelId())[1:8]
+		summary += fmt.Sprint(entry.Payload.TurnNum())
 		summary += ` @turn `
 		summary += fmt.Sprint(entry.Payload.TurnNum())
+
 	}
 	for _, entry := range msg.SignedProposals() {
 		summary += `propose `
-		summary += fmt.Sprint(entry.Payload.Proposal.ChannelID)[0:8]
+		summary += fmt.Sprint(entry.Payload.Proposal.ChannelID)[1:8]
 		summary += ` funds `
-		summary += fmt.Sprint(entry.Payload.Proposal.ToAdd.Target())[0:8]
+		summary += fmt.Sprint(entry.Payload.Proposal.ToAdd.Target())[1:8]
 	}
 	return summary
 }

--- a/client/engine/messageservice/vectorclock_testmessageservice.go
+++ b/client/engine/messageservice/vectorclock_testmessageservice.go
@@ -27,7 +27,7 @@ type VectorClockTestMessageService struct {
 // NewTestMessageService returns a running TestMessageService
 // It accepts an address, a broker, and a max delay for messages.
 // Messages will be handled with a random delay between 0 and maxDelay
-func NewVectorClockTestMessageService(address types.Address, broker Broker, maxDelay time.Duration) VectorClockTestMessageService {
+func NewVectorClockTestMessageService(address types.Address, broker Broker, maxDelay time.Duration, logDir string) VectorClockTestMessageService {
 
 	vctms := VectorClockTestMessageService{
 		TestMessageService: TestMessageService{
@@ -37,7 +37,7 @@ func NewVectorClockTestMessageService(address types.Address, broker Broker, maxD
 			maxDelay:  maxDelay,
 			fromPeers: make(chan []byte, 5),
 		},
-		goveclogger: govec.InitGoVector(address.String(), "../artifacts/vectorclock/"+address.String(), govec.GetDefaultConfig()),
+		goveclogger: govec.InitGoVector(address.String(), logDir+"/"+address.String(), govec.GetDefaultConfig()),
 	}
 
 	vctms.connect(broker)

--- a/client/engine/messageservice/vectorclock_testmessageservice.go
+++ b/client/engine/messageservice/vectorclock_testmessageservice.go
@@ -27,7 +27,7 @@ type VectorClockTestMessageService struct {
 // NewTestMessageService returns a running TestMessageService
 // It accepts an address, a broker, and a max delay for messages.
 // Messages will be handled with a random delay between 0 and maxDelay
-func NewVectorClockTestMessageService(address types.Address, broker Broker, maxDelay time.Duration, logDir string) VectorClockTestMessageService {
+func NewVectorClockTestMessageService(address types.Address, broker Broker, maxDelay time.Duration, logDir string, prettyName string) VectorClockTestMessageService {
 
 	vctms := VectorClockTestMessageService{
 		TestMessageService: TestMessageService{
@@ -37,7 +37,7 @@ func NewVectorClockTestMessageService(address types.Address, broker Broker, maxD
 			maxDelay:  maxDelay,
 			fromPeers: make(chan []byte, 5),
 		},
-		goveclogger: govec.InitGoVector(address.String(), logDir+"/"+address.String(), govec.GetDefaultConfig()),
+		goveclogger: govec.InitGoVector(prettyName, logDir+"/"+address.String(), govec.GetDefaultConfig()),
 	}
 
 	vctms.connect(broker)

--- a/client/engine/messageservice/vectorclock_testmessageservice.go
+++ b/client/engine/messageservice/vectorclock_testmessageservice.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/DistributedClocks/GoVector/govec"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -18,63 +18,38 @@ import (
 //  2. "connect" with one another via gochans
 //  3. run independently in information-silo goroutines, while
 //     communicating on the simulated network
-type TestMessageService struct {
-	address types.Address
+type VectorClockTestMessageService struct {
+	TestMessageService
+	goveclogger *govec.GoLog // vector clock logger
 
-	// connection to Engine:
-	in       chan protocols.Message // for recieving messages from engine
-	out      chan protocols.Message // for sending message to engine
-	maxDelay time.Duration          // the max delay for messages
-
-	// connection with Peers:
-	fromPeers chan []byte // for receiving serialized messages from peers
-}
-
-// A Broker manages a mapping from identifying address to a TestMessageService,
-// allowing messages sent from one message service to be directed to the intended
-// recipient
-type Broker struct {
-	services map[types.Address]TestMessageService
-}
-
-func NewBroker() Broker {
-	b := Broker{
-		services: make(map[common.Address]TestMessageService),
-	}
-
-	return b
 }
 
 // NewTestMessageService returns a running TestMessageService
 // It accepts an address, a broker, and a max delay for messages.
 // Messages will be handled with a random delay between 0 and maxDelay
-func NewTestMessageService(address types.Address, broker Broker, maxDelay time.Duration) TestMessageService {
-	tms := TestMessageService{
+func NewVectorClockTestMessageService(address types.Address, broker Broker, maxDelay time.Duration) VectorClockTestMessageService {
+
+	vctms := VectorClockTestMessageService{
+		TestMessageService:{
 		address:   address,
 		in:        make(chan protocols.Message, 5),
 		out:       make(chan protocols.Message, 5),
 		maxDelay:  maxDelay,
 		fromPeers: make(chan []byte, 5),
+		},
+		goveclogger: govec.InitGoVector(address.String(), "../artifacts/vectorclock/"+address.String(), govec.GetDefaultConfig())
 	}
+	
+	vctms.connect(broker)
+	go vctms.routeFromPeers()
+	go vctms.routeToPeers(broker)
 
-	tms.connect(broker)
-	go tms.routeFromPeers()
-	go tms.routeToPeers(broker)
-
-	return tms
-}
-
-func (t TestMessageService) Out() <-chan protocols.Message {
-	return t.out
-}
-
-func (t TestMessageService) In() chan<- protocols.Message {
-	return t.in
+	return vctms
 }
 
 // dispatchMessage is responsible for dispatching a message to the appropriate peer message service.
 // If there is a mean delay it will wait a random amount of time(based on meanDelay) before sending the message.
-func (t TestMessageService) dispatchMessage(message protocols.Message, b Broker) {
+func (t VectorClockTestMessageService) dispatchMessage(message protocols.Message, b Broker) {
 	if t.maxDelay > 0 {
 		randomDelay := time.Duration(rand.Int63n(t.maxDelay.Nanoseconds()))
 		time.Sleep(randomDelay)
@@ -89,34 +64,33 @@ func (t TestMessageService) dispatchMessage(message protocols.Message, b Broker)
 		if err != nil {
 			panic(`could not serialize message`)
 		}
-		peer.fromPeers <- []byte(serializedMsg)
+		vectorClockMessage := t.goveclogger.PrepareSend("Sending Message", serializedMsg, govec.GetDefaultLogOptions())
+		peer.fromPeers <- vectorClockMessage
 	} else {
 		panic(fmt.Sprintf("client %v has no connection to client %v",
 			t.address, message.To))
 	}
 }
 
-// connect registers the message service with the broker
-func (tms TestMessageService) connect(b Broker) {
-	b.services[tms.address] = tms
-}
-
 // routeToPeers listens for messages from the engine, and dispatches them
-func (tms TestMessageService) routeToPeers(b Broker) {
-	for message := range tms.in {
-		go tms.dispatchMessage(message, b)
+func (vctms VectorClockTestMessageService) routeToPeers(b Broker) {
+	for message := range vctms.in {
+		go vctms.dispatchMessage(message, b)
 	}
 }
 
 // routeFromPeers listens for messages from peers, deserializes them and feeds them to the engine
-func (tms TestMessageService) routeFromPeers() {
-	for message := range tms.fromPeers {
+func (vctms VectorClockTestMessageService) routeFromPeers() {
+	for vectorClockMessage := range vctms.fromPeers {
+		message := []byte("")
+		vctms.goveclogger.UnpackReceive("Receiving Message", vectorClockMessage, &message, govec.GetDefaultLogOptions())
 		msg, err := protocols.DeserializeMessage(string(message))
 		if err != nil {
-			panic(fmt.Errorf("could not deserialize message :%w", err))
+			panic(err)
 		}
-		tms.out <- msg
+		vctms.out <- msg
 	}
+
 }
 
 // ┌──────────┐toMsg       in┌───────────┐

--- a/client/engine/messageservice/vectorclock_testmessageservice.go
+++ b/client/engine/messageservice/vectorclock_testmessageservice.go
@@ -21,7 +21,13 @@ type VectorClockTestMessageService struct {
 // NewVectorClockTestMessageService returns a running VectorClockTestMessageService
 // It accepts an address, a broker, a max delay for messages and a prettyName for use in the log output.
 // Messages will be handled with a random delay between 0 and maxDelay
-func NewVectorClockTestMessageService(address types.Address, broker Broker, maxDelay time.Duration, logDir string, prettyName string) VectorClockTestMessageService {
+func NewVectorClockTestMessageService(
+	address types.Address,
+	broker Broker,
+	maxDelay time.Duration,
+	logDir string,
+	prettyName string,
+) VectorClockTestMessageService {
 
 	vctms := VectorClockTestMessageService{
 		TestMessageService: TestMessageService{

--- a/client/engine/messageservice/vectorclock_testmessageservice.go
+++ b/client/engine/messageservice/vectorclock_testmessageservice.go
@@ -30,16 +30,16 @@ type VectorClockTestMessageService struct {
 func NewVectorClockTestMessageService(address types.Address, broker Broker, maxDelay time.Duration) VectorClockTestMessageService {
 
 	vctms := VectorClockTestMessageService{
-		TestMessageService:{
-		address:   address,
-		in:        make(chan protocols.Message, 5),
-		out:       make(chan protocols.Message, 5),
-		maxDelay:  maxDelay,
-		fromPeers: make(chan []byte, 5),
+		TestMessageService: TestMessageService{
+			address:   address,
+			in:        make(chan protocols.Message, 5),
+			out:       make(chan protocols.Message, 5),
+			maxDelay:  maxDelay,
+			fromPeers: make(chan []byte, 5),
 		},
-		goveclogger: govec.InitGoVector(address.String(), "../artifacts/vectorclock/"+address.String(), govec.GetDefaultConfig())
+		goveclogger: govec.InitGoVector(address.String(), "../artifacts/vectorclock/"+address.String(), govec.GetDefaultConfig()),
 	}
-	
+
 	vctms.connect(broker)
 	go vctms.routeFromPeers()
 	go vctms.routeToPeers(broker)

--- a/client/engine/messageservice/vectorclock_testmessageservice.go
+++ b/client/engine/messageservice/vectorclock_testmessageservice.go
@@ -64,12 +64,16 @@ func (t VectorClockTestMessageService) dispatchMessage(message protocols.Message
 		if err != nil {
 			panic(`could not serialize message`)
 		}
-		vectorClockMessage := t.goveclogger.PrepareSend("Sending Message", serializedMsg, govec.GetDefaultLogOptions())
+		vectorClockMessage := t.goveclogger.PrepareSend(summarizeMessageSend(message), serializedMsg, govec.GetDefaultLogOptions())
 		peer.fromPeers <- vectorClockMessage
 	} else {
 		panic(fmt.Sprintf("client %v has no connection to client %v",
 			t.address, message.To))
 	}
+}
+
+func summarizeMessageSend(msg protocols.Message) string {
+	return "Send: " + string(msg.Payloads[0].ObjectiveId)
 }
 
 // routeToPeers listens for messages from the engine, and dispatches them

--- a/client_test/directfund_test.go
+++ b/client_test/directfund_test.go
@@ -17,9 +17,11 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
+const ledgerChannelDeposit = 5_000_000
+
 func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.Client) types.Destination {
 	// Set up an outcome that requires both participants to deposit
-	outcome := testdata.Outcomes.Create(*alpha.Address, *beta.Address, 5_000_000, 5_000_000)
+	outcome := testdata.Outcomes.Create(*alpha.Address, *beta.Address, ledgerChannelDeposit, ledgerChannelDeposit)
 
 	request := directfund.ObjectiveRequest{
 		MyAddress:         *alpha.Address,
@@ -51,7 +53,7 @@ func TestDirectFund(t *testing.T) {
 
 	directlyFundALedgerChannel(t, clientA, clientB)
 
-	want := testdata.Outcomes.Create(*clientA.Address, *clientB.Address, 5, 5)
+	want := testdata.Outcomes.Create(*clientA.Address, *clientB.Address, ledgerChannelDeposit, ledgerChannelDeposit)
 	// Ensure that we create a consensus channel in the store
 	for _, store := range []store.Store{storeA, storeB} {
 		var con *consensus_channel.ConsensusChannel

--- a/client_test/directfund_test.go
+++ b/client_test/directfund_test.go
@@ -19,7 +19,7 @@ import (
 
 func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.Client) types.Destination {
 	// Set up an outcome that requires both participants to deposit
-	outcome := testdata.Outcomes.Create(*alpha.Address, *beta.Address, 5, 5)
+	outcome := testdata.Outcomes.Create(*alpha.Address, *beta.Address, 5_000_000, 5_000_000)
 
 	request := directfund.ObjectiveRequest{
 		MyAddress:         *alpha.Address,

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -77,7 +77,15 @@ func setupClient(pk []byte, chain chainservice.MockChain, msgBroker messageservi
 // setupIntstrumentedClient is a helper function that contructs a client and returns the new client and its store.
 //
 // The client will be _instrumented_, which is useful in debugging. In particular it will output logs containing vector clock stamps into the supplied logDir directory.
-func setupInstrumentedClient(pk []byte, chain chainservice.MockChain, msgBroker messageservice.Broker, logDestination io.Writer, meanMessageDelay time.Duration, logDir string, prettyName string) (client.Client, store.Store) {
+func setupInstrumentedClient(
+	pk []byte,
+	chain chainservice.MockChain,
+	msgBroker messageservice.Broker,
+	logDestination io.Writer,
+	meanMessageDelay time.Duration,
+	logDir string,
+	prettyName string,
+) (client.Client, store.Store) {
 	myAddress := crypto.GetAddressFromSecretKeyBytes(pk)
 	chain.Subscribe(myAddress)
 	chainservice := chainservice.NewSimpleChainService(chain, myAddress)

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -74,7 +74,7 @@ func setupClient(pk []byte, chain chainservice.MockChain, msgBroker messageservi
 	return client.New(messageservice, chainservice, storeA, logDestination), storeA
 }
 
-// setupIntstumentedClient is a helper function that contructs a client and returns the new client and its store.
+// setupIntstrumentedClient is a helper function that contructs a client and returns the new client and its store.
 //
 // The client will be _instrumented_, which is useful in debugging. In particular it will output logs containing vector clock stamps into the supplied logDir directory.
 func setupInstrumentedClient(pk []byte, chain chainservice.MockChain, msgBroker messageservice.Broker, logDestination io.Writer, meanMessageDelay time.Duration, logDir string, prettyName string) (client.Client, store.Store) {

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -77,11 +77,11 @@ func setupClient(pk []byte, chain chainservice.MockChain, msgBroker messageservi
 // setupIntstumentedClient is a helper function that contructs a client and returns the new client and its store.
 //
 // The client will be _instrumented_, which is useful in debugging. In particular it will output logs containing vector clock stamps into the supplied logDir directory.
-func setupInstrumentedClient(pk []byte, chain chainservice.MockChain, msgBroker messageservice.Broker, logDestination io.Writer, meanMessageDelay time.Duration, logDir string) (client.Client, store.Store) {
+func setupInstrumentedClient(pk []byte, chain chainservice.MockChain, msgBroker messageservice.Broker, logDestination io.Writer, meanMessageDelay time.Duration, logDir string, prettyName string) (client.Client, store.Store) {
 	myAddress := crypto.GetAddressFromSecretKeyBytes(pk)
 	chain.Subscribe(myAddress)
 	chainservice := chainservice.NewSimpleChainService(chain, myAddress)
-	messageservice := messageservice.NewVectorClockTestMessageService(myAddress, msgBroker, meanMessageDelay, logDir)
+	messageservice := messageservice.NewVectorClockTestMessageService(myAddress, msgBroker, meanMessageDelay, logDir, prettyName)
 	storeA := store.NewMemStore(pk)
 	return client.New(messageservice, chainservice, storeA, logDestination), storeA
 }

--- a/client_test/virtualdefund_test.go
+++ b/client_test/virtualdefund_test.go
@@ -99,12 +99,12 @@ func checkAliceIreneLedgerOutcome(t *testing.T, vId types.Destination, outcome c
 	if outcome.IncludesTarget(vId) {
 		t.Errorf("The outcome %+v should not contain a guarantee for the virtual channel %s", outcome, vId)
 	}
-	expectedLeaderBalance := consensus_channel.NewBalance(alice.Destination(), big.NewInt(int64(5-totalPaidToBob)))
+	expectedLeaderBalance := consensus_channel.NewBalance(alice.Destination(), big.NewInt(int64(ledgerChannelDeposit-totalPaidToBob)))
 	if diff := cmp.Diff(expectedLeaderBalance, outcome.Leader()); diff != "" {
 		t.Errorf("Unexpected leader balance: %s", diff)
 	}
 
-	expectedFollowerBalance := consensus_channel.NewBalance(irene.Destination(), big.NewInt(int64(5+totalPaidToBob)))
+	expectedFollowerBalance := consensus_channel.NewBalance(irene.Destination(), big.NewInt(int64(ledgerChannelDeposit+totalPaidToBob)))
 	if diff := cmp.Diff(expectedFollowerBalance, outcome.Follower()); diff != "" {
 		t.Errorf("Unexpected follower balance: %s", diff)
 	}
@@ -115,12 +115,12 @@ func checkIreneBobLedgerOutcome(t *testing.T, vId types.Destination, outcome con
 	if outcome.IncludesTarget(vId) {
 		t.Errorf("The outcome %+v should not contain a guarantee for the virtual channel %s", outcome, vId)
 	}
-	expectedLeaderBalance := consensus_channel.NewBalance(irene.Destination(), big.NewInt(int64(5-totalPaidToBob)))
+	expectedLeaderBalance := consensus_channel.NewBalance(irene.Destination(), big.NewInt(int64(ledgerChannelDeposit-totalPaidToBob)))
 	if diff := cmp.Diff(expectedLeaderBalance, outcome.Leader()); diff != "" {
 		t.Errorf("Unexpected leader balance: %s", diff)
 	}
 
-	expectedFollowerBalance := consensus_channel.NewBalance(bob.Destination(), big.NewInt(int64(5+totalPaidToBob)))
+	expectedFollowerBalance := consensus_channel.NewBalance(bob.Destination(), big.NewInt(int64(ledgerChannelDeposit+totalPaidToBob)))
 	if diff := cmp.Diff(expectedFollowerBalance, outcome.Follower()); diff != "" {
 		t.Errorf("Unexpected follower balance: %s", diff)
 	}

--- a/client_test/virtualfund_largescale_integration_test.go
+++ b/client_test/virtualfund_largescale_integration_test.go
@@ -29,6 +29,10 @@ import (
 // The output shiviz.log can be pasted into https://bestchai.bitbucket.io/shiviz/ to visualize the messages which are sent.
 func TestLargeScaleVirtualFundIntegration(t *testing.T) {
 
+	t.Skip() // This test is skipped because it requires an external dependency to run.
+	// go install github.com/DistributedClocks/GoVector@latest
+	// You may need to add GOPATH/bin to your PATH
+
 	// Increase numRetrievalClients to simulate multiple retrieval clients all wanting to pay the same retrieval provider through the same hub
 	const numRetrievalClients = 1
 

--- a/client_test/virtualfund_largescale_integration_test.go
+++ b/client_test/virtualfund_largescale_integration_test.go
@@ -22,6 +22,9 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
+// TestLargeScaleVirtualFundIntegration spins up one retrieval provider, one payment hub and several retrieval clients.
+// The clients are instrumented and emit vector clock logs
+// The output shiviz.log can be pasted into https://bestchai.bitbucket.io/shiviz/ to visualize the messages which are sent.
 func TestLargeScaleVirtualFundIntegration(t *testing.T) {
 	const numRetrievalClients = 1
 

--- a/client_test/virtualfund_largescale_integration_test.go
+++ b/client_test/virtualfund_largescale_integration_test.go
@@ -2,6 +2,7 @@ package client_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"math/rand"
 	"os"
@@ -25,6 +26,7 @@ func TestLargeScaleVirtualFundIntegration(t *testing.T) {
 	const numRetrievalClients = 1
 
 	logDir := "../artifacts/vectorclock"
+
 	os.RemoveAll(logDir)
 
 	logFile := "largescale_client_test.log"
@@ -35,15 +37,15 @@ func TestLargeScaleVirtualFundIntegration(t *testing.T) {
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	retrievalProvider, retrievalProviderStore := setupInstrumentedClient(bob.PrivateKey, chain, broker, logDestination, 0, logDir)
-	paymentHub, _ := setupInstrumentedClient(irene.PrivateKey, chain, broker, logDestination, 0, logDir)
+	retrievalProvider, retrievalProviderStore := setupInstrumentedClient(bob.PrivateKey, chain, broker, logDestination, 0, logDir, "RP")
+	paymentHub, _ := setupInstrumentedClient(irene.PrivateKey, chain, broker, logDestination, 0, logDir, "PH")
 
 	directlyFundALedgerChannel(t, retrievalProvider, paymentHub)
 
 	retrievalClients := make([]client.Client, numRetrievalClients)
-	for i, _ := range retrievalClients {
+	for i := range retrievalClients {
 		secretKey, _ := nc.GeneratePrivateKeyAndAddress()
-		retrievalClients[i], _ = setupInstrumentedClient(secretKey, chain, broker, logDestination, 0, logDir)
+		retrievalClients[i], _ = setupInstrumentedClient(secretKey, chain, broker, logDestination, 0, logDir, "RC"+fmt.Sprint(i))
 		directlyFundALedgerChannel(t, retrievalClients[i], paymentHub)
 		go createVirtualChannelWithRetrievalProvider(retrievalClients[i], retrievalProvider)
 	}
@@ -57,7 +59,6 @@ func TestLargeScaleVirtualFundIntegration(t *testing.T) {
 	logDestination.Write(finalOutcome)
 
 	combineLogs(t, logDir, "shiviz.log")
-	// replaceAddresses(logDir, "shiviz.log")
 
 }
 

--- a/client_test/virtualfund_largescale_integration_test.go
+++ b/client_test/virtualfund_largescale_integration_test.go
@@ -4,6 +4,10 @@ import (
 	"encoding/json"
 	"math/big"
 	"math/rand"
+	"os"
+	"os/exec"
+	"path"
+	"runtime"
 	"testing"
 	"time"
 
@@ -21,6 +25,8 @@ func TestLargeScaleVirtualFundIntegration(t *testing.T) {
 	const numRetrievalClients = 1
 
 	logDir := "../artifacts/vectorclock"
+	os.RemoveAll(logDir)
+
 	logFile := "largescale_client_test.log"
 
 	truncateLog(logFile)
@@ -50,6 +56,17 @@ func TestLargeScaleVirtualFundIntegration(t *testing.T) {
 
 	logDestination.Write(finalOutcome)
 
+	combineLogs(t, logDir, "shiviz.log")
+	// replaceAddresses(logDir, "shiviz.log")
+
+}
+
+func combineLogs(t *testing.T, logDir string, combinedLogsFilename string) {
+	_, filename, _, _ := runtime.Caller(1)
+	logDir = path.Join(path.Dir(filename), logDir)
+	// NOTE: you may need to add GOPATH to PATH
+	output, err := exec.Command("GoVector", "--log_type", "shiviz", "--log_dir", logDir, "--outfile", path.Join(logDir, combinedLogsFilename)).Output()
+	t.Log(string(output), err)
 }
 
 func createVirtualChannelWithRetrievalProvider(c client.Client, retrievalProvider client.Client) protocols.ObjectiveId {

--- a/client_test/virtualfund_largescale_integration_test.go
+++ b/client_test/virtualfund_largescale_integration_test.go
@@ -1,0 +1,70 @@
+package client_test
+
+import (
+	"encoding/json"
+	"math/big"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/statechannels/go-nitro/client"
+	"github.com/statechannels/go-nitro/client/engine/chainservice"
+	"github.com/statechannels/go-nitro/client/engine/messageservice"
+	nc "github.com/statechannels/go-nitro/crypto"
+	td "github.com/statechannels/go-nitro/internal/testdata"
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/protocols/virtualfund"
+	"github.com/statechannels/go-nitro/types"
+)
+
+func TestLargeScaleVirtualFundIntegration(t *testing.T) {
+	const numRetrievalClients = 10
+
+	logFile := "largescale_client_test.log"
+	truncateLog(logFile)
+	logDestination := newLogWriter(logFile)
+
+	chain := chainservice.NewMockChain()
+	broker := messageservice.NewBroker()
+
+	retrievalProvider, retrievalProviderStore := setupClient(bob.PrivateKey, chain, broker, logDestination, 0)
+	paymentHub, _ := setupClient(irene.PrivateKey, chain, broker, logDestination, 0)
+
+	directlyFundALedgerChannel(t, retrievalProvider, paymentHub)
+
+	retrievalClients := make([]client.Client, numRetrievalClients)
+	for i, _ := range retrievalClients {
+		secretKey, _ := nc.GeneratePrivateKeyAndAddress()
+		retrievalClients[i], _ = setupClient(secretKey, chain, broker, logDestination, 0)
+		directlyFundALedgerChannel(t, retrievalClients[i], paymentHub)
+		go createVirtualChannelWithRetrievalProvider(retrievalClients[i], retrievalProvider)
+	}
+
+	<-time.After(5 * time.Second)
+
+	retrievalProviderHubConnection, _ := retrievalProviderStore.GetConsensusChannel(*paymentHub.Address)
+
+	foo, _ := json.Marshal(retrievalProviderHubConnection.SupportedSignedState().State().Outcome)
+
+	logDestination.Write(foo)
+
+}
+
+func createVirtualChannelWithRetrievalProvider(c client.Client, retrievalProvider client.Client) protocols.ObjectiveId {
+	withRetrievalProvider := virtualfund.ObjectiveRequest{
+		MyAddress:    *c.Address,
+		CounterParty: *retrievalProvider.Address,
+		Intermediary: irene.Address(),
+		Outcome: td.Outcomes.Create(
+			*c.Address,
+			*retrievalProvider.Address,
+			1,
+			1,
+		),
+		AppDefinition:     types.Address{},
+		AppData:           types.Bytes{},
+		ChallengeDuration: big.NewInt(0),
+		Nonce:             rand.Int63(),
+	}
+	return c.CreateVirtualChannel(withRetrievalProvider)
+}

--- a/client_test/virtualfund_largescale_integration_test.go
+++ b/client_test/virtualfund_largescale_integration_test.go
@@ -22,8 +22,10 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-// TestLargeScaleVirtualFundIntegration spins up one retrieval provider, one payment hub and several retrieval clients.
-// The clients are instrumented and emit vector clock logs
+// TestLargeScaleVirtualFundIntegration may be used to test a "large scale" payment channel newtork.
+// It uses terminology from the Filecoin retrieval market:
+// It spins up one retrieval provider, one payment hub and several (a configurable number of) retrieval clients.
+// The clients are instrumented and emit vector clock logs, which are combined into an output file ../artifacts/shiviz.log at the end of the test run.
 // The output shiviz.log can be pasted into https://bestchai.bitbucket.io/shiviz/ to visualize the messages which are sent.
 func TestLargeScaleVirtualFundIntegration(t *testing.T) {
 	const numRetrievalClients = 1

--- a/client_test/virtualfund_largescale_integration_test.go
+++ b/client_test/virtualfund_largescale_integration_test.go
@@ -44,9 +44,9 @@ func TestLargeScaleVirtualFundIntegration(t *testing.T) {
 
 	retrievalProviderHubConnection, _ := retrievalProviderStore.GetConsensusChannel(*paymentHub.Address)
 
-	foo, _ := json.Marshal(retrievalProviderHubConnection.SupportedSignedState().State().Outcome)
+	finalOutcome, _ := json.Marshal(retrievalProviderHubConnection.SupportedSignedState().State().Outcome)
 
-	logDestination.Write(foo)
+	logDestination.Write(finalOutcome)
 
 }
 

--- a/client_test/virtualfund_largescale_integration_test.go
+++ b/client_test/virtualfund_largescale_integration_test.go
@@ -20,22 +20,24 @@ import (
 func TestLargeScaleVirtualFundIntegration(t *testing.T) {
 	const numRetrievalClients = 1
 
+	logDir := "../artifacts/vectorclock"
 	logFile := "largescale_client_test.log"
+
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	retrievalProvider, retrievalProviderStore := setupClient(bob.PrivateKey, chain, broker, logDestination, 0)
-	paymentHub, _ := setupClient(irene.PrivateKey, chain, broker, logDestination, 0)
+	retrievalProvider, retrievalProviderStore := setupInstrumentedClient(bob.PrivateKey, chain, broker, logDestination, 0, logDir)
+	paymentHub, _ := setupInstrumentedClient(irene.PrivateKey, chain, broker, logDestination, 0, logDir)
 
 	directlyFundALedgerChannel(t, retrievalProvider, paymentHub)
 
 	retrievalClients := make([]client.Client, numRetrievalClients)
 	for i, _ := range retrievalClients {
 		secretKey, _ := nc.GeneratePrivateKeyAndAddress()
-		retrievalClients[i], _ = setupClient(secretKey, chain, broker, logDestination, 0)
+		retrievalClients[i], _ = setupInstrumentedClient(secretKey, chain, broker, logDestination, 0, logDir)
 		directlyFundALedgerChannel(t, retrievalClients[i], paymentHub)
 		go createVirtualChannelWithRetrievalProvider(retrievalClients[i], retrievalProvider)
 	}

--- a/client_test/virtualfund_largescale_integration_test.go
+++ b/client_test/virtualfund_largescale_integration_test.go
@@ -103,5 +103,5 @@ func createVirtualChannelWithRetrievalProvider(c client.Client, retrievalProvide
 		ChallengeDuration: big.NewInt(0),
 		Nonce:             rand.Int63(),
 	}
-	return c.CreateVirtualChannel(withRetrievalProvider)
+	return c.CreateVirtualChannel(withRetrievalProvider).Id
 }

--- a/client_test/virtualfund_largescale_integration_test.go
+++ b/client_test/virtualfund_largescale_integration_test.go
@@ -58,7 +58,9 @@ func TestLargeScaleVirtualFundIntegration(t *testing.T) {
 		secretKey, _ := nc.GeneratePrivateKeyAndAddress()
 		retrievalClients[i], _ = setupInstrumentedClient(secretKey, chain, broker, logDestination, 0, vectorClockLogDir, "RC"+fmt.Sprint(i))
 		directlyFundALedgerChannel(t, retrievalClients[i], paymentHub)
-		go createVirtualChannelWithRetrievalProvider(retrievalClients[i], retrievalProvider)
+	}
+	for _, client := range retrievalClients {
+		go createVirtualChannelWithRetrievalProvider(client, retrievalProvider)
 	}
 
 	// HACK: wait a second for stuff to happen (be better to wait for objectives to finish)

--- a/client_test/virtualfund_largescale_integration_test.go
+++ b/client_test/virtualfund_largescale_integration_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestLargeScaleVirtualFundIntegration(t *testing.T) {
-	const numRetrievalClients = 10
+	const numRetrievalClients = 1
 
 	logFile := "largescale_client_test.log"
 	truncateLog(logFile)

--- a/client_test/virtualfund_largescale_integration_test.go
+++ b/client_test/virtualfund_largescale_integration_test.go
@@ -61,7 +61,7 @@ func TestLargeScaleVirtualFundIntegration(t *testing.T) {
 
 	finalOutcome, _ := json.Marshal(retrievalProviderHubConnection.SupportedSignedState().State().Outcome)
 
-	logDestination.Write(finalOutcome)
+	_, _ = logDestination.Write(finalOutcome)
 
 	combineLogs(t, vectorClockLogDir, "shiviz.log")
 

--- a/client_test/virtualfund_largescale_integration_test.go
+++ b/client_test/virtualfund_largescale_integration_test.go
@@ -55,7 +55,7 @@ func TestLargeScaleVirtualFundIntegration(t *testing.T) {
 		go createVirtualChannelWithRetrievalProvider(retrievalClients[i], retrievalProvider)
 	}
 
-	<-time.After(5 * time.Second)
+	<-time.After(1 * time.Second)
 
 	retrievalProviderHubConnection, _ := retrievalProviderStore.GetConsensusChannel(*paymentHub.Address)
 

--- a/client_test/virtualfund_largescale_integration_test.go
+++ b/client_test/virtualfund_largescale_integration_test.go
@@ -71,8 +71,10 @@ func combineLogs(t *testing.T, logDir string, combinedLogsFilename string) {
 	_, filename, _, _ := runtime.Caller(1)
 	logDir = path.Join(path.Dir(filename), logDir)
 	// NOTE: you may need to add GOPATH to PATH
-	output, err := exec.Command("GoVector", "--log_type", "shiviz", "--log_dir", logDir, "--outfile", path.Join(logDir, combinedLogsFilename)).Output()
-	t.Log(string(output), err)
+	_, err := exec.Command("GoVector", "--log_type", "shiviz", "--log_dir", logDir, "--outfile", path.Join(logDir, combinedLogsFilename)).Output()
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func createVirtualChannelWithRetrievalProvider(c client.Client, retrievalProvider client.Client) protocols.ObjectiveId {

--- a/client_test/virtualfund_largescale_integration_test.go
+++ b/client_test/virtualfund_largescale_integration_test.go
@@ -30,9 +30,9 @@ import (
 func TestLargeScaleVirtualFundIntegration(t *testing.T) {
 	const numRetrievalClients = 1
 
-	logDir := "../artifacts/vectorclock"
+	vectorClockLogDir := "../artifacts/vectorclock"
 
-	os.RemoveAll(logDir)
+	os.RemoveAll(vectorClockLogDir)
 
 	logFile := "largescale_client_test.log"
 
@@ -42,15 +42,15 @@ func TestLargeScaleVirtualFundIntegration(t *testing.T) {
 	chain := chainservice.NewMockChain()
 	broker := messageservice.NewBroker()
 
-	retrievalProvider, retrievalProviderStore := setupInstrumentedClient(bob.PrivateKey, chain, broker, logDestination, 0, logDir, "RP")
-	paymentHub, _ := setupInstrumentedClient(irene.PrivateKey, chain, broker, logDestination, 0, logDir, "PH")
+	retrievalProvider, retrievalProviderStore := setupInstrumentedClient(bob.PrivateKey, chain, broker, logDestination, 0, vectorClockLogDir, "RP")
+	paymentHub, _ := setupInstrumentedClient(irene.PrivateKey, chain, broker, logDestination, 0, vectorClockLogDir, "PH")
 
 	directlyFundALedgerChannel(t, retrievalProvider, paymentHub)
 
 	retrievalClients := make([]client.Client, numRetrievalClients)
 	for i := range retrievalClients {
 		secretKey, _ := nc.GeneratePrivateKeyAndAddress()
-		retrievalClients[i], _ = setupInstrumentedClient(secretKey, chain, broker, logDestination, 0, logDir, "RC"+fmt.Sprint(i))
+		retrievalClients[i], _ = setupInstrumentedClient(secretKey, chain, broker, logDestination, 0, vectorClockLogDir, "RC"+fmt.Sprint(i))
 		directlyFundALedgerChannel(t, retrievalClients[i], paymentHub)
 		go createVirtualChannelWithRetrievalProvider(retrievalClients[i], retrievalProvider)
 	}
@@ -63,7 +63,7 @@ func TestLargeScaleVirtualFundIntegration(t *testing.T) {
 
 	logDestination.Write(finalOutcome)
 
-	combineLogs(t, logDir, "shiviz.log")
+	combineLogs(t, vectorClockLogDir, "shiviz.log")
 
 }
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/VictoriaMetrics/fastcache v1.6.0 // indirect
 	github.com/btcsuite/btcd v0.20.1-beta // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/daviddengcn/go-colortext v1.0.0 // indirect
 	github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea // indirect
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/go-ole/go-ole v1.2.1 // indirect
@@ -32,6 +33,8 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20210305035536-64b5b1c73954 // indirect
 	github.com/tklauser/go-sysconf v0.3.5 // indirect
 	github.com/tklauser/numcpus v0.2.2 // indirect
+	github.com/vmihailenco/msgpack/v5 v5.1.4 // indirect
+	github.com/vmihailenco/tagparser v0.1.2 // indirect
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
 	golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 )
 
 require (
+	github.com/DistributedClocks/GoVector v0.0.0-20210402100930-db949c81a0af // indirect
 	github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 // indirect
 	github.com/VictoriaMetrics/fastcache v1.6.0 // indirect
 	github.com/btcsuite/btcd v0.20.1-beta // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/statechannels/go-nitro
 go 1.18
 
 require (
+	github.com/DistributedClocks/GoVector v0.0.0-20210402100930-db949c81a0af
 	github.com/ethereum/go-ethereum v1.10.8
 	github.com/google/go-cmp v0.5.6
 )
 
 require (
-	github.com/DistributedClocks/GoVector v0.0.0-20210402100930-db949c81a0af // indirect
 	github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 // indirect
 	github.com/VictoriaMetrics/fastcache v1.6.0 // indirect
 	github.com/btcsuite/btcd v0.20.1-beta // indirect

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,7 @@ github.com/golangci/lint-1 v0.0.0-20181222135242-d2cdd8c08219/go.mod h1:/X8TswGS
 github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450/go.mod h1:Bk6SMAONeMXrxql8uvOKuAZSu8aM5RUGv+1C6IJaEho=
 github.com/golangplus/bytes v1.0.0/go.mod h1:AdRaCFwmc/00ZzELMWb01soso6W1R/++O1XL80yAn+A=
 github.com/golangplus/fmt v1.0.0/go.mod h1:zpM0OfbMCjPtd2qkTD/jX2MgiFCqklhSUFyDW44gVQE=
+github.com/golangplus/testing v1.0.0 h1:+ZeeiKZENNOMkTTELoSySazi+XaEhVO0mb+eanrSEUQ=
 github.com/golangplus/testing v1.0.0/go.mod h1:ZDreixUV3YzhoVraIDyOzHrr76p6NUh6k/pPg/Q3gYA=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbt
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/DistributedClocks/GoVector v0.0.0-20210402100930-db949c81a0af h1:dZA/5RPZb4h+6EPdMIyQ1SE62NBBGIp6O1UNowh+Ozg=
+github.com/DistributedClocks/GoVector v0.0.0-20210402100930-db949c81a0af/go.mod h1:KhO62KYM3s2gEKM3ESiiI4pgvEPHz96Y1R1ceFpyVBg=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 h1:fLjPD/aNc3UIOA6tDi6QXUemppXK3P9BI7mr2hd6gx8=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
@@ -90,6 +92,7 @@ github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/daviddengcn/go-colortext v1.0.0/go.mod h1:zDqEI5NVUop5QPpVJUxE9UO10hRnmkD5G4Pmri9+m4c=
 github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea h1:j4317fAZh7X6GqbFowYdYdI0L9bwxL07jyPZIdepyZ0=
 github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
 github.com/deepmap/oapi-codegen v1.6.0/go.mod h1:ryDa9AgbELGeB+YEXE1dR53yAjHwFvE9iAUlWl9Al3M=
@@ -164,6 +167,10 @@ github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golangci/lint-1 v0.0.0-20181222135242-d2cdd8c08219/go.mod h1:/X8TswGSh1pIozq4ZwCfxS0WA5JGXguxk94ar/4c87Y=
+github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450/go.mod h1:Bk6SMAONeMXrxql8uvOKuAZSu8aM5RUGv+1C6IJaEho=
+github.com/golangplus/bytes v1.0.0/go.mod h1:AdRaCFwmc/00ZzELMWb01soso6W1R/++O1XL80yAn+A=
+github.com/golangplus/fmt v1.0.0/go.mod h1:zpM0OfbMCjPtd2qkTD/jX2MgiFCqklhSUFyDW44gVQE=
+github.com/golangplus/testing v1.0.0/go.mod h1:ZDreixUV3YzhoVraIDyOzHrr76p6NUh6k/pPg/Q3gYA=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/flatbuffers v1.11.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
@@ -243,6 +250,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
@@ -347,6 +355,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/goleveldb v1.0.1-0.20210305035536-64b5b1c73954 h1:xQdMZ1WLrgkkvOZ/LDQxjVxMLdby7osSh4ZEVa5sIjs=
@@ -361,6 +370,8 @@ github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/X
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+github.com/vmihailenco/msgpack/v5 v5.1.4/go.mod h1:C5gboKD0TJPqWDTVTtrQNfRbiBwHZGo8UTqP/9/XvLI=
+github.com/vmihailenco/tagparser v0.1.2/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -580,6 +591,7 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce h1:+JknDZhAj8YMt7GC73Ei8pv4MzjDUNPHgQWJdtMAaDU=

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,7 @@ github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/daviddengcn/go-colortext v1.0.0 h1:ANqDyC0ys6qCSvuEK7l3g5RaehL/Xck9EX8ATG8oKsE=
 github.com/daviddengcn/go-colortext v1.0.0/go.mod h1:zDqEI5NVUop5QPpVJUxE9UO10hRnmkD5G4Pmri9+m4c=
 github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea h1:j4317fAZh7X6GqbFowYdYdI0L9bwxL07jyPZIdepyZ0=
 github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
@@ -370,7 +371,9 @@ github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/X
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+github.com/vmihailenco/msgpack/v5 v5.1.4 h1:6K44/cU6dMNGkVTGGuu7ef2NdSRFMhAFGGLfE3cqtHM=
 github.com/vmihailenco/msgpack/v5 v5.1.4/go.mod h1:C5gboKD0TJPqWDTVTtrQNfRbiBwHZGo8UTqP/9/XvLI=
+github.com/vmihailenco/tagparser v0.1.2 h1:gnjoVuB/kljJ5wICEEOpx98oXMWPLj22G67Vbd1qPqc=
 github.com/vmihailenco/tagparser v0.1.2/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=


### PR DESCRIPTION
The instrumented test message service enables a partial order to be defined on the message send/receive events in multiple `go-nitro` clients running an integration test. This in turn allows the test run to be visualized by relying on logical time (and not physical time). See https://en.wikipedia.org/wiki/Vector_clock and https://github.com/DistributedClocks/GoVector.

The original motivation for this work is to have a visual way of depicting a successful integration test. I believe it will also be very useful in understanding test runs, debugging our code and checking invariants; especially when we start to compare multiple test runs, or start to play with protocol changes, artificial message delays, and so on. 

Using the instrumented test message service, the additional test produces a logfile (not checked in, but uploaded as a CI artifact) like the following, which you can try out at https://bestchai.bitbucket.io/shiviz/:

```log
(?<host>\S*) (?<clock>{.*})\n(?<event>.*)

PH {"PH":1}
Initialization Complete
PH {"PH":2, "RP":2}
INFO Receiving Message
PH {"PH":3, "RP":2}
INFO send Lxf01c730 @turn 0
PH {"PH":4, "RP":2}
INFO send Lxf01c731 @turn 1
PH {"PH":5, "RP":5}
INFO Receiving Message
PH {"PH":6, "RP":5, "RC0":2}
INFO Receiving Message
PH {"PH":7, "RP":5, "RC0":2}
INFO send Lxc4c0080 @turn 0
PH {"RP":5, "RC0":4, "PH":8}
INFO Receiving Message
PH {"PH":9, "RP":5, "RC0":4}
INFO send Lxc4c0081 @turn 1
PH {"PH":10, "RP":5, "RC0":7}
INFO Receiving Message
PH {"PH":11, "RP":7, "RC0":7}
INFO Receiving Message
PH {"PH":12, "RP":7, "RC0":7}
INFO send Vx97bddb0 @turn 0
PH {"PH":13, "RP":7, "RC0":7}
INFO send Vx97bddb0 @turn 0
PH {"PH":14, "RP":10, "RC0":7}
INFO Receiving Message
PH {"RC0":10, "PH":15, "RP":10}
INFO Receiving Message
PH {"PH":16, "RP":10, "RC0":10}
INFO propose xf01c73 funds x97bddb
PH {"PH":17, "RP":10, "RC0":10}
INFO propose xc4c008 funds x97bddb
PH {"PH":18, "RP":10, "RC0":10}
INFO send Vx97bddb1 @turn 1
PH {"RP":10, "RC0":10, "PH":19}
INFO send Vx97bddb1 @turn 1
PH {"PH":20, "RP":13, "RC0":10}
INFO Receiving Message
PH {"RC0":14, "PH":21, "RP":13}
INFO Receiving Message
RC0 {"RC0":1}
Initialization Complete
RC0 {"RC0":2}
INFO send Lxc4c0080 @turn 0
RC0 {"RC0":3, "RP":5, "PH":7}
INFO Receiving Message
RC0 {"RP":5, "PH":7, "RC0":4}
INFO send Lxc4c0081 @turn 1
RC0 {"RC0":5, "RP":5, "PH":9}
INFO Receiving Message
RC0 {"RC0":6, "RP":5, "PH":9}
INFO send Vx97bddb0 @turn 0
RC0 {"RC0":7, "RP":5, "PH":9}
INFO send Vx97bddb0 @turn 0
RC0 {"RC0":8, "RP":8, "PH":9}
INFO Receiving Message
RC0 {"RC0":9, "RP":8, "PH":13}
INFO Receiving Message
RC0 {"PH":13, "RC0":10, "RP":8}
INFO propose xc4c008 funds x97bddb
RC0 {"RC0":11, "RP":10, "PH":17}
INFO Receiving Message
RC0 {"RP":12, "PH":17, "RC0":12}
INFO Receiving Message
RC0 {"RP":12, "PH":18, "RC0":13}
INFO Receiving Message
RC0 {"RC0":14, "RP":12, "PH":18}
INFO send Vx97bddb1 @turn 1
RC0 {"RC0":15, "RP":12, "PH":18}
INFO send Vx97bddb1 @turn 1
RP {"RP":1}
Initialization Complete
RP {"RP":2}
INFO send Lxf01c730 @turn 0
RP {"RP":3, "PH":3}
INFO Receiving Message
RP {"RP":4, "PH":4}
INFO Receiving Message
RP {"RP":5, "PH":4}
INFO send Lxf01c731 @turn 1
RP {"RP":6, "PH":9, "RC0":6}
INFO Receiving Message
RP {"RC0":6, "RP":7, "PH":9}
INFO send Vx97bddb0 @turn 0
RP {"RC0":6, "RP":8, "PH":9}
INFO send Vx97bddb0 @turn 0
RP {"RP":9, "PH":12, "RC0":7}
INFO Receiving Message
RP {"RP":10, "PH":12, "RC0":7}
INFO propose xf01c73 funds x97bddb
RP {"RP":11, "PH":16, "RC0":10}
INFO Receiving Message
RP {"PH":16, "RC0":10, "RP":12}
INFO send Vx97bddb1 @turn 1
RP {"RP":13, "PH":16, "RC0":10}
INFO send Vx97bddb1 @turn 1
RP {"PH":19, "RC0":10, "RP":14}
INFO Receiving Message
RP {"RP":15, "PH":19, "RC0":15}
INFO Receiving Message
```

which visualizes as
![Screenshot 2022-05-05 at 16 06 57](https://user-images.githubusercontent.com/1833419/166954041-caaaebb0-6fa6-4b7d-9280-14476cc72642.png)
(it is snipped off at the bottom).

Here RP (retrieval provider) and RC0 (retrieval client) begin by opening a ledger connection to PH (payment hub). After that RC0 proposes a virtual channel with RP through PH.

You can spot some interesting motifs:
* request / response (pre fund setups)
* crossing in flight (post fund setups)
* broadcast (pre fund setups for 3 party channels)

