### PR TITLE
fix version of golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3.1.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.29
+          version: v1.45.2
 
       - name: make bin folder
         run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,6 +15,9 @@ jobs:
           go-version: "^1.18.0"
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.1.0
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: v1.29
 
       - name: make bin folder
         run: |

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -88,7 +88,7 @@ func setupInstrumentedClient(
 ) (client.Client, store.Store) {
 	myAddress := crypto.GetAddressFromSecretKeyBytes(pk)
 	chain.Subscribe(myAddress)
-	chainservice := chainservice.NewSimpleChainService(chain, myAddress)
+	chainservice := chainservice.NewSimpleChainService(&chain, myAddress)
 	messageservice := messageservice.NewVectorClockTestMessageService(myAddress, msgBroker, meanMessageDelay, logDir, prettyName)
 	storeA := store.NewMemStore(pk)
 	return client.New(messageservice, chainservice, storeA, logDestination), storeA


### PR DESCRIPTION
This prevents unannounced / unexpected linting errors from appearing due to newer versions of the linting tool being published. 


Context: I tried upgrading my local linter, but seemed to find quite a lot of false positives. So I think the cutting edge version is not so great. Hence the decision to fix the version for now. 

More context: There are several linters which are "disabled because of go1.18". Therefore we expect quite a lot of significant changes to linting in the short term. 