### PR TITLE
Create basic TCP message service

### DIFF
--- a/client/engine/messageservice/simple-tcp/simpletcp-messageservice.go
+++ b/client/engine/messageservice/simple-tcp/simpletcp-messageservice.go
@@ -1,0 +1,157 @@
+package simpletcp
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/types"
+)
+
+const (
+	CONN_TYPE = "tcp"
+	DELIMETER = '\n'
+)
+
+// SimpleTCPMessageService is a rudimentary message service that uses TCP to send and receive messages
+type SimpleTCPMessageService struct {
+	in  chan protocols.Message // for receiving messages from engine
+	out chan protocols.Message // for sending message to engine
+
+	peers map[types.Address]string
+
+	listener net.Listener // The listener for incoming connections on our port
+
+	quit chan struct{} // quit is used to signal the goroutine to stop
+
+}
+
+// NewTestMessageService returns a running SimpleTcpMessageService listening on the given url
+func NewSimpleTCPMessageService(myUrl string, peers map[types.Address]string) *SimpleTCPMessageService {
+
+	l, err := net.Listen(CONN_TYPE, myUrl)
+	if err != nil {
+		panic(err)
+	}
+	h := &SimpleTCPMessageService{
+		in:    make(chan protocols.Message, 5),
+		out:   make(chan protocols.Message, 5),
+		peers: peers,
+
+		listener: l,
+		quit:     make(chan struct{}),
+	}
+
+	go h.listenForIncoming()
+	go h.listenForOutgoing()
+
+	return h
+
+}
+
+// listenForOutgoing listens for any messages that should be sent out to peers and sends them
+func (s *SimpleTCPMessageService) listenForOutgoing() {
+	for {
+		select {
+		case <-s.quit:
+			return
+
+		case m := <-s.in:
+			{
+				peer, ok := s.peers[m.To]
+
+				if !ok {
+					panic(fmt.Errorf("no peer port for %s", m.To))
+				}
+
+				raw, err := m.Serialize()
+
+				// Append the delimiter to the message to indicate the end of the message
+				raw = fmt.Sprintf("%s%c", raw, DELIMETER)
+
+				if err != nil {
+					panic(err)
+				}
+
+				conn, err := net.Dial(CONN_TYPE, peer)
+				if err != nil {
+					select {
+					case <-s.quit: // If we are quitting we can ignore the error
+						return
+					default:
+						panic(err)
+					}
+				}
+				_, err = conn.Write([]byte(raw))
+				if err != nil {
+					select {
+					case <-s.quit: // If we are quitting we can ignore the error
+						return
+					default:
+						panic(err)
+					}
+				}
+				conn.Close()
+
+			}
+
+		}
+	}
+
+}
+
+// listenForIncoming listens for any incoming messages from other peers
+func (s *SimpleTCPMessageService) listenForIncoming() {
+	for {
+		conn, err := s.listener.Accept()
+
+		if err != nil {
+			select {
+			case <-s.quit:
+				return
+			default:
+				panic(err)
+			}
+		}
+
+		raw, err := bufio.NewReader(conn).ReadString(DELIMETER)
+
+		if err != nil {
+			select {
+			case <-s.quit: // If we are quitting we can ignore the error
+				return
+			default:
+				panic(err)
+			}
+
+		}
+		m, err := protocols.DeserializeMessage(raw)
+		if err != nil {
+			panic(err)
+		}
+		s.out <- m
+
+		conn.Close()
+
+	}
+
+}
+
+func (s *SimpleTCPMessageService) Out() <-chan protocols.Message {
+	return s.out
+}
+
+func (s *SimpleTCPMessageService) In() chan<- protocols.Message {
+	return s.in
+}
+
+// Close closes the SimpleTCPMessageService
+func (s *SimpleTCPMessageService) Close() {
+	close(s.quit)
+	s.listener.Close()
+
+	close(s.in)
+	close(s.out)
+
+}

--- a/client/engine/messageservice/simple-tcp/simpletcp-messageservice.go
+++ b/client/engine/messageservice/simple-tcp/simpletcp-messageservice.go
@@ -151,7 +151,4 @@ func (s *SimpleTCPMessageService) Close() {
 	close(s.quit)
 	s.listener.Close()
 
-	close(s.in)
-	close(s.out)
-
 }

