### PR TITLE
reduce noise in CI logs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Test
         timeout-minutes: 1
-        run: go test -v ./... -count=2 -shuffle=on
+        run: go test ./... -count=2 -shuffle=on
 
       - name: Archive logs
         if: always()


### PR DESCRIPTION
by removing "verbose" flag

