### PR TITLE
add `staticcheck` to CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.45.2
+      
+      - name: Staticcheck # see: staticcheck.io
+        uses: dominikh/staticcheck-action@v1.2.0
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run staticcheck # see: staticcheck.io
         uses: dominikh/staticcheck-action@v1.2.0
         with:
-          version: "2022.1"
+          version: "2022.1.2"
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.45.2
       
-      - name: Staticcheck # see: staticcheck.io
+      - name: Run staticcheck # see: staticcheck.io
         uses: dominikh/staticcheck-action@v1.2.0
 
       - name: Build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,6 +21,8 @@ jobs:
       
       - name: Run staticcheck # see: staticcheck.io
         uses: dominikh/staticcheck-action@v1.2.0
+        with:
+          version: "2022.1"
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,6 +23,8 @@ jobs:
         uses: dominikh/staticcheck-action@v1.2.0
         with:
           version: "2022.1.2"
+          install-go: false
+          min-go-version: 1.18
 
       - name: Build
         run: go build -v ./...

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -53,7 +53,6 @@ func (cc *EthChainService) SendTransaction(tx protocols.ChainTransaction) {
 	c := make(chan struct{})
 	cc.in <- TransactionWithStatusChan{ChainTransaction: tx, done: c}
 	<-c
-	return
 }
 
 func (cc EthChainService) In() chan<- TransactionWithStatusChan {

--- a/client/engine/chainservice/eth_chainservice_test.go
+++ b/client/engine/chainservice/eth_chainservice_test.go
@@ -18,7 +18,7 @@ import (
 func TestEthChainService(t *testing.T) {
 	// Setup transacting EOA
 	key, _ := crypto.GenerateKey()
-	auth := bind.NewKeyedTransactor(key)
+	auth, _ := bind.NewKeyedTransactorWithChainID(key, big.NewInt(1337)) // 1337 according to docs on SimulatedBackend
 	auth.GasPrice = big.NewInt(10000000000)
 	address := auth.From
 	balance, _ := new(big.Int).SetString("10000000000000000000", 10) // 10 eth in wei


### PR DESCRIPTION
Closes #725 

https://staticcheck.io is a fairly opinionated linter / static analysis tool. It flagged a bunch of reasonable stuff in PR #694 (one per commit in that PR), so it seems like a good idea to include in the CI.


---

#### Code quality

- [x] I have written clear commit messages

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
