### PR TITLE
Do not hardcode Ethereum transaction gas price

### DIFF
--- a/client/engine/chainservice/adjudicator/challenge_test.go
+++ b/client/engine/chainservice/adjudicator/challenge_test.go
@@ -75,7 +75,6 @@ func TestChallenge(t *testing.T) {
 	// Setup transacting EOA
 	key, _ := crypto.GenerateKey()
 	auth, _ := bind.NewKeyedTransactorWithChainID(key, big.NewInt(1337)) // 1337 according to godoc on backends.NewSimulatedBackend
-	auth.GasPrice = big.NewInt(10000000000)
 	address := auth.From
 	balance := new(big.Int)
 	balance.SetString("10000000000000000000", 10) // 10 eth in wei

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -3,7 +3,6 @@ package chainservice
 import (
 	"context"
 	"log"
-	"math/big"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -51,10 +50,9 @@ func NewEthChainService(chain ethChain, na *NitroAdjudicator.NitroAdjudicator, n
 // defaultTxOpts returns transaction options suitable for most transaction submissions
 func (ecs *EthChainService) defaultTxOpts() *bind.TransactOpts {
 	return &bind.TransactOpts{
-		From:     ecs.txSigner.From,
-		Nonce:    ecs.txSigner.Nonce,
-		Signer:   ecs.txSigner.Signer,
-		GasPrice: big.NewInt(10000000000),
+		From:   ecs.txSigner.From,
+		Nonce:  ecs.txSigner.Nonce,
+		Signer: ecs.txSigner.Signer,
 	}
 }
 


### PR DESCRIPTION
`GasPrice` value was originally added to the code base in an attempt to help debug failing transactions. It is unclear whether it helped debugging efforts. 