### PR TITLE
Hide `simpleChainService` struct

### DIFF
--- a/client/engine/chainservice/simplechainservice.go
+++ b/client/engine/chainservice/simplechainservice.go
@@ -5,8 +5,8 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-// SimpleChainService forwards inputted transactions to a MockChain, and passes Events straight back.
-type SimpleChainService struct {
+// simpleChainService forwards inputted transactions to a MockChain, and passes Events straight back.
+type simpleChainService struct {
 	out chan Event                      // out is the chan used to send Events to the engine
 	in  chan protocols.ChainTransaction // in is the chan used to receive Transactions from the engine
 
@@ -16,7 +16,7 @@ type SimpleChainService struct {
 
 // NewSimpleChainService returns a SimpleChainService which is listening for transactions and events.
 func NewSimpleChainService(mc *MockChain, address types.Address) ChainService {
-	mcs := SimpleChainService{}
+	mcs := simpleChainService{}
 	mcs.out = make(chan Event)
 	mcs.in = make(chan protocols.ChainTransaction)
 	mcs.chain = mc
@@ -30,24 +30,24 @@ func NewSimpleChainService(mc *MockChain, address types.Address) ChainService {
 }
 
 // Out returns the out chan but narrows the type so that external consumers may only receive on it.
-func (mcs SimpleChainService) Out() <-chan Event {
+func (mcs simpleChainService) Out() <-chan Event {
 	return mcs.out
 }
 
 // In returns the in chan but narrows the type so that external consumers may only send on it.
-func (mcs SimpleChainService) In() chan<- protocols.ChainTransaction {
+func (mcs simpleChainService) In() chan<- protocols.ChainTransaction {
 	return mcs.in
 }
 
 // forwardTransactions pipes transactions to the MockChain
-func (mcs SimpleChainService) forwardTransactions() {
+func (mcs simpleChainService) forwardTransactions() {
 	for tx := range mcs.in {
 		mcs.chain.In() <- tx
 	}
 }
 
 // forwardEvents pipes events from the MockChain
-func (mcs SimpleChainService) forwardEvents() {
+func (mcs simpleChainService) forwardEvents() {
 	for event := range mcs.chain.Out(mcs.address) {
 		mcs.out <- event
 	}

--- a/client/engine/chainservice/simplechainservice.go
+++ b/client/engine/chainservice/simplechainservice.go
@@ -20,6 +20,7 @@ func NewSimpleChainService(mc *MockChain, address types.Address) ChainService {
 	mcs.out = make(chan Event)
 	mcs.in = make(chan protocols.ChainTransaction)
 	mcs.chain = mc
+	mcs.chain.Subscribe(address)
 	mcs.address = address
 
 	go mcs.forwardEvents()

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -67,7 +67,6 @@ func waitTimeForCompletedObjectiveIds(t *testing.T, client *client.Client, timeo
 // setupClient is a helper function that contructs a client and returns the new client and its store.
 func setupClient(pk []byte, chain chainservice.MockChain, msgBroker messageservice.Broker, logDestination io.Writer, meanMessageDelay time.Duration) (client.Client, store.Store) {
 	myAddress := crypto.GetAddressFromSecretKeyBytes(pk)
-	chain.Subscribe(myAddress)
 	chainservice := chainservice.NewSimpleChainService(&chain, myAddress)
 	messageservice := messageservice.NewTestMessageService(myAddress, msgBroker, meanMessageDelay)
 	storeA := store.NewMemStore(pk)


### PR DESCRIPTION
Following #687, another minor api simplification.

`NewSimpleChainService` is the consumption point for this file and the intended method to create a simple chain service. Hiding the struct prevents callers from attempting struct literal instantiation.