### PR TITLE
Increase the default timeout for objectives to complete

### DIFF
--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/statechannels/go-nitro/protocols"
 )
 
-const defaultTimeout = time.Second
+const defaultTimeout = 5 * time.Second
 
 // waitWithTimeoutForCompletedObjectiveIds waits up to the given timeout for completed objectives and returns when the all objective ids provided have been completed.
 // If the timeout lapses and the objectives have not all completed, the parent test will be failed.

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/statechannels/go-nitro/protocols"
 )
 
-const defaultTimeout = 5 * time.Second
+const defaultTimeout = 10 * time.Second
 
 // waitWithTimeoutForCompletedObjectiveIds waits up to the given timeout for completed objectives and returns when the all objective ids provided have been completed.
 // If the timeout lapses and the objectives have not all completed, the parent test will be failed.


### PR DESCRIPTION
Attempt to address #700.

I think we can justify this "fix" by adopting a strategy where correctness and performance are tested separately. 

We have a "benchmark" test (although since #688 the output of the test is not save anywhere), we should file an issue for that) for testing performance. And it is something we plan to dig much deeper into soon. 

It seems clear that a few seconds is sometimes not enough to let a test run its course. It may well indicate a bottleneck, but it _probably_ doesn't indicate a bug. 