### PR TITLE
remove TurnNum func on SignedState

### DIFF
--- a/channel/state/signedstate.go
+++ b/channel/state/signedstate.go
@@ -158,11 +158,6 @@ func (ss SignedState) ChannelId() types.Destination {
 	return cId
 }
 
-// TurnNum returns the turn number of the state.
-func (ss SignedState) TurnNum() uint64 {
-	return ss.state.TurnNum
-}
-
 // SortInfo returns the channel id and turn number of the state, so the state can be easily sorted.
 func (ss SignedState) SortInfo() (types.Destination, uint64) {
 	cId := ss.State().ChannelId()

--- a/client/engine/messageservice/vectorclock_testmessageservice.go
+++ b/client/engine/messageservice/vectorclock_testmessageservice.go
@@ -90,10 +90,11 @@ func summarizeMessageSend(msg protocols.Message) string {
 		} else {
 			summary += `L`
 		}
+		_, turnNum := entry.Payload.SortInfo()
 		summary += fmt.Sprint(entry.Payload.ChannelId())[1:8]
-		summary += fmt.Sprint(entry.Payload.TurnNum())
+		summary += fmt.Sprint(turnNum)
 		summary += ` @turn `
-		summary += fmt.Sprint(entry.Payload.TurnNum())
+		summary += fmt.Sprint(turnNum)
 
 	}
 	return summary


### PR DESCRIPTION
Fixes #606 

Since `TurnNum` is already a public field on the `SignedState` we don't need a getter function as well.

`TurNum()` used to be used to sort payloads but that has been replaced by `SortInfo()`