### PR TITLE
Only one message service closes a TCP connection

### DIFF
--- a/client/engine/messageservice/simple-tcp/simpletcp-messageservice.go
+++ b/client/engine/messageservice/simple-tcp/simpletcp-messageservice.go
@@ -118,8 +118,6 @@ func (s *SimpleTCPMessageService) listenForIncoming() {
 		}
 		s.out <- m
 
-		conn.Close()
-
 	}
 
 }


### PR DESCRIPTION
Instead of both message services trying to close the connection, the dialer message service is now responsible for closing it. This prevents the dialer message service throwing an error if the receiver message service closes the connection early.