### PR TITLE
Check for existing ledger channels when constructing direct fund objective

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -269,7 +269,7 @@ func (e *Engine) handleAPIEvent(apiEvent APIEvent) (ObjectiveChangeEvent, error)
 			return e.attemptProgress(&vdfo)
 
 		case directfund.ObjectiveRequest:
-			dfo, err := directfund.NewObjective(request, true, e.store.GetChannelByParticipant, e.store.GetConsensusChannel)
+			dfo, err := directfund.NewObjective(request, true, e.store.GetChannelsByParticipant, e.store.GetConsensusChannel)
 			if err != nil {
 				return ObjectiveChangeEvent{}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 			}

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -269,7 +269,7 @@ func (e *Engine) handleAPIEvent(apiEvent APIEvent) (ObjectiveChangeEvent, error)
 			return e.attemptProgress(&vdfo)
 
 		case directfund.ObjectiveRequest:
-			dfo, err := directfund.NewObjective(request, true)
+			dfo, err := directfund.NewObjective(request, true, e.store.GetChannelByParticipant, e.store.GetConsensusChannel)
 			if err != nil {
 				return ObjectiveChangeEvent{}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 			}

--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -174,6 +174,7 @@ func (ms *MemStore) getChannelById(id types.Destination) (channel.Channel, error
 	return ch, nil
 }
 
