### PR TITLE
Fix cloning for proposals

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -659,7 +659,7 @@ type Add struct {
 
 // Clone returns a deep copy of the receiver.
 func (a *Add) Clone() Add {
-	if a == nil {
+	if a == nil || a.LeftDeposit == nil {
 		return Add{}
 	}
 	return Add{

--- a/channel/consensus_channel/consensus_channel_test.go
+++ b/channel/consensus_channel/consensus_channel_test.go
@@ -3,6 +3,7 @@ package consensus_channel
 import (
 	"errors"
 	"math/big"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -191,6 +192,20 @@ func TestConsensusChannel(t *testing.T) {
 		}
 	}
 
+	testEmptyProposalClone := func(t *testing.T) {
+		add := Add{}
+		clonedAdd := add.Clone()
+		if !reflect.DeepEqual(add, clonedAdd) {
+			t.Fatalf("cloned add is not equal to original")
+		}
+		remove := Remove{}
+		clonedRemove := remove.Clone()
+
+		if !reflect.DeepEqual(remove, clonedRemove) {
+			t.Fatalf("cloned remove is not equal to original")
+		}
+	}
+	t.Run(`TestEmptyProposalClone`, testEmptyProposalClone)
 	t.Run(`TestApplyingAddProposalToVars`, testApplyingAddProposalToVars)
 	t.Run(`TestApplyingRemoveProposalToVars`, testApplyingRemoveProposalToVars)
 	t.Run(`TestConsensusChannelFunctionality`, testConsensusChannelFunctionality)


### PR DESCRIPTION
Whenever we clone a proposal we clone both the [ToAdd and ToRemove](https://github.com/statechannels/go-nitro/blob/ag/handle-empty-proposal-clone/channel/consensus_channel/consensus_channel.go#L581:L581) once of which will be an empty zero value.

However cloning an empty `ToAdd` will fail as it attempts to use nil pointers to big ints. This PR fixes this by copying the logic from Remove's [clone](https://github.com/statechannels/go-nitro/blob/ag/handle-empty-proposal-clone/channel/consensus_channel/consensus_channel.go#L839:L839) into Adds.

This PR also adds a simple test to check that cloning empty proposals works.