### PR TITLE
Some improvements to "large scale instrumented test"

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,14 +19,6 @@ jobs:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.45.2
 
-      - name: make bin folder
-        run: |
-          mkdir -p $GITHUB_WORKSPACE/bin
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
-
-      - name: install GoVector
-        run: GOPATH=$($GITHUB_WORKSPACE/bin) go install github.com/DistributedClocks/GoVector@latest
-
       - name: Build
         run: go build -v ./...
 

--- a/client/engine/messageservice/vectorclock_summarize_test.go
+++ b/client/engine/messageservice/vectorclock_summarize_test.go
@@ -1,0 +1,65 @@
+package messageservice
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/internal/testactors"
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/types"
+)
+
+func TestSummarizeMessage(t *testing.T) {
+
+	msg1 := protocols.Message{
+		To: testactors.Alice.Address(),
+		Payloads: []protocols.MessagePayload{
+			{
+				ObjectiveId: "some-Oid",
+				SignedState: state.SignedState{},
+				SignedProposal: consensus_channel.SignedProposal{
+					Proposal: consensus_channel.Proposal{LedgerID: types.Destination{3}, ToAdd: consensus_channel.Add{
+						Guarantee:   consensus_channel.NewGuarantee(big.NewInt(4), types.Destination{9}, types.Destination{8}, types.Destination{7}),
+						LeftDeposit: big.NewInt(3),
+					}},
+					TurnNum: 2,
+				},
+			},
+		},
+	}
+
+	got1 := summarizeMessageSend(msg1)
+	want1 := "886B:propose 0x0300000000000000000000000000000000000000000000000000000000000000 funds 0x0900000000000000000000000000000000000000000000000000000000000000"
+
+	if got1 != want1 {
+		t.Fatalf("wrong message summary: got %s, wanted %s", got1, want1)
+	}
+
+	msg2 := protocols.Message{
+		To: testactors.Alice.Address(),
+		Payloads: []protocols.MessagePayload{
+			{
+				ObjectiveId: "some-Oid",
+				SignedState: state.SignedState{},
+				SignedProposal: consensus_channel.SignedProposal{
+					Proposal: consensus_channel.Proposal{LedgerID: types.Destination{3}, ToRemove: consensus_channel.Remove{
+						Target:      types.Destination{7},
+						LeftAmount:  big.NewInt(2),
+						RightAmount: big.NewInt(3),
+					}},
+					TurnNum: 2,
+				},
+			},
+		},
+	}
+
+	got2 := summarizeMessageSend(msg2)
+	want2 := "886B:propose 0x0300000000000000000000000000000000000000000000000000000000000000 defunds 0x0700000000000000000000000000000000000000000000000000000000000000"
+
+	if got2 != want2 {
+		t.Fatalf("wrong message summary: got %s, wanted %s", got2, want2)
+	}
+
+}

