### PR TITLE
Prevent directdefund on active ledger channels

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -217,6 +217,11 @@ func (c *ConsensusChannel) Follower() common.Address {
 	return c.fp.Participants[Follower]
 }
 
+// FundeingTargets returns a list of channels funded by the ConsensusChannel
+func (c *ConsensusChannel) FundingTargets() []types.Destination {
+	return c.current.Outcome.fundingTargets()
+}
+
 func (c *ConsensusChannel) Accept(p SignedProposal) error {
 	panic("UNIMPLEMENTED")
 }
@@ -499,6 +504,17 @@ func (o *LedgerOutcome) AsOutcome() outcome.Exit {
 			Allocations: allocations,
 		},
 	}
+}
+
+// fundingTargets returns a list of channels funded by the LedgerOutcome
+func (o *LedgerOutcome) fundingTargets() []types.Destination {
+	targets := []types.Destination{}
+
+	for dest := range o.guarantees {
+		targets = append(targets, dest)
+	}
+
+	return targets
 }
 
 // Vars stores the turn number and outcome for a state in a consensus channel.

--- a/client/client.go
+++ b/client/client.go
@@ -59,7 +59,7 @@ func (c *Client) handleEngineEvents() {
 
 		}
 
-		for _, erred := range update.ErredObjectives {
+		for _, erred := range update.FailedObjectives {
 			c.failedObjectives <- erred
 		}
 

--- a/client/client.go
+++ b/client/client.go
@@ -22,6 +22,7 @@ type Client struct {
 	engine              engine.Engine // The core business logic of the client
 	Address             *types.Address
 	completedObjectives chan protocols.ObjectiveId
+	failedObjectives    chan protocols.ObjectiveId
 }
 
 // New is the constructor for a Client. It accepts a messaging service, a chain service, and a store as injected dependencies.
@@ -35,6 +36,7 @@ func New(messageService messageservice.MessageService, chainservice chainservice
 
 	c.engine = engine.New(messageService, chainservice, store, logDestination, policymaker, metricsApi)
 	c.completedObjectives = make(chan protocols.ObjectiveId, 100)
+	c.failedObjectives = make(chan protocols.ObjectiveId, 100)
 
 	// Start the engine in a go routine
 	go c.engine.Run()
@@ -57,6 +59,10 @@ func (c *Client) handleEngineEvents() {
 
 		}
 
+		for _, erred := range update.ErredObjectives {
+			c.failedObjectives <- erred
+		}
+
 	}
 }
 
