### PR TITLE
Remove panics from ChainService

### DIFF
--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -73,7 +73,7 @@ type ChainService interface {
 	// SubscribeToEvents creates and returs a subscription channel.
 	SubscribeToEvents(types.Address) <-chan Event
 	// SendTransaction is for sending transactions with the chain service
-	SendTransaction(protocols.ChainTransaction)
+	SendTransaction(protocols.ChainTransaction) error
 	// GetConsensusAppAddress returns the address of a deployed ConsensusApp (for ledger channels)
 	GetConsensusAppAddress() types.Address
 }

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -73,21 +73,21 @@ func (ecs *EthChainService) SendTransaction(tx protocols.ChainTransaction) error
 			} else {
 				tokenTransactor, err := Token.NewTokenTransactor(tokenAddress, ecs.chain)
 				if err != nil {
-					panic(err)
+					return err
 				}
 				_, err = tokenTransactor.Approve(ecs.defaultTxOpts(), ecs.naAddress, amount)
 				if err != nil {
-					panic(err)
+					return err
 				}
 			}
 			holdings, err := ecs.na.Holdings(&bind.CallOpts{}, tokenAddress, tx.ChannelId())
 			if err != nil {
-				panic(err)
+				return err
 			}
 
 			ethTx, err := ecs.na.Deposit(txOpts, tokenAddress, tx.ChannelId(), holdings, amount)
 			if err != nil {
-				panic(err)
+				return err
 			}
 			ethTxs = append(ethTxs, ethTx)
 		}
@@ -105,7 +105,7 @@ func (ecs *EthChainService) SendTransaction(tx protocols.ChainTransaction) error
 		}}
 		_, err := ecs.na.ConcludeAndTransferAllAssets(ecs.defaultTxOpts(), nitroFixedPart, nitroSignedVariableParts)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		return nil
 

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -3,6 +3,7 @@ package chainservice
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"math/big"
 
@@ -33,11 +34,12 @@ type EthChainService struct {
 	naAddress           common.Address
 	consensusAppAddress common.Address
 	txSigner            *bind.TransactOpts
+	logger              *log.Logger
 }
 
 // NewEthChainService constructs a chain service that submits transactions to a NitroAdjudicator
 // and listens to events from an eventSource