--- a/client/engine/messageservice/vectorclock_testmessageservice.go
+++ b/client/engine/messageservice/vectorclock_testmessageservice.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/DistributedClocks/GoVector/govec"
+	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -81,8 +82,14 @@ func summarizeMessageSend(msg protocols.Message) string {
 	for _, entry := range msg.SignedProposals() {
 		summary += `propose `
 		summary += fmt.Sprint(entry.Payload.Proposal.LedgerID)
-		summary += ` funds `
-		summary += fmt.Sprint(entry.Payload.Proposal.ToAdd.Target())
+		if (entry.Payload.Proposal.ToAdd != consensus_channel.Add{}) {
+			summary += ` funds `
+			summary += fmt.Sprint(entry.Payload.Proposal.ToAdd.Target())
+		}
+		if (entry.Payload.Proposal.ToRemove != consensus_channel.Remove{}) {
+			summary += ` defunds `
+			summary += fmt.Sprint(entry.Payload.Proposal.ToRemove.Target)
+		}
 	}
 	for _, entry := range msg.SignedStates() {
 		summary += `send `

--- a/client/engine/messageservice/vectorclock_testmessageservice.go
+++ b/client/engine/messageservice/vectorclock_testmessageservice.go
@@ -26,7 +26,6 @@ func NewVectorClockTestMessageService(
 	broker Broker,
 	maxDelay time.Duration,
 	logDir string,
-	prettyName string,
 ) VectorClockTestMessageService {
 
 	vctms := VectorClockTestMessageService{
@@ -37,7 +36,7 @@ func NewVectorClockTestMessageService(
 			maxDelay:  maxDelay,
 			fromPeers: make(chan []byte, 5),
 		},
-		goveclogger: govec.InitGoVector(prettyName, logDir+"/"+address.String(), govec.GetDefaultConfig()),
+		goveclogger: govec.InitGoVector(address.String(), logDir+"/"+address.String(), govec.GetDefaultConfig()),
 	}
 
 	vctms.connect(broker)
@@ -81,20 +80,14 @@ func summarizeMessageSend(msg protocols.Message) string {
 	summary := fmt.Sprint(size) + "B:"
 	for _, entry := range msg.SignedProposals() {
 		summary += `propose `
-		summary += fmt.Sprint(entry.Payload.Proposal.LedgerID)[1:8]
+		summary += fmt.Sprint(entry.Payload.Proposal.LedgerID)
 		summary += ` funds `
-		summary += fmt.Sprint(entry.Payload.Proposal.ToAdd.Target())[1:8]
+		summary += fmt.Sprint(entry.Payload.Proposal.ToAdd.Target())
 	}
 	for _, entry := range msg.SignedStates() {
 		summary += `send `
-		if len(entry.Payload.State().Participants) == 3 {
-			summary += `V`
-		} else {
-			summary += `L`
-		}
 		_, turnNum := entry.Payload.SortInfo()
-		summary += fmt.Sprint(entry.Payload.ChannelId())[1:8]
-		summary += fmt.Sprint(turnNum)
+		summary += fmt.Sprint(entry.Payload.ChannelId())
 		summary += ` @turn `
 		summary += fmt.Sprint(turnNum)
 

--- a/client/engine/messageservice/vectorclock_testmessageservice.go
+++ b/client/engine/messageservice/vectorclock_testmessageservice.go
@@ -76,7 +76,9 @@ func (t VectorClockTestMessageService) dispatchMessage(message protocols.Message
 // summarizeMessageSend returns a string which tersely summarizes the supplied message.
 // It may be used to make logs more readable.
 func summarizeMessageSend(msg protocols.Message) string {
-	summary := ""
+	str, _ := msg.Serialize()
+	size := len([]byte(str))
+	summary := fmt.Sprint(size) + "B:"
 	for _, entry := range msg.SignedProposals() {
 		summary += `propose `
 		summary += fmt.Sprint(entry.Payload.Proposal.LedgerID)[1:8]

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -84,12 +84,11 @@ func setupInstrumentedClient(
 	logDestination io.Writer,
 	meanMessageDelay time.Duration,
 	logDir string,
-	prettyName string,
 ) (client.Client, store.Store) {
 	myAddress := crypto.GetAddressFromSecretKeyBytes(pk)
 	chain.Subscribe(myAddress)
 	chainservice := chainservice.NewSimpleChainService(&chain, myAddress)
-	messageservice := messageservice.NewVectorClockTestMessageService(myAddress, msgBroker, meanMessageDelay, logDir, prettyName)
+	messageservice := messageservice.NewVectorClockTestMessageService(myAddress, msgBroker, meanMessageDelay, logDir)
 	storeA := store.NewMemStore(pk)
 	return client.New(messageservice, chainservice, storeA, logDestination), storeA
 }

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -74,25 +74,6 @@ func setupClient(pk []byte, chain chainservice.MockChain, msgBroker messageservi
 	return client.New(messageservice, chainservice, storeA, logDestination), storeA
 }
 
-// setupIntstrumentedClient is a helper function that contructs a client and returns the new client and its store.
-//
-// The client will be _instrumented_, which is useful in debugging. In particular it will output logs containing vector clock stamps into the supplied logDir directory.
-func setupInstrumentedClient(
-	pk []byte,
-	chain chainservice.MockChain,
-	msgBroker messageservice.Broker,
-	logDestination io.Writer,
-	meanMessageDelay time.Duration,
-	logDir string,
-) (client.Client, store.Store) {
-	myAddress := crypto.GetAddressFromSecretKeyBytes(pk)
-	chain.Subscribe(myAddress)
-	chainservice := chainservice.NewSimpleChainService(&chain, myAddress)
-	messageservice := messageservice.NewVectorClockTestMessageService(myAddress, msgBroker, meanMessageDelay, logDir)
-	storeA := store.NewMemStore(pk)
-	return client.New(messageservice, chainservice, storeA, logDestination), storeA
-}
-
 func truncateLog(logFile string) {
 	logDestination := newLogWriter(logFile)
 

--- a/client_test/virtualfund_largescale_integration_test.go
+++ b/client_test/virtualfund_largescale_integration_test.go
@@ -33,7 +33,7 @@ func TestLargeScaleVirtualFundIntegration(t *testing.T) {
 	prettyPrintDict := make(map[string]string)
 
 	// Increase numRetrievalClients to simulate multiple retrieval clients all wanting to pay the same retrieval provider through the same hub
-	const numRetrievalClients = 1
+	const numRetrievalClients = 3
 
 	// Set a directory for each client to store vector clock logs, and cleat it.
 	vectorClockLogDir := "../artifacts/vectorclock"


### PR DESCRIPTION
* Uses a global "pretty print dictionary", managed by the test script, to prettify the output logs (which are reverted to contain un-clipped addresses and destinations). 
* Removes the need to run GoVector CLI as an external dependency (it was a very lightweight utility which I have rewritten)
* Enables us greater control of the order of actors in the resulting shiviz visualisation
* Focuses vector clock logging to _after_ the ledger channels have been created.
* unskips the test so everyone will now run it