### PR TITLE
fix nitro-protocol/package.json so it can be used in imports

### DIFF
--- a/nitro-protocol/package.json
+++ b/nitro-protocol/package.json
@@ -1,8 +1,11 @@
 {
-  "name": "contracts",
-  "version": "1.0.0",
+  "name": "@statechannels/nitro-protocol",
+  "version": "2.0.0-alpha.0",
   "description": "",
   "main": "index.js",
+  "files": [
+    "/contracts/**/*.sol"
+  ],
   "scripts": {
     "contracts:deploy-localhost": "npx hardhat deploy --network localhost --export-all addresses.json && node ./scripts/postdeploy.ts",
     "contracts:node": "npx hardhat node --no-deploy",


### PR DESCRIPTION
**Title** Fix nitro-protocol package.json to allow imports

**Body** 

The `package.json` in the nitro-protocol package directory did not list the files it exports making it impossible to import contracts when added as a dependency via npm.

With the changes it is now possible to use [gitpkg](https://gitpkg.vercel.app/) to add the latest nitro-protocol as a dependency in Solidity projects and import the contracts  (e.g. `import '@statechannels/nitro-protocol/contracts/NitroAdjudicator.sol'`)

Even if the protocol is not ready for release yet it is handy being able to add a dependency this way to experiment and test