-func NewEthChainService(chain ethChain, na *NitroAdjudicator.NitroAdjudicator, naAddress common.Address, caAddress common.Address, txSigner *bind.TransactOpts) (*EthChainService, error) {
+func NewEthChainService(chain ethChain, na *NitroAdjudicator.NitroAdjudicator, naAddress common.Address, caAddress common.Address, txSigner *bind.TransactOpts, logDestination io.Writer) (*EthChainService, error) {
 	ecs := EthChainService{chainServiceBase: newChainServiceBase()}
 	ecs.out = safesync.Map[chan Event]{}
 	ecs.chain = chain
@@ -45,6 +47,9 @@ func NewEthChainService(chain ethChain, na *NitroAdjudicator.NitroAdjudicator, n
 	ecs.naAddress = naAddress
 	ecs.consensusAppAddress = caAddress
 	ecs.txSigner = txSigner
+
+	logPrefix := "chainservice " + txSigner.From.String() + ": "
+	ecs.logger = log.New(logDestination, logPrefix, log.Lmicroseconds|log.Lshortfile)
 
 	err := ecs.subcribeToEvents()
 

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -69,7 +69,6 @@ func (ecs *EthChainService) defaultTxOpts() *bind.TransactOpts {
 func (ecs *EthChainService) SendTransaction(tx protocols.ChainTransaction) error {
 	switch tx := tx.(type) {
 	case protocols.DepositTransaction:
-		ethTxs := []*ethTypes.Transaction{}
 		for tokenAddress, amount := range tx.Deposit {
 			txOpts := ecs.defaultTxOpts()
 			ethTokenAddress := common.Address{}
@@ -90,11 +89,10 @@ func (ecs *EthChainService) SendTransaction(tx protocols.ChainTransaction) error
 				return err
 			}
 
-			ethTx, err := ecs.na.Deposit(txOpts, tokenAddress, tx.ChannelId(), holdings, amount)
+			_, err = ecs.na.Deposit(txOpts, tokenAddress, tx.ChannelId(), holdings, amount)
 			if err != nil {
 				return err
 			}
-			ethTxs = append(ethTxs, ethTx)
 		}
 		return nil
 	case protocols.WithdrawAllTransaction:

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -137,13 +137,14 @@ func (ecs *EthChainService) listenForLogEvents(sub ethereum.Subscription, logs c
 	for {
 		select {
 		case err := <-sub.Err():
-			log.Fatal(err)
+			// TODO should we try resubscribing to chain events
+			ecs.logger.Printf("event subscription error: %v", err)
 		case chainEvent := <-logs:
 			switch chainEvent.Topics[0] {
 			case depositedTopic:
 				nad, err := ecs.na.ParseDeposited(chainEvent)
 				if err != nil {
-					log.Fatal(err)
+					ecs.logger.Printf("error in ParseDeposited: %v", err)
 				}
 
 				event := NewDepositedEvent(nad.Destination, chainEvent.BlockNumber, nad.Asset, nad.AmountDeposited, nad.DestinationHoldings)
@@ -151,30 +152,33 @@ func (ecs *EthChainService) listenForLogEvents(sub ethereum.Subscription, logs c
 			case allocationUpdatedTopic:
 				au, err := ecs.na.ParseAllocationUpdated(chainEvent)
 				if err != nil {
-					panic(err)
+					ecs.logger.Printf("error in ParseAllocationUpdated: %v", err)
 				}
 
 				tx, pending, err := ecs.chain.TransactionByHash(context.Background(), chainEvent.TxHash)
-				if pending || err != nil {
-					panic("Expected transacion to be part of the chain")
+				if pending {
+					ecs.logger.Printf("Expected transacion to be part of the chain, but the transaction is pending")
+				}
+				if err != nil {
+					ecs.logger.Printf("error in TransactoinByHash: %v", err)
 				}
 
 				assetAddress, amount, err := getChainHolding(ecs.na, tx, au)
 				if err != nil {
-					panic(err)
+					ecs.logger.Printf("error in getChainHoldings: %v", err)
 				}
 				event := NewAllocationUpdatedEvent(au.ChannelId, chainEvent.BlockNumber, assetAddress, amount)
 				ecs.broadcast(event)
 			case concludedTopic:
 				ce, err := ecs.na.ParseConcluded(chainEvent)
 				if err != nil {
-					panic(err)
+					ecs.logger.Printf("error in ParseConcluded: %v", err)
 				}
 
 				event := ConcludedEvent{commonEvent: commonEvent{channelID: ce.ChannelId, BlockNum: chainEvent.BlockNumber}}
 				ecs.broadcast(event)
 			default:
-				panic("Unknown chain event")
+				ecs.logger.Printf("Unknown chain event")
 			}
 		}
 	}

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -2,6 +2,7 @@ package chainservice
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"math/big"
 
@@ -60,7 +61,7 @@ func (ecs *EthChainService) defaultTxOpts() *bind.TransactOpts {
 }
 
 // SendTransaction sends the transaction and blocks until it has been submitted.
-func (ecs *EthChainService) SendTransaction(tx protocols.ChainTransaction) []*ethTypes.Transaction {
+func (ecs *EthChainService) SendTransaction(tx protocols.ChainTransaction) error {
 	switch tx := tx.(type) {
 	case protocols.DepositTransaction:
 		ethTxs := []*ethTypes.Transaction{}
@@ -90,7 +91,7 @@ func (ecs *EthChainService) SendTransaction(tx protocols.ChainTransaction) []*et
 			}
 			ethTxs = append(ethTxs, ethTx)
 		}
-		return ethTxs
+		return nil
 	case protocols.WithdrawAllTransaction:
 		state := tx.SignedState.State()
 		signatures := tx.SignedState.Signatures()
@@ -102,14 +103,14 @@ func (ecs *EthChainService) SendTransaction(tx protocols.ChainTransaction) []*et
 			Sigs:         nitroSignatures,
 			SignedBy:     big.NewInt(0b11),
 		}}
-		ethTx, err := ecs.na.ConcludeAndTransferAllAssets(ecs.defaultTxOpts(), nitroFixedPart, nitroSignedVariableParts)
+		_, err := ecs.na.ConcludeAndTransferAllAssets(ecs.defaultTxOpts(), nitroFixedPart, nitroSignedVariableParts)
 		if err != nil {
 			panic(err)
 		}
-		return []*ethTypes.Transaction{ethTx}
+		return nil
 
 	default:
-		panic("unexpected chain transaction")
+		return fmt.Errorf("unexpected transaction type %T", tx)
 	}
 }
 

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -107,10 +107,7 @@ func (ecs *EthChainService) SendTransaction(tx protocols.ChainTransaction) error
 			SignedBy:     big.NewInt(0b11),
 		}}
 		_, err := ecs.na.ConcludeAndTransferAllAssets(ecs.defaultTxOpts(), nitroFixedPart, nitroSignedVariableParts)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 
 	default:
 		return fmt.Errorf("unexpected transaction type %T", tx)

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -37,7 +37,7 @@ type EthChainService struct {
 
 // NewEthChainService constructs a chain service that submits transactions to a NitroAdjudicator
 // and listens to events from an eventSource
-func NewEthChainService(chain ethChain, na *NitroAdjudicator.NitroAdjudicator, naAddress common.Address, caAddress common.Address, txSigner *bind.TransactOpts) *EthChainService {
+func NewEthChainService(chain ethChain, na *NitroAdjudicator.NitroAdjudicator, naAddress common.Address, caAddress common.Address, txSigner *bind.TransactOpts) (*EthChainService, error) {
 	ecs := EthChainService{chainServiceBase: newChainServiceBase()}
 	ecs.out = safesync.Map[chan Event]{}
 	ecs.chain = chain
@@ -48,7 +48,7 @@ func NewEthChainService(chain ethChain, na *NitroAdjudicator.NitroAdjudicator, n
 
 	go ecs.listenForLogEvents()
 
-	return &ecs
+	return &ecs, nil
 }
 
 // defaultTxOpts returns transaction options suitable for most transaction submissions

--- a/client/engine/chainservice/mockchain.go
+++ b/client/engine/chainservice/mockchain.go
@@ -1,6 +1,8 @@
 package chainservice
 
 import (
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
@@ -37,7 +39,7 @@ func NewMockChainWithTransactionListener(txListener chan protocols.ChainTransact
 }
 
 // SendTransaction responds to the given tx.
-func (mc *MockChain) SendTransaction(tx protocols.ChainTransaction) {
+func (mc *MockChain) SendTransaction(tx protocols.ChainTransaction) error {
 	*mc.blockNum++
 	if mc.txListener != nil {
 		mc.txListener <- tx
@@ -58,8 +60,9 @@ func (mc *MockChain) SendTransaction(tx protocols.ChainTransaction) {
 		}
 		mc.holdings[tx.ChannelId()] = types.Funds{}
 	default:
-		panic("unexpected chain transaction")
+		return fmt.Errorf("unexpected transaction type %T", tx)
 	}
+	return nil
 }
 
 // GetConsensusAppAddress returns the zero address, since the mock chain will not run any application logic.

--- a/client/engine/chainservice/mockchain_test.go
+++ b/client/engine/chainservice/mockchain_test.go
@@ -38,13 +38,20 @@ func TestDeposit(t *testing.T) {
 	testTx := protocols.NewDepositTransaction(types.Destination(common.HexToHash(`4ebd366d014a173765ba1e50f284c179ade31f20441bec41664712aac6cc461d`)), testDeposit)
 
 	// Send one transaction and receive one event from it.
-	chain.SendTransaction(testTx)
+	err = chain.SendTransaction(testTx)
+	if err != nil {
+		t.Error(err)
+	}
 	event := <-eventFeedA
 
 	checkReceivedEventIsValid(t, event, testTx.Deposit, testTx.ChannelId())
 
 	// Send the transaction again and receive another event
-	chain.SendTransaction(testTx)
+	err = chain.SendTransaction(testTx)
+	if err != nil {
+		t.Error(err)
+	}
+
 	event = <-eventFeedA
 
 	// The expectation is that the MockChainService remembered the previous deposit and added this one to it:

--- a/client/engine/chainservice/mockchain_test.go
+++ b/client/engine/chainservice/mockchain_test.go
@@ -40,7 +40,7 @@ func TestDeposit(t *testing.T) {
 	// Send one transaction and receive one event from it.
 	err = chain.SendTransaction(testTx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	event := <-eventFeedA
 
@@ -49,7 +49,7 @@ func TestDeposit(t *testing.T) {
 	// Send the transaction again and receive another event
 	err = chain.SendTransaction(testTx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	event = <-eventFeedA

--- a/client/engine/chainservice/simulated_backend_chainservice.go
+++ b/client/engine/chainservice/simulated_backend_chainservice.go
@@ -43,12 +43,17 @@ type SimulatedBackendChainService struct {
 // NewSimulatedBackendChainService constructs a chain service that submits transactions to a NitroAdjudicator
 // and listens to events from an eventSource
 func NewSimulatedBackendChainService(sim simulatedChain, bindings bindings,
-	txSigner *bind.TransactOpts) ChainService {
-	return &SimulatedBackendChainService{sim: sim, EthChainService: NewEthChainService(sim,
+	txSigner *bind.TransactOpts) (ChainService, error) {
+	ethChainService, err := NewEthChainService(sim,
 		bindings.Adjudicator.Contract,
 		bindings.Adjudicator.Address,
 		bindings.ConsensusApp.Address,
-		txSigner)}
+		txSigner)
+
+	if err != nil {
+		return &SimulatedBackendChainService{}, err
+	}
+	return &SimulatedBackendChainService{sim: sim, EthChainService: ethChainService}, nil
 }
 
 // SendTransaction sends the transaction and blocks until it has been mined.

--- a/client/engine/chainservice/simulated_backend_chainservice.go
+++ b/client/engine/chainservice/simulated_backend_chainservice.go
@@ -2,6 +2,7 @@ package chainservice
 
 import (
 	"errors"
+	"io"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -43,12 +44,13 @@ type SimulatedBackendChainService struct {
 // NewSimulatedBackendChainService constructs a chain service that submits transactions to a NitroAdjudicator
 // and listens to events from an eventSource
 func NewSimulatedBackendChainService(sim simulatedChain, bindings bindings,
-	txSigner *bind.TransactOpts) (ChainService, error) {
+	txSigner *bind.TransactOpts, logDestination io.Writer) (ChainService, error) {
 	ethChainService, err := NewEthChainService(sim,
 		bindings.Adjudicator.Contract,
 		bindings.Adjudicator.Address,
 		bindings.ConsensusApp.Address,
-		txSigner)
+		txSigner,
+		logDestination)
 
 	if err != nil {
 		return &SimulatedBackendChainService{}, err

--- a/client/engine/chainservice/simulated_backend_chainservice.go
+++ b/client/engine/chainservice/simulated_backend_chainservice.go
@@ -52,9 +52,13 @@ func NewSimulatedBackendChainService(sim simulatedChain, bindings bindings,
 }
 
 // SendTransaction sends the transaction and blocks until it has been mined.
-func (sbcs *SimulatedBackendChainService) SendTransaction(tx protocols.ChainTransaction) {
-	sbcs.EthChainService.SendTransaction(tx)
+func (sbcs *SimulatedBackendChainService) SendTransaction(tx protocols.ChainTransaction) error {
+	err := sbcs.EthChainService.SendTransaction(tx)
+	if err != nil {
+		return err
+	}
 	sbcs.sim.Commit()
+	return nil
 }
 
 // SetupSimulatedBackend creates a new SimulatedBackend with the supplied number of transacting accounts, deploys the Nitro Adjudicator and returns both.

--- a/client/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/client/engine/chainservice/simulated_backend_chainservice_test.go
@@ -59,7 +59,10 @@ func TestDepositSimulatedBackendChainService(t *testing.T) {
 
 	out := cs.SubscribeToEvents(ethAccounts[0].From)
 	// Submit transactiom
-	cs.SendTransaction(testTx)
+	err = cs.SendTransaction(testTx)
+	if err != nil {
+		t.Error(err)
+	}
 
 	// Check that the recieved events matches the expected event
 	for i := 0; i < 2; i++ {
@@ -114,7 +117,10 @@ func TestConcludeSimulatedBackendChainService(t *testing.T) {
 	cId := concludeState.ChannelId()
 
 	depositTx := protocols.NewDepositTransaction(cId, testDeposit)
-	cs.SendTransaction(depositTx)
+	err = cs.SendTransaction(depositTx)
+	if err != nil {
+		t.Error(err)
+	}
 	<-out
 
 	signedConcludeState := state.NewSignedState(concludeState)
@@ -127,8 +133,10 @@ func TestConcludeSimulatedBackendChainService(t *testing.T) {
 		t.Fatal(err)
 	}
 	concludeTx := protocols.NewWithdrawAllTransaction(cId, signedConcludeState)
-	cs.SendTransaction(concludeTx)
-
+	err = cs.SendTransaction(concludeTx)
+	if err != nil {
+		t.Error(err)
+	}
 	// Check that the recieved event matches the expected event
 	concludedEvent := <-out
 	expectedEvent := ConcludedEvent{commonEvent: commonEvent{channelID: cId, BlockNum: 3}}

--- a/client/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/client/engine/chainservice/simulated_backend_chainservice_test.go
@@ -70,7 +70,7 @@ func TestDepositSimulatedBackendChainService(t *testing.T) {
 	// Submit transactiom
 	err = cs.SendTransaction(testTx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	// Check that the recieved events matches the expected event
@@ -131,7 +131,7 @@ func TestConcludeSimulatedBackendChainService(t *testing.T) {
 	depositTx := protocols.NewDepositTransaction(cId, testDeposit)
 	err = cs.SendTransaction(depositTx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	<-out
 
@@ -147,7 +147,7 @@ func TestConcludeSimulatedBackendChainService(t *testing.T) {
 	concludeTx := protocols.NewWithdrawAllTransaction(cId, signedConcludeState)
 	err = cs.SendTransaction(concludeTx)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	// Check that the recieved event matches the expected event
 	concludedEvent := <-out

--- a/client/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/client/engine/chainservice/simulated_backend_chainservice_test.go
@@ -43,7 +43,10 @@ func TestDepositSimulatedBackendChainService(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cs := NewSimulatedBackendChainService(sim, bindings, ethAccounts[0])
+	cs, err := NewSimulatedBackendChainService(sim, bindings, ethAccounts[0])
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if err != nil {
 		t.Fatal(err)
@@ -88,7 +91,10 @@ func TestConcludeSimulatedBackendChainService(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cs := NewSimulatedBackendChainService(sim, bindings, ethAccounts[0])
+	cs, err := NewSimulatedBackendChainService(sim, bindings, ethAccounts[0])
+	if err != nil {
+		t.Fatal(err)
+	}
 	out := cs.SubscribeToEvents(ethAccounts[0].From)
 
 	var concludeState = state.State{

--- a/client/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/client/engine/chainservice/simulated_backend_chainservice_test.go
@@ -36,6 +36,12 @@ var concludeOutcome = outcome.Exit{
 	},
 }
 
+type NoopLogger struct{}
+
+func (l NoopLogger) Write(p []byte) (n int, err error) {
+	return 0, nil
+}
+
 func TestDepositSimulatedBackendChainService(t *testing.T) {
 	one := big.NewInt(1)
 	sim, bindings, ethAccounts, err := SetupSimulatedBackend(1)
@@ -43,7 +49,7 @@ func TestDepositSimulatedBackendChainService(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cs, err := NewSimulatedBackendChainService(sim, bindings, ethAccounts[0])
+	cs, err := NewSimulatedBackendChainService(sim, bindings, ethAccounts[0], NoopLogger{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +97,7 @@ func TestConcludeSimulatedBackendChainService(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cs, err := NewSimulatedBackendChainService(sim, bindings, ethAccounts[0])
+	cs, err := NewSimulatedBackendChainService(sim, bindings, ethAccounts[0], NoopLogger{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client_test/directdefund_test.go
+++ b/client_test/directdefund_test.go
@@ -37,15 +37,15 @@ func TestDirectDefund(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	chainA, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[0])
+	chainA, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[0], logDestination)
 	if err != nil {
 		t.Fatal(err)
 	}
-	chainI, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[1])
+	chainI, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[1], logDestination)
 	if err != nil {
 		t.Fatal(err)
 	}
-	chainB, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[2])
+	chainB, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[2], logDestination)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client_test/directdefund_test.go
+++ b/client_test/directdefund_test.go
@@ -37,9 +37,18 @@ func TestDirectDefund(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	chainA := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[0])
-	chainI := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[1])
-	chainB := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[2])
+	chainA, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	chainI, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	chainB, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[2])
+	if err != nil {
+		t.Fatal(err)
+	}
 	// End chain service setup
 
 	broker := messageservice.NewBroker()

--- a/client_test/directfund_test.go
+++ b/client_test/directfund_test.go
@@ -113,11 +113,11 @@ func TestDirectFund(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	chainA, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[0])
+	chainA, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[0], logDestination)
 	if err != nil {
 		t.Fatal(err)
 	}
-	chainB, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[1])
+	chainB, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[1], logDestination)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client_test/directfund_test.go
+++ b/client_test/directfund_test.go
@@ -113,8 +113,14 @@ func TestDirectFund(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	chainA := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[0])
-	chainB := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[1])
+	chainA, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	chainB, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[1])
+	if err != nil {
+		t.Fatal(err)
+	}
 	// End chain service setup
 
 	broker := messageservice.NewBroker()


### PR DESCRIPTION
Fixes https://github.com/statechannels/go-nitro/issues/770.

One option is to allow a state channel wallet to continue to operate even if its chain service fails. This allows the wallet to continue to run application channels. This PR enables this mode of operation and includes the following changes:
- Calls to the chainservice APIs (such as initialization and transaction submission) now return errors. The caller can decide how to handle a returned error.
- Errors in event subscription logic are logged.

Note that a wallet should not operate for too long without a working chainservice. The duration of time that a wallet can run without a chainservice (assuming opening new directly-funded channels is not urgent) depends on challenge timeout duration.