### PR TITLE
Add Transaction Submitted flag to Direct Fund/Defund objectives

### DIFF
--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -31,9 +31,10 @@ var (
 
 // Objective is a cache of data computed by reading from the store. It stores (potentially) infinite data
 type Objective struct {
-	Status       protocols.ObjectiveStatus
-	C            *channel.Channel
-	finalTurnNum uint64
+	Status               protocols.ObjectiveStatus
+	C                    *channel.Channel
+	finalTurnNum         uint64
+	transactionSubmitted bool // whether a transation for the objective has been submitted or not
 }
 
 // isInConsensusOrFinalState returns true if the channel has a final state or latest state that is supported
@@ -255,12 +256,13 @@ func (o Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Side
 	}
 
 	// Withdrawal of funds
-	if !updated.fullyWithdrawn() {
-		// TODO #314: before submiting a withdrawal transaction, we should check if a withdrawal transaction has already been submitted
+	if !updated.fullyWithdrawn() && !updated.transactionSubmitted {
+
 		// The first participant in the channel submits the withdrawAll transaction
 		if updated.C.MyIndex == 0 {
 			withdrawAll := protocols.ChainTransaction{Type: protocols.WithdrawAllTransactionType, ChannelId: updated.C.Id}
 			sideEffects.TransactionsToSubmit = append(sideEffects.TransactionsToSubmit, withdrawAll)
+			updated.transactionSubmitted = true
 		}
 		// Every participant waits for all channel funds to be distributed, even if the participant has no funds in the channel
 		return &updated, sideEffects, WaitingForWithdraw, nil

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -175,9 +175,12 @@ func TestCrankAlice(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, se, wf, err = updated.Crank(&alice.PrivateKey)
+	updated, se, wf, err = updated.Crank(&alice.PrivateKey)
 	if err != nil {
 		t.Error(err)
+	}
+	if !updated.(*Objective).transactionSubmitted {
+		t.Fatalf("Expected transactionSubmitted flag to be set to true")
 	}
 
 	if wf != WaitingForWithdraw {
@@ -258,9 +261,13 @@ func TestCrankBob(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, se, wf, err = updated.Crank(&bob.PrivateKey)
+	updated, se, wf, err = updated.Crank(&bob.PrivateKey)
 	if err != nil {
 		t.Error(err)
+	}
+
+	if updated.(*Objective).transactionSubmitted {
+		t.Fatalf("Expected transactionSubmitted flag to be set to false")
 	}
 
 	if wf != WaitingForWithdraw {

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -39,6 +39,7 @@ type Objective struct {
 	myDepositTarget          types.Funds // I want to get the on chain holdings up to this much
 	fullyFundedThreshold     types.Funds // if the on chain holdings are equal
 	latestBlockNumber        uint64      // the latest block number we've seen
+	transactionSubmitted     bool        // whether a transation for the objective has been submitted or not
 }
 
 // NewObjective creates a new direct funding objective from a given request.
@@ -265,8 +266,9 @@ func (o Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Side
 		return &updated, sideEffects, WaitingForMyTurnToFund, nil
 	}
 
-	if !fundingComplete && safeToDeposit && amountToDeposit.IsNonZero() {
+	if !fundingComplete && safeToDeposit && amountToDeposit.IsNonZero() && !updated.transactionSubmitted {
 		deposit := protocols.ChainTransaction{Type: protocols.DepositTransactionType, ChannelId: updated.C.Id, Deposit: amountToDeposit}
+		updated.transactionSubmitted = true
 		sideEffects.TransactionsToSubmit = append(sideEffects.TransactionsToSubmit, deposit)
 	}
 

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -250,7 +250,11 @@ func TestCrank(t *testing.T) {
 
 	// Manually make the first "deposit"
 	o.C.OnChainFunding[testState.Outcome[0].Asset] = testState.Outcome[0].Allocations[0].Amount
-	_, sideEffects, waitingFor, err = o.Crank(&alice.PrivateKey)
+	updated, sideEffects, waitingFor, err := o.Crank(&alice.PrivateKey)
+
+	if !updated.(*Objective).transactionSubmitted {
+		t.Fatalf("Expected transactionSubmitted flag to be set to true")
+	}
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Add a `transactionSubmitted` flag to direct funding/defunding that gets set when we generate a transaction side effect. This prevents us from submitting duplicate transactions if `crank` gets triggered again before we detect a chain event.

Fixes #608 
Fixes #314