### PR TITLE
EthChainService approves erc20 transfers

### DIFF
--- a/client/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/client/engine/chainservice/simulated_backend_chainservice_test.go
@@ -60,7 +60,6 @@ func TestDepositSimulatedBackendChainService(t *testing.T) {
 
 	cs := NewSimulatedBackendChainService(sim, bindings.Adjudicator.Contract, bindings.Adjudicator.Address, ethAccounts[0])
 
-	_, err = bindings.Token.Contract.Approve(ethAccounts[0], bindings.Adjudicator.Address, one)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Addresses https://github.com/statechannels/go-nitro/pull/763#issuecomment-1171376545.

Prior to this PR, EthChainService assumed that for, any erc20 token deposit, tokens have already been approved for transfer. This PR adds the token approval logic to the EthChainService so that a finegrain token transfer is approved immediately prior to the nitro deposit transaction.