+// GetChannelsByParticipant returns any channels that include the given participant
 func (ms *MemStore) GetChannelsByParticipant(participant types.Address) []*channel.Channel {
 	toReturn := []*channel.Channel{}
 	ms.channels.Range(func(key string, chJSON []byte) bool {

--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -174,6 +174,32 @@ func (ms *MemStore) getChannelById(id types.Destination) (channel.Channel, error
 	return ch, nil
 }
 
+func (ms *MemStore) GetChannelByParticipant(participant types.Address) (c *channel.Channel, ok bool) {
+	ms.channels.Range(func(key string, chJSON []byte) bool {
+
+		var ch channel.Channel
+		err := json.Unmarshal(chJSON, &ch)
+
+		if err != nil {
+			return true // channel not found, continue looking
+		}
+
+		participants := ch.FixedPart.Participants
+		for _, p := range participants {
+			if p == participant {
+				c = &ch
+				ok = true
+				return false // we have found the target channel: break the Range loop
+			}
+
+		}
+
+		return true // channel not found: continue looking
+	})
+
+	return
+}
+
 // GetConsensusChannelById returns a ConsensusChannel with the given channel id
 func (ms *MemStore) GetConsensusChannelById(id types.Destination) (channel *consensus_channel.ConsensusChannel, err error) {
 

--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -174,7 +174,8 @@ func (ms *MemStore) getChannelById(id types.Destination) (channel.Channel, error
 	return ch, nil
 }
 
-func (ms *MemStore) GetChannelByParticipant(participant types.Address) (c *channel.Channel, ok bool) {
+func (ms *MemStore) GetChannelsByParticipant(participant types.Address) []*channel.Channel {
+	toReturn := []*channel.Channel{}
 	ms.channels.Range(func(key string, chJSON []byte) bool {
 
 		var ch channel.Channel
@@ -187,9 +188,7 @@ func (ms *MemStore) GetChannelByParticipant(participant types.Address) (c *chann
 		participants := ch.FixedPart.Participants
 		for _, p := range participants {
 			if p == participant {
-				c = &ch
-				ok = true
-				return false // we have found the target channel: break the Range loop
+				toReturn = append(toReturn, &ch)
 			}
 
 		}
@@ -197,7 +196,7 @@ func (ms *MemStore) GetChannelByParticipant(participant types.Address) (c *chann
 		return true // channel not found: continue looking
 	})
 
-	return
+	return toReturn
 }
 
 // GetConsensusChannelById returns a ConsensusChannel with the given channel id

--- a/client/engine/store/memstore_test.go
+++ b/client/engine/store/memstore_test.go
@@ -197,18 +197,16 @@ func TestConsensusChannelStore(t *testing.T) {
 	}
 }
 
-func TestGetChannelByParticipant(t *testing.T) {
+func TestGetChannelsByParticipant(t *testing.T) {
 	sk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
 
 	ms := store.NewMemStore(sk)
-	want := td.Objectives.Directfund.GenericDFO().C
+	c := td.Objectives.Directfund.GenericDFO().C
+	want := []*channel.Channel{c}
+	_ = ms.SetChannel(c)
 
-	ms.SetChannel(want)
+	got := ms.GetChannelsByParticipant(c.Participants[0])
 
-	got, ok := ms.GetChannelByParticipant(want.Participants[0])
-	if !ok {
-		t.Fatalf("expected to find the inserted  channel, but didn't")
-	}
 	if diff := cmp.Diff(got, want, cmp.AllowUnexported(channel.Channel{}, big.Int{}, state.SignedState{})); diff != "" {
 		t.Fatalf("fetched result different than expected %s", diff)
 	}

--- a/client/engine/store/memstore_test.go
+++ b/client/engine/store/memstore_test.go
@@ -196,3 +196,21 @@ func TestConsensusChannelStore(t *testing.T) {
 		t.Fatalf("fetched result different than expected %s", diff)
 	}
 }
+
+func TestGetChannelByParticipant(t *testing.T) {
+	sk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
+
+	ms := store.NewMemStore(sk)
+	want := td.Objectives.Directfund.GenericDFO().C
+
+	ms.SetChannel(want)
+
+	got, ok := ms.GetChannelByParticipant(want.Participants[0])
+	if !ok {
+		t.Fatalf("expected to find the inserted  channel, but didn't")
+	}
+	if diff := cmp.Diff(got, want, cmp.AllowUnexported(channel.Channel{}, big.Int{}, state.SignedState{})); diff != "" {
+		t.Fatalf("fetched result different than expected %s", diff)
+	}
+
+}

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -25,7 +25,7 @@ type Store interface {
 	SetObjective(protocols.Objective) error                                       // Write an objective
 
 	GetChannelById(id types.Destination) (c *channel.Channel, ok bool)
-	GetChannelByParticipant(participant types.Address) (c *channel.Channel, ok bool) // Returns any channel that includes the given participant
+	GetChannelsByParticipant(participant types.Address) []*channel.Channel // Returns any channels that includes the given participant
 	SetChannel(*channel.Channel) error
 	DestroyChannel(id types.Destination)
 

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -25,6 +25,7 @@ type Store interface {
 	SetObjective(protocols.Objective) error                                       // Write an objective
 
 	GetChannelById(id types.Destination) (c *channel.Channel, ok bool)
+	GetChannelByParticipant(participant types.Address) (c *channel.Channel, ok bool) // Returns any channel that includes the given participant
 	SetChannel(*channel.Channel) error
 	DestroyChannel(id types.Destination)
 

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -43,16 +43,8 @@ var Objectives objectiveCollection = objectiveCollection{
 
 func genericDFO() directfund.Objective {
 	ts := testState.Clone()
-	request := directfund.ObjectiveRequest{
-		MyAddress:         ts.Participants[0],
-		CounterParty:      ts.Participants[1],
-		AppData:           ts.AppData,
-		AppDefinition:     ts.AppDefinition,
-		ChallengeDuration: ts.ChallengeDuration,
-		Nonce:             ts.ChannelNonce.Int64(),
-		Outcome:           ts.Outcome,
-	}
-	testObj, err := directfund.NewObjective(request, false)
+	ts.TurnNum = 0
+	testObj, err := directfund.ConstructFromState(false, ts, ts.Participants[0])
 	if err != nil {
 		panic(fmt.Errorf("error constructing genericDFO: %w", err))
 	}

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -41,8 +41,15 @@ type Objective struct {
 	latestBlockNumber        uint64      // the latest block number we've seen
 }
 
+// GetChannelByIdFunction specifies a function that can be used to retreive channels from a store.
+type GetChannelByParticipantFunction func(participant types.Address) (channel *channel.Channel, ok bool)
+
+// GetTwoPartyConsensusLedgerFuncion describes functions which return a ConsensusChannel ledger channel between
+// the calling client and the given counterparty, if such a channel exists.
+type GetTwoPartyConsensusLedgerFunction func(counterparty types.Address) (ledger *consensus_channel.ConsensusChannel, ok bool)
+
 // NewObjective creates a new direct funding objective from a given request.
-func NewObjective(request ObjectiveRequest, preApprove bool) (Objective, error) {
+func NewObjective(request ObjectiveRequest, preApprove bool, getChannel GetChannelByParticipantFunction, getTwoPartyConsensusLedger GetTwoPartyConsensusLedgerFunction) (Objective, error) {
 
 	objective, err := ConstructFromState(preApprove,
 		state.State{


### PR DESCRIPTION
Fixes #627

Adds a check when creating a direct funding objective that no other ledger channels exist with the counterparty.

We check both for `channel.Channel` for any "in-flight" direct funding objectives as well as `consenus_channel.ConsensusChannel` for any completed direct funding objectives.

This prevents us from creating multiple ledger channels with a counterparty and not knowing which channel to choose when virtual funding.