### PR TITLE
gas benchmarking fixtures use a trivialapp

### DIFF
--- a/nitro-protocol/gas-benchmarks/fixtures.ts
+++ b/nitro-protocol/gas-benchmarks/fixtures.ts
@@ -20,7 +20,7 @@ import {
 } from '../src/contract/outcome';
 import {FixedPart, getVariablePart, hashState, SignedVariablePart} from '../src/contract/state';
 
-import {nitroAdjudicator, provider} from './vanillaSetup';
+import {nitroAdjudicator, provider, trivialAppAddress} from './vanillaSetup';
 
 export const chainId = '0x7a69'; // 31337 in hex (hardhat network default)
 
@@ -48,7 +48,7 @@ class TestChannel {
       chainId,
       channelNonce,
       participants: wallets.map(w => w.address),
-      appDefinition: '0x8504FcA6e1e73947850D66D032435AC931892116',
+      appDefinition: trivialAppAddress, // TODO adjust this to point to an appropriate (deployed) application, according to the channel type
       challengeDuration: 600,
     };
     this.allocations = allocations;
@@ -66,7 +66,7 @@ class TestChannel {
   someState(asset: string): State {
     return {
       challengeDuration: 600,
-      appDefinition: '0x8504FcA6e1e73947850D66D032435AC931892116',
+      appDefinition: trivialAppAddress, // TODO adjust this to point to an appropriate (deployed) application, according to the channel type
       channel: this.fixedPart,
       turnNum: 6,
       isFinal: false,


### PR DESCRIPTION
Previously, we could skip the application check altogether by having all participants countersign the same state.

But now, we must check the application. Hence there is a call to a contract, which previously did not need to be deployed, but now needs to be.

For now we will use the TrivialApp. Longer term we would want to use non trivial apps depending on the channel type.

We use some tricks to predict the contract address, since we need to know this _before_ the test runner starts.

This means that the gas benchmarks can now at least run. The number still need updating, and we should file some issues to return and replace the trivial app with something non trivial.