### PR TITLE
Change engine -> {msg,chain} service comms to be synchronous 

### DIFF
--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -46,6 +46,6 @@ type ChainEventHandler interface {
 type ChainService interface {
 	// Out returns a chan for receiving events from the chain service
 	Out() <-chan Event
-	// Send is for sending transactions with the message service
+	// Send is for sending transactions with the chain service
 	Send(protocols.ChainTransaction)
 }

--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -44,6 +44,8 @@ type ChainEventHandler interface {
 }
 
 type ChainService interface {
+	// Out returns a chan for receiving events from the chain service
 	Out() <-chan Event
-	In() chan<- protocols.ChainTransaction
+	// Send is for sending transactions with the message service
+	Send(protocols.ChainTransaction)
 }

--- a/client/engine/chainservice/mockchain_test.go
+++ b/client/engine/chainservice/mockchain_test.go
@@ -26,7 +26,6 @@ func TestDeposit(t *testing.T) {
 	mcsA := NewSimpleChainService(&chain, a)
 	mcsB := NewSimpleChainService(&chain, b)
 
-	inA := mcsA.In()
 	outA := mcsA.Out()
 
 	// Prepare test data to trigger MockChainService
@@ -40,7 +39,7 @@ func TestDeposit(t *testing.T) {
 	}
 
 	// Send one transaction into one of the SimpleChainServices and receive one event from it.
-	inA <- testTx
+	mcsA.Send(testTx)
 	event := <-outA
 
 	if event.ChannelID() != testTx.ChannelId {
@@ -51,7 +50,7 @@ func TestDeposit(t *testing.T) {
 	}
 
 	// Send the transaction again and receive another event
-	inA <- testTx
+	mcsA.Send(testTx)
 	event = <-outA
 
 	// The expectation is that the MockChainService remembered the previous deposit and added this one to it:

--- a/client/engine/chainservice/simplechainservice.go
+++ b/client/engine/chainservice/simplechainservice.go
@@ -33,7 +33,7 @@ func (mcs simpleChainService) Out() <-chan Event {
 
 // Send pipes transactions to the MockChain
 func (mcs simpleChainService) Send(tx protocols.ChainTransaction) {
-	mcs.chain.In() <- tx // TODO block until this has been successful / convert chain.In to a sync call
+	mcs.chain.In() <- tx // TODO convert chain.In to a sync call
 }
 
 // forwardEvents pipes events from the MockChain

--- a/client/engine/chainservice/simplechainservice.go
+++ b/client/engine/chainservice/simplechainservice.go
@@ -7,8 +7,7 @@ import (
 
 // simpleChainService forwards inputted transactions to a MockChain, and passes Events straight back.
 type simpleChainService struct {
-	out chan Event                      // out is the chan used to send Events to the engine
-	in  chan protocols.ChainTransaction // in is the chan used to receive Transactions from the engine
+	out chan Event // out is the chan used to send Events to the engine
 
 	address types.Address // address is used to subscribe to the MockChain's Out chan
 	chain   *MockChain
@@ -18,13 +17,11 @@ type simpleChainService struct {
 func NewSimpleChainService(mc *MockChain, address types.Address) ChainService {
 	mcs := simpleChainService{}
 	mcs.out = make(chan Event)
-	mcs.in = make(chan protocols.ChainTransaction)
 	mcs.chain = mc
 	mcs.chain.Subscribe(address)
 	mcs.address = address
 
 	go mcs.forwardEvents()
-	go mcs.forwardTransactions()
 
 	return mcs
 }
@@ -34,16 +31,9 @@ func (mcs simpleChainService) Out() <-chan Event {
 	return mcs.out
 }
 
-// In returns the in chan but narrows the type so that external consumers may only send on it.
-func (mcs simpleChainService) In() chan<- protocols.ChainTransaction {
-	return mcs.in
-}
-
-// forwardTransactions pipes transactions to the MockChain
-func (mcs simpleChainService) forwardTransactions() {
-	for tx := range mcs.in {
-		mcs.chain.In() <- tx
-	}
+// Send pipes transactions to the MockChain
+func (mcs simpleChainService) Send(tx protocols.ChainTransaction) {
+	mcs.chain.In() <- tx // TODO block until this has been successful / convert chain.In to a sync call
 }
 
 // forwardEvents pipes events from the MockChain

--- a/client/engine/messageservice/messageservice.go
+++ b/client/engine/messageservice/messageservice.go
@@ -6,6 +6,6 @@ import "github.com/statechannels/go-nitro/protocols"
 type MessageService interface {
 	// Out returns a chan for receiving messages from the message service
 	Out() <-chan protocols.Message
-	// In returns a chan for sending messages to the message service
-	In() chan<- protocols.Message
+	// Send is for sending messages with the message service
+	Send(protocols.Message)
 }

--- a/client/engine/messageservice/simple-tcp/simpletcp-messageservice.go
+++ b/client/engine/messageservice/simple-tcp/simpletcp-messageservice.go
@@ -16,7 +16,6 @@ const (
 
 // SimpleTCPMessageService is a rudimentary message service that uses TCP to send and receive messages
 type SimpleTCPMessageService struct {
-	in  chan protocols.Message // for receiving messages from engine
 	out chan protocols.Message // for sending message to engine
 
 	peers map[types.Address]string
@@ -35,7 +34,6 @@ func NewSimpleTCPMessageService(myUrl string, peers map[types.Address]string) *S
 		panic(err)
 	}
 	h := &SimpleTCPMessageService{
-		in:    make(chan protocols.Message, 5),
 		out:   make(chan protocols.Message, 5),
 		peers: peers,
 
@@ -44,53 +42,40 @@ func NewSimpleTCPMessageService(myUrl string, peers map[types.Address]string) *S
 	}
 
 	go h.listenForIncoming()
-	go h.listenForOutgoing()
 
 	return h
 
 }
 
-// listenForOutgoing listens for any messages that should be sent out to peers and sends them
-func (s *SimpleTCPMessageService) listenForOutgoing() {
-	for {
-		select {
-		case <-s.quit:
-			return
+// Send dispatches messages
+func (s *SimpleTCPMessageService) Send(msg protocols.Message) {
+	peer, ok := s.peers[msg.To]
 
-		case m := <-s.in:
-			{
-				peer, ok := s.peers[m.To]
-
-				if !ok {
-					panic(fmt.Errorf("no peer port for %s", m.To))
-				}
-
-				raw, err := m.Serialize()
-
-				// Append the delimiter to the message to indicate the end of the message
-				raw = fmt.Sprintf("%s%c", raw, DELIMETER)
-
-				if err != nil {
-					s.panicIfRunning(err)
-					return
-				}
-
-				conn, err := net.Dial(CONN_TYPE, peer)
-				if err != nil {
-					s.panicIfRunning(err)
-					return
-				}
-				_, err = conn.Write([]byte(raw))
-				if err != nil {
-					s.panicIfRunning(err)
-					return
-				}
-				conn.Close()
-
-			}
-
-		}
+	if !ok {
+		panic(fmt.Errorf("no peer port for %s", msg.To))
 	}
+
+	raw, err := msg.Serialize()
+
+	// Append the delimiter to the message to indicate the end of the message
+	raw = fmt.Sprintf("%s%c", raw, DELIMETER)
+
+	if err != nil {
+		s.panicIfRunning(err)
+		return
+	}
+
+	conn, err := net.Dial(CONN_TYPE, peer)
+	if err != nil {
+		s.panicIfRunning(err)
+		return
+	}
+	_, err = conn.Write([]byte(raw))
+	if err != nil {
+		s.panicIfRunning(err)
+		return
+	}
+	conn.Close()
 
 }
 
@@ -134,10 +119,6 @@ func (s *SimpleTCPMessageService) panicIfRunning(err error) {
 
 func (s *SimpleTCPMessageService) Out() <-chan protocols.Message {
 	return s.out
-}
-
-func (s *SimpleTCPMessageService) In() chan<- protocols.Message {
-	return s.in
 }
 
 // Close closes the SimpleTCPMessageService

--- a/client/engine/messageservice/test-messageservice_test.go
+++ b/client/engine/messageservice/test-messageservice_test.go
@@ -23,7 +23,7 @@ var aToB protocols.Message = protocols.Message{
 func TestConnect(t *testing.T) {
 	bobOut := bobMS.Out()
 
-	aliceMS.in <- aToB
+	aliceMS.Send(aToB)
 
 	got := <-bobOut
 


### PR DESCRIPTION
Closes #720 . 

Possibly relevant to #704 , #700 .

Pros:
- easier to debug this code because fewer go routines
- easier to reason about control flow of the engine
- lower probability to have a race condition?

Cons
- _might_ have an adverse effect on performance (anecdotal evidence)
- may increase probability for a dead lock?