### PR TITLE
Remove MyAddress from ObjectiveRequest

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -71,7 +71,7 @@ func (c *Client) CreateVirtualChannel(objectiveRequest virtualfund.ObjectiveRequ
 	// Send the event to the engine
 	c.engine.FromAPI <- apiEvent
 
-	return objectiveRequest.Response()
+	return objectiveRequest.Response(*c.Address)
 }
 
 // CloseVirtualChannel attempts to close and defund the given virtually funded channel.
@@ -80,7 +80,6 @@ func (c *Client) CloseVirtualChannel(channelId types.Destination, paidToBob *big
 	objectiveRequest := virtualdefund.ObjectiveRequest{
 		ChannelId: channelId,
 		PaidToBob: paidToBob,
-		MyAddress: *c.Address,
 	}
 	apiEvent := engine.APIEvent{
 		ObjectiveToSpawn: objectiveRequest,
@@ -88,7 +87,7 @@ func (c *Client) CloseVirtualChannel(channelId types.Destination, paidToBob *big
 	// Send the event to the engine
 	c.engine.FromAPI <- apiEvent
 
-	return objectiveRequest.Id()
+	return objectiveRequest.Id(*c.Address)
 
 }
 
@@ -101,7 +100,7 @@ func (c *Client) CreateDirectChannel(objectiveRequest directfund.ObjectiveReques
 	// Send the event to the engine
 	c.engine.FromAPI <- apiEvent
 
-	return objectiveRequest.Response()
+	return objectiveRequest.Response(*c.Address)
 
 }
 
@@ -117,6 +116,6 @@ func (c *Client) CloseDirectChannel(channelId types.Destination) protocols.Objec
 	// Send the event to the engine
 	c.engine.FromAPI <- apiEvent
 
-	return objectiveRequest.Id()
+	return objectiveRequest.Id(*c.Address)
 
 }

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -253,14 +253,14 @@ func (e *Engine) handleAPIEvent(apiEvent APIEvent) (ObjectiveChangeEvent, error)
 		switch request := (apiEvent.ObjectiveToSpawn).(type) {
 
 		case virtualfund.ObjectiveRequest:
-			vfo, err := virtualfund.NewObjective(*e.store.GetAddress(), request, e.store.GetConsensusChannel)
+			vfo, err := virtualfund.NewObjective(request, true, *e.store.GetAddress(), e.store.GetConsensusChannel)
 			if err != nil {
 				return ObjectiveChangeEvent{}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 			}
 			return e.attemptProgress(&vfo)
 
 		case virtualdefund.ObjectiveRequest:
-			vdfo, err := virtualdefund.NewObjective(true, *e.store.GetAddress(), request, e.store.GetChannelById, e.store.GetConsensusChannel)
+			vdfo, err := virtualdefund.NewObjective(request, true, *e.store.GetAddress(), e.store.GetChannelById, e.store.GetConsensusChannel)
 			if err != nil {
 				return ObjectiveChangeEvent{}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 			}
@@ -274,7 +274,7 @@ func (e *Engine) handleAPIEvent(apiEvent APIEvent) (ObjectiveChangeEvent, error)
 			return e.attemptProgress(&dfo)
 
 		case directdefund.ObjectiveRequest:
-			ddfo, err := directdefund.NewObjective(true, request.ChannelId, e.store.GetConsensusChannelById)
+			ddfo, err := directdefund.NewObjective(request, true, e.store.GetConsensusChannelById)
 			if err != nil {
 				return ObjectiveChangeEvent{}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 			}

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -253,21 +253,21 @@ func (e *Engine) handleAPIEvent(apiEvent APIEvent) (ObjectiveChangeEvent, error)
 		switch request := (apiEvent.ObjectiveToSpawn).(type) {
 
 		case virtualfund.ObjectiveRequest:
-			vfo, err := virtualfund.NewObjective(request, e.store.GetConsensusChannel)
+			vfo, err := virtualfund.NewObjective(*e.store.GetAddress(), request, e.store.GetConsensusChannel)
 			if err != nil {
 				return ObjectiveChangeEvent{}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 			}
 			return e.attemptProgress(&vfo)
 
 		case virtualdefund.ObjectiveRequest:
-			vdfo, err := virtualdefund.NewObjective(true, request, e.store.GetChannelById, e.store.GetConsensusChannel)
+			vdfo, err := virtualdefund.NewObjective(true, *e.store.GetAddress(), request, e.store.GetChannelById, e.store.GetConsensusChannel)
 			if err != nil {
 				return ObjectiveChangeEvent{}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 			}
 			return e.attemptProgress(&vdfo)
 
 		case directfund.ObjectiveRequest:
-			dfo, err := directfund.NewObjective(request, true, e.store.GetChannelsByParticipant, e.store.GetConsensusChannel)
+			dfo, err := directfund.NewObjective(request, true, *e.store.GetAddress(), e.store.GetChannelsByParticipant, e.store.GetConsensusChannel)
 			if err != nil {
 				return ObjectiveChangeEvent{}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 			}

--- a/client_test/directfund_test.go
+++ b/client_test/directfund_test.go
@@ -24,7 +24,6 @@ func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.C
 	outcome := testdata.Outcomes.Create(*alpha.Address, *beta.Address, ledgerChannelDeposit, ledgerChannelDeposit)
 
 	request := directfund.ObjectiveRequest{
-		MyAddress:         *alpha.Address,
 		CounterParty:      *beta.Address,
 		Outcome:           outcome,
 		AppDefinition:     types.Address{},

--- a/client_test/virtualfund_benchmark_test.go
+++ b/client_test/virtualfund_benchmark_test.go
@@ -49,7 +49,6 @@ func TestVirtualFundBenchmark(t *testing.T) {
 func benchmarkVirtualChannelCreation(t *testing.T, alice, bob client.Client, irene types.Address, done chan interface{}) {
 	outcome := testdata.Outcomes.Create(*alice.Address, *bob.Address, 1, 1)
 	request := virtualfund.ObjectiveRequest{
-		MyAddress:         *alice.Address,
 		CounterParty:      *bob.Address,
 		Intermediary:      irene,
 		Outcome:           outcome,

--- a/client_test/virtualfund_largescale_integration_test.go
+++ b/client_test/virtualfund_largescale_integration_test.go
@@ -93,7 +93,6 @@ func combineLogs(t *testing.T, logDir string, combinedLogsFilename string) {
 
 func createVirtualChannelWithRetrievalProvider(c client.Client, retrievalProvider client.Client) protocols.ObjectiveId {
 	withRetrievalProvider := virtualfund.ObjectiveRequest{
-		MyAddress:    *c.Address,
 		CounterParty: *retrievalProvider.Address,
 		Intermediary: irene.Address(),
 		Outcome: td.Outcomes.Create(

--- a/client_test/virtualfund_multi_party_test.go
+++ b/client_test/virtualfund_multi_party_test.go
@@ -31,7 +31,6 @@ func TestVirtualFundMultiParty(t *testing.T) {
 	directlyFundALedgerChannel(t, clientIrene, clientBob)
 	directlyFundALedgerChannel(t, clientIrene, clientBrian)
 	withBobRequest := virtualfund.ObjectiveRequest{
-		MyAddress:    alice.Address(),
 		CounterParty: bob.Address(),
 		Intermediary: irene.Address(),
 		Outcome: td.Outcomes.Create(
@@ -46,7 +45,6 @@ func TestVirtualFundMultiParty(t *testing.T) {
 		Nonce:             rand.Int63(),
 	}
 	withBrianRequest := virtualfund.ObjectiveRequest{
-		MyAddress:    alice.Address(),
 		CounterParty: brian.Address(),
 		Intermediary: irene.Address(),
 		Outcome: td.Outcomes.Create(

--- a/client_test/virtualfund_test.go
+++ b/client_test/virtualfund_test.go
@@ -23,7 +23,6 @@ func openVirtualChannels(t *testing.T, clientA client.Client, clientB client.Cli
 	for i := 0; i < int(numOfChannels); i++ {
 		outcome := td.Outcomes.Create(alice.Address(), bob.Address(), 1, 1)
 		request := virtualfund.ObjectiveRequest{
-			MyAddress:         alice.Address(),
 			CounterParty:      bob.Address(),
 			Intermediary:      irene.Address(),
 			Outcome:           outcome,

--- a/client_test/virtualfund_with_message_delays_test.go
+++ b/client_test/virtualfund_with_message_delays_test.go
@@ -51,7 +51,7 @@ func createVirtualChannels(client client.Client, counterParty types.Address, int
 	for i := uint(0); i < amountOfChannels; i++ {
 		outcome := td.Outcomes.Create(*client.Address, counterParty, 1, 1)
 		request := virtualfund.ObjectiveRequest{
-			MyAddress:         *client.Address,
+
 			CounterParty:      counterParty,
 			Intermediary:      intermediary,
 			Outcome:           outcome,

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -74,7 +74,7 @@ func genericVFO() virtualfund.Objective {
 	})
 	lookup := ledgerPath.GetLedgerLookup(testactors.Alice.Address())
 
-	testVFO, err := virtualfund.NewObjective(ts.Participants[0], request, lookup)
+	testVFO, err := virtualfund.NewObjective(request, true, ts.Participants[0], lookup)
 	if err != nil {
 		panic(fmt.Errorf("error constructing genericVFO: %w", err))
 	}

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -58,7 +58,6 @@ func genericVFO() virtualfund.Objective {
 	ts.Participants[2] = testactors.Bob.Address()
 
 	request := virtualfund.ObjectiveRequest{
-		ts.Participants[0],
 		ts.Participants[1],
 		ts.Participants[2],
 		ts.AppDefinition,
@@ -75,7 +74,7 @@ func genericVFO() virtualfund.Objective {
 	})
 	lookup := ledgerPath.GetLedgerLookup(testactors.Alice.Address())
 
-	testVFO, err := virtualfund.NewObjective(request, lookup)
+	testVFO, err := virtualfund.NewObjective(ts.Participants[0], request, lookup)
 	if err != nil {
 		panic(fmt.Errorf("error constructing genericVFO: %w", err))
 	}

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -64,13 +64,13 @@ type GetConsensusChannel func(channelId types.Destination) (ledger *consensus_ch
 
 // NewObjective initiates an Objective with the supplied channel
 func NewObjective(
+	request ObjectiveRequest,
 	preApprove bool,
-	channelId types.Destination,
 	getConsensusChannel GetConsensusChannel,
 ) (Objective, error) {
-	cc, err := getConsensusChannel(channelId)
+	cc, err := getConsensusChannel(request.ChannelId)
 	if err != nil {
-		return Objective{}, fmt.Errorf("could not find channel %s; %w", channelId, err)
+		return Objective{}, fmt.Errorf("could not find channel %s; %w", request.ChannelId, err)
 	}
 
 	c, err := CreateChannelFromConsensusChannel(*cc)
@@ -135,8 +135,10 @@ func ConstructObjectiveFromState(
 	}
 
 	cId := s.ChannelId()
-
-	return NewObjective(preApprove, cId, getConsensusChannel)
+	request := ObjectiveRequest{
+		ChannelId: cId,
+	}
+	return NewObjective(request, preApprove, getConsensusChannel)
 }
 
 // Public methods on the DirectDefundingObjective

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -318,6 +318,6 @@ type ObjectiveRequest struct {
 }
 
 // Id returns the objective id for the request.
-func (r ObjectiveRequest) Id() protocols.ObjectiveId {
+func (r ObjectiveRequest) Id(myAddress types.Address) protocols.ObjectiveId {
 	return protocols.ObjectiveId(ObjectivePrefix + r.ChannelId.String())
 }

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -74,9 +74,9 @@ func newTestObjective() (Objective, error) {
 	getConsensusChannel := func(id types.Destination) (channel *consensus_channel.ConsensusChannel, err error) {
 		return cc, nil
 	}
-
+	request := ObjectiveRequest{ChannelId: cc.Id}
 	// Assert that valid constructor args do not result in error
-	o, err := NewObjective(true, cc.Id, getConsensusChannel)
+	o, err := NewObjective(request, true, getConsensusChannel)
 	if err != nil {
 		return Objective{}, err
 	}

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -50,12 +50,12 @@ type GetChannelsByParticipantFunction func(participant types.Address) []*channel
 type GetTwoPartyConsensusLedgerFunction func(counterparty types.Address) (ledger *consensus_channel.ConsensusChannel, ok bool)
 
 // NewObjective creates a new direct funding objective from a given request.
-func NewObjective(request ObjectiveRequest, preApprove bool, getChannels GetChannelsByParticipantFunction, getTwoPartyConsensusLedger GetTwoPartyConsensusLedgerFunction) (Objective, error) {
+func NewObjective(request ObjectiveRequest, preApprove bool, myAddress types.Address, getChannels GetChannelsByParticipantFunction, getTwoPartyConsensusLedger GetTwoPartyConsensusLedgerFunction) (Objective, error) {
 
 	objective, err := ConstructFromState(preApprove,
 		state.State{
 			ChainId:           big.NewInt(9001), // TODO https://github.com/statechannels/go-nitro/issues/601
-			Participants:      []types.Address{request.MyAddress, request.CounterParty},
+			Participants:      []types.Address{myAddress, request.CounterParty},
 			ChannelNonce:      big.NewInt(request.Nonce),
 			AppDefinition:     request.AppDefinition,
 			ChallengeDuration: request.ChallengeDuration,
@@ -64,7 +64,7 @@ func NewObjective(request ObjectiveRequest, preApprove bool, getChannels GetChan
 			TurnNum:           0,
 			IsFinal:           false,
 		},
-		request.MyAddress,
+		myAddress,
 	)
 	if err != nil {
 		return Objective{}, fmt.Errorf("could not create new objective: %w", err)
@@ -409,7 +409,6 @@ func IsDirectFundObjective(id protocols.ObjectiveId) bool {
 
 // ObjectiveRequest represents a request to create a new direct funding objective.
 type ObjectiveRequest struct {
-	MyAddress         types.Address
 	CounterParty      types.Address
 	AppDefinition     types.Address
 	AppData           types.Bytes
@@ -419,9 +418,9 @@ type ObjectiveRequest struct {
 }
 
 // Id returns the objective id for the request.
-func (r ObjectiveRequest) Id() protocols.ObjectiveId {
+func (r ObjectiveRequest) Id(myAddress types.Address) protocols.ObjectiveId {
 	fixedPart := state.FixedPart{ChainId: big.NewInt(9001), // TODO add this field to the request and pull it from there. https://github.com/statechannels/go-nitro/issues/601
-		Participants:      []types.Address{r.MyAddress, r.CounterParty},
+		Participants:      []types.Address{myAddress, r.CounterParty},
 		ChannelNonce:      big.NewInt(r.Nonce),
 		ChallengeDuration: r.ChallengeDuration}
 
@@ -436,9 +435,9 @@ type ObjectiveResponse struct {
 }
 
 // Response computes and returns the appropriate response from the request.
-func (r ObjectiveRequest) Response() ObjectiveResponse {
+func (r ObjectiveRequest) Response(myAddress types.Address) ObjectiveResponse {
 	fixedPart := state.FixedPart{ChainId: big.NewInt(9001), // TODO add this field to the request and pull it from there. https://github.com/statechannels/go-nitro/issues/601
-		Participants:      []types.Address{r.MyAddress, r.CounterParty},
+		Participants:      []types.Address{myAddress, r.CounterParty},
 		ChannelNonce:      big.NewInt(r.Nonce),
 		ChallengeDuration: r.ChallengeDuration}
 

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -56,7 +56,7 @@ func TestNew(t *testing.T) {
 		return nil, false
 	}
 	request := ObjectiveRequest{
-		MyAddress:         testState.Participants[0],
+
 		CounterParty:      testState.Participants[1],
 		AppDefinition:     testState.AppDefinition,
 		AppData:           testState.AppData,
@@ -65,7 +65,7 @@ func TestNew(t *testing.T) {
 		Nonce:             testState.ChannelNonce.Int64(),
 	}
 	// Assert that valid constructor args do not result in error
-	if _, err := NewObjective(request, false, getByParticipant, getByConsensus); err != nil {
+	if _, err := NewObjective(request, false, testState.Participants[0], getByParticipant, getByConsensus); err != nil {
 		t.Error(err)
 	}
 
@@ -74,14 +74,14 @@ func TestNew(t *testing.T) {
 		return []*channel.Channel{c}
 	}
 
-	if _, err := NewObjective(request, false, getByParticipantHasChannel, getByConsensus); err == nil {
+	if _, err := NewObjective(request, false, testState.Participants[0], getByParticipantHasChannel, getByConsensus); err == nil {
 		t.Errorf("Expected an error when constructing with an objective when an existing channel exists")
 	}
 
 	getByConsensusHasChannel := func(id types.Address) (*consensus_channel.ConsensusChannel, bool) {
 		return nil, true
 	}
-	if _, err := NewObjective(request, false, getByParticipant, getByConsensusHasChannel); err == nil {
+	if _, err := NewObjective(request, false, testState.Participants[0], getByParticipant, getByConsensusHasChannel); err == nil {
 		t.Errorf("Expected an error when constructing with an objective when an existing channel consensus channel exists")
 	}
 

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -98,5 +98,5 @@ const (
 
 // ObjectiveRequest is a request to create a new objective.
 type ObjectiveRequest interface {
-	Id() ObjectiveId
+	Id(types.Address) ObjectiveId
 }

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -61,9 +61,9 @@ type GetChannelByIdFunction func(id types.Destination) (channel *channel.Channel
 type GetTwoPartyConsensusLedgerFunction func(counterparty types.Address) (ledger *consensus_channel.ConsensusChannel, ok bool)
 
 // NewObjective constructs a new virtual defund objective
-func NewObjective(preApprove bool,
+func NewObjective(request ObjectiveRequest,
+	preApprove bool,
 	myAddress types.Address,
-	request ObjectiveRequest,
 	getChannel GetChannelByIdFunction,
 	getConsensusChannel GetTwoPartyConsensusLedgerFunction) (Objective, error) {
 	var status protocols.ObjectiveStatus
@@ -151,9 +151,10 @@ func ConstructObjectiveFromState(
 	if err != nil {
 		return Objective{}, err
 	}
-	return NewObjective(true,
-		myAddress,
+	return NewObjective(
 		ObjectiveRequest{channelId, paidToBob},
+		true,
+		myAddress,
 		getChannel,
 		getTwoPartyConsensusLedger)
 }

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -62,6 +62,7 @@ type GetTwoPartyConsensusLedgerFunction func(counterparty types.Address) (ledger
 
 // NewObjective constructs a new virtual defund objective
 func NewObjective(preApprove bool,
+	myAddress types.Address,
 	request ObjectiveRequest,
 	getChannel GetChannelByIdFunction,
 	getConsensusChannel GetTwoPartyConsensusLedgerFunction) (Objective, error) {
@@ -89,7 +90,7 @@ func NewObjective(preApprove bool,
 	var toMyLeft, toMyRight *consensus_channel.ConsensusChannel
 	var ok bool
 
-	switch request.MyAddress {
+	switch myAddress {
 	case alice:
 		toMyRight, ok = getConsensusChannel(intermediary)
 		if !ok {
@@ -151,7 +152,8 @@ func ConstructObjectiveFromState(
 		return Objective{}, err
 	}
 	return NewObjective(true,
-		ObjectiveRequest{channelId, paidToBob, myAddress},
+		myAddress,
+		ObjectiveRequest{channelId, paidToBob},
 		getChannel,
 		getTwoPartyConsensusLedger)
 }
@@ -554,10 +556,9 @@ func isZero(sig state.Signature) bool {
 type ObjectiveRequest struct {
 	ChannelId types.Destination
 	PaidToBob *big.Int
-	MyAddress types.Address
 }
 
 // Id returns the objective id for the request.
-func (r ObjectiveRequest) Id() protocols.ObjectiveId {
+func (r ObjectiveRequest) Id(types.Address) protocols.ObjectiveId {
 	return protocols.ObjectiveId(ObjectivePrefix + r.ChannelId.String())
 }

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -39,12 +39,11 @@ func TestInvalidUpdate(t *testing.T) {
 	request := ObjectiveRequest{
 		ChannelId: vId,
 		PaidToBob: big.NewInt(int64(data.paid)),
-		MyAddress: alice.Address(),
 	}
 
 	getChannel, getConsensusChannel := generateStoreGetters(0, vId, data.vFinal)
 
-	virtualDefund, err := NewObjective(false, request, getChannel, getConsensusChannel)
+	virtualDefund, err := NewObjective(false, alice.Address(), request, getChannel, getConsensusChannel)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,12 +70,11 @@ func testUpdateAs(my ta.Actor) func(t *testing.T) {
 		request := ObjectiveRequest{
 			ChannelId: vId,
 			PaidToBob: big.NewInt(int64(data.paid)),
-			MyAddress: my.Address(),
 		}
 
 		getChannel, getConsensusChannel := generateStoreGetters(my.Role, vId, data.vInitial)
 
-		virtualDefund, err := NewObjective(false, request, getChannel, getConsensusChannel)
+		virtualDefund, err := NewObjective(false, my.Address(), request, getChannel, getConsensusChannel)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -107,11 +105,10 @@ func testCrankAs(my ta.Actor) func(t *testing.T) {
 		request := ObjectiveRequest{
 			ChannelId: vId,
 			PaidToBob: big.NewInt(int64(data.paid)),
-			MyAddress: my.Address(),
 		}
 
 		getChannel, getConsensusChannel := generateStoreGetters(my.Role, vId, data.vInitial)
-		virtualDefund, err := NewObjective(true, request, getChannel, getConsensusChannel)
+		virtualDefund, err := NewObjective(true, my.Address(), request, getChannel, getConsensusChannel)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -198,12 +195,11 @@ func TestApproveReject(t *testing.T) {
 	request := ObjectiveRequest{
 		ChannelId: vId,
 		PaidToBob: big.NewInt(int64(data.paid)),
-		MyAddress: alice.Address(),
 	}
 
 	getChannel, getConsensusChannel := generateStoreGetters(0, vId, data.vInitial)
 
-	virtualDefund, err := NewObjective(false, request, getChannel, getConsensusChannel)
+	virtualDefund, err := NewObjective(false, alice.Address(), request, getChannel, getConsensusChannel)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -43,7 +43,7 @@ func TestInvalidUpdate(t *testing.T) {
 
 	getChannel, getConsensusChannel := generateStoreGetters(0, vId, data.vFinal)
 
-	virtualDefund, err := NewObjective(false, alice.Address(), request, getChannel, getConsensusChannel)
+	virtualDefund, err := NewObjective(request, false, alice.Address(), getChannel, getConsensusChannel)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +74,7 @@ func testUpdateAs(my ta.Actor) func(t *testing.T) {
 
 		getChannel, getConsensusChannel := generateStoreGetters(my.Role, vId, data.vInitial)
 
-		virtualDefund, err := NewObjective(false, my.Address(), request, getChannel, getConsensusChannel)
+		virtualDefund, err := NewObjective(request, false, my.Address(), getChannel, getConsensusChannel)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -108,7 +108,7 @@ func testCrankAs(my ta.Actor) func(t *testing.T) {
 		}
 
 		getChannel, getConsensusChannel := generateStoreGetters(my.Role, vId, data.vInitial)
-		virtualDefund, err := NewObjective(true, my.Address(), request, getChannel, getConsensusChannel)
+		virtualDefund, err := NewObjective(request, true, my.Address(), getChannel, getConsensusChannel)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -199,7 +199,7 @@ func TestApproveReject(t *testing.T) {
 
 	getChannel, getConsensusChannel := generateStoreGetters(0, vId, data.vInitial)
 
-	virtualDefund, err := NewObjective(false, alice.Address(), request, getChannel, getConsensusChannel)
+	virtualDefund, err := NewObjective(request, false, alice.Address(), getChannel, getConsensusChannel)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -129,7 +129,7 @@ type Objective struct {
 }
 
 // NewObjective creates a new virtual funding objective from a given request.
-func NewObjective(myAddress types.Address, request ObjectiveRequest, getTwoPartyConsensusLedger GetTwoPartyConsensusLedgerFunction) (Objective, error) {
+func NewObjective(request ObjectiveRequest, preApprove bool, myAddress types.Address, getTwoPartyConsensusLedger GetTwoPartyConsensusLedgerFunction) (Objective, error) {
 	rightCC, ok := getTwoPartyConsensusLedger(request.Intermediary)
 
 	if !ok {
@@ -137,7 +137,7 @@ func NewObjective(myAddress types.Address, request ObjectiveRequest, getTwoParty
 	}
 	var leftCC *consensus_channel.ConsensusChannel
 
-	objective, err := constructFromState(true,
+	objective, err := constructFromState(preApprove,
 		state.State{
 			ChainId:           big.NewInt(9001), // TODO https://github.com/statechannels/go-nitro/issues/601
 			Participants:      []types.Address{myAddress, request.Intermediary, request.CounterParty},

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -129,18 +129,18 @@ type Objective struct {
 }
 
 // NewObjective creates a new virtual funding objective from a given request.
-func NewObjective(request ObjectiveRequest, getTwoPartyConsensusLedger GetTwoPartyConsensusLedgerFunction) (Objective, error) {
+func NewObjective(myAddress types.Address, request ObjectiveRequest, getTwoPartyConsensusLedger GetTwoPartyConsensusLedgerFunction) (Objective, error) {
 	rightCC, ok := getTwoPartyConsensusLedger(request.Intermediary)
 
 	if !ok {
-		return Objective{}, fmt.Errorf("could not find ledger for %s and %s", request.MyAddress, request.Intermediary)
+		return Objective{}, fmt.Errorf("could not find ledger for %s and %s", myAddress, request.Intermediary)
 	}
 	var leftCC *consensus_channel.ConsensusChannel
 
 	objective, err := constructFromState(true,
 		state.State{
 			ChainId:           big.NewInt(9001), // TODO https://github.com/statechannels/go-nitro/issues/601
-			Participants:      []types.Address{request.MyAddress, request.Intermediary, request.CounterParty},
+			Participants:      []types.Address{myAddress, request.Intermediary, request.CounterParty},
 			ChannelNonce:      big.NewInt(request.Nonce),
 			ChallengeDuration: request.ChallengeDuration,
 			AppData:           request.AppData,
@@ -148,7 +148,7 @@ func NewObjective(request ObjectiveRequest, getTwoPartyConsensusLedger GetTwoPar
 			TurnNum:           0,
 			IsFinal:           false,
 		},
-		request.MyAddress,
+		myAddress,
 		leftCC, rightCC)
 	if err != nil {
 		return Objective{}, fmt.Errorf("error creating objective: %w", err)
@@ -650,7 +650,6 @@ func (o *Objective) updateLedgerWithGuarantee(ledgerConnection Connection, sk *[
 
 // ObjectiveRequest represents a request to create a new virtual funding objective.
 type ObjectiveRequest struct {
-	MyAddress         types.Address
 	Intermediary      types.Address
 	CounterParty      types.Address
 	AppDefinition     types.Address
@@ -661,9 +660,9 @@ type ObjectiveRequest struct {
 }
 
 // Id returns the objective id for the request.
-func (r ObjectiveRequest) Id() protocols.ObjectiveId {
+func (r ObjectiveRequest) Id(myAddress types.Address) protocols.ObjectiveId {
 	fixedPart := state.FixedPart{ChainId: big.NewInt(9001), // TODO https://github.com/statechannels/go-nitro/issues/601
-		Participants:      []types.Address{r.MyAddress, r.Intermediary, r.CounterParty},
+		Participants:      []types.Address{myAddress, r.Intermediary, r.CounterParty},
 		ChannelNonce:      big.NewInt(r.Nonce),
 		ChallengeDuration: r.ChallengeDuration}
 
@@ -678,9 +677,9 @@ type ObjectiveResponse struct {
 }
 
 // Response computes and returns the appropriate response from the request.
-func (r ObjectiveRequest) Response() ObjectiveResponse {
+func (r ObjectiveRequest) Response(myAddress types.Address) ObjectiveResponse {
 	fixedPart := state.FixedPart{ChainId: big.NewInt(9001), // TODO add this field to the request and pull it from there. https://github.com/statechannels/go-nitro/issues/601
-		Participants:      []types.Address{r.MyAddress, r.Intermediary, r.CounterParty},
+		Participants:      []types.Address{myAddress, r.Intermediary, r.CounterParty},
 		ChannelNonce:      big.NewInt(r.Nonce),
 		ChallengeDuration: r.ChallengeDuration}
 


### PR DESCRIPTION
Fixes #677 

Removes `MyAddress` from the `ObjectiveRequest` so the client API doesn't require it to be passed in.

I've also done a slight refactor of the `NewObjective` constructors so they all take in arguments in the same order.