### PR TITLE
reimplement MockChain transaction re-broadcast

### DIFF
--- a/client/engine/chainservice/mockchain.go
+++ b/client/engine/chainservice/mockchain.go
@@ -12,8 +12,9 @@ import (
 type MockChain struct {
 	ChainServiceBase
 
-	holdings map[types.Destination]types.Funds // holdings tracks funds for each channel
-	blockNum *uint64                           // MockChain is often passed around by value. The pointer allows for shared state.
+	holdings   map[types.Destination]types.Funds // holdings tracks funds for each channel
+	blockNum   *uint64                           // MockChain is often passed around by value. The pointer allows for shared state.
+	txListener chan protocols.ChainTransaction   // this is used to broadcast transactions that have been received
 }
 
 // NewMockChain returns a new MockChain.
@@ -26,9 +27,24 @@ func NewMockChain() *MockChain {
 	return &mc
 }
 
+// NewMockChainWithTransactionListener returns a new mock chain that will send transactions to the supplied chan.
+// This lets us easily rebroadcast transactions to other mock chains.
+func NewMockChainWithTransactionListener(txListener chan protocols.ChainTransaction) *MockChain {
+	mc := NewMockChain()
+	mc.txListener = txListener
+	return mc
+}
+
 // SendTransaction responds to the given tx.
 func (mc *MockChain) SendTransaction(tx protocols.ChainTransaction) {
 	*mc.blockNum++
+	if mc.txListener != nil {
+		// Send to txListener and ignore if the chan is full
+		select {
+		case mc.txListener <- tx:
+		default:
+		}
+	}
 	if tx.Deposit.IsNonZero() {
 		mc.holdings[tx.ChannelId] = mc.holdings[tx.ChannelId].Add(tx.Deposit)
 	}

--- a/client/engine/chainservice/mockchain.go
+++ b/client/engine/chainservice/mockchain.go
@@ -39,11 +39,7 @@ func NewMockChainWithTransactionListener(txListener chan protocols.ChainTransact
 func (mc *MockChain) SendTransaction(tx protocols.ChainTransaction) {
 	*mc.blockNum++
 	if mc.txListener != nil {
-		// Send to txListener and ignore if the chan is full
-		select {
-		case mc.txListener <- tx:
-		default:
-		}
+		mc.txListener <- tx
 	}
 	if tx.Deposit.IsNonZero() {
 		mc.holdings[tx.ChannelId] = mc.holdings[tx.ChannelId].Add(tx.Deposit)


### PR DESCRIPTION
To support `testground` tests  the MockChain previously allowed a `chan` to be passed in that receives any submitted transactions. This lets us listen for transactions a `MockChain` receives and replay them on other clients `MockChain`s.

This reimplements that behaviour after the recent chain service refactor. This should only be temporary until we're using a shared ganache/geth instance.