### PR TITLE
chore: fix spelling errors

### DIFF
--- a/.adr/flowchart-vs-statechart.md
+++ b/.adr/flowchart-vs-statechart.md
@@ -17,7 +17,7 @@ For the flow chart, declared side effects are shown with a ! and the blocking co
 
 - It reduces replication of state between the enumerable and extended parts
 - It emphasizes that information can be absorbed independently of the enumerable state (by default, although it is possible to have a dependence on the extended state). It is simple to process **passive** transitions.
-- It emphasizes that the state can **actively** transition independently of the events recieved.
+- It emphasizes that the state can **actively** transition independently of the events received.
 - The separation betwen passive and active transitions makes restarting protocols straightforward. After all of the information is fed into the objective (in any order), a crank will get things going.
 
 ## Discarded code

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -211,7 +211,7 @@ func (c *ConsensusChannel) Leader() common.Address {
 	return c.fp.Participants[Leader]
 }
 
-// Follower returns the address of the participant who recieves and contersigns
+// Follower returns the address of the participant who receives and contersigns
 // proposals.
 func (c *ConsensusChannel) Follower() common.Address {
 	return c.fp.Participants[Follower]
@@ -396,7 +396,7 @@ func (lo *LedgerOutcome) Leader() Balance {
 	return lo.leader
 }
 
-// Follower returns teh follower's balance.
+// Follower returns the follower's balance.
 func (lo *LedgerOutcome) Follower() Balance {
 	return lo.follower
 }
@@ -550,7 +550,7 @@ type SignedVars struct {
 	Signatures [2]state.Signature
 }
 
-// clone returns a deep copy of the reciever.
+// clone returns a deep copy of the receiver.
 func (sv *SignedVars) clone() SignedVars {
 	clonedSignatures := [2]state.Signature{
 		sv.Signatures[0],
@@ -566,7 +566,7 @@ func (sv *SignedVars) clone() SignedVars {
 //
 // Exactly one of {toAdd, toRemove} should be non nil.
 type Proposal struct {
-	// LedgerID is the ChannelID of the ConsensusChannel which should recieve the proposal.
+	// LedgerID is the ChannelID of the ConsensusChannel which should receive the proposal.
 	//
 	// The target virtual channel ID is contained in the Add / Remove struct.
 	LedgerID types.Destination
@@ -642,7 +642,7 @@ type SignedProposal struct {
 	TurnNum  uint64
 }
 
-// Clone returns a deep copy of the reciever.
+// Clone returns a deep copy of the receiver.
 func (sp *SignedProposal) Clone() SignedProposal {
 	sp2 := SignedProposal{sp.Signature, sp.Proposal.Clone(), sp.TurnNum}
 	return sp2

--- a/channel/state/outcome/allocation.go
+++ b/channel/state/outcome/allocation.go
@@ -129,7 +129,7 @@ var allocationsTy = abi.ArgumentMarshaling{
 	},
 }
 
-// DivertToGuarantee returns a new Allocations, identical to the reciever but with
+// DivertToGuarantee returns a new Allocations, identical to the receiver but with
 // the leftDestination's amount reduced by leftAmount,
 // the rightDestination's amount reduced by rightAmount,
 // and a Guarantee appended for the guaranteeDestination

--- a/channel/state/outcome/exit.go
+++ b/channel/state/outcome/exit.go
@@ -26,7 +26,7 @@ func (s SingleAssetExit) Equal(r SingleAssetExit) bool {
 
 }
 
-// Clone returns a deep clone of the reciever.
+// Clone returns a deep clone of the receiver.
 func (s SingleAssetExit) Clone() SingleAssetExit {
 	return SingleAssetExit{
 		Asset:       s.Asset,
@@ -62,7 +62,7 @@ func (a Exit) Equal(b Exit) bool {
 	return true
 }
 
-// Clone returns a deep clone of the reciever.
+// Clone returns a deep clone of the receiver.
 func (e Exit) Clone() Exit {
 	clone := make(Exit, len(e))
 	for i, sae := range e {

--- a/channel/state/signedstate.go
+++ b/channel/state/signedstate.go
@@ -90,7 +90,7 @@ func (ss SignedState) GetParticipantSignature(participantIndex uint) (crypto.Sig
 	}
 }
 
-// Merge checks the passed SignedState's state and the reciever's state for equality, andd adds each signature from the former to the latter.
+// Merge checks the passed SignedState's state and the receiver's state for equality, and adds each signature from the former to the latter.
 func (ss SignedState) Merge(ss2 SignedState) error {
 	if !ss.state.Equal(ss2.state) {
 		return errors.New(`cannot merge signed states with distinct state hashes`)

--- a/client/engine/chainservice/mockchain.go
+++ b/client/engine/chainservice/mockchain.go
@@ -11,7 +11,7 @@ import (
 // It keeps a record of of holdings and adjudication status for each channel, accepts transactions and emits events.
 type MockChain struct {
 	out map[types.Address]chan Event    // out is a mapping with a chan for each connected ChainService, used to send Events to that service
-	in  chan protocols.ChainTransaction // in is the chan used to recieve Transactions from multiple ChainServices
+	in  chan protocols.ChainTransaction // in is the chan used to receive Transactions from multiple ChainServices
 
 	holdings map[types.Destination]types.Funds // holdings tracks funds for each channel
 	blockNum uint64

--- a/client/engine/chainservice/mockchain_test.go
+++ b/client/engine/chainservice/mockchain_test.go
@@ -39,7 +39,7 @@ func TestDeposit(t *testing.T) {
 		Type:      protocols.DepositTransactionType,
 	}
 
-	// Send one transaction into one of the SimpleChainServices and recieve one event from it.
+	// Send one transaction into one of the SimpleChainServices and receive one event from it.
 	inA <- testTx
 	event := <-outA
 
@@ -50,7 +50,7 @@ func TestDeposit(t *testing.T) {
 		t.Fatalf(`holdings mismatch: expected %v but got %v`, testTx.Deposit, event.(DepositedEvent).Holdings)
 	}
 
-	// Send the transaction again and recieve another event
+	// Send the transaction again and receive another event
 	inA <- testTx
 	event = <-outA
 

--- a/client/engine/chainservice/simplechainservice.go
+++ b/client/engine/chainservice/simplechainservice.go
@@ -8,7 +8,7 @@ import (
 // SimpleChainService forwards inputted transactions to a MockChain, and passes Events straight back.
 type SimpleChainService struct {
 	out chan Event                      // out is the chan used to send Events to the engine
-	in  chan protocols.ChainTransaction // in is the chan used to recieve Transactions from the engine
+	in  chan protocols.ChainTransaction // in is the chan used to receive Transactions from the engine
 
 	address types.Address // address is used to subscribe to the MockChain's Out chan
 	chain   *MockChain

--- a/client/engine/messageservice/messageservice.go
+++ b/client/engine/messageservice/messageservice.go
@@ -4,7 +4,7 @@ package messageservice // import "github.com/statechannels/go-nitro/client/messa
 import "github.com/statechannels/go-nitro/protocols"
 
 type MessageService interface {
-	// Out returns a chan for recieving messages from the message service
+	// Out returns a chan for receiving messages from the message service
 	Out() <-chan protocols.Message
 	// In returns a chan for sending messages to the message service
 	In() chan<- protocols.Message

--- a/client/engine/messageservice/test-messageservice.go
+++ b/client/engine/messageservice/test-messageservice.go
@@ -10,7 +10,7 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-// TestMessageService is an implementaion of the MessageService interface
+// TestMessageService is an implementation of the MessageService interface
 // for use in multi-engine test environments.
 //
 // It allows for individual nitro-clients / engines to:
@@ -22,7 +22,7 @@ type TestMessageService struct {
 	address types.Address
 
 	// connection to Engine:
-	in       chan protocols.Message // for recieving messages from engine
+	in       chan protocols.Message // for receiving messages from engine
 	out      chan protocols.Message // for sending message to engine
 	maxDelay time.Duration          // the max delay for messages
 

--- a/client/engine/messageservice/test-messageservice_test.go
+++ b/client/engine/messageservice/test-messageservice_test.go
@@ -28,7 +28,7 @@ func TestConnect(t *testing.T) {
 	got := <-bobOut
 
 	if got.Payloads[0].ObjectiveId != testId {
-		t.Fatalf("expected bob to recieve ObjectiveId %v, but recieved %v",
+		t.Fatalf("expected bob to receive ObjectiveId %v, but received %v",
 			testId, got.Payloads[0].ObjectiveId)
 	}
 }

--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -261,7 +261,7 @@ func (ms *MemStore) GetObjectiveByChannelId(channelId types.Destination) (protoc
 	return objective, err == nil
 }
 
-// populateChannelData fetches stored Channel data relevent to the given
+// populateChannelData fetches stored Channel data relevant to the given
 // objective and attaches it to the objective. The channel data is attached
 // in-place of the objectives existing channel pointers.
 func (ms *MemStore) populateChannelData(obj protocols.Objective) error {

--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -30,7 +30,7 @@ func SignEthereumMessage(message []byte, secretKey []byte) (Signature, error) {
 	}
 	sig := SplitSignature(concatenatedSignature)
 
-	// This step is necessary to remain compatible wih the ecrecover precompile
+	// This step is necessary to remain compatible with the ecrecover precompile
 	if int(sig.V) < 27 {
 		sig.V = byte(int(sig.V + 27))
 	}
@@ -42,7 +42,7 @@ func SignEthereumMessage(message []byte, secretKey []byte) (Signature, error) {
 // It reconstructs the appropriate digest and recovers an address via secp256k1 public key recovery
 func RecoverEthereumMessageSigner(message []byte, signature Signature) (common.Address, error) {
 
-	// This step is necessary to remain compatible wih the ecrecover precompile
+	// This step is necessary to remain compatible with the ecrecover precompile
 	sig := signature
 	if int(sig.V) >= 27 {
 		sig.V = byte(int(sig.V - 27))

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -34,7 +34,7 @@ type Objective struct {
 	Status               protocols.ObjectiveStatus
 	C                    *channel.Channel
 	finalTurnNum         uint64
-	transactionSubmitted bool // whether a transation for the objective has been submitted or not
+	transactionSubmitted bool // whether a transition for the objective has been submitted or not
 }
 
 // isInConsensusOrFinalState returns true if the channel has a final state or latest state that is supported
@@ -56,7 +56,7 @@ func isInConsensusOrFinalState(c *channel.Channel) (bool, error) {
 	return cmp.Equal(latestSS.State(), latestSupportedState), nil
 }
 
-// GetChannelByIdFunction specifies a function that can be used to retreive channels from a store.
+// GetChannelByIdFunction specifies a function that can be used to retrieve channels from a store.
 type GetChannelByIdFunction func(id types.Destination) (channel *channel.Channel, ok bool)
 
 // GetConsensusChannel describes functions which return a ConsensusChannel ledger channel for a channel id.

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -39,10 +39,10 @@ type Objective struct {
 	myDepositTarget          types.Funds // I want to get the on chain holdings up to this much
 	fullyFundedThreshold     types.Funds // if the on chain holdings are equal
 	latestBlockNumber        uint64      // the latest block number we've seen
-	transactionSubmitted     bool        // whether a transation for the objective has been submitted or not
+	transactionSubmitted     bool        // whether a transition for the objective has been submitted or not
 }
 
-// GetChannelByIdFunction specifies a function that can be used to retreive channels from a store.
+// GetChannelByIdFunction specifies a function that can be used to retrieve channels from a store.
 type GetChannelsByParticipantFunction func(participant types.Address) []*channel.Channel
 
 // GetTwoPartyConsensusLedgerFuncion describes functions which return a ConsensusChannel ledger channel between

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -98,7 +98,7 @@ func TestConstructFromState(t *testing.T) {
 	finalState.IsFinal = true
 
 	if _, err := ConstructFromState(false, finalState, testState.Participants[0]); err == nil {
-		t.Error("expected an error when constructing with an intial state marked final, but got nil")
+		t.Error("expected an error when constructing with an initial state marked final, but got nil")
 	}
 
 	nonParticipant := common.HexToAddress("0x5b53f71453aeCb03D837bfe170570d40aE736CB4")

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -23,7 +23,7 @@ const (
 // The turn number used for the final state
 const FinalTurnNum = 2
 
-// Objective contains relevent information for the defund objective
+// Objective contains relevant information for the defund objective
 type Objective struct {
 	Status protocols.ObjectiveStatus
 
@@ -53,7 +53,7 @@ type Objective struct {
 
 const ObjectivePrefix = "VirtualDefund-"
 
-// GetChannelByIdFunction specifies a function that can be used to retreive channels from a store.
+// GetChannelByIdFunction specifies a function that can be used to retrieve channels from a store.
 type GetChannelByIdFunction func(id types.Destination) (channel *channel.Channel, ok bool)
 
 // GetTwoPartyConsensusLedgerFuncion describes functions which return a ConsensusChannel ledger channel between

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -39,7 +39,7 @@ type Connection struct {
 	GuaranteeInfo GuaranteeInfo
 }
 
-// insertGuaranteeInfo mutates the reciever Connection struct.
+// insertGuaranteeInfo mutates the receiver Connection struct.
 func (c *Connection) insertGuaranteeInfo(a0 types.Funds, b0 types.Funds, vId types.Destination, left types.Destination, right types.Destination) error {
 
 	c.GuaranteeInfo = GuaranteeInfo{
@@ -63,7 +63,7 @@ func (c *Connection) insertGuaranteeInfo(a0 types.Funds, b0 types.Funds, vId typ
 	return nil
 }
 
-// handleProposal recieves a signed proposal and acts according to the leader / follower
+// handleProposal receives a signed proposal and acts according to the leader / follower
 // status of the Connection's ConsensusChannel
 func (c *Connection) handleProposal(sp consensus_channel.SignedProposal) error {
 	if c == nil {
@@ -483,12 +483,12 @@ func (o *Objective) clone() Objective {
 	return clone
 }
 
-// isAlice returns true if the reciever represents participant 0 in the virtualfund protocol.
+// isAlice returns true if the receiver represents participant 0 in the virtualfund protocol.
 func (o *Objective) isAlice() bool {
 	return o.MyRole == 0
 }
 
-// isBob returns true if the reciever represents participant n+1 in the virtualfund protocol.
+// isBob returns true if the receiver represents participant n+1 in the virtualfund protocol.
 func (o *Objective) isBob() bool {
 	return o.MyRole == o.n+1
 }

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -463,7 +463,7 @@ func TestCrankAsP1(t *testing.T) {
 }
 
 // assertSupportedPrefund checks that all three participants have signed the prefund. It
-// is used to manually inspect the objective after Update recieves counterparty signatures.
+// is used to manually inspect the objective after Update receives counterparty signatures.
 func assertSupportedPrefund(o *Objective, t *testing.T) {
 	if !o.V.SignedStateForTurnNum[0].HasSignatureForParticipant(alice.Role) {
 		t.Fatal(`Objective prefund state not signed by alice`)

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ The following roadmap gives an idea of the various packages that compose the `go
 ├── client 🚧                  # exposes an API to the consuming application
 │   └── engine 🚧              # coordinate the client components, runs the protocols
 │       ├── chainservice 🚧    # watch the chain and submit transactions
-│       ├── messageservice 🚧  # send and recieves messages from peers
+│       ├── messageservice 🚧  # send and receives messages from peers
 │       └── store 🚧           # store keys, state updates and other critical data
 ├── client_test 🚧             # integration tests involving multiple clients
 ├── crypto  ✅                 # create Ethereum accounts, create & recover signatures


### PR DESCRIPTION
Toward #609 

I came across goreportcard.com, essentially a linting service, which kindly listed our 6 million usages of `recieve`.

All of these changes are to comments or to error strings - no variables were renamed.

https://goreportcard.com/report/github.com/statechannels/go-nitro

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
