### PR TITLE
Fixes from `staticcheck`

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -32,9 +32,8 @@ type Channel struct {
 // New constructs a new Channel from the supplied state.
 func New(s state.State, myIndex uint) (*Channel, error) {
 	c := Channel{}
-	var err error
+	var err error = s.Validate()
 
-	err = s.Validate()
 	if err != nil {
 		return &c, err
 	}

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -196,7 +196,7 @@ func (c Channel) LatestSupportedState() (state.State, error) {
 // LatestSignedState fetches the state with the largest turn number signed by at least one participant.
 func (c Channel) LatestSignedState() (state.SignedState, error) {
 	if len(c.SignedStateForTurnNum) == 0 {
-		return state.SignedState{}, errors.New("No states are signed")
+		return state.SignedState{}, errors.New("no states are signed")
 	}
 	latestTurn := uint64(0)
 	for k := range c.SignedStateForTurnNum {

--- a/channel/consensus_channel/serde.go
+++ b/channel/consensus_channel/serde.go
@@ -50,9 +50,8 @@ type jsonRemove struct {
 
 // MarshalJSON returns a JSON representation of the Remove
 func (r Remove) MarshalJSON() ([]byte, error) {
-	jsonR := jsonRemove{
-		r.Target, r.LeftAmount,
-	}
+	jsonR := jsonRemove(r)
+
 	return json.Marshal(jsonR)
 }
 
@@ -81,7 +80,7 @@ type jsonProposal struct {
 
 // MarshalJSON returns a JSON representation of the Proposal
 func (p Proposal) MarshalJSON() ([]byte, error) {
-	jsonP := jsonProposal{p.LedgerID, p.ToAdd, p.ToRemove}
+	jsonP := jsonProposal(p)
 
 	return json.Marshal(jsonP)
 }

--- a/channel/state/outcome/exit.go
+++ b/channel/state/outcome/exit.go
@@ -235,7 +235,7 @@ func (e Exit) DivertToGuarantee(
 		newAllocations, err := sae.Allocations.DivertToGuarantee(leftDestination, rightDestination, leftAmount, rightAmount, guaranteeDestination)
 
 		if err != nil {
-			return Exit{}, fmt.Errorf("Could not divert to guarantee: %w", err)
+			return Exit{}, fmt.Errorf("could not divert to guarantee: %w", err)
 		}
 		f[i].Allocations = newAllocations
 	}

--- a/client/engine/chainservice/adjudicator/challenge_test.go
+++ b/client/engine/chainservice/adjudicator/challenge_test.go
@@ -74,7 +74,7 @@ func TestChallenge(t *testing.T) {
 
 	// Setup transacting EOA
 	key, _ := crypto.GenerateKey()
-	auth := bind.NewKeyedTransactor(key)
+	auth, _ := bind.NewKeyedTransactorWithChainID(key, big.NewInt(1337)) // 1337 according to godoc on backends.NewSimulatedBackend
 	auth.GasPrice = big.NewInt(10000000000)
 	address := auth.From
 	balance := new(big.Int)

--- a/client/engine/store/memstore_test.go
+++ b/client/engine/store/memstore_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/go-cmp/cmp"
 	"github.com/statechannels/go-nitro/channel"
-	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	cc "github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/client/engine/store"
@@ -27,10 +26,10 @@ func compareObjectives(a, b protocols.Objective) string {
 		channel.Channel{},
 		big.Int{},
 		state.SignedState{},
-		consensus_channel.ConsensusChannel{},
-		consensus_channel.Vars{},
-		consensus_channel.LedgerOutcome{},
-		consensus_channel.Balance{},
+		cc.ConsensusChannel{},
+		cc.Vars{},
+		cc.LedgerOutcome{},
+		cc.Balance{},
 	))
 }
 
@@ -91,7 +90,7 @@ func TestGetObjectiveByChannelId(t *testing.T) {
 		t.Errorf("error setting objective %v: %s", dfo, err.Error())
 	}
 
-	got, ok := ms.GetObjectiveByChannelId(dfo.C.Id)
+	_, ok := ms.GetObjectiveByChannelId(dfo.C.Id)
 	if ok {
 		t.Error("when an unapproved objective is stored, the objective should not own the channel")
 	}
@@ -101,7 +100,7 @@ func TestGetObjectiveByChannelId(t *testing.T) {
 	if err := ms.SetObjective(&dfo); err != nil {
 		t.Errorf("error setting objective %v: %s", dfo, err.Error())
 	}
-	got, ok = ms.GetObjectiveByChannelId(dfo.C.Id)
+	got, ok := ms.GetObjectiveByChannelId(dfo.C.Id)
 
 	if !ok {
 		t.Errorf("expected to find the inserted objective, but didn't")
@@ -152,12 +151,12 @@ func TestConsensusChannelStore(t *testing.T) {
 	existingGuarantee := cc.NewGuarantee(big.NewInt(1), types.Destination{1}, left.AsAllocation().Destination, right.AsAllocation().Destination)
 	outcome := cc.NewLedgerOutcome(asset, left, right, []cc.Guarantee{existingGuarantee})
 
-	initialVars := consensus_channel.Vars{Outcome: *outcome, TurnNum: 0}
+	initialVars := cc.Vars{Outcome: *outcome, TurnNum: 0}
 
 	aliceSig, _ := initialVars.AsState(fp).Sign(ta.Alice.PrivateKey)
 	bobsSig, _ := initialVars.AsState(fp).Sign(ta.Bob.PrivateKey)
 
-	leader, err := consensus_channel.NewLeaderChannel(
+	leader, err := cc.NewLeaderChannel(
 		fp,
 		0,
 		*outcome,

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -26,7 +26,7 @@ const ObjectivePrefix = "DirectDefunding-"
 var (
 	ErrNotApproved             = errors.New("objective not approved")
 	ErrChannelUpdateInProgress = errors.New("can only defund a channel when the latest state is supported or when the channel has a final state")
-	ErrNoFinalState            = errors.New("Cannot spawn direct defund objective without a final state")
+	ErrNoFinalState            = errors.New("cannot spawn direct defund objective without a final state")
 )
 
 // Objective is a cache of data computed by reading from the store. It stores (potentially) infinite data
@@ -233,7 +233,7 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 
 	latestSignedState, err := updated.C.LatestSignedState()
 	if err != nil {
-		return &updated, sideEffects, WaitingForNothing, errors.New("The channel must contain at least one signed state to crank the defund objective")
+		return &updated, sideEffects, WaitingForNothing, errors.New("the channel must contain at least one signed state to crank the defund objective")
 	}
 
 	// Finalize and sign a state if no supported, finalized state exists

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -88,10 +88,8 @@ func channelsExistWithCounterparty(counterparty types.Address, getChannels GetCh
 	}
 
 	_, ok := getTwoPartyConsensusLedger(counterparty)
-	if ok {
-		return true
-	}
-	return false
+
+	return ok
 }
 
 // ConstructFromState initiates a Objective with data calculated from

--- a/protocols/virtualdefund/helpers_test.go
+++ b/protocols/virtualdefund/helpers_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
-	"github.com/statechannels/go-nitro/internal/testactors"
 	ta "github.com/statechannels/go-nitro/internal/testactors"
 	. "github.com/statechannels/go-nitro/internal/testhelpers"
 	"github.com/statechannels/go-nitro/protocols"
@@ -22,19 +21,19 @@ func generateLedgers(myRole uint, vId types.Destination) (left, right *consensus
 	switch myRole {
 	case 0:
 		{
-			return nil, prepareConsensusChannel(uint(consensus_channel.Leader), testactors.Alice, testactors.Irene, generateGuarantee(testactors.Alice, testactors.Irene, vId))
+			return nil, prepareConsensusChannel(uint(consensus_channel.Leader), ta.Alice, ta.Irene, generateGuarantee(ta.Alice, ta.Irene, vId))
 		}
 	case 1:
 		{
 
-			return prepareConsensusChannel(uint(consensus_channel.Follower), testactors.Alice, testactors.Irene, generateGuarantee(testactors.Alice, testactors.Irene, vId)),
-				prepareConsensusChannel(uint(consensus_channel.Leader), testactors.Irene, testactors.Bob, generateGuarantee(testactors.Irene, testactors.Bob, vId))
+			return prepareConsensusChannel(uint(consensus_channel.Follower), ta.Alice, ta.Irene, generateGuarantee(ta.Alice, ta.Irene, vId)),
+				prepareConsensusChannel(uint(consensus_channel.Leader), ta.Irene, ta.Bob, generateGuarantee(ta.Irene, ta.Bob, vId))
 
 		}
 	case 2:
 		{
 
-			return prepareConsensusChannel(uint(consensus_channel.Follower), testactors.Irene, testactors.Bob, generateGuarantee(testactors.Irene, testactors.Bob, vId)), nil
+			return prepareConsensusChannel(uint(consensus_channel.Follower), ta.Irene, ta.Bob, generateGuarantee(ta.Irene, ta.Bob, vId)), nil
 
 		}
 	default:
@@ -65,7 +64,7 @@ func generateStoreGetters(myRole uint, vId types.Destination, vFinal state.State
 }
 
 // generateGuarantee generates a guarantee for the given participants and vId
-func generateGuarantee(left, right testactors.Actor, vId types.Destination) consensus_channel.Guarantee {
+func generateGuarantee(left, right ta.Actor, vId types.Destination) consensus_channel.Guarantee {
 	return consensus_channel.NewGuarantee(big.NewInt(10), vId, left.Destination(), right.Destination())
 
 }
@@ -74,7 +73,7 @@ func generateGuarantee(left, right testactors.Actor, vId types.Destination) cons
 //  - allocating 0 to left
 //  - allocating 0 to right
 //  - including the given guarantees
-func prepareConsensusChannel(role uint, left, right testactors.Actor, guarantees ...consensus_channel.Guarantee) *consensus_channel.ConsensusChannel {
+func prepareConsensusChannel(role uint, left, right ta.Actor, guarantees ...consensus_channel.Guarantee) *consensus_channel.ConsensusChannel {
 	fp := state.FixedPart{
 		ChainId:           big.NewInt(9001),
 		Participants:      []types.Address{left.Address(), right.Address()},
@@ -197,7 +196,7 @@ func checkForLeaderProposals(t *testing.T, se protocols.SideEffects, o *Objectiv
 }
 
 // signProposal signs a proposal with the given actor's private key
-func signProposal(me testactors.Actor, p consensus_channel.Proposal, c *consensus_channel.ConsensusChannel, turnNum uint64) (consensus_channel.SignedProposal, error) {
+func signProposal(me ta.Actor, p consensus_channel.Proposal, c *consensus_channel.ConsensusChannel, turnNum uint64) (consensus_channel.SignedProposal, error) {
 
 	con := c.ConsensusVars()
 	vars := con.Clone()

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/statechannels/go-nitro/channel/state"
 	ta "github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/internal/testhelpers"
-	. "github.com/statechannels/go-nitro/internal/testhelpers"
 	"github.com/statechannels/go-nitro/protocols"
 )
 
@@ -126,8 +125,8 @@ func testCrankAs(my ta.Actor) func(t *testing.T) {
 
 		testhelpers.Equals(t, waitingFor, WaitingForCompleteFinal)
 		signedByMe := state.NewSignedState(data.vFinal)
-		SignState(&signedByMe, &my.PrivateKey)
-		AssertStateSentToEveryone(t, se, signedByMe, my, allActors)
+		testhelpers.SignState(&signedByMe, &my.PrivateKey)
+		testhelpers.AssertStateSentToEveryone(t, se, signedByMe, my, allActors)
 
 		// Update the signatures on the objective so the final state is fully signed
 		signedByOthers := signStateByOthers(my, state.NewSignedState(data.vFinal))

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -442,12 +442,12 @@ func (o *Objective) fundingComplete() bool {
 	// A = P_0 and B=P_n are special cases. A only does the guarantee for L_0 (deducting a0), and B only foes the guarantee for L_n (deducting b0).
 
 	switch {
-	case o.isAlice(): // Alice
+	case o.isAlice():
 		return o.ToMyRight.Funded()
+	case o.isBob():
+		return o.ToMyLeft.Funded()
 	default: // Intermediary
 		return o.ToMyRight.Funded() && o.ToMyLeft.Funded()
-	case o.isBob(): // Bob
-		return o.ToMyLeft.Funded()
 	}
 
 }

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -204,11 +204,11 @@ func constructFromState(
 	for i := range initialStateOfV.Outcome {
 		asset := initialStateOfV.Outcome[i].Asset
 		if initialStateOfV.Outcome[i].Allocations[0].Destination != types.AddressToDestination(initialStateOfV.Participants[0]) {
-			return Objective{}, errors.New("Allocation in slot 0 does not correspond to participant 0")
+			return Objective{}, errors.New("allocation in slot 0 does not correspond to participant 0")
 		}
 		amount0 := initialStateOfV.Outcome[i].Allocations[0].Amount
 		if initialStateOfV.Outcome[i].Allocations[1].Destination != types.AddressToDestination(initialStateOfV.Participants[init.n+1]) {
-			return Objective{}, errors.New("Allocation in slot 1 does not correspond to participant " + fmt.Sprint(init.n+1))
+			return Objective{}, errors.New("allocation in slot 1 does not correspond to participant " + fmt.Sprint(init.n+1))
 		}
 		amount1 := initialStateOfV.Outcome[i].Allocations[1].Amount
 		if init.a0[asset] == nil {

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -11,8 +11,7 @@ import (
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
-	"github.com/statechannels/go-nitro/internal/testactors"
-	actors "github.com/statechannels/go-nitro/internal/testactors"
+	ta "github.com/statechannels/go-nitro/internal/testactors"
 	. "github.com/statechannels/go-nitro/internal/testhelpers"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
@@ -30,8 +29,8 @@ type testData struct {
 	followerLedgers ledgerLookup
 }
 
-var alice, p1, bob actors.Actor = actors.Alice, actors.Irene, actors.Bob
-var allActors []actors.Actor = []actors.Actor{alice, p1, bob}
+var alice, p1, bob ta.Actor = ta.Alice, ta.Irene, ta.Bob
+var allActors []ta.Actor = []ta.Actor{alice, p1, bob}
 
 // newTestData returns new copies of consistent test data each time it is called
 func newTestData() testData {
@@ -89,7 +88,7 @@ func newTestData() testData {
 
 type Tester func(t *testing.T)
 
-func testNew(a actors.Actor) Tester {
+func testNew(a ta.Actor) Tester {
 	return func(t *testing.T) {
 		td := newTestData()
 		lookup := td.leaderLedgers
@@ -123,7 +122,7 @@ func testNew(a actors.Actor) Tester {
 
 // diffFromCorrectConnection compares the guarantee stored on a connection with
 // the guarantee we expect, given the expected left and right actors
-func diffFromCorrectConnection(c *Connection, left, right actors.Actor) string {
+func diffFromCorrectConnection(c *Connection, left, right ta.Actor) string {
 	td := newTestData()
 	vPreFund := td.vPreFund
 
@@ -148,7 +147,7 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func testCloneAs(my actors.Actor) Tester {
+func testCloneAs(my ta.Actor) Tester {
 	return func(t *testing.T) {
 		td := newTestData()
 		vPreFund := td.vPreFund
@@ -477,7 +476,7 @@ func assertSupportedPrefund(o *Objective, t *testing.T) {
 }
 
 // assertOneProposalSent fails the test instantly if the supplied side effects does not contain a message for the supplied actor with the supplied expected signed proposal.
-func assertOneProposalSent(t *testing.T, ses protocols.SideEffects, sp consensus_channel.SignedProposal, to actors.Actor) {
+func assertOneProposalSent(t *testing.T, ses protocols.SideEffects, sp consensus_channel.SignedProposal, to ta.Actor) {
 	numProposals := 0
 	for _, msg := range ses.MessagesToSend {
 		if len(msg.SignedProposals()) > 0 {
@@ -496,7 +495,7 @@ func assertOneProposalSent(t *testing.T, ses protocols.SideEffects, sp consensus
 }
 
 // assertMessageSentTo asserts that ses contains a message
-func assertStateSentTo(t *testing.T, ses protocols.SideEffects, expected state.SignedState, to testactors.Actor) {
+func assertStateSentTo(t *testing.T, ses protocols.SideEffects, expected state.SignedState, to ta.Actor) {
 	found := false
 	for _, msg := range ses.MessagesToSend {
 		toAddress := to.Address()

--- a/types/destination.go
+++ b/types/destination.go
@@ -23,9 +23,7 @@ func (d Destination) ToAddress() (Address, error) {
 	}
 
 	address := Address{}
-	for i, b := range d[12:] {
-		address[i] = b
-	}
+	copy(address[:], d[12:])
 	return address, nil
 }
 


### PR DESCRIPTION
> [Staticcheck](staticcheck.io) is a state of the art linter for the Go programming language. Using static analysis, it finds bugs and performance issues, offers simplifications, and enforces style rules.

The checks / suggestions seem pretty good to me. One flagged item from staticcheck is ignored:

- client/engine/chainservice/adjudicator/challenge_test.go:77:10: bind.NewKeyedTransactor is deprecated: Use NewKeyedTransactorWithChainID instead.  (SA1019)
  - the suggested method is more complicated & requires chain data which I think we don't have right now - would need to be mocked.


Previously ignored, but now incorporated:
- types/destination.go:26:2: should use copy() instead of a loop (S1001)
  - this looks like an error to me! The loop in question is copying from a slice to an `Address`, which is an Array at bottom and not a slice (which `copy` needs). [oops!](https://github.com/dominikh/go-tools/issues/1276#issuecomment-1130190339)

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
- [ ] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [ ] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [ ] I have assigned this PR to the appropriate GitHub Milestone