@@ -65,6 +71,11 @@ func (c *Client) handleEngineEvents() {
 // CompletedObjectives returns a chan that receives a objective id whenever that objective is completed
 func (c *Client) CompletedObjectives() <-chan protocols.ObjectiveId {
 	return c.completedObjectives
+}
+
+// FailedObjectives returns a chan that receives a objective id whenever that objective has failed
+func (c *Client) FailedObjectives() <-chan protocols.ObjectiveId {
+	return c.failedObjectives
 }
 
 // CreateVirtualChannel creates a virtual channel with the counterParty using ledger channels with the intermediary.

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -61,7 +61,7 @@ type ObjectiveChangeEvent struct {
 	// These are objectives that are now completed
 	CompletedObjectives []protocols.Objective
 	// These are objectives that have failed
-	ErredObjectives []protocols.ObjectiveId
+	FailedObjectives []protocols.ObjectiveId
 }
 
 type CompletedObjectiveEvent struct {
@@ -339,7 +339,7 @@ func (e *Engine) handleAPIEvent(apiEvent APIEvent) (ObjectiveChangeEvent, error)
 			e.metrics.RecordObjectiveStarted(request.Id(*e.store.GetAddress()))
 			ddfo, err := directdefund.NewObjective(request, true, e.store.GetConsensusChannelById)
 			if err != nil {
-				return ObjectiveChangeEvent{ErredObjectives: []protocols.ObjectiveId{request.Id(e.metrics.me)}}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
+				return ObjectiveChangeEvent{FailedObjectives: []protocols.ObjectiveId{request.Id(e.metrics.me)}}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 			}
 			// If ddfo creation was successful, destroy the consensus channel to prevent it being used (a Channel will now take over governance)
 			e.store.DestroyConsensusChannel(request.ChannelId)

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -339,7 +339,7 @@ func (e *Engine) handleAPIEvent(apiEvent APIEvent) (ObjectiveChangeEvent, error)
 			e.metrics.RecordObjectiveStarted(request.Id(*e.store.GetAddress()))
 			ddfo, err := directdefund.NewObjective(request, true, e.store.GetConsensusChannelById)
 			if err != nil {
-				return ObjectiveChangeEvent{FailedObjectives: []protocols.ObjectiveId{request.Id(e.metrics.me)}}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
+				return ObjectiveChangeEvent{FailedObjectives: []protocols.ObjectiveId{request.Id(*e.store.GetAddress())}}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 			}
 			// If ddfo creation was successful, destroy the consensus channel to prevent it being used (a Channel will now take over governance)
 			e.store.DestroyConsensusChannel(request.ChannelId)

--- a/client_test/directdefund_test.go
+++ b/client_test/directdefund_test.go
@@ -2,12 +2,18 @@
 package client_test // import "github.com/statechannels/go-nitro/client_test"
 
 import (
+	"math/big"
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	"github.com/statechannels/go-nitro/client/engine/store"
+	"github.com/statechannels/go-nitro/internal/testdata"
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -26,41 +32,80 @@ func TestDirectDefund(t *testing.T) {
 	logDestination := newLogWriter(logFile)
 
 	// Setup chain service
-	sim, na, naAddress, ethAccounts, err := chainservice.SetupSimulatedBackend(2)
+	sim, na, naAddress, ethAccounts, err := chainservice.SetupSimulatedBackend(3)
 	if err != nil {
 		t.Fatal(err)
 	}
 	chainA := chainservice.NewSimulatedBackendChainService(sim, na, naAddress, ethAccounts[0])
-	chainB := chainservice.NewSimulatedBackendChainService(sim, na, naAddress, ethAccounts[1])
+	chainI := chainservice.NewSimulatedBackendChainService(sim, na, naAddress, ethAccounts[1])
+	chainB := chainservice.NewSimulatedBackendChainService(sim, na, naAddress, ethAccounts[2])
 	// End chain service setup
 
 	broker := messageservice.NewBroker()
 
+	// Client setup
 	clientA, storeA := setupClient(alice.PrivateKey, chainA, broker, logDestination, 0)
+	clientI, _ := setupClient(irene.PrivateKey, chainI, broker, logDestination, 0)
 	clientB, storeB := setupClient(bob.PrivateKey, chainB, broker, logDestination, 0)
+	// End Client setup
 
-	channelId := directlyFundALedgerChannel(t, clientA, clientB)
-	directlyDefundALedgerChannel(t, clientA, clientB, channelId)
+	// test successful condition for setup / teadown of unused ledger channel
+	{
+		channelId := directlyFundALedgerChannel(t, clientA, clientB)
+		directlyDefundALedgerChannel(t, clientA, clientB, channelId)
 
-	// Ensure that we no longer have a consensus channel in the store
-	// And that we have a regular Channel instead
-	for _, clientStore := range []store.Store{storeA, storeB} {
+		// Ensure that we no longer have a consensus channel in the store
+		// And that we have a regular Channel instead
+		for _, clientStore := range []store.Store{storeA, storeB} {
 
-		// Ensure that we have a regular channel in the store
-		// And that we no longer have a consensus channel in the store
-		c, channelInStore := clientStore.GetChannelById(channelId)
-		_, err := clientStore.GetConsensusChannelById(channelId)
-		if !channelInStore {
-			t.Fatalf("expected a Channel to have been created")
+			// Ensure that we have a regular channel in the store
+			// And that we no longer have a consensus channel in the store
+			c, channelInStore := clientStore.GetChannelById(channelId)
+			_, err := clientStore.GetConsensusChannelById(channelId)
+			if !channelInStore {
+				t.Fatalf("expected a Channel to have been created")
+			}
+			if consensusChannelStillInStore := (err == nil); consensusChannelStillInStore {
+				t.Fatalf("Expected ConsensusChannel to have been destroyed in %v's store, but it was not", clientStore.GetAddress())
+			}
+
+			if c.OnChainFunding.IsNonZero() {
+				t.Fatal("Expected zero on chain funding, but got nonzero")
+			}
+
 		}
-		if consensusChannelStillInStore := (err == nil); consensusChannelStillInStore {
-			t.Fatalf("Expected ConsensusChannel to have been destroyed in %v's store, but it was not", clientStore.GetAddress())
-		}
+	}
 
-		if c.OnChainFunding.IsNonZero() {
-			t.Fatal("Expected zero on chain funding, but got nonzero")
+	// test failure of teardown of a ledger channel currently funding a virtual channel
+	{
+		ddfoTarget := directlyFundALedgerChannel(t, clientA, clientI)
+		directlyFundALedgerChannel(t, clientI, clientB)
+
+		// create & virtual channel between A and B through I
+		outcome := testdata.Outcomes.Create(alice.Address(), bob.Address(), 1, 1)
+		request := virtualfund.ObjectiveRequest{
+			CounterParty:      bob.Address(),
+			Intermediary:      irene.Address(),
+			Outcome:           outcome,
+			AppDefinition:     types.Address{},
+			AppData:           types.Bytes{},
+			ChallengeDuration: big.NewInt(0),
+			Nonce:             rand.Int63(),
+		}
+		response := clientA.CreateVirtualChannel(request)
+
+		waitTimeForCompletedObjectiveIds(t, &clientA, defaultTimeout, response.Id)
+
+		clientA.CloseDirectChannel(ddfoTarget)
+
+		select {
+		case <-time.After(time.Second * 10):
+			t.Fatalf("expected ddfo on active ledger channel to fail, but no failures occurred within 10 seconds")
+		case rejected := <-clientA.FailedObjectives():
+			if rejected != protocols.ObjectiveId("DirectDefunding-"+ddfoTarget.String()) {
+				t.Errorf("expected ddfo on active ledger channel to fail, but it didn't")
+			}
 		}
 
 	}
-
 }

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -26,6 +26,7 @@ const ObjectivePrefix = "DirectDefunding-"
 var (
 	ErrChannelUpdateInProgress = errors.New("can only defund a channel when the latest state is supported or when the channel has a final state")
 	ErrNoFinalState            = errors.New("cannot spawn direct defund objective without a final state")
+	ErrNotEmpty                = errors.New("ledger channel has running guarantees")
 )
 
 // Objective is a cache of data computed by reading from the store. It stores (potentially) infinite data
@@ -73,7 +74,7 @@ func NewObjective(
 	}
 
 	if len(cc.FundingTargets()) != 0 {
-		return Objective{}, fmt.Errorf("ledger channel has running guarantees")
+		return Objective{}, ErrNotEmpty
 	}
 
 	c, err := CreateChannelFromConsensusChannel(*cc)

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -72,6 +72,10 @@ func NewObjective(
 		return Objective{}, fmt.Errorf("could not find channel %s; %w", request.ChannelId, err)
 	}
 
+	if len(cc.FundingTargets()) != 0 {
+		return Objective{}, fmt.Errorf("ledger channel has running guarantees")
+	}
+
 	c, err := CreateChannelFromConsensusChannel(*cc)
 	if err != nil {
 		return Objective{}, fmt.Errorf("could not create Channel from ConsensusChannel; %w", err)


### PR DESCRIPTION
Closes #762, in the direction of "disallow". This seems preferable because it makes for a better ratio of `[offchain work] / [onchain work]` for the protocol at large.

**Changes**

PR adds:
- [a simple check](https://github.com/statechannels/go-nitro/blob/2ca592a3053a326eb3956e34b0a58d6750179364/protocols/directdefund/directdefund.go#L76) on the consensus channel targeted by a `directdefund` objective.
- a pipeline for communication of failed objectives from the engine to the client

**How Has This Been Tested?** [Optional]

A test has been added to `client_test`, which
- sets up a ledger channel
- funds a virtual channel
- attempts to close the ledger channel
- asserts on the returned objective failure

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [x] I have assigned this PR to the appropriate GitHub Milestone
