### PR TITLE
Clean up chain service event structs

### DIFF
--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -13,9 +13,12 @@ type Event interface {
 
 // CommonEvent declares fields shared by all chain events
 type CommonEvent struct {
-	channelID          types.Destination
-	AdjudicationStatus protocols.AdjudicationStatus
-	BlockNum           uint64
+	channelID types.Destination
+	BlockNum  uint64
+}
+
+func (ce CommonEvent) ChannelID() types.Destination {
+	return ce.channelID
 }
 
 // DepositedEvent is an internal representation of the deposited blockchain event
@@ -24,18 +27,10 @@ type DepositedEvent struct {
 	Holdings types.Funds // indexed by asset
 }
 
-func (de DepositedEvent) ChannelID() types.Destination {
-	return de.channelID
-}
-
 // AllocationUpdated is an internal representation of the AllocatonUpdated blockchain event
 type AllocationUpdatedEvent struct {
 	CommonEvent
 	Holdings types.Funds // indexed by asset
-}
-
-func (de AllocationUpdatedEvent) ChannelID() types.Destination {
-	return de.channelID
 }
 
 // todo implement other event types

--- a/client/engine/chainservice/mockchain.go
+++ b/client/engine/chainservice/mockchain.go
@@ -84,9 +84,8 @@ func (mc MockChain) handleTx(tx protocols.ChainTransaction) {
 	case protocols.DepositTransactionType:
 		event = DepositedEvent{
 			CommonEvent: CommonEvent{
-				channelID:          tx.ChannelId,
-				AdjudicationStatus: protocols.AdjudicationStatus{TurnNumRecord: 0},
-				BlockNum:           mc.blockNum},
+				channelID: tx.ChannelId,
+				BlockNum:  mc.blockNum},
 
 			Holdings: mc.holdings[tx.ChannelId],
 		}
@@ -94,9 +93,8 @@ func (mc MockChain) handleTx(tx protocols.ChainTransaction) {
 		mc.holdings[tx.ChannelId] = types.Funds{}
 		event = AllocationUpdatedEvent{
 			CommonEvent: CommonEvent{
-				channelID:          tx.ChannelId,
-				AdjudicationStatus: protocols.AdjudicationStatus{TurnNumRecord: 0},
-				BlockNum:           mc.blockNum},
+				channelID: tx.ChannelId,
+				BlockNum:  mc.blockNum},
 
 			Holdings: mc.holdings[tx.ChannelId],
 		}


### PR DESCRIPTION
- `AdjudicationStatus` is not a part of every event type.
- Define `ChannelID()` on the `CommonEvent`