--- a/client_test/directfund_simple_tcp_test.go
+++ b/client_test/directfund_simple_tcp_test.go
@@ -17,7 +17,6 @@ import (
 // setupClientWithSimpleTCP is a helper function that contructs a client and returns the new client and its store.
 func setupClientWithSimpleTCP(pk []byte, chain chainservice.MockChain, peers map[types.Address]string, logDestination io.Writer, meanMessageDelay time.Duration) (client.Client, *simpletcp.SimpleTCPMessageService) {
 	myAddress := crypto.GetAddressFromSecretKeyBytes(pk)
-	chain.Subscribe(myAddress)
 	chainservice := chainservice.NewSimpleChainService(&chain, myAddress)
 	messageservice := simpletcp.NewSimpleTCPMessageService(peers[myAddress], peers)
 	storeA := store.NewMemStore(pk)

--- a/client_test/directfund_simple_tcp_test.go
+++ b/client_test/directfund_simple_tcp_test.go
@@ -1,0 +1,46 @@
+// Package client_test contains helpers and integration tests for go-nitro clients
+package client_test // import "github.com/statechannels/go-nitro/client_test"
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/statechannels/go-nitro/client"
+	"github.com/statechannels/go-nitro/client/engine/chainservice"
+	simpletcp "github.com/statechannels/go-nitro/client/engine/messageservice/simple-tcp"
+	"github.com/statechannels/go-nitro/client/engine/store"
+	"github.com/statechannels/go-nitro/crypto"
+	"github.com/statechannels/go-nitro/types"
+)
+
+// setupClientWithSimpleTCP is a helper function that contructs a client and returns the new client and its store.
+func setupClientWithSimpleTCP(pk []byte, chain chainservice.MockChain, peers map[types.Address]string, logDestination io.Writer, meanMessageDelay time.Duration) (client.Client, *simpletcp.SimpleTCPMessageService) {
+	myAddress := crypto.GetAddressFromSecretKeyBytes(pk)
+	chain.Subscribe(myAddress)
+	chainservice := chainservice.NewSimpleChainService(&chain, myAddress)
+	messageservice := simpletcp.NewSimpleTCPMessageService(peers[myAddress], peers)
+	storeA := store.NewMemStore(pk)
+	return client.New(messageservice, chainservice, storeA, logDestination), messageservice
+}
+
+func TestSimpleTCPMessageService(t *testing.T) {
+
+	// Setup logging
+	logFile := "test_direct_fund_with_simple_tcp.log"
+	truncateLog(logFile)
+	logDestination := newLogWriter(logFile)
+
+	chain := chainservice.NewMockChain()
+
+	peers := map[types.Address]string{
+		alice.Address(): "localhost:3005",
+		bob.Address():   "localhost:3006",
+	}
+	clientA, msA := setupClientWithSimpleTCP(alice.PrivateKey, chain, peers, logDestination, 0)
+	clientB, msB := setupClientWithSimpleTCP(bob.PrivateKey, chain, peers, logDestination, 0)
+	defer msA.Close()
+	defer msB.Close()
+	directlyFundALedgerChannel(t, clientA, clientB)
+
+}

--- a/client_test/virtualfund_simple_tcp_test.go
+++ b/client_test/virtualfund_simple_tcp_test.go
@@ -1,0 +1,39 @@
+package client_test
+
+import (
+	"testing"
+
+	"github.com/statechannels/go-nitro/client/engine/chainservice"
+	"github.com/statechannels/go-nitro/types"
+)
+
+func TestVirtualFundWithSimpleTCPMessageService(t *testing.T) {
+
+	// Setup logging
+	logFile := "test_virtual_fund_with_simple_tcp.log"
+	truncateLog(logFile)
+	logDestination := newLogWriter(logFile)
+
+	chain := chainservice.NewMockChain()
+
+	peers := map[types.Address]string{
+		alice.Address(): "localhost:3005",
+		bob.Address():   "localhost:3006",
+		irene.Address(): "localhost:3007",
+	}
+
+	clientA, msgA := setupClientWithSimpleTCP(alice.PrivateKey, chain, peers, logDestination, 0)
+	clientB, msgB := setupClientWithSimpleTCP(bob.PrivateKey, chain, peers, logDestination, 0)
+	clientI, msgI := setupClientWithSimpleTCP(irene.PrivateKey, chain, peers, logDestination, 0)
+	defer msgA.Close()
+	defer msgB.Close()
+	defer msgI.Close()
+
+	directlyFundALedgerChannel(t, clientA, clientI)
+	directlyFundALedgerChannel(t, clientI, clientB)
+
+	ids := createVirtualChannels(clientA, bob.Address(), irene.Address(), 5)
+	waitTimeForCompletedObjectiveIds(t, &clientA, defaultTimeout, ids...)
+	waitTimeForCompletedObjectiveIds(t, &clientB, defaultTimeout, ids...)
+	waitTimeForCompletedObjectiveIds(t, &clientI, defaultTimeout, ids...)
+}


### PR DESCRIPTION
This PR implements a basic message service that works over TCP. The main motivation is allowing us to set up test scenarios that can have client's running in different processes/machines that can communicate with each-other. 

Currently this message service assumes that the address of all other messages services will be known when creating the service.
