### PR TITLE
EthChainService adheres to ChainService interface

### DIFF
--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -2,6 +2,9 @@
 package chainservice // import "github.com/statechannels/go-nitro/client/chainservice"
 
 import (
+	"fmt"
+
+	"github.com/statechannels/go-nitro/client/engine/store/safesync"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -50,4 +53,44 @@ type ChainService interface {
 	SubscribeToEvents(types.Address) <-chan Event
 	// SendTransaction is for sending transactions with the chain service
 	SendTransaction(protocols.ChainTransaction)
+}
+
+type ChainServiceBase struct {
+	out safesync.Map[chan Event]
+}
+
+func NewChainServiceBase() ChainServiceBase {
+	return ChainServiceBase{out: safesync.Map[chan Event]{}}
+}
+
+// Subscribe inserts a go chan (for the supplied address) into the ChainService.
+func (csb *ChainServiceBase) SubscribeToEvents(a types.Address) <-chan Event {
+	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
+	c := make(chan Event, 10)
+	csb.out.Store(a.String(), c)
+	return c
+}
+
+// EventFeed returns the out chan for a particular ChainService, and narrows the type so that external consumers may only receive on it.
+func (csb *ChainServiceBase) EventFeed(a types.Address) (<-chan Event, error) {
+	c, ok := csb.out.Load(a.String())
+	if !ok {
+		return nil, fmt.Errorf("no subscription for address %v", a)
+	}
+	return c, nil
+}
+
+func (csb *ChainServiceBase) broadcast(event Event) {
+	csb.out.Range(func(_ string, channel chan Event) bool {
+		attemptSend(channel, event)
+		return true
+	})
+}
+
+// attemptSend sends event to the supplied chan, and drops it if the chan is full
+func attemptSend(out chan Event, event Event) {
+	select {
+	case out <- event:
+	default:
+	}
 }

--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -59,7 +59,8 @@ type ChainServiceBase struct {
 	out safesync.Map[chan Event]
 }
 
-func NewChainServiceBase() ChainServiceBase {
+// newChainServiceBase constructs a ChainServiceBase. Only implementations of ChainService interface should call the constructor.
+func newChainServiceBase() ChainServiceBase {
 	return ChainServiceBase{out: safesync.Map[chan Event]{}}
 }
 

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -31,7 +31,7 @@ type EthChainService struct {
 // NewEthChainService constructs a chain service that submits transactions to a NitroAdjudicator
 // and listens to events from an eventSource
 func NewEthChainService(na *NitroAdjudicator.NitroAdjudicator, naAddress common.Address, txSigner *bind.TransactOpts, es eventSource) *EthChainService {
-	ecs := EthChainService{ChainServiceBase: NewChainServiceBase()}
+	ecs := EthChainService{ChainServiceBase: newChainServiceBase()}
 	ecs.out = safesync.Map[chan Event]{}
 	ecs.na = na
 	ecs.txSigner = txSigner

--- a/client/engine/chainservice/eth_chainservice_test.go
+++ b/client/engine/chainservice/eth_chainservice_test.go
@@ -50,13 +50,14 @@ func TestEthChainService(t *testing.T) {
 		Type:      protocols.DepositTransactionType,
 	}
 
+	out := cc.SubscribeToEvents(address)
 	// Submit transactiom
 	cc.SendTransaction(testTx)
 
 	sim.Commit()
 
 	// Check that the recieved event matches the expected event
-	receivedEvent := <-cc.out
+	receivedEvent := <-out
 	expectedEvent := DepositedEvent{CommonEvent: CommonEvent{channelID: channelID}, Holdings: testDeposit}
 	if diff := cmp.Diff(expectedEvent, receivedEvent, cmp.AllowUnexported(CommonEvent{})); diff != "" {
 		t.Fatalf("Clone: mismatch (-want +got):\n%s", diff)

--- a/client/engine/chainservice/eth_chainservice_test.go
+++ b/client/engine/chainservice/eth_chainservice_test.go
@@ -19,7 +19,6 @@ func TestEthChainService(t *testing.T) {
 	// Setup transacting EOA
 	key, _ := crypto.GenerateKey()
 	auth, _ := bind.NewKeyedTransactorWithChainID(key, big.NewInt(1337)) // 1337 according to docs on SimulatedBackend
-	auth.GasPrice = big.NewInt(10000000000)
 	address := auth.From
 	balance, _ := new(big.Int).SetString("10000000000000000000", 10) // 10 eth in wei
 

--- a/client/engine/chainservice/mockchain.go
+++ b/client/engine/chainservice/mockchain.go
@@ -1,9 +1,6 @@
 package chainservice
 
 import (
-	"fmt"
-
-	"github.com/statechannels/go-nitro/client/engine/store/safesync"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -13,38 +10,20 @@ import (
 //
 // It keeps a record of of holdings and adjudication status for each channel, accepts transactions and emits events.
 type MockChain struct {
-	out safesync.Map[chan Event] // out is a mapping with a chan for each connected ChainService, used to send Events to that service
+	ChainServiceBase
 
 	holdings map[types.Destination]types.Funds // holdings tracks funds for each channel
 	blockNum *uint64                           // MockChain is often passed around by value. The pointer allows for shared state.
 }
 
-// EventFeed returns the out chan for a particular ChainService, and narrows the type so that external consumers may only receive on it.
-func (mc *MockChain) EventFeed(a types.Address) (<-chan Event, error) {
-	c, ok := mc.out.Load(a.String())
-	if !ok {
-		return nil, fmt.Errorf("no subscription for address %v", a)
-	}
-	return c, nil
-}
-
 // NewMockChain returns a new MockChain.
 func NewMockChain() *MockChain {
-	mc := MockChain{}
-	mc.out = safesync.Map[chan Event]{}
+	mc := MockChain{ChainServiceBase: NewChainServiceBase()}
 	mc.holdings = make(map[types.Destination]types.Funds)
 	mc.blockNum = new(uint64)
 	*mc.blockNum = 1
 
 	return &mc
-}
-
-// Subscribe inserts a go chan (for the supplied address) into the MockChain.
-func (mc *MockChain) SubscribeToEvents(a types.Address) <-chan Event {
-	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
-	c := make(chan Event, 10)
-	mc.out.Store(a.String(), c)
-	return c
 }
 
 // SendTransaction responds to the given tx.
@@ -76,16 +55,5 @@ func (mc *MockChain) SendTransaction(tx protocols.ChainTransaction) {
 		panic("unexpected chain transaction")
 	}
 
-	mc.out.Range(func(key string, value chan Event) bool {
-		attemptSend(value, event)
-		return true
-	})
-}
-
-// attemptSend sends event to the supplied chan, and drops it if the chan is full
-func attemptSend(out chan Event, event Event) {
-	select {
-	case out <- event:
-	default:
-	}
+	mc.broadcast(event)
 }

--- a/client/engine/chainservice/mockchain.go
+++ b/client/engine/chainservice/mockchain.go
@@ -18,7 +18,7 @@ type MockChain struct {
 
 // NewMockChain returns a new MockChain.
 func NewMockChain() *MockChain {
-	mc := MockChain{ChainServiceBase: NewChainServiceBase()}
+	mc := MockChain{ChainServiceBase: newChainServiceBase()}
 	mc.holdings = make(map[types.Destination]types.Funds)
 	mc.blockNum = new(uint64)
 	*mc.blockNum = 1


### PR DESCRIPTION
In this PR:
- `EthChainService` interface is modified to adhere to the `ChainService` interface from https://github.com/statechannels/go-nitro/pull/733.
- Common logic between `EthChainService` and `MockChain` is factored out.