### PR TITLE
Fix GitHub CI `npm install` by using --legacy-peer-deps

### DIFF
--- a/.github/workflows/bindings-check.yml
+++ b/.github/workflows/bindings-check.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd ./nitro-protocol
-          npm install
+          npm ci --legacy-peer-deps
 
       - name: make bin folder
         run: |

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
       - name: Install dependencies
-        run: npm install
+        run: npm ci --legacy-peer-deps
       - name: Compile contracts
         run: npx hardhat compile
       - name: Run eslint (including prettier)


### PR DESCRIPTION
#676 introduces a GitHub Actions issue related to peer-deps:

``` bash
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: @nomiclabs/hardhat-waffle@2.0.3
npm ERR! Found: @nomiclabs/hardhat-ethers@0.3.0-beta.13
npm ERR! node_modules/@nomiclabs/hardhat-ethers
npm ERR!   dev @nomiclabs/hardhat-ethers@"npm:hardhat-deploy-ethers@^0.3.0-beta.13" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @nomiclabs/hardhat-ethers@"^2.0.0" from @nomiclabs/hardhat-waffle@2.0.3
npm ERR! node_modules/@nomiclabs/hardhat-waffle
npm ERR!   dev @nomiclabs/hardhat-waffle@"^2.0.2" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: @nomiclabs/hardhat-ethers@2.0.[6](https://github.com/statechannels/go-nitro/runs/6967242499?check_suite_focus=true#step:4:7)
npm ERR! node_modules/@nomiclabs/hardhat-ethers
npm ERR!   peer @nomiclabs/hardhat-ethers@"^2.0.0" from @nomiclabs/hardhat-waffle@2.0.3
npm ERR!   node_modules/@nomiclabs/hardhat-waffle
npm ERR!     dev @nomiclabs/hardhat-waffle@"^2.0.2" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /home/runner/.npm/eresolve-report.txt for a full report.
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2022-06-20T12_54_01_03[8](https://github.com/statechannels/go-nitro/runs/6967242499?check_suite_focus=true#step:4:9)Z-debug-0.log
```

This issue is caused by an [npm-alias created for `@nomiclabs/hardhat-ethers` hiding `hardhat-deploy-ethers`.](https://github.com/statechannels/go-nitro/blob/main/nitro-protocol/package.json#L23)

As of time of creating this PR, there seems to be [no general solution to this issue](https://github.com/wighawag/hardhat-deploy-ethers/issues/13).

Thus, it was decided to bypass the problem by using `--legacy-peer-deps` flag (good post about it [here](https://stackoverflow.com/questions/66239691/what-does-npm-install-legacy-peer-deps-do-exactly-when-is-it-recommended-wh)).

Also `npm ci` is used instead of `npm i` to make a clean install of dependencies (copied from `npm help ci`):
> In short, the main differences between using npm install and npm ci are:
>
>       • The project must have an existing package-lock.json or npm-shrinkwrap.json.
>
>       • If dependencies in the package lock do not match those in package.json, npm ci will exit with an error, instead of updating the package lock.
>
>       • npm ci can only install entire projects at a time: individual dependencies cannot be added with this command.
>
>       • If a node_modules is already present, it will be automatically removed before npm ci begins its install.

Nevertheless, `--legacy-peer-deps` is not a cure and an issue to fix peer-deps and return to pure `npm ci` is to be created.