### PR TITLE
Add channel defunding to EthChainService

### DIFF
--- a/client/engine/chainservice/adjudicator/challenge_test.go
+++ b/client/engine/chainservice/adjudicator/challenge_test.go
@@ -101,10 +101,10 @@ func TestChallenge(t *testing.T) {
 	tx, err := na.Challenge(
 		auth,
 		IForceMoveFixedPart(s.FixedPart()),
-		[]IForceMoveAppVariablePart{convertVariablePart(s.VariablePart())},
-		[]IForceMoveSignature{convertSignature(aSig), convertSignature(bSig)},
+		[]IForceMoveAppVariablePart{ConvertVariablePart(s.VariablePart())},
+		[]IForceMoveSignature{ConvertSignature(aSig), ConvertSignature(bSig)},
 		[]uint8{0, 0},
-		convertSignature(challengerSig),
+		ConvertSignature(challengerSig),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/client/engine/chainservice/adjudicator/typeconversions.go
+++ b/client/engine/chainservice/adjudicator/typeconversions.go
@@ -8,7 +8,7 @@ import (
 	nc "github.com/statechannels/go-nitro/crypto"
 )
 
-func convertVariablePart(vp state.VariablePart) IForceMoveAppVariablePart {
+func ConvertVariablePart(vp state.VariablePart) IForceMoveAppVariablePart {
 	return IForceMoveAppVariablePart{
 		AppData: vp.AppData,
 		TurnNum: big.NewInt(int64(vp.TurnNum)),
@@ -38,7 +38,7 @@ func convertAllocations(as outcome.Allocations) []ExitFormatAllocation {
 	return b
 }
 
-func convertSignature(s nc.Signature) IForceMoveSignature {
+func ConvertSignature(s nc.Signature) IForceMoveSignature {
 	sig := IForceMoveSignature{
 		V: s.V,
 	}

--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -36,6 +36,10 @@ type AllocationUpdatedEvent struct {
 	Holdings types.Funds // indexed by asset
 }
 
+type ConcludedEvent struct {
+	CommonEvent
+}
+
 // todo implement other event types
 // Concluded
 // ChallengeRegistered

--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -36,6 +36,7 @@ type AllocationUpdatedEvent struct {
 	Holdings types.Funds // indexed by asset
 }
 
+// ConcludedEvent is an internal representation of the Concluded blockchain event
 type ConcludedEvent struct {
 	CommonEvent
 }

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -65,7 +65,19 @@ func (ecs *EthChainService) SendTransaction(tx protocols.ChainTransaction) {
 				panic(err)
 			}
 		}
-	// TODO handle other transaction types
+	case protocols.WithdrawAllTransaction:
+		withdrawTx := tx.(protocols.WithdrawAllTransaction)
+
+		state := withdrawTx.SignedState.State()
+		signatures := withdrawTx.SignedState.Signatures()
+		nitroFixedPart := NitroAdjudicator.IForceMoveFixedPart(state.FixedPart())
+		nitroVariablePart := NitroAdjudicator.ConvertVariablePart(state.VariablePart())
+		nitroSignatures := []NitroAdjudicator.IForceMoveSignature{NitroAdjudicator.ConvertSignature(signatures[0]), NitroAdjudicator.ConvertSignature(signatures[1])}
+
+		_, err := ecs.na.ConcludeAndTransferAllAssets(&txOpt, nitroFixedPart, nitroVariablePart, 1, []uint8{0, 0}, nitroSignatures)
+		if err != nil {
+			panic(err)
+		}
 	default:
 		panic("unexpected chain transaction")
 	}

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -17,6 +17,7 @@ import (
 )
 
 var depositedTopic = crypto.Keccak256Hash([]byte("Deposited(bytes32,address,uint256,uint256)"))
+var allocationUpdatedTopic = crypto.Keccak256Hash([]byte("AllocationUpdated(bytes32,uint256,uint256)"))
 
 type eventSource interface {
 	SubscribeFilterLogs(ctx context.Context, query ethereum.FilterQuery, ch chan<- ethTypes.Log) (ethereum.Subscription, error)
@@ -115,7 +116,14 @@ func (ecs *EthChainService) listenForLogEvents(na *NitroAdjudicator.NitroAdjudic
 					Holdings: holdings,
 				}
 				ecs.broadcast(event)
-			// TODO introduce the remaining events
+			case allocationUpdatedTopic:
+				au, err := na.ParseAllocationUpdated(chainEvent)
+				if err != nil {
+					panic(err)
+				}
+
+				event := AllocationUpdatedEvent{CommonEvent: CommonEvent{channelID: au.ChannelId, BlockNum: chainEvent.BlockNumber}, Holdings: types.Funds{}}
+				ecs.broadcast(event)
 			default:
 				panic("Unknown chain event")
 			}

--- a/client/engine/chainservice/mockchain.go
+++ b/client/engine/chainservice/mockchain.go
@@ -41,27 +41,28 @@ func (mc *MockChain) SendTransaction(tx protocols.ChainTransaction) {
 	if mc.txListener != nil {
 		mc.txListener <- tx
 	}
-	if tx.Deposit.IsNonZero() {
-		mc.holdings[tx.ChannelId] = mc.holdings[tx.ChannelId].Add(tx.Deposit)
-	}
 	var event Event
-	switch tx.Type {
-	case protocols.DepositTransactionType:
+	switch tx.(type) {
+	case protocols.DepositTransaction:
+		depositTx := tx.(protocols.DepositTransaction)
+		if depositTx.Deposit.IsNonZero() {
+			mc.holdings[tx.ChannelId()] = mc.holdings[tx.ChannelId()].Add(depositTx.Deposit)
+		}
 		event = DepositedEvent{
 			CommonEvent: CommonEvent{
-				channelID: tx.ChannelId,
+				channelID: tx.ChannelId(),
 				BlockNum:  *mc.blockNum},
 
-			Holdings: mc.holdings[tx.ChannelId],
+			Holdings: mc.holdings[tx.ChannelId()],
 		}
-	case protocols.WithdrawAllTransactionType:
-		mc.holdings[tx.ChannelId] = types.Funds{}
+	case protocols.WithdrawAllTransaction:
+		mc.holdings[tx.ChannelId()] = types.Funds{}
 		event = AllocationUpdatedEvent{
 			CommonEvent: CommonEvent{
-				channelID: tx.ChannelId,
+				channelID: tx.ChannelId(),
 				BlockNum:  *mc.blockNum},
 
-			Holdings: mc.holdings[tx.ChannelId],
+			Holdings: mc.holdings[tx.ChannelId()],
 		}
 	default:
 		panic("unexpected chain transaction")

--- a/client/engine/chainservice/mockchain_test.go
+++ b/client/engine/chainservice/mockchain_test.go
@@ -35,18 +35,14 @@ func TestDeposit(t *testing.T) {
 	testDeposit := types.Funds{
 		common.HexToAddress("0x00"): big.NewInt(1),
 	}
-	testTx := protocols.ChainTransaction{
-		ChannelId: types.Destination(common.HexToHash(`4ebd366d014a173765ba1e50f284c179ade31f20441bec41664712aac6cc461d`)),
-		Deposit:   testDeposit,
-		Type:      protocols.DepositTransactionType,
-	}
+	testTx := protocols.NewDepositTransaction(types.Destination(common.HexToHash(`4ebd366d014a173765ba1e50f284c179ade31f20441bec41664712aac6cc461d`)), testDeposit)
 
 	// Send one transaction and receive one event from it.
 	chain.SendTransaction(testTx)
 	event := <-eventFeedA
 
-	if event.ChannelID() != testTx.ChannelId {
-		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, event.ChannelID())
+	if event.ChannelID() != testTx.ChannelId() {
+		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId(), event.ChannelID())
 	}
 	if !event.(DepositedEvent).Holdings.Equal(testTx.Deposit) {
 		t.Fatalf(`holdings mismatch: expected %v but got %v`, testTx.Deposit, event.(DepositedEvent).Holdings)
@@ -59,8 +55,8 @@ func TestDeposit(t *testing.T) {
 	// The expectation is that the MockChainService remembered the previous deposit and added this one to it:
 	expectedHoldings := testTx.Deposit.Add(testTx.Deposit)
 
-	if event.ChannelID() != testTx.ChannelId {
-		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, event.ChannelID())
+	if event.ChannelID() != testTx.ChannelId() {
+		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId(), event.ChannelID())
 	}
 	if !event.(DepositedEvent).Holdings.Equal(expectedHoldings) {
 		t.Fatalf(`holdings mismatch: expected %v but got %v`, expectedHoldings, event.(DepositedEvent).Holdings)
@@ -69,8 +65,8 @@ func TestDeposit(t *testing.T) {
 	// Pull an event out of the other mock chain service and check that
 	eventB := <-eventFeedB
 
-	if eventB.ChannelID() != testTx.ChannelId {
-		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, eventB.ChannelID())
+	if eventB.ChannelID() != testTx.ChannelId() {
+		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId(), eventB.ChannelID())
 	}
 	if !eventB.(DepositedEvent).Holdings.Equal(testTx.Deposit) {
 		t.Fatalf(`holdings mismatch: expected %v but got %v`, testTx.Deposit, eventB.(DepositedEvent).Holdings)
@@ -79,8 +75,8 @@ func TestDeposit(t *testing.T) {
 	// Pull another event out of the other mock chain service and check that
 	eventB = <-eventFeedB
 
-	if eventB.ChannelID() != testTx.ChannelId {
-		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId, eventB.ChannelID())
+	if eventB.ChannelID() != testTx.ChannelId() {
+		t.Fatalf(`channelId mismatch: expected %v but got %v`, testTx.ChannelId(), eventB.ChannelID())
 	}
 	if !eventB.(DepositedEvent).Holdings.Equal(expectedHoldings) {
 		t.Fatalf(`holdings mismatch: expected %v but got %v`, expectedHoldings, eventB.(DepositedEvent).Holdings)

--- a/client/engine/chainservice/simulated_backend_chainservice.go
+++ b/client/engine/chainservice/simulated_backend_chainservice.go
@@ -1,6 +1,7 @@
 package chainservice
 
 import (
+	"context"
 	"errors"
 	"math/big"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	NitroAdjudicator "github.com/statechannels/go-nitro/client/engine/chainservice/adjudicator"
 	"github.com/statechannels/go-nitro/protocols"
@@ -18,6 +20,7 @@ var ErrUnableToAssignBigInt = errors.New("simulated_backend_chainservice: unable
 type transactionProcessor interface {
 	eventSource
 	Commit()
+	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 }
 
 // SimulatedBackendChainService extends EthChainService to automatically mine a block for every transaction
@@ -34,9 +37,9 @@ func NewSimulatedBackendChainService(sim transactionProcessor, na *NitroAdjudica
 }
 
 // SendTransaction sends the transaction and blocks until it has been mined.
-func (ecs *SimulatedBackendChainService) SendTransaction(tx protocols.ChainTransaction) {
-	ecs.EthChainService.SendTransaction(tx)
-	ecs.sim.Commit()
+func (sbcs *SimulatedBackendChainService) SendTransaction(tx protocols.ChainTransaction) {
+	sbcs.EthChainService.SendTransaction(tx)
+	sbcs.sim.Commit()
 }
 
 // SetupSimulatedBackend creates a new SimulatedBackend with the supplied number of transacting accounts, deploys the Nitro Adjudicator and returns both.

--- a/client/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/client/engine/chainservice/simulated_backend_chainservice_test.go
@@ -19,10 +19,6 @@ type actor struct {
 	PrivateKey []byte
 }
 
-func (a actor) Destination() types.Destination {
-	return types.AddressToDestination(a.Address)
-}
-
 // actors namespaces the actors exported for test consumption
 type actors struct {
 	Alice actor

--- a/client/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/client/engine/chainservice/simulated_backend_chainservice_test.go
@@ -1,16 +1,79 @@
 package chainservice
 
 import (
+	"bytes"
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/go-cmp/cmp"
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
 
-func TestSimulatedBackendChainService(t *testing.T) {
+type actor struct {
+	Address    types.Address
+	PrivateKey []byte
+}
+
+func (a actor) Destination() types.Destination {
+	return types.AddressToDestination(a.Address)
+}
+
+// actors namespaces the actors exported for test consumption
+type actors struct {
+	Alice actor
+	Bob   actor
+}
+
+// Actors is the endpoint for tests to consume constructed statechannel
+// network participants (public-key secret-key pairs)
+var Actors actors = actors{
+	Alice: actor{
+		common.HexToAddress(`0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE`),
+		common.Hex2Bytes(`2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d`),
+	},
+	Bob: actor{
+		common.HexToAddress(`0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94`),
+		common.Hex2Bytes(`0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4`),
+	},
+}
+
+var concludeOutcome = outcome.Exit{
+	outcome.SingleAssetExit{
+		Asset: types.Address{},
+		Allocations: outcome.Allocations{
+			outcome.Allocation{
+				Destination: types.AddressToDestination(common.HexToAddress(`0xF5A1BB5607C9D079E46d1B3Dc33f257d937b43BD`)),
+				Amount:      big.NewInt(1),
+			},
+			outcome.Allocation{
+				Destination: types.AddressToDestination(common.HexToAddress(`0xEe18fF1575055691009aa246aE608132C57a422c`)),
+				Amount:      big.NewInt(1),
+			},
+		},
+	},
+}
+
+var concludeState = state.State{
+	ChainId: big.NewInt(1337),
+	Participants: []types.Address{
+		Actors.Alice.Address,
+		Actors.Bob.Address,
+	},
+	ChannelNonce:      big.NewInt(37140676580),
+	AppDefinition:     types.Address{},
+	ChallengeDuration: &big.Int{},
+	AppData:           []byte{},
+	Outcome:           concludeOutcome,
+	TurnNum:           uint64(2),
+	IsFinal:           true,
+}
+
+func TestDepositSimulatedBackendChainService(t *testing.T) {
 	sim, na, naAddress, ethAccounts, err := SetupSimulatedBackend(1)
 	if err != nil {
 		t.Fatal(err)
@@ -36,5 +99,69 @@ func TestSimulatedBackendChainService(t *testing.T) {
 		t.Fatalf("Received event did not match expectation; (-want +got):\n%s", diff)
 	}
 
+	sim.Close()
+}
+
+func TestConcludeSimulatedBackendChainService(t *testing.T) {
+	// Generate Signatures
+	aSig, _ := concludeState.Sign(Actors.Alice.PrivateKey)
+	bSig, _ := concludeState.Sign(Actors.Bob.PrivateKey)
+
+	sim, na, naAddress, ethAccounts, err := SetupSimulatedBackend(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cs := NewSimulatedBackendChainService(sim, na, naAddress, ethAccounts[0])
+	out := cs.SubscribeToEvents(ethAccounts[0].From)
+
+	// Fund channel
+	testDeposit := types.Funds{
+		common.HexToAddress("0x00"): big.NewInt(2),
+	}
+	cId := concludeState.ChannelId()
+
+	depositTx := protocols.NewDepositTransaction(cId, testDeposit)
+	cs.SendTransaction(depositTx)
+	<-out
+
+	signedConcludeState := state.NewSignedState(concludeState)
+	err = signedConcludeState.AddSignature(aSig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = signedConcludeState.AddSignature(bSig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	concludeTx := protocols.NewWithdrawAllTransaction(cId, signedConcludeState)
+	cs.SendTransaction(concludeTx)
+
+	// Check that the recieved event matches the expected event
+	concludedEvent := <-out
+	expectedEvent := ConcludedEvent{CommonEvent: CommonEvent{channelID: cId, BlockNum: 3}}
+	if diff := cmp.Diff(expectedEvent, concludedEvent, cmp.AllowUnexported(CommonEvent{})); diff != "" {
+		t.Fatalf("Received event did not match expectation; (-want +got):\n%s", diff)
+	}
+
+	// Check that the recieved event matches the expected event
+	allocationUpdatedEvent := <-out
+	expectedEvent2 := AllocationUpdatedEvent{CommonEvent: CommonEvent{channelID: cId, BlockNum: 3}, Holdings: types.Funds{}}
+	if diff := cmp.Diff(expectedEvent2, allocationUpdatedEvent, cmp.AllowUnexported(CommonEvent{})); diff != "" {
+		t.Fatalf("Received event did not match expectation; (-want +got):\n%s", diff)
+	}
+
+	// Inspect state of chain (call StatusOf)
+	statusOnChain, err := na.StatusOf(&bind.CallOpts{}, cId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	emptyBytes := [32]byte{}
+	// Make assertion
+	if !bytes.Equal(statusOnChain[:], emptyBytes[:]) {
+		t.Fatalf("Adjudicator not updated as expected, got %v wanted %v", common.Bytes2Hex(statusOnChain[:]), common.Bytes2Hex(emptyBytes[:]))
+	}
+
+	// Not sure if this is necessary
 	sim.Close()
 }

--- a/client/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/client/engine/chainservice/simulated_backend_chainservice_test.go
@@ -23,11 +23,7 @@ func TestSimulatedBackendChainService(t *testing.T) {
 		common.HexToAddress("0x00"): big.NewInt(1),
 	}
 	channelID := types.Destination(common.HexToHash(`4ebd366d014a173765ba1e50f284c179ade31f20441bec41664712aac6cc461d`))
-	testTx := protocols.ChainTransaction{
-		ChannelId: channelID,
-		Deposit:   testDeposit,
-		Type:      protocols.DepositTransactionType,
-	}
+	testTx := protocols.NewDepositTransaction(channelID, testDeposit)
 
 	out := cs.SubscribeToEvents(ethAccounts[0].From)
 	// Submit transactiom

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -336,7 +336,7 @@ func (e *Engine) executeSideEffects(sideEffects protocols.SideEffects) {
 		e.msg.Send(message)
 	}
 	for _, tx := range sideEffects.TransactionsToSubmit {
-		e.logger.Printf("Sending chain transaction for channel %s", tx.ChannelId)
+		e.logger.Printf("Sending chain transaction for channel %s", tx.ChannelId())
 		e.chain.SendTransaction(tx)
 	}
 	for _, proposal := range sideEffects.ProposalsToProcess {

--- a/client_test/directdefund_test.go
+++ b/client_test/directdefund_test.go
@@ -25,11 +25,19 @@ func TestDirectDefund(t *testing.T) {
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
-	chain := chainservice.NewMockChain()
+	// Setup chain service
+	sim, na, naAddress, ethAccounts, err := chainservice.SetupSimulatedBackend(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chainA := chainservice.NewSimulatedBackendChainService(sim, na, naAddress, ethAccounts[0])
+	chainB := chainservice.NewSimulatedBackendChainService(sim, na, naAddress, ethAccounts[1])
+	// End chain service setup
+
 	broker := messageservice.NewBroker()
 
-	clientA, storeA := setupClient(alice.PrivateKey, chain, broker, logDestination, 0)
-	clientB, storeB := setupClient(bob.PrivateKey, chain, broker, logDestination, 0)
+	clientA, storeA := setupClient(alice.PrivateKey, chainA, broker, logDestination, 0)
+	clientB, storeB := setupClient(bob.PrivateKey, chainB, broker, logDestination, 0)
 
 	channelId := directlyFundALedgerChannel(t, clientA, clientB)
 	directlyDefundALedgerChannel(t, clientA, clientB, channelId)

--- a/client_test/directfund_test.go
+++ b/client_test/directfund_test.go
@@ -31,7 +31,7 @@ func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.C
 		AppDefinition:     types.Address{},
 		AppData:           types.Bytes{},
 		ChallengeDuration: big.NewInt(0),
-		Nonce:             rand.Int63(),
+		Nonce:             int64(rand.Int31()),
 	}
 	response := alpha.CreateDirectChannel(request)
 

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -258,10 +258,9 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 	}
 
 	// Withdrawal of funds
-	if !updated.fullyWithdrawn() && !updated.transactionSubmitted {
-
+	if !updated.fullyWithdrawn() {
 		// The first participant in the channel submits the withdrawAll transaction
-		if updated.C.MyIndex == 0 {
+		if updated.C.MyIndex == 0 && !updated.transactionSubmitted {
 			withdrawAll := protocols.NewWithdrawAllTransaction(updated.C.Id, latestSignedState)
 			sideEffects.TransactionsToSubmit = append(sideEffects.TransactionsToSubmit, withdrawAll)
 			updated.transactionSubmitted = true

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -260,7 +260,7 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 
 		// The first participant in the channel submits the withdrawAll transaction
 		if updated.C.MyIndex == 0 {
-			withdrawAll := protocols.ChainTransaction{Type: protocols.WithdrawAllTransactionType, ChannelId: updated.C.Id}
+			withdrawAll := protocols.NewWithdrawAllTransaction(updated.C.Id)
 			sideEffects.TransactionsToSubmit = append(sideEffects.TransactionsToSubmit, withdrawAll)
 			updated.transactionSubmitted = true
 		}

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -260,7 +260,7 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 
 		// The first participant in the channel submits the withdrawAll transaction
 		if updated.C.MyIndex == 0 {
-			withdrawAll := protocols.NewWithdrawAllTransaction(updated.C.Id)
+			withdrawAll := protocols.NewWithdrawAllTransaction(updated.C.Id, latestSignedState)
 			sideEffects.TransactionsToSubmit = append(sideEffects.TransactionsToSubmit, withdrawAll)
 			updated.transactionSubmitted = true
 		}

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -210,6 +210,8 @@ func (o *Objective) UpdateWithChainEvent(event chainservice.Event) (protocols.Ob
 				updated.C.OnChainFunding = e.Holdings.Clone()
 			}
 		}
+	case chainservice.ConcludedEvent:
+		break
 	default:
 		return &updated, fmt.Errorf("objective %+v cannot handle event %+v", updated, event)
 	}

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -183,13 +183,9 @@ func TestCrankAlice(t *testing.T) {
 		t.Fatalf(`WaitingFor: expected %v, got %v`, WaitingForWithdraw, wf)
 	}
 
-	expectedSE = protocols.SideEffects{TransactionsToSubmit: []protocols.ChainTransaction{{
-		Type:      protocols.WithdrawAllTransactionType,
-		ChannelId: o.C.Id,
-		Deposit:   types.Funds{},
-	}}}
+	expectedSE = protocols.SideEffects{TransactionsToSubmit: []protocols.ChainTransaction{protocols.NewWithdrawAllTransaction(o.C.Id)}}
 
-	if diff := cmp.Diff(expectedSE, se); diff != "" {
+	if diff := cmp.Diff(expectedSE, se, cmp.AllowUnexported(expectedSE, protocols.ChainTransactionBase{})); diff != "" {
 		t.Fatalf("Side effects mismatch (-want +got):\n%s", diff)
 	}
 

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -185,7 +185,7 @@ func TestCrankAlice(t *testing.T) {
 
 	expectedSE = protocols.SideEffects{TransactionsToSubmit: []protocols.ChainTransaction{protocols.NewWithdrawAllTransaction(o.C.Id, finalStateSignedByAliceBob)}}
 
-	if diff := cmp.Diff(expectedSE, se, cmp.AllowUnexported(expectedSE, protocols.ChainTransactionBase{})); diff != "" {
+	if diff := cmp.Diff(expectedSE, se, cmp.AllowUnexported(expectedSE, state.SignedState{}, protocols.ChainTransactionBase{})); diff != "" {
 		t.Fatalf("Side effects mismatch (-want +got):\n%s", diff)
 	}
 

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -183,7 +183,7 @@ func TestCrankAlice(t *testing.T) {
 		t.Fatalf(`WaitingFor: expected %v, got %v`, WaitingForWithdraw, wf)
 	}
 
-	expectedSE = protocols.SideEffects{TransactionsToSubmit: []protocols.ChainTransaction{protocols.NewWithdrawAllTransaction(o.C.Id)}}
+	expectedSE = protocols.SideEffects{TransactionsToSubmit: []protocols.ChainTransaction{protocols.NewWithdrawAllTransaction(o.C.Id, finalStateSignedByAliceBob)}}
 
 	if diff := cmp.Diff(expectedSE, se, cmp.AllowUnexported(expectedSE, protocols.ChainTransactionBase{})); diff != "" {
 		t.Fatalf("Side effects mismatch (-want +got):\n%s", diff)

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -299,7 +299,7 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 	}
 
 	if !fundingComplete && safeToDeposit && amountToDeposit.IsNonZero() && !updated.transactionSubmitted {
-		deposit := protocols.ChainTransaction{Type: protocols.DepositTransactionType, ChannelId: updated.C.Id, Deposit: amountToDeposit}
+		deposit := protocols.NewDepositTransaction(updated.C.Id, amountToDeposit)
 		updated.transactionSubmitted = true
 		sideEffects.TransactionsToSubmit = append(sideEffects.TransactionsToSubmit, deposit)
 	}

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -54,7 +54,7 @@ func NewObjective(request ObjectiveRequest, preApprove bool, myAddress types.Add
 
 	objective, err := ConstructFromState(preApprove,
 		state.State{
-			ChainId:           big.NewInt(9001), // TODO https://github.com/statechannels/go-nitro/issues/601
+			ChainId:           big.NewInt(1337), // TODO https://github.com/statechannels/go-nitro/issues/601
 			Participants:      []types.Address{myAddress, request.CounterParty},
 			ChannelNonce:      big.NewInt(request.Nonce),
 			AppDefinition:     request.AppDefinition,
@@ -435,7 +435,7 @@ type ObjectiveResponse struct {
 
 // Response computes and returns the appropriate response from the request.
 func (r ObjectiveRequest) Response(myAddress types.Address) ObjectiveResponse {
-	fixedPart := state.FixedPart{ChainId: big.NewInt(9001), // TODO add this field to the request and pull it from there. https://github.com/statechannels/go-nitro/issues/601
+	fixedPart := state.FixedPart{ChainId: big.NewInt(1337), // TODO add this field to the request and pull it from there. https://github.com/statechannels/go-nitro/issues/601
 		Participants:      []types.Address{myAddress, r.CounterParty},
 		ChannelNonce:      big.NewInt(r.Nonce),
 		ChallengeDuration: r.ChallengeDuration}

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -207,14 +207,10 @@ func TestCrank(t *testing.T) {
 		MessagesToSend: protocols.CreateSignedStateMessages(s.Id(), postFundSS, 0),
 	}
 	expectedFundingSideEffects := protocols.SideEffects{
-		TransactionsToSubmit: []protocols.ChainTransaction{{
-			Type:      protocols.DepositTransactionType,
-			ChannelId: s.C.Id,
-			Deposit: types.Funds{
+		TransactionsToSubmit: []protocols.ChainTransaction{
+			protocols.NewDepositTransaction(s.C.Id, types.Funds{
 				testState.Outcome[0].Asset: testState.Outcome[0].Allocations[0].Amount,
-			},
-		}},
-	}
+			})}}
 	// END test data preparation
 
 	// Assert that cranking an unapproved objective returns an error
@@ -270,7 +266,7 @@ func TestCrank(t *testing.T) {
 		t.Fatalf(`WaitingFor: expected %v, got %v`, WaitingForCompleteFunding, waitingFor)
 	}
 
-	if diff := cmp.Diff(expectedFundingSideEffects, sideEffects); diff != "" {
+	if diff := cmp.Diff(expectedFundingSideEffects, sideEffects, cmp.AllowUnexported(expectedFundingSideEffects, protocols.ChainTransactionBase{})); diff != "" {
 		t.Fatalf("Side effects mismatch (-want +got):\n%s", diff)
 	}
 

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -9,24 +9,39 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-// TransactionType is an enumeration of possible chain transactions
-type TransactionType string
-
-const (
-	DepositTransactionType     TransactionType = "Deposit"
-	WithdrawAllTransactionType TransactionType = "Withdraw"
-)
-
 var (
 	ErrNotApproved = errors.New("objective not approved")
 )
 
-// ChainTransaction is an object to be sent to a blockchain provider.
-type ChainTransaction struct {
-	// TODO support other transaction types (deposit, challenge, respond, conclude)
-	Type      TransactionType
-	ChannelId types.Destination
-	Deposit   types.Funds
+// ChainTransaction defines the interface that every transaction must implement
+type ChainTransaction interface {
+	ChannelId() types.Destination
+}
+
+// ChainTransactionBase is a convenience struct that is embedded in other transaction structs. It is exported only to allow cmp.Diff to compare transactions
+type ChainTransactionBase struct {
+	channelId types.Destination
+}
+
+func (cct ChainTransactionBase) ChannelId() types.Destination {
+	return cct.channelId
+}
+
+type DepositTransaction struct {
+	ChainTransaction
+	Deposit types.Funds
+}
+
+func NewDepositTransaction(channelId types.Destination, deposit types.Funds) DepositTransaction {
+	return DepositTransaction{ChainTransaction: ChainTransactionBase{channelId: channelId}, Deposit: deposit}
+}
+
+type WithdrawAllTransaction struct {
+	ChainTransaction
+}
+
+func NewWithdrawAllTransaction(channelId types.Destination) WithdrawAllTransaction {
+	return WithdrawAllTransaction{ChainTransaction: ChainTransactionBase{channelId: channelId}}
 }
 
 // SideEffects are effects to be executed by an imperative shell

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -38,10 +38,11 @@ func NewDepositTransaction(channelId types.Destination, deposit types.Funds) Dep
 
 type WithdrawAllTransaction struct {
 	ChainTransaction
+	SignedState state.SignedState
 }
 
-func NewWithdrawAllTransaction(channelId types.Destination) WithdrawAllTransaction {
-	return WithdrawAllTransaction{ChainTransaction: ChainTransactionBase{channelId: channelId}}
+func NewWithdrawAllTransaction(channelId types.Destination, signedState state.SignedState) WithdrawAllTransaction {
+	return WithdrawAllTransaction{SignedState: signedState, ChainTransaction: ChainTransactionBase{channelId: channelId}}
 }
 
 // SideEffects are effects to be executed by an imperative shell


### PR DESCRIPTION
The primary goal of this PR is to use the EthChainService instead of the MockChain in the `TestDirectDefund` client test. To accomplish that:
- Conclude transaction is added to the EthChainService.
- Concluded and AllocationUpdated events are added to the EthChainService.
- A test is added for the above logic.
- ChannelNonce and wait-for-withdrawal bug fixes are implemented.