### PR TITLE
Keep track of latest block number in direct defunding

### DIFF
--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -34,7 +34,9 @@ type Objective struct {
 	Status               protocols.ObjectiveStatus
 	C                    *channel.Channel
 	finalTurnNum         uint64
-	transactionSubmitted bool // whether a transition for the objective has been submitted or not
+	transactionSubmitted bool   // whether a transition for the objective has been submitted or not
+	latestBlockNumber    uint64 // the latest block number we've seen
+
 }
 
 // isInConsensusOrFinalState returns true if the channel has a final state or latest state that is supported
@@ -209,9 +211,10 @@ func (o *Objective) UpdateWithChainEvent(event chainservice.Event) (protocols.Ob
 	switch e := event.(type) {
 	case chainservice.AllocationUpdatedEvent:
 		{
-			// todo: check block number
-			if e.Holdings != nil {
+
+			if e.Holdings != nil && e.BlockNum > updated.latestBlockNumber {
 				updated.C.OnChainFunding = e.Holdings.Clone()
+				updated.latestBlockNumber = e.BlockNum
 			}
 		}
 	default:
@@ -311,7 +314,7 @@ func (o *Objective) clone() Objective {
 	clone.C = cClone
 	clone.finalTurnNum = o.finalTurnNum
 	clone.transactionSubmitted = o.transactionSubmitted
-
+	clone.latestBlockNumber = o.latestBlockNumber
 	return clone
 }
 

--- a/protocols/directdefund/serde.go
+++ b/protocols/directdefund/serde.go
@@ -15,6 +15,7 @@ type jsonObjective struct {
 	C                     types.Destination
 	FinalTurnNum          uint64
 	TransactionSumbmitted bool
+	LatestBlockNumber     uint64
 }
 
 // MarshalJSON returns a JSON representation of the DirectDefundObjective
@@ -27,6 +28,7 @@ func (o Objective) MarshalJSON() ([]byte, error) {
 		o.C.Id,
 		o.finalTurnNum,
 		o.transactionSubmitted,
+		o.latestBlockNumber,
 	}
 
 	return json.Marshal(jsonDDFO)
@@ -55,6 +57,7 @@ func (o *Objective) UnmarshalJSON(data []byte) error {
 	o.C.Id = jsonDDFO.C
 	o.finalTurnNum = jsonDDFO.FinalTurnNum
 	o.transactionSubmitted = jsonDDFO.TransactionSumbmitted
+	o.latestBlockNumber = jsonDDFO.LatestBlockNumber
 
 	return nil
 }


### PR DESCRIPTION
This updates direct defunding to keep track of the latest block number and ignore events with a stale block number.

This follows the same pattern that we use in direct funding.