### PR TITLE
subscribe to chain during chainservice construction

### DIFF
--- a/client/engine/chainservice/simplechainservice.go
+++ b/client/engine/chainservice/simplechainservice.go
@@ -20,6 +20,7 @@ func NewSimpleChainService(mc *MockChain, address types.Address) ChainService {
 	mcs.out = make(chan Event)
 	mcs.in = make(chan protocols.ChainTransaction)
 	mcs.chain = mc
+	mcs.chain.Subscribe(address)
 	mcs.address = address
 
 	go mcs.forwardEvents()

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -67,7 +67,6 @@ func waitTimeForCompletedObjectiveIds(t *testing.T, client *client.Client, timeo
 // setupClient is a helper function that contructs a client and returns the new client and its store.
 func setupClient(pk []byte, chain chainservice.MockChain, msgBroker messageservice.Broker, logDestination io.Writer, meanMessageDelay time.Duration) (client.Client, store.Store) {
 	myAddress := crypto.GetAddressFromSecretKeyBytes(pk)
-	chain.Subscribe(myAddress)
 	chainservice := chainservice.NewSimpleChainService(&chain, myAddress)
 	messageservice := messageservice.NewTestMessageService(myAddress, msgBroker, meanMessageDelay)
 	storeA := store.NewMemStore(pk)


### PR DESCRIPTION
This is a small optimization to the overall `go-nitro` API. 

However, I am seeing an unexpected test failure locally: 

```
panic: client 0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE has no connection to client 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94

goroutine 69 [running]:
github.com/statechannels/go-nitro/client/engine/messageservice.TestMessageService.dispatchMessage({{0xaa, 0xa6, 0x62, 0x8e, 0xc4, 0x4a, 0x8a, 0x74, 0x29, 0x87, ...}, ...}, ...)
	/Users/georgeknee/statechannels/go-nitro/client/engine/messageservice/test-messageservice.go:94 +0x279
created by github.com/statechannels/go-nitro/client/engine/messageservice.TestMessageService.routeToPeers
	/Users/georgeknee/statechannels/go-nitro/client/engine/messageservice/test-messageservice.go:107 +0x54
FAIL	github.com/statechannels/go-nitro/client_test	0.234s
```

It seems to pass on CI, though 🤔 .