### PR TITLE
Return NextProposal as side-effect of ledger funding `Crank`s

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -183,11 +183,9 @@ func (e *Engine) handleMessage(message protocols.Message) (ObjectiveChangeEvent,
 		}
 		allCompleted.CompletedObjectives = append(allCompleted.CompletedObjectives, progressEvent.CompletedObjectives...)
 
-		// relatedObjectiveCompletions, err := e.attemptProgressForRelatedObjectives(&updatedObjective)
 		if err != nil {
 			return ObjectiveChangeEvent{}, err
 		}
-		// allCompleted.CompletedObjectives = append(allCompleted.CompletedObjectives, relatedObjectiveCompletions.CompletedObjectives...)
 
 	}
 
@@ -219,11 +217,9 @@ func (e *Engine) handleMessage(message protocols.Message) (ObjectiveChangeEvent,
 
 		allCompleted.CompletedObjectives = append(allCompleted.CompletedObjectives, progressEvent.CompletedObjectives...)
 
-		// relatedProgressEvent, err := e.attemptProgressForRelatedObjectives(&updatedObjective)
 		if err != nil {
 			return ObjectiveChangeEvent{}, err
 		}
-		// allCompleted.CompletedObjectives = append(allCompleted.CompletedObjectives, relatedProgressEvent.CompletedObjectives...)
 
 	}
 	return allCompleted, nil

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -33,6 +33,7 @@ type ChainTransaction struct {
 type SideEffects struct {
 	MessagesToSend       []Message
 	TransactionsToSubmit []ChainTransaction
+	ProposalsToProcess   []consensus_channel.Proposal
 }
 
 // WaitingFor is an enumerable "pause-point" computed from an Objective. It describes how the objective is blocked on actions by third parties (i.e. co-participants or the blockchain).

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -400,6 +400,12 @@ func (o *Objective) updateLedgerToRemoveGuarantee(ledger *consensus_channel.Cons
 			if err != nil {
 				return protocols.SideEffects{}, fmt.Errorf("could not sign proposal: %w", err)
 			}
+			// ledger sideEffect
+			if proposals := ledger.ProposalQueue(); len(proposals) != 0 {
+				sideEffects.ProposalsToProcess = append(sideEffects.ProposalsToProcess, proposals[0].Proposal)
+			}
+
+			// messaging sideEffect
 			recipient := ledger.Leader()
 			message := protocols.CreateSignedProposalMessage(recipient, sp)
 			sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, message)

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -597,8 +597,14 @@ func (o *Objective) acceptLedgerUpdate(c Connection, sk *[]byte) (protocols.Side
 	if err != nil {
 		return protocols.SideEffects{}, fmt.Errorf("no proposed state found for ledger channel %w", err)
 	}
-
 	sideEffects := protocols.SideEffects{}
+
+	// ledger sideEffect
+	if proposals := ledger.ProposalQueue(); len(proposals) != 0 {
+		sideEffects.ProposalsToProcess = append(sideEffects.ProposalsToProcess, proposals[0].Proposal)
+	}
+
+	// message sideEffect
 	recipient := ledger.Leader()
 	message := protocols.CreateSignedProposalMessage(recipient, sp)
 	sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, message)


### PR DESCRIPTION
This is another option re [messages arriving out of order can cause virtual protocols to stall](https://www.notion.so/statechannels/Messages-arriving-out-of-order-can-cause-virtual-protocols-to-stall-fc5fe7a1121f4b289a6f6384c1ed4429). 

Closes #684 - this workflow achieves the goal of returning / processing a single objective at a time
Closes #685, by way of refactor

**Changes**

PR introduces an internal `fromLedger` channel for the engine to execute "flywheel" cranks - cranking virtual funding objective `B` that has become freed up during the execution of another virtual protocol `A` after `A` alters the state of one or more ledger channels.

Specifically, `vfo.Crank` and `vdfo.Crank` now each return a `ProposalToProcess` when they make adjustments to any ledger channel's proposalQueue. Execution of this sideEffect is just passing the proposal into the `fromLedger` channel, where it is handled in the the engine's main `Run` loop in the same manner as messages from the `FromAPI`, `fromChain`, and `fromMsg` channels.

This:
- removes the potentially confusing/surprising chain of objective cranks that can be started by `handleMessage`
- eliminates the [problem](https://github.com/statechannels/go-nitro/pull/686#issuecomment-1127889458) of discovering sequential queued proposals (this one recursese - the `handelProposal` crank will return more Proposals if they are ready)
- makes the `Run` loop the starting point for each `Crank`

**Incidental Discovery**
Implementing this made it clear that only ledger-channel followers need ever re-crank objectives after the ledger channel's proposalQueue is trimmed. This wasn't obvious to me.

**How Has This Been Tested?**

This is a refactor. Existing tests pass.

**⚠️ Does this require multiple approvals?**

- [ ] Is it a significant change to architecture or design?
  - borderline 

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
