### PR TITLE
Clean up chainservice events

### DIFF
--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -34,9 +34,8 @@ type asset struct {
 // DepositedEvent is an internal representation of the deposited blockchain event
 type DepositedEvent struct {
 	CommonEvent
-	Asset           common.Address
-	AmountDeposited *big.Int
-	NowHeld         *big.Int
+	asset
+	NowHeld *big.Int
 }
 
 // AllocationUpdated is an internal representation of the AllocatonUpdated blockchain event
@@ -49,6 +48,10 @@ type AllocationUpdatedEvent struct {
 // ConcludedEvent is an internal representation of the Concluded blockchain event
 type ConcludedEvent struct {
 	CommonEvent
+}
+
+func NewDepositedEvent(channelId types.Destination, blockNum uint64, assetAddress common.Address, assetAmount *big.Int, nowHeld *big.Int) DepositedEvent {
+	return DepositedEvent{CommonEvent{channelId, blockNum}, asset{AssetAddress: assetAddress, AssetAmount: assetAmount}, nowHeld}
 }
 
 func NewAllocationUpdatedEvent(channelId types.Destination, blockNum uint64, assetAddress common.Address, assetAmount *big.Int) AllocationUpdatedEvent {

--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -16,13 +16,13 @@ type Event interface {
 	ChannelID() types.Destination
 }
 
-// CommonEvent declares fields shared by all chain events
-type CommonEvent struct {
+// commonEvent declares fields shared by all chain events
+type commonEvent struct {
 	channelID types.Destination
 	BlockNum  uint64
 }
 
-func (ce CommonEvent) ChannelID() types.Destination {
+func (ce commonEvent) ChannelID() types.Destination {
 	return ce.channelID
 }
 
@@ -33,7 +33,7 @@ type asset struct {
 
 // DepositedEvent is an internal representation of the deposited blockchain event
 type DepositedEvent struct {
-	CommonEvent
+	commonEvent
 	asset
 	NowHeld *big.Int
 }
@@ -41,21 +41,21 @@ type DepositedEvent struct {
 // AllocationUpdated is an internal representation of the AllocatonUpdated blockchain event
 // The event includes the token address and amount at the block that generated the event
 type AllocationUpdatedEvent struct {
-	CommonEvent
+	commonEvent
 	asset
 }
 
 // ConcludedEvent is an internal representation of the Concluded blockchain event
 type ConcludedEvent struct {
-	CommonEvent
+	commonEvent
 }
 
 func NewDepositedEvent(channelId types.Destination, blockNum uint64, assetAddress common.Address, assetAmount *big.Int, nowHeld *big.Int) DepositedEvent {
-	return DepositedEvent{CommonEvent{channelId, blockNum}, asset{AssetAddress: assetAddress, AssetAmount: assetAmount}, nowHeld}
+	return DepositedEvent{commonEvent{channelId, blockNum}, asset{AssetAddress: assetAddress, AssetAmount: assetAmount}, nowHeld}
 }
 
 func NewAllocationUpdatedEvent(channelId types.Destination, blockNum uint64, assetAddress common.Address, assetAmount *big.Int) AllocationUpdatedEvent {
-	return AllocationUpdatedEvent{CommonEvent{channelId, blockNum}, asset{AssetAddress: assetAddress, AssetAmount: assetAmount}}
+	return AllocationUpdatedEvent{commonEvent{channelId, blockNum}, asset{AssetAddress: assetAddress, AssetAmount: assetAmount}}
 }
 
 // todo implement other event types

--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -26,6 +26,11 @@ func (ce CommonEvent) ChannelID() types.Destination {
 	return ce.channelID
 }
 
+type asset struct {
+	AssetAddress common.Address
+	AssetAmount  *big.Int
+}
+
 // DepositedEvent is an internal representation of the deposited blockchain event
 type DepositedEvent struct {
 	CommonEvent
@@ -38,13 +43,16 @@ type DepositedEvent struct {
 // The event includes the token address and amount at the block that generated the event
 type AllocationUpdatedEvent struct {
 	CommonEvent
-	AssetAddress common.Address
-	AssetAmount  *big.Int
+	asset
 }
 
 // ConcludedEvent is an internal representation of the Concluded blockchain event
 type ConcludedEvent struct {
 	CommonEvent
+}
+
+func NewAllocationUpdatedEvent(channelId types.Destination, blockNum uint64, assetAddress common.Address, assetAmount *big.Int) AllocationUpdatedEvent {
+	return AllocationUpdatedEvent{CommonEvent{channelId, blockNum}, asset{AssetAddress: assetAddress, AssetAmount: assetAmount}}
 }
 
 // todo implement other event types

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -154,7 +154,7 @@ func (ecs *EthChainService) listenForLogEvents() {
 				if err != nil {
 					panic(err)
 				}
-				event := AllocationUpdatedEvent{CommonEvent: CommonEvent{channelID: au.ChannelId, BlockNum: chainEvent.BlockNumber}, AssetAddress: assetAddress, AssetAmount: amount}
+				event := NewAllocationUpdatedEvent(au.ChannelId, chainEvent.BlockNumber, assetAddress, amount)
 				ecs.broadcast(event)
 			case concludedTopic:
 				ce, err := ecs.na.ParseConcluded(chainEvent)

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -129,15 +129,7 @@ func (ecs *EthChainService) listenForLogEvents() {
 					log.Fatal(err)
 				}
 
-				event := DepositedEvent{
-					CommonEvent: CommonEvent{
-						channelID: nad.Destination,
-						BlockNum:  chainEvent.BlockNumber,
-					},
-					Asset:           nad.Asset,
-					AmountDeposited: nad.AmountDeposited,
-					NowHeld:         nad.DestinationHoldings,
-				}
+				event := NewDepositedEvent(nad.Destination, chainEvent.BlockNumber, nad.Asset, nad.AmountDeposited, nad.DestinationHoldings)
 				ecs.broadcast(event)
 			case allocationUpdatedTopic:
 				au, err := ecs.na.ParseAllocationUpdated(chainEvent)

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -154,7 +154,7 @@ func (ecs *EthChainService) listenForLogEvents() {
 					panic(err)
 				}
 
-				event := ConcludedEvent{CommonEvent: CommonEvent{channelID: ce.ChannelId, BlockNum: chainEvent.BlockNumber}}
+				event := ConcludedEvent{commonEvent: commonEvent{channelID: ce.ChannelId, BlockNum: chainEvent.BlockNumber}}
 				ecs.broadcast(event)
 			default:
 				panic("Unknown chain event")

--- a/client/engine/chainservice/mockchain.go
+++ b/client/engine/chainservice/mockchain.go
@@ -60,13 +60,7 @@ func (mc *MockChain) SendTransaction(tx protocols.ChainTransaction) {
 		}
 	case protocols.WithdrawAllTransaction:
 		for assetAddress := range mc.holdings[tx.ChannelId()] {
-			event := AllocationUpdatedEvent{
-				CommonEvent: CommonEvent{
-					channelID: tx.ChannelId(),
-					BlockNum:  *mc.blockNum},
-				AssetAddress: assetAddress,
-				AssetAmount:  common.Big0,
-			}
+			event := NewAllocationUpdatedEvent(tx.ChannelId(), *mc.blockNum, assetAddress, common.Big0)
 			mc.broadcast(event)
 		}
 		mc.holdings[tx.ChannelId()] = types.Funds{}

--- a/client/engine/chainservice/mockchain.go
+++ b/client/engine/chainservice/mockchain.go
@@ -48,14 +48,7 @@ func (mc *MockChain) SendTransaction(tx protocols.ChainTransaction) {
 			mc.holdings[tx.ChannelId()] = mc.holdings[tx.ChannelId()].Add(tx.Deposit)
 		}
 		for address, amount := range tx.Deposit {
-			event := DepositedEvent{
-				CommonEvent: CommonEvent{
-					channelID: tx.ChannelId(),
-					BlockNum:  *mc.blockNum},
-				Asset:           address,
-				AmountDeposited: amount,
-				NowHeld:         mc.holdings[tx.ChannelId()][address],
-			}
+			event := NewDepositedEvent(tx.ChannelId(), *mc.blockNum, address, amount, mc.holdings[tx.ChannelId()][address])
 			mc.broadcast(event)
 		}
 	case protocols.WithdrawAllTransaction:

--- a/client/engine/chainservice/mockchain_test.go
+++ b/client/engine/chainservice/mockchain_test.go
@@ -67,7 +67,7 @@ func checkReceivedEventIsValid(t *testing.T, receivedEvent Event, holdings types
 	}
 
 	depositEvent := receivedEvent.(DepositedEvent)
-	if depositEvent.NowHeld.Cmp(holdings[depositEvent.Asset]) != 0 {
-		t.Fatalf(`holdings mismatch: expected %v but got %v`, holdings[depositEvent.Asset], depositEvent.NowHeld)
+	if depositEvent.NowHeld.Cmp(holdings[depositEvent.AssetAddress]) != 0 {
+		t.Fatalf(`holdings mismatch: expected %v but got %v`, holdings[depositEvent.AssetAddress], depositEvent.NowHeld)
 	}
 }

--- a/client/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/client/engine/chainservice/simulated_backend_chainservice_test.go
@@ -80,11 +80,11 @@ func TestDepositSimulatedBackendChainService(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		receivedEvent := <-out
 		dEvent := receivedEvent.(DepositedEvent)
-		expectedEvent := DepositedEvent{CommonEvent: CommonEvent{channelID: channelID, BlockNum: 2}, Asset: dEvent.Asset, NowHeld: testDeposit[dEvent.Asset], AmountDeposited: testDeposit[dEvent.Asset]}
-		if diff := cmp.Diff(expectedEvent, dEvent, cmp.AllowUnexported(CommonEvent{}, big.Int{})); diff != "" {
+		expectedEvent := NewDepositedEvent(channelID, 2, dEvent.AssetAddress, testDeposit[dEvent.AssetAddress], testDeposit[dEvent.AssetAddress])
+		if diff := cmp.Diff(expectedEvent, dEvent, cmp.AllowUnexported(DepositedEvent{}, CommonEvent{}, big.Int{})); diff != "" {
 			t.Fatalf("Received event did not match expectation; (-want +got):\n%s", diff)
 		}
-		delete(testDeposit, dEvent.Asset)
+		delete(testDeposit, dEvent.AssetAddress)
 	}
 
 	if len(testDeposit) != 0 {

--- a/client/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/client/engine/chainservice/simulated_backend_chainservice_test.go
@@ -137,12 +137,9 @@ func TestConcludeSimulatedBackendChainService(t *testing.T) {
 
 	// Check that the recieved event matches the expected event
 	allocationUpdatedEvent := <-out
-	expectedEvent2 := AllocationUpdatedEvent{
-		CommonEvent:  CommonEvent{channelID: cId, BlockNum: 3},
-		AssetAddress: common.Address{},
-		AssetAmount:  new(big.Int).SetInt64(1)}
+	expectedEvent2 := NewAllocationUpdatedEvent(cId, 3, common.Address{}, new(big.Int).SetInt64(1))
 
-	if diff := cmp.Diff(expectedEvent2, allocationUpdatedEvent, cmp.AllowUnexported(CommonEvent{}, big.Int{})); diff != "" {
+	if diff := cmp.Diff(expectedEvent2, allocationUpdatedEvent, cmp.AllowUnexported(AllocationUpdatedEvent{}, CommonEvent{}, big.Int{})); diff != "" {
 		t.Fatalf("Received event did not match expectation; (-want +got):\n%s", diff)
 	}
 

--- a/client/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/client/engine/chainservice/simulated_backend_chainservice_test.go
@@ -81,7 +81,7 @@ func TestDepositSimulatedBackendChainService(t *testing.T) {
 		receivedEvent := <-out
 		dEvent := receivedEvent.(DepositedEvent)
 		expectedEvent := NewDepositedEvent(channelID, 2, dEvent.AssetAddress, testDeposit[dEvent.AssetAddress], testDeposit[dEvent.AssetAddress])
-		if diff := cmp.Diff(expectedEvent, dEvent, cmp.AllowUnexported(DepositedEvent{}, CommonEvent{}, big.Int{})); diff != "" {
+		if diff := cmp.Diff(expectedEvent, dEvent, cmp.AllowUnexported(DepositedEvent{}, commonEvent{}, big.Int{})); diff != "" {
 			t.Fatalf("Received event did not match expectation; (-want +got):\n%s", diff)
 		}
 		delete(testDeposit, dEvent.AssetAddress)
@@ -130,8 +130,8 @@ func TestConcludeSimulatedBackendChainService(t *testing.T) {
 
 	// Check that the recieved event matches the expected event
 	concludedEvent := <-out
-	expectedEvent := ConcludedEvent{CommonEvent: CommonEvent{channelID: cId, BlockNum: 3}}
-	if diff := cmp.Diff(expectedEvent, concludedEvent, cmp.AllowUnexported(CommonEvent{})); diff != "" {
+	expectedEvent := ConcludedEvent{commonEvent: commonEvent{channelID: cId, BlockNum: 3}}
+	if diff := cmp.Diff(expectedEvent, concludedEvent, cmp.AllowUnexported(ConcludedEvent{}, commonEvent{})); diff != "" {
 		t.Fatalf("Received event did not match expectation; (-want +got):\n%s", diff)
 	}
 
@@ -139,7 +139,7 @@ func TestConcludeSimulatedBackendChainService(t *testing.T) {
 	allocationUpdatedEvent := <-out
 	expectedEvent2 := NewAllocationUpdatedEvent(cId, 3, common.Address{}, new(big.Int).SetInt64(1))
 
-	if diff := cmp.Diff(expectedEvent2, allocationUpdatedEvent, cmp.AllowUnexported(AllocationUpdatedEvent{}, CommonEvent{}, big.Int{})); diff != "" {
+	if diff := cmp.Diff(expectedEvent2, allocationUpdatedEvent, cmp.AllowUnexported(AllocationUpdatedEvent{}, commonEvent{}, big.Int{})); diff != "" {
 		t.Fatalf("Received event did not match expectation; (-want +got):\n%s", diff)
 	}
 

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -270,7 +270,7 @@ func TestCrankBob(t *testing.T) {
 	}
 
 	// The third crank. Bob is expected to enter the terminal state of the defunding protocol.
-	updated, err = updated.(*Objective).UpdateWithChainEvent(chainservice.AllocationUpdatedEvent{AssetAddress: types.Address{}, AssetAmount: common.Big0})
+	updated, err = updated.(*Objective).UpdateWithChainEvent(chainservice.NewAllocationUpdatedEvent(types.Destination{}, 0, common.Address{}, common.Big0))
 
 	if err != nil {
 		t.Error(err)

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -255,7 +255,7 @@ func (o *Objective) UpdateWithChainEvent(event chainservice.Event) (protocols.Ob
 		return &updated, fmt.Errorf("objective %+v cannot handle event %+v", updated, event)
 	}
 	if de.BlockNum > updated.latestBlockNumber {
-		updated.C.OnChainFunding[de.Asset] = de.NowHeld
+		updated.C.OnChainFunding[de.AssetAddress] = de.NowHeld
 		updated.latestBlockNumber = de.BlockNum
 	}
 

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -150,7 +150,7 @@ func TestUpdate(t *testing.T) {
 		common.Address{}: big.NewInt(3),
 	}
 	highBlockNum := uint64(200)
-	updatedObjective, err = s.UpdateWithChainEvent(chainservice.DepositedEvent{Asset: common.Address{}, NowHeld: big.NewInt(3), CommonEvent: chainservice.CommonEvent{BlockNum: highBlockNum}})
+	updatedObjective, err = s.UpdateWithChainEvent(chainservice.NewDepositedEvent(types.Destination{}, highBlockNum, common.Address{}, big.NewInt(3), big.NewInt(3)))
 	if err != nil {
 		t.Error(err)
 	}
@@ -167,7 +167,7 @@ func TestUpdate(t *testing.T) {
 	staleFunding[common.Address{}] = big.NewInt(2)
 	lowBlockNum := uint64(100)
 
-	updatedObjective, _ = updated.UpdateWithChainEvent(chainservice.DepositedEvent{Asset: common.Address{}, NowHeld: big.NewInt(2), CommonEvent: chainservice.CommonEvent{BlockNum: uint64(lowBlockNum)}})
+	updatedObjective, _ = updated.UpdateWithChainEvent(chainservice.NewDepositedEvent(types.Destination{}, uint64(lowBlockNum), common.Address{}, big.NewInt(2), big.NewInt(2)))
 
 	updated = updatedObjective.(*Objective)
 


### PR DESCRIPTION
This PR introduces:
- `asset` struct for the address + amount field pair.
- Uses the struct in Deposited and AllocationUpdated events.
- Converts a public `CommonEvent` to a private `commonEvent` 