### PR TITLE
Remove SubscribeToEvents from the ChainService interface

### DIFF
--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -73,25 +73,3 @@ type ChainService interface {
 	// GetConsensusAppAddress returns the address of a deployed ConsensusApp (for ledger channels)
 	GetConsensusAppAddress() types.Address
 }
-
-type chainServiceBase struct {
-	out chan Event
-}
-
-// newChainServiceBase constructs a ChainServiceBase. Only implementations of ChainService interface should call the constructor.
-func newChainServiceBase() chainServiceBase {
-	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
-	return chainServiceBase{out: make(chan Event, 10)}
-}
-
-// EventFeed returns the out chan, and narrows the type so that external consumers may only receive on it.
-func (csb *chainServiceBase) EventFeed() <-chan Event {
-	return csb.out
-}
-
-func (csb *chainServiceBase) broadcast(event Event) {
-	select {
-	case csb.out <- event:
-	default:
-	}
-}

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -27,30 +27,25 @@ type ethChain interface {
 }
 
 type EthChainService struct {
-	chainServiceBase
 	chain               ethChain
 	na                  *NitroAdjudicator.NitroAdjudicator
 	naAddress           common.Address
 	consensusAppAddress common.Address
 	txSigner            *bind.TransactOpts
+	out                 chan Event
 	logger              *log.Logger
 }
 
 // NewEthChainService constructs a chain service that submits transactions to a NitroAdjudicator
 // and listens to events from an eventSource
-func NewEthChainService(chain ethChain, na *NitroAdjudicator.NitroAdjudicator, naAddress common.Address, caAddress common.Address, txSigner *bind.TransactOpts, logDestination io.Writer) (*EthChainService, error) {
-	ecs := EthChainService{chainServiceBase: newChainServiceBase()}
-	ecs.chain = chain
-	ecs.na = na
-	ecs.naAddress = naAddress
-	ecs.consensusAppAddress = caAddress
-	ecs.txSigner = txSigner
-
+func NewEthChainService(chain ethChain, na *NitroAdjudicator.NitroAdjudicator,
+	naAddress common.Address, caAddress common.Address, txSigner *bind.TransactOpts, logDestination io.Writer) (*EthChainService, error) {
 	logPrefix := "chainservice " + txSigner.From.String() + ": "
-	ecs.logger = log.New(logDestination, logPrefix, log.Lmicroseconds|log.Lshortfile)
+	logger := log.New(logDestination, logPrefix, log.Lmicroseconds|log.Lshortfile)
+	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
+	ecs := EthChainService{chain, na, naAddress, caAddress, txSigner, make(chan Event, 10), logger}
 
 	err := ecs.subcribeToEvents()
-
 	return &ecs, err
 }
 
@@ -141,7 +136,7 @@ func (ecs *EthChainService) listenForLogEvents(sub ethereum.Subscription, logs c
 				}
 
 				event := NewDepositedEvent(nad.Destination, chainEvent.BlockNumber, nad.Asset, nad.AmountDeposited, nad.DestinationHoldings)
-				ecs.broadcast(event)
+				ecs.out <- event
 			case allocationUpdatedTopic:
 				au, err := ecs.na.ParseAllocationUpdated(chainEvent)
 				if err != nil {
@@ -161,7 +156,7 @@ func (ecs *EthChainService) listenForLogEvents(sub ethereum.Subscription, logs c
 					ecs.logger.Printf("error in getChainHoldings: %v", err)
 				}
 				event := NewAllocationUpdatedEvent(au.ChannelId, chainEvent.BlockNumber, assetAddress, amount)
-				ecs.broadcast(event)
+				ecs.out <- event
 			case concludedTopic:
 				ce, err := ecs.na.ParseConcluded(chainEvent)
 				if err != nil {
@@ -169,10 +164,15 @@ func (ecs *EthChainService) listenForLogEvents(sub ethereum.Subscription, logs c
 				}
 
 				event := ConcludedEvent{commonEvent: commonEvent{channelID: ce.ChannelId, BlockNum: chainEvent.BlockNumber}}
-				ecs.broadcast(event)
+				ecs.out <- event
 			default:
 				ecs.logger.Printf("Unknown chain event")
 			}
 		}
 	}
+}
+
+// EventFeed returns the out chan, and narrows the type so that external consumers may only receive on it.
+func (ecs *EthChainService) EventFeed() <-chan Event {
+	return ecs.out
 }

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	NitroAdjudicator "github.com/statechannels/go-nitro/client/engine/chainservice/adjudicator"
 	Token "github.com/statechannels/go-nitro/client/engine/chainservice/erc20"
-	"github.com/statechannels/go-nitro/client/engine/store/safesync"
 	"github.com/statechannels/go-nitro/protocols"
 )
 
@@ -41,7 +40,6 @@ type EthChainService struct {
 // and listens to events from an eventSource
 func NewEthChainService(chain ethChain, na *NitroAdjudicator.NitroAdjudicator, naAddress common.Address, caAddress common.Address, txSigner *bind.TransactOpts, logDestination io.Writer) (*EthChainService, error) {
 	ecs := EthChainService{chainServiceBase: newChainServiceBase()}
-	ecs.out = safesync.Map[chan Event]{}
 	ecs.chain = chain
 	ecs.na = na
 	ecs.naAddress = naAddress

--- a/client/engine/chainservice/mock_chain.go
+++ b/client/engine/chainservice/mock_chain.go
@@ -1,0 +1,74 @@
+package chainservice
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/client/engine/store/safesync"
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/types"
+)
+
+// MockChain is an in-memory "chain" that accepts transactions and broadcasts events
+type MockChain interface {
+	SubmitTransaction(protocols.ChainTransaction) error // unlike an ethereum blockchain, Mockhain accepts go-nitro protocols.ChainTransaction
+	SubscribeToEvents(a types.Address) <-chan Event     // returns a channel that produces all chain Events
+}
+
+// MockChainImpl mimicks the Ethereum blockchain by keeping track of block numbers and account balances.
+type MockChainImpl struct {
+	blockNum uint64
+	// holdings tracks funds for each channel.
+	holdings map[types.Destination]types.Funds
+	// out maps addresses to an Event channel. Given that MockChainServices only subscribe
+	// (and never unsubscribe) to events, this can be converted to a list.
+	out safesync.Map[chan Event]
+}
+
+// NewMockChainImpl creates a new MockChainImpl
+func NewMockChainImpl() *MockChainImpl {
+	chain := MockChainImpl{}
+	chain.blockNum = 1
+	chain.holdings = make(map[types.Destination]types.Funds)
+	chain.out = safesync.Map[chan Event]{}
+	return &chain
+}
+
+// SubmitTransaction updates internal state and brodcasts events
+func (mc *MockChainImpl) SubmitTransaction(tx protocols.ChainTransaction) error {
+	mc.blockNum++
+	switch tx := tx.(type) {
+	case protocols.DepositTransaction:
+		if tx.Deposit.IsNonZero() {
+			mc.holdings[tx.ChannelId()] = mc.holdings[tx.ChannelId()].Add(tx.Deposit)
+		}
+		for address, amount := range tx.Deposit {
+			event := NewDepositedEvent(tx.ChannelId(), mc.blockNum, address, amount, mc.holdings[tx.ChannelId()][address])
+			mc.broadcastEvent(event)
+		}
+	case protocols.WithdrawAllTransaction:
+		for assetAddress := range mc.holdings[tx.ChannelId()] {
+			event := NewAllocationUpdatedEvent(tx.ChannelId(), mc.blockNum, assetAddress, common.Big0)
+			mc.broadcastEvent(event)
+		}
+		mc.holdings[tx.ChannelId()] = types.Funds{}
+	default:
+		return fmt.Errorf("unexpected transaction type %T", tx)
+	}
+	return nil
+}
+
+func (mc *MockChainImpl) broadcastEvent(event Event) {
+	mc.out.Range(func(_ string, channel chan Event) bool {
+		channel <- event
+		return true
+	})
+}
+
+// SubscribeToEvents creates, stores, and returns a new Event channel
+func (mc *MockChainImpl) SubscribeToEvents(a types.Address) <-chan Event {
+	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
+	c := make(chan Event, 10)
+	mc.out.Store(a.String(), c)
+	return c
+}

--- a/client/engine/chainservice/mock_chain.go
+++ b/client/engine/chainservice/mock_chain.go
@@ -9,13 +9,8 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-// MockChain is an in-memory "chain" that accepts transactions and broadcasts events
-type MockChain interface {
-	SubmitTransaction(protocols.ChainTransaction) error // unlike an ethereum blockchain, Mockhain accepts go-nitro protocols.ChainTransaction
-	SubscribeToEvents(a types.Address) <-chan Event     // returns a channel that produces all chain Events
-}
-
-// MockChainImpl mimicks the Ethereum blockchain by keeping track of block numbers and account balances.
+// MockChainImpl mimicks the Ethereum blockchain by keeping track of block numbers and account balances in memory
+// MockChain accepts transactions and broadcasts events.
 type MockChainImpl struct {
 	blockNum uint64
 	// holdings tracks funds for each channel.
@@ -35,6 +30,7 @@ func NewMockChainImpl() *MockChainImpl {
 }
 
 // SubmitTransaction updates internal state and brodcasts events
+// unlike an ethereum blockchain, Mockhain accepts go-nitro protocols.ChainTransaction
 func (mc *MockChainImpl) SubmitTransaction(tx protocols.ChainTransaction) error {
 	mc.blockNum++
 	switch tx := tx.(type) {
@@ -65,7 +61,7 @@ func (mc *MockChainImpl) broadcastEvent(event Event) {
 	})
 }
 
-// SubscribeToEvents creates, stores, and returns a new Event channel
+// SubscribeToEvents creates, stores, and returns a new Event channel that produces all chain Events
 func (mc *MockChainImpl) SubscribeToEvents(a types.Address) <-chan Event {
 	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
 	c := make(chan Event, 10)

--- a/client/engine/chainservice/mock_chain.go
+++ b/client/engine/chainservice/mock_chain.go
@@ -9,9 +9,9 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-// MockChainImpl mimicks the Ethereum blockchain by keeping track of block numbers and account balances in memory
+// MockChain mimicks the Ethereum blockchain by keeping track of block numbers and account balances in memory
 // MockChain accepts transactions and broadcasts events.
-type MockChainImpl struct {
+type MockChain struct {
 	blockNum uint64
 	// holdings tracks funds for each channel.
 	holdings map[types.Destination]types.Funds
@@ -20,9 +20,9 @@ type MockChainImpl struct {
 	out safesync.Map[chan Event]
 }
 
-// NewMockChainImpl creates a new MockChainImpl
-func NewMockChainImpl() *MockChainImpl {
-	chain := MockChainImpl{}
+// NewMockChain creates a new MockChain
+func NewMockChain() *MockChain {
+	chain := MockChain{}
 	chain.blockNum = 1
 	chain.holdings = make(map[types.Destination]types.Funds)
 	chain.out = safesync.Map[chan Event]{}
@@ -31,7 +31,7 @@ func NewMockChainImpl() *MockChainImpl {
 
 // SubmitTransaction updates internal state and brodcasts events
 // unlike an ethereum blockchain, Mockhain accepts go-nitro protocols.ChainTransaction
-func (mc *MockChainImpl) SubmitTransaction(tx protocols.ChainTransaction) error {
+func (mc *MockChain) SubmitTransaction(tx protocols.ChainTransaction) error {
 	mc.blockNum++
 	switch tx := tx.(type) {
 	case protocols.DepositTransaction:
@@ -54,7 +54,7 @@ func (mc *MockChainImpl) SubmitTransaction(tx protocols.ChainTransaction) error 
 	return nil
 }
 
-func (mc *MockChainImpl) broadcastEvent(event Event) {
+func (mc *MockChain) broadcastEvent(event Event) {
 	mc.out.Range(func(_ string, channel chan Event) bool {
 		channel <- event
 		return true
@@ -62,7 +62,7 @@ func (mc *MockChainImpl) broadcastEvent(event Event) {
 }
 
 // SubscribeToEvents creates, stores, and returns a new Event channel that produces all chain Events
-func (mc *MockChainImpl) SubscribeToEvents(a types.Address) <-chan Event {
+func (mc *MockChain) SubscribeToEvents(a types.Address) <-chan Event {
 	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
 	c := make(chan Event, 10)
 	mc.out.Store(a.String(), c)

--- a/client/engine/chainservice/mock_chainservice.go
+++ b/client/engine/chainservice/mock_chainservice.go
@@ -8,13 +8,13 @@ import (
 
 // MockChainService adheres to the ChainService interface. The constructor accepts a MockChain, which allows multiple clients to share the same, in-memory chain.
 type MockChainService struct {
-	chain      MockChain
+	chain      *MockChainImpl
 	txListener chan protocols.ChainTransaction // this is used to broadcast transactions that have been received
 	eventFeed  <-chan Event
 }
 
 // NewMockChainService returns a new MockChainService.
-func NewMockChainService(chain MockChain, address common.Address) *MockChainService {
+func NewMockChainService(chain *MockChainImpl, address common.Address) *MockChainService {
 	mc := MockChainService{chain: chain}
 	mc.eventFeed = chain.SubscribeToEvents(address)
 	return &mc
@@ -22,7 +22,7 @@ func NewMockChainService(chain MockChain, address common.Address) *MockChainServ
 
 // NewMockChainWithTransactionListener returns a new MockChainService that will send transactions to the supplied chan.
 // This lets us easily rebroadcast transactions to other MockChainServices.
-func NewMockChainWithTransactionListener(chain MockChain, address common.Address, txListener chan protocols.ChainTransaction) *MockChainService {
+func NewMockChainWithTransactionListener(chain *MockChainImpl, address common.Address, txListener chan protocols.ChainTransaction) *MockChainService {
 	mc := NewMockChainService(chain, address)
 	mc.txListener = txListener
 	return mc

--- a/client/engine/chainservice/mock_chainservice.go
+++ b/client/engine/chainservice/mock_chainservice.go
@@ -3,6 +3,7 @@ package chainservice
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/types"
 )
 
 // MockChainService adheres to the ChainService interface. The constructor accepts a MockChain, which allows multiple clients to share the same, in-memory chain.

--- a/client/engine/chainservice/mock_chainservice.go
+++ b/client/engine/chainservice/mock_chainservice.go
@@ -1,77 +1,9 @@
 package chainservice
 
 import (
-	"fmt"
-
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/statechannels/go-nitro/client/engine/store/safesync"
 	"github.com/statechannels/go-nitro/protocols"
-	"github.com/statechannels/go-nitro/types"
 )
-
-// MockChain is an in-memory "chain" that accepts transactions and broadcasts events
-type MockChain interface {
-	SubmitTransaction(protocols.ChainTransaction) error // unlike an ethereum blockchain, Mockhain accepts go-nitro protocols.ChainTransaction
-	SubscribeToEvents(a types.Address) <-chan Event     // returns a channel that produces all chain Events
-}
-
-// MockChainImpl mimicks the Ethereum blockchain by keeping track of block numbers and account balances.
-type MockChainImpl struct {
-	blockNum uint64
-	// holdings tracks funds for each channel.
-	holdings map[types.Destination]types.Funds
-	// out maps addresses to an Event channel. Given that MockChainServices only subscribe
-	// (and never unsubscribe) to events, this can be converted to a list.
-	out safesync.Map[chan Event]
-}
-
-// NewMockChainImpl creates a new MockChainImpl
-func NewMockChainImpl() *MockChainImpl {
-	chain := MockChainImpl{}
-	chain.blockNum = 1
-	chain.holdings = make(map[types.Destination]types.Funds)
-	chain.out = safesync.Map[chan Event]{}
-	return &chain
-}
-
-// SubmitTransaction updates internal state and brodcasts events
-func (mc *MockChainImpl) SubmitTransaction(tx protocols.ChainTransaction) error {
-	mc.blockNum++
-	switch tx := tx.(type) {
-	case protocols.DepositTransaction:
-		if tx.Deposit.IsNonZero() {
-			mc.holdings[tx.ChannelId()] = mc.holdings[tx.ChannelId()].Add(tx.Deposit)
-		}
-		for address, amount := range tx.Deposit {
-			event := NewDepositedEvent(tx.ChannelId(), mc.blockNum, address, amount, mc.holdings[tx.ChannelId()][address])
-			mc.broadcastEvent(event)
-		}
-	case protocols.WithdrawAllTransaction:
-		for assetAddress := range mc.holdings[tx.ChannelId()] {
-			event := NewAllocationUpdatedEvent(tx.ChannelId(), mc.blockNum, assetAddress, common.Big0)
-			mc.broadcastEvent(event)
-		}
-		mc.holdings[tx.ChannelId()] = types.Funds{}
-	default:
-		return fmt.Errorf("unexpected transaction type %T", tx)
-	}
-	return nil
-}
-
-func (mc *MockChainImpl) broadcastEvent(event Event) {
-	mc.out.Range(func(_ string, channel chan Event) bool {
-		channel <- event
-		return true
-	})
-}
-
-// SubscribeToEvents creates, stores, and returns a new Event channel
-func (mc *MockChainImpl) SubscribeToEvents(a types.Address) <-chan Event {
-	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
-	c := make(chan Event, 10)
-	mc.out.Store(a.String(), c)
-	return c
-}
 
 // MockChainService adheres to the ChainService interface. The constructor accepts a MockChain, which allows multiple clients to share the same, in-memory chain.
 type MockChainService struct {

--- a/client/engine/chainservice/mock_chainservice.go
+++ b/client/engine/chainservice/mock_chainservice.go
@@ -4,59 +4,45 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/client/engine/store/safesync"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
 
-// MockChainService provides an interface which simulates a blockchain network. It is designed for use as a central service which multiple
-// ChainServices connect to with Go chans.
-//
-// It keeps a record of of holdings and adjudication status for each channel, accepts transactions and emits events.
-type MockChainService struct {
-	chainServiceBase
-
-	holdings   map[types.Destination]types.Funds // holdings tracks funds for each channel
-	blockNum   *uint64                           // MockChain is often passed around by value. The pointer allows for shared state.
-	txListener chan protocols.ChainTransaction   // this is used to broadcast transactions that have been received
+type MockChain interface {
+	SubmitTransaction(protocols.ChainTransaction) error
+	SubscribeToEvents(a types.Address) <-chan Event
 }
 
-// NewMockChainService returns a new MockChain.
-func NewMockChainService() *MockChainService {
-	mc := MockChainService{chainServiceBase: newChainServiceBase()}
-	mc.holdings = make(map[types.Destination]types.Funds)
-	mc.blockNum = new(uint64)
-	*mc.blockNum = 1
-
-	return &mc
+type MockChainImpl struct {
+	blockNum uint64
+	holdings map[types.Destination]types.Funds // holdings tracks funds for each channel
+	out      safesync.Map[chan Event]
 }
 
-// NewMockChainWithTransactionListener returns a new mock chain that will send transactions to the supplied chan.
-// This lets us easily rebroadcast transactions to other mock chains.
-func NewMockChainWithTransactionListener(txListener chan protocols.ChainTransaction) *MockChainService {
-	mc := NewMockChainService()
-	mc.txListener = txListener
-	return mc
+func NewMockChainImpl() *MockChainImpl {
+	chain := MockChainImpl{}
+	chain.blockNum = 1
+	chain.holdings = make(map[types.Destination]types.Funds)
+	chain.out = safesync.Map[chan Event]{}
+	return &chain
 }
 
-// SendTransaction responds to the given tx.
-func (mc *MockChainService) SendTransaction(tx protocols.ChainTransaction) error {
-	*mc.blockNum++
-	if mc.txListener != nil {
-		mc.txListener <- tx
-	}
+func (mc *MockChainImpl) SubmitTransaction(tx protocols.ChainTransaction) error {
+	mc.blockNum++
 	switch tx := tx.(type) {
 	case protocols.DepositTransaction:
 		if tx.Deposit.IsNonZero() {
 			mc.holdings[tx.ChannelId()] = mc.holdings[tx.ChannelId()].Add(tx.Deposit)
 		}
 		for address, amount := range tx.Deposit {
-			event := NewDepositedEvent(tx.ChannelId(), *mc.blockNum, address, amount, mc.holdings[tx.ChannelId()][address])
-			mc.broadcast(event)
+			event := NewDepositedEvent(tx.ChannelId(), mc.blockNum, address, amount, mc.holdings[tx.ChannelId()][address])
+			mc.broadcastEvent(event)
 		}
 	case protocols.WithdrawAllTransaction:
 		for assetAddress := range mc.holdings[tx.ChannelId()] {
-			event := NewAllocationUpdatedEvent(tx.ChannelId(), *mc.blockNum, assetAddress, common.Big0)
-			mc.broadcast(event)
+			event := NewAllocationUpdatedEvent(tx.ChannelId(), mc.blockNum, assetAddress, common.Big0)
+			mc.broadcastEvent(event)
 		}
 		mc.holdings[tx.ChannelId()] = types.Funds{}
 	default:
@@ -65,7 +51,62 @@ func (mc *MockChainService) SendTransaction(tx protocols.ChainTransaction) error
 	return nil
 }
 
+func (mc *MockChainImpl) broadcastEvent(event Event) {
+	mc.out.Range(func(_ string, channel chan Event) bool {
+		channel <- event
+		return true
+	})
+}
+
+func (mc *MockChainImpl) SubscribeToEvents(a types.Address) <-chan Event {
+	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
+	c := make(chan Event, 10)
+	mc.out.Store(a.String(), c)
+	return c
+}
+
+// MockChainService provides an interface which simulates a blockchain network. It is designed for use as a central service which multiple
+// ChainServices connect to with Go chans.
+//
+// It keeps a record of of holdings and adjudication status for each channel, accepts transactions and emits events.
+type MockChainService struct {
+	chainServiceBase
+
+	chain      MockChain
+	txListener chan protocols.ChainTransaction // this is used to broadcast transactions that have been received
+}
+
+// NewMockChainService returns a new MockChain.
+func NewMockChainService(chain MockChain, address common.Address) *MockChainService {
+	mc := MockChainService{chainServiceBase: newChainServiceBase()}
+	mc.chain = chain
+	in := chain.SubscribeToEvents(address)
+	go func() {
+		for e := range in {
+			mc.out <- e
+		}
+	}()
+	return &mc
+}
+
+// NewMockChainWithTransactionListener returns a new mock chain that will send transactions to the supplied chan.
+// This lets us easily rebroadcast transactions to other mock chains.
+// func NewMockChainWithTransactionListener(txListener chan protocols.ChainTransaction) *MockChainService {
+// 	mc := NewMockChainService()
+// 	mc.txListener = txListener
+// 	return mc
+// }
+
+// SendTransaction responds to the given tx.
+func (mc *MockChainService) SendTransaction(tx protocols.ChainTransaction) error {
+	// if mc.txListener != nil {
+	// 	mc.txListener <- tx
+	// }
+
+	return mc.chain.SubmitTransaction(tx)
+}
+
 // GetConsensusAppAddress returns the zero address, since the mock chain will not run any application logic.
-func (mc *MockChain) GetConsensusAppAddress() types.Address {
+func (mc *MockChainService) GetConsensusAppAddress() types.Address {
 	return types.Address{}
 }

--- a/client/engine/chainservice/mock_chainservice.go
+++ b/client/engine/chainservice/mock_chainservice.go
@@ -8,11 +8,11 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-// MockChain provides an interface which simulates a blockchain network. It is designed for use as a central service which multiple
+// MockChainService provides an interface which simulates a blockchain network. It is designed for use as a central service which multiple
 // ChainServices connect to with Go chans.
 //
 // It keeps a record of of holdings and adjudication status for each channel, accepts transactions and emits events.
-type MockChain struct {
+type MockChainService struct {
 	chainServiceBase
 
 	holdings   map[types.Destination]types.Funds // holdings tracks funds for each channel
@@ -20,9 +20,9 @@ type MockChain struct {
 	txListener chan protocols.ChainTransaction   // this is used to broadcast transactions that have been received
 }
 
-// NewMockChain returns a new MockChain.
-func NewMockChain() *MockChain {
-	mc := MockChain{chainServiceBase: newChainServiceBase()}
+// NewMockChainService returns a new MockChain.
+func NewMockChainService() *MockChainService {
+	mc := MockChainService{chainServiceBase: newChainServiceBase()}
 	mc.holdings = make(map[types.Destination]types.Funds)
 	mc.blockNum = new(uint64)
 	*mc.blockNum = 1
@@ -32,14 +32,14 @@ func NewMockChain() *MockChain {
 
 // NewMockChainWithTransactionListener returns a new mock chain that will send transactions to the supplied chan.
 // This lets us easily rebroadcast transactions to other mock chains.
-func NewMockChainWithTransactionListener(txListener chan protocols.ChainTransaction) *MockChain {
-	mc := NewMockChain()
+func NewMockChainWithTransactionListener(txListener chan protocols.ChainTransaction) *MockChainService {
+	mc := NewMockChainService()
 	mc.txListener = txListener
 	return mc
 }
 
 // SendTransaction responds to the given tx.
-func (mc *MockChain) SendTransaction(tx protocols.ChainTransaction) error {
+func (mc *MockChainService) SendTransaction(tx protocols.ChainTransaction) error {
 	*mc.blockNum++
 	if mc.txListener != nil {
 		mc.txListener <- tx

--- a/client/engine/chainservice/mock_chainservice.go
+++ b/client/engine/chainservice/mock_chainservice.go
@@ -8,13 +8,13 @@ import (
 
 // MockChainService adheres to the ChainService interface. The constructor accepts a MockChain, which allows multiple clients to share the same, in-memory chain.
 type MockChainService struct {
-	chain      *MockChainImpl
+	chain      *MockChain
 	txListener chan protocols.ChainTransaction // this is used to broadcast transactions that have been received
 	eventFeed  <-chan Event
 }
 
 // NewMockChainService returns a new MockChainService.
-func NewMockChainService(chain *MockChainImpl, address common.Address) *MockChainService {
+func NewMockChainService(chain *MockChain, address common.Address) *MockChainService {
 	mc := MockChainService{chain: chain}
 	mc.eventFeed = chain.SubscribeToEvents(address)
 	return &mc
@@ -22,7 +22,7 @@ func NewMockChainService(chain *MockChainImpl, address common.Address) *MockChai
 
 // NewMockChainWithTransactionListener returns a new MockChainService that will send transactions to the supplied chan.
 // This lets us easily rebroadcast transactions to other MockChainServices.
-func NewMockChainWithTransactionListener(chain *MockChainImpl, address common.Address, txListener chan protocols.ChainTransaction) *MockChainService {
+func NewMockChainWithTransactionListener(chain *MockChain, address common.Address, txListener chan protocols.ChainTransaction) *MockChainService {
 	mc := NewMockChainService(chain, address)
 	mc.txListener = txListener
 	return mc

--- a/client/engine/chainservice/mock_chainservice.go
+++ b/client/engine/chainservice/mock_chainservice.go
@@ -91,17 +91,17 @@ func NewMockChainService(chain MockChain, address common.Address) *MockChainServ
 
 // NewMockChainWithTransactionListener returns a new mock chain that will send transactions to the supplied chan.
 // This lets us easily rebroadcast transactions to other mock chains.
-// func NewMockChainWithTransactionListener(txListener chan protocols.ChainTransaction) *MockChainService {
-// 	mc := NewMockChainService()
-// 	mc.txListener = txListener
-// 	return mc
-// }
+func NewMockChainWithTransactionListener(chain MockChain, address common.Address, txListener chan protocols.ChainTransaction) *MockChainService {
+	mc := NewMockChainService(chain, address)
+	mc.txListener = txListener
+	return mc
+}
 
 // SendTransaction responds to the given tx.
 func (mc *MockChainService) SendTransaction(tx protocols.ChainTransaction) error {
-	// if mc.txListener != nil {
-	// 	mc.txListener <- tx
-	// }
+	if mc.txListener != nil {
+		mc.txListener <- tx
+	}
 
 	return mc.chain.SubmitTransaction(tx)
 }

--- a/client/engine/chainservice/mock_chainservice_test.go
+++ b/client/engine/chainservice/mock_chainservice_test.go
@@ -13,7 +13,7 @@ func TestDeposit(t *testing.T) {
 	// The MockChain should react to a deposit transaction for a given channel by sending an event with updated holdings for that channel
 
 	// Construct MockChain
-	var chain = NewMockChain()
+	var chain = NewMockChainService()
 	eventFeed := chain.EventFeed()
 
 	// Prepare test data to trigger MockChainService

--- a/client/engine/chainservice/mock_chainservice_test.go
+++ b/client/engine/chainservice/mock_chainservice_test.go
@@ -15,7 +15,7 @@ func TestDeposit(t *testing.T) {
 	var b = types.Address(common.HexToAddress(`b`))
 
 	// Construct MockChain
-	chain := NewMockChainImpl()
+	chain := NewMockChain()
 	chainServiceA := NewMockChainService(chain, a)
 	chainServiceB := NewMockChainService(chain, b)
 

--- a/client/engine/chainservice/mock_chainservice_test.go
+++ b/client/engine/chainservice/mock_chainservice_test.go
@@ -11,10 +11,16 @@ import (
 
 func TestDeposit(t *testing.T) {
 	// The MockChain should react to a deposit transaction for a given channel by sending an event with updated holdings for that channel
+	var a = types.Address(common.HexToAddress(`a`))
+	var b = types.Address(common.HexToAddress(`b`))
 
 	// Construct MockChain
-	var chain = NewMockChainService()
-	eventFeed := chain.EventFeed()
+	chain := NewMockChainImpl()
+	chainServiceA := NewMockChainService(chain, a)
+	chainServiceB := NewMockChainService(chain, b)
+
+	eventFeedA := chainServiceA.EventFeed()
+	eventFeedB := chainServiceB.EventFeed()
 
 	// Prepare test data to trigger MockChainService
 	testDeposit := types.Funds{
@@ -23,26 +29,34 @@ func TestDeposit(t *testing.T) {
 	testTx := protocols.NewDepositTransaction(types.Destination(common.HexToHash(`4ebd366d014a173765ba1e50f284c179ade31f20441bec41664712aac6cc461d`)), testDeposit)
 
 	// Send one transaction and receive one event from it.
-	err := chain.SendTransaction(testTx)
+	err := chainServiceA.SendTransaction(testTx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	event := <-eventFeed
+	event := <-eventFeedA
 
 	checkReceivedEventIsValid(t, event, testTx.Deposit, testTx.ChannelId())
 
 	// Send the transaction again and receive another event
-	err = chain.SendTransaction(testTx)
+	err = chainServiceB.SendTransaction(testTx)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	event = <-eventFeed
+	event = <-eventFeedA
 
 	// The expectation is that the MockChainService remembered the previous deposit and added this one to it:
 	expectedHoldings := testTx.Deposit.Add(testTx.Deposit)
 
 	checkReceivedEventIsValid(t, event, expectedHoldings, testTx.ChannelId())
+
+	// Pull an event out of the other mock chain service and check that
+	eventB := <-eventFeedB
+	checkReceivedEventIsValid(t, eventB, testTx.Deposit, testTx.ChannelId())
+
+	// Pull another event out of the other mock chain service and check that
+	eventB = <-eventFeedB
+	checkReceivedEventIsValid(t, eventB, expectedHoldings, testTx.ChannelId())
 }
 
 func checkReceivedEventIsValid(t *testing.T, receivedEvent Event, holdings types.Funds, channelId types.Destination) {

--- a/client/engine/chainservice/mockchain_test.go
+++ b/client/engine/chainservice/mockchain_test.go
@@ -10,26 +10,11 @@ import (
 )
 
 func TestDeposit(t *testing.T) {
-	// The MockChain should react to a deposit transaction for a given channel by sending an event with updated holdings for that channel to all subsribers
+	// The MockChain should react to a deposit transaction for a given channel by sending an event with updated holdings for that channel
 
-	var a = types.Address(common.HexToAddress(`a`))
-	var b = types.Address(common.HexToAddress(`b`))
-
-	// Construct MockChain and tell it the subscriber addresses.
-	// This is not super elegant but gets around data races -- the constructor will make channels and then run a listener which will send on them.
+	// Construct MockChain
 	var chain = NewMockChain()
-	chain.SubscribeToEvents(a)
-	chain.SubscribeToEvents(b)
-
-	eventFeedA, err := chain.EventFeed(a)
-	if err != nil {
-		t.Fatalf("subscription for address a failed")
-	}
-
-	eventFeedB, err := chain.EventFeed(b)
-	if err != nil {
-		t.Fatalf("subscription for address b failed")
-	}
+	eventFeed := chain.EventFeed()
 
 	// Prepare test data to trigger MockChainService
 	testDeposit := types.Funds{
@@ -38,11 +23,11 @@ func TestDeposit(t *testing.T) {
 	testTx := protocols.NewDepositTransaction(types.Destination(common.HexToHash(`4ebd366d014a173765ba1e50f284c179ade31f20441bec41664712aac6cc461d`)), testDeposit)
 
 	// Send one transaction and receive one event from it.
-	err = chain.SendTransaction(testTx)
+	err := chain.SendTransaction(testTx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	event := <-eventFeedA
+	event := <-eventFeed
 
 	checkReceivedEventIsValid(t, event, testTx.Deposit, testTx.ChannelId())
 
@@ -52,20 +37,12 @@ func TestDeposit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	event = <-eventFeedA
+	event = <-eventFeed
 
 	// The expectation is that the MockChainService remembered the previous deposit and added this one to it:
 	expectedHoldings := testTx.Deposit.Add(testTx.Deposit)
 
 	checkReceivedEventIsValid(t, event, expectedHoldings, testTx.ChannelId())
-
-	// Pull an event out of the other mock chain service and check that
-	eventB := <-eventFeedB
-	checkReceivedEventIsValid(t, eventB, testTx.Deposit, testTx.ChannelId())
-
-	// Pull another event out of the other mock chain service and check that
-	eventB = <-eventFeedB
-	checkReceivedEventIsValid(t, eventB, expectedHoldings, testTx.ChannelId())
 }
 
 func checkReceivedEventIsValid(t *testing.T, receivedEvent Event, holdings types.Funds, channelId types.Destination) {

--- a/client/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/client/engine/chainservice/simulated_backend_chainservice_test.go
@@ -66,7 +66,7 @@ func TestDepositSimulatedBackendChainService(t *testing.T) {
 	channelID := types.Destination(common.HexToHash(`4ebd366d014a173765ba1e50f284c179ade31f20441bec41664712aac6cc461d`))
 	testTx := protocols.NewDepositTransaction(channelID, testDeposit)
 
-	out := cs.SubscribeToEvents(ethAccounts[0].From)
+	out := cs.EventFeed()
 	// Submit transactiom
 	err = cs.SendTransaction(testTx)
 	if err != nil {
@@ -101,7 +101,7 @@ func TestConcludeSimulatedBackendChainService(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	out := cs.SubscribeToEvents(ethAccounts[0].From)
+	out := cs.EventFeed()
 
 	var concludeState = state.State{
 		ChainId: big.NewInt(1337),

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -80,7 +80,7 @@ func New(msg messageservice.MessageService, chain chainservice.ChainService, sto
 
 	// bind to inbound chans
 	e.FromAPI = make(chan APIEvent)
-	e.fromChain = chain.SubscribeToEvents(*e.store.GetAddress())
+	e.fromChain = chain.EventFeed()
 	e.fromMsg = msg.Out()
 
 	e.chain = chain

--- a/client_test/directfund_simple_tcp_test.go
+++ b/client_test/directfund_simple_tcp_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // setupClientWithSimpleTCP is a helper function that contructs a client and returns the new client and its store.
-func setupClientWithSimpleTCP(pk []byte, chain *chainservice.MockChain, peers map[types.Address]string, logDestination io.Writer, meanMessageDelay time.Duration) (client.Client, *simpletcp.SimpleTCPMessageService) {
+func setupClientWithSimpleTCP(pk []byte, chain *chainservice.MockChainService, peers map[types.Address]string, logDestination io.Writer, meanMessageDelay time.Duration) (client.Client, *simpletcp.SimpleTCPMessageService) {
 	myAddress := crypto.GetAddressFromSecretKeyBytes(pk)
 	messageservice := simpletcp.NewSimpleTCPMessageService(peers[myAddress], peers)
 	storeA := store.NewMemStore(pk)
@@ -30,7 +30,7 @@ func TestSimpleTCPMessageService(t *testing.T) {
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
-	chain := chainservice.NewMockChain()
+	chain := chainservice.NewMockChainService()
 
 	peers := map[types.Address]string{
 		alice.Address(): "localhost:3005",

--- a/client_test/directfund_simple_tcp_test.go
+++ b/client_test/directfund_simple_tcp_test.go
@@ -30,7 +30,7 @@ func TestSimpleTCPMessageService(t *testing.T) {
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
-	chain := chainservice.NewMockChainImpl()
+	chain := chainservice.NewMockChain()
 	chainServiceA := chainservice.NewMockChainService(chain, alice.Address())
 	chainServiceB := chainservice.NewMockChainService(chain, bob.Address())
 

--- a/client_test/directfund_simple_tcp_test.go
+++ b/client_test/directfund_simple_tcp_test.go
@@ -30,14 +30,16 @@ func TestSimpleTCPMessageService(t *testing.T) {
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
-	chain := chainservice.NewMockChainService()
+	chain := chainservice.NewMockChainImpl()
+	chainServiceA := chainservice.NewMockChainService(chain, alice.Address())
+	chainServiceB := chainservice.NewMockChainService(chain, bob.Address())
 
 	peers := map[types.Address]string{
 		alice.Address(): "localhost:3005",
 		bob.Address():   "localhost:3006",
 	}
-	clientA, msA := setupClientWithSimpleTCP(alice.PrivateKey, chain, peers, logDestination, 0)
-	clientB, msB := setupClientWithSimpleTCP(bob.PrivateKey, chain, peers, logDestination, 0)
+	clientA, msA := setupClientWithSimpleTCP(alice.PrivateKey, chainServiceA, peers, logDestination, 0)
+	clientB, msB := setupClientWithSimpleTCP(bob.PrivateKey, chainServiceB, peers, logDestination, 0)
 	defer msA.Close()
 	defer msB.Close()
 	directlyFundALedgerChannel(t, clientA, clientB)

--- a/client_test/directfund_test.go
+++ b/client_test/directfund_test.go
@@ -53,7 +53,7 @@ func TestWhenObjectiveIsRejected(t *testing.T) {
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
-	chain := chainservice.NewMockChainImpl()
+	chain := chainservice.NewMockChain()
 	chainServiceA := chainservice.NewMockChainService(chain, alice.Address())
 	chainServiceB := chainservice.NewMockChainService(chain, alice.Address())
 	broker := messageservice.NewBroker()

--- a/client_test/directfund_test.go
+++ b/client_test/directfund_test.go
@@ -53,7 +53,7 @@ func TestWhenObjectiveIsRejected(t *testing.T) {
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
-	chain := chainservice.NewMockChain()
+	chain := chainservice.NewMockChainService()
 	broker := messageservice.NewBroker()
 
 	meanMessageDelay := time.Duration(0)

--- a/client_test/directfund_test.go
+++ b/client_test/directfund_test.go
@@ -53,11 +53,13 @@ func TestWhenObjectiveIsRejected(t *testing.T) {
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
-	chain := chainservice.NewMockChainService()
+	chain := chainservice.NewMockChainImpl()
+	chainServiceA := chainservice.NewMockChainService(chain, alice.Address())
+	chainServiceB := chainservice.NewMockChainService(chain, alice.Address())
 	broker := messageservice.NewBroker()
 
 	meanMessageDelay := time.Duration(0)
-	clientA, storeA := setupClient(alice.PrivateKey, chain, broker, logDestination, meanMessageDelay)
+	clientA, storeA := setupClient(alice.PrivateKey, chainServiceA, broker, logDestination, meanMessageDelay)
 	var (
 		clientB client.Client
 		storeB  store.Store
@@ -65,7 +67,7 @@ func TestWhenObjectiveIsRejected(t *testing.T) {
 	{
 		messageservice := messageservice.NewTestMessageService(bob.Address(), broker, meanMessageDelay)
 		storeB = store.NewMemStore(bob.PrivateKey)
-		clientB = client.New(messageservice, chain, storeB, logDestination, &RejectingPolicyMaker{}, nil)
+		clientB = client.New(messageservice, chainServiceB, storeB, logDestination, &RejectingPolicyMaker{}, nil)
 	}
 
 	outcome := testdata.Outcomes.Create(alice.Address(), bob.Address(), ledgerChannelDeposit, ledgerChannelDeposit)

--- a/client_test/virtualdefund_test.go
+++ b/client_test/virtualdefund_test.go
@@ -45,12 +45,15 @@ func TestVirtualDefundIntegrationWithMessageDelay(t *testing.T) {
 
 // runVirtualDefundIntegrationTest runs a virtual defund integration test using the provided message delay, objective timeout and log destination
 func runVirtualDefundIntegrationTest(t *testing.T, messageDelay time.Duration, objectiveTimeout time.Duration, logDestination io.Writer) {
-	chain := chainservice.NewMockChainService()
+	chain := chainservice.NewMockChainImpl()
+	chainServiceA := chainservice.NewMockChainService(chain, alice.Address())
+	chainServiceB := chainservice.NewMockChainService(chain, bob.Address())
+	chainServiceI := chainservice.NewMockChainService(chain, irene.Address())
 	broker := messageservice.NewBroker()
 
-	clientA, storeA := setupClient(alice.PrivateKey, chain, broker, logDestination, messageDelay)
-	clientB, storeB := setupClient(bob.PrivateKey, chain, broker, logDestination, messageDelay)
-	clientI, storeI := setupClient(irene.PrivateKey, chain, broker, logDestination, messageDelay)
+	clientA, storeA := setupClient(alice.PrivateKey, chainServiceA, broker, logDestination, messageDelay)
+	clientB, storeB := setupClient(bob.PrivateKey, chainServiceB, broker, logDestination, messageDelay)
+	clientI, storeI := setupClient(irene.PrivateKey, chainServiceI, broker, logDestination, messageDelay)
 
 	numOfVirtualChannels := uint(5)
 	paidToBob := uint(1)

--- a/client_test/virtualdefund_test.go
+++ b/client_test/virtualdefund_test.go
@@ -45,7 +45,7 @@ func TestVirtualDefundIntegrationWithMessageDelay(t *testing.T) {
 
 // runVirtualDefundIntegrationTest runs a virtual defund integration test using the provided message delay, objective timeout and log destination
 func runVirtualDefundIntegrationTest(t *testing.T, messageDelay time.Duration, objectiveTimeout time.Duration, logDestination io.Writer) {
-	chain := chainservice.NewMockChain()
+	chain := chainservice.NewMockChainService()
 	broker := messageservice.NewBroker()
 
 	clientA, storeA := setupClient(alice.PrivateKey, chain, broker, logDestination, messageDelay)

--- a/client_test/virtualdefund_test.go
+++ b/client_test/virtualdefund_test.go
@@ -45,7 +45,7 @@ func TestVirtualDefundIntegrationWithMessageDelay(t *testing.T) {
 
 // runVirtualDefundIntegrationTest runs a virtual defund integration test using the provided message delay, objective timeout and log destination
 func runVirtualDefundIntegrationTest(t *testing.T, messageDelay time.Duration, objectiveTimeout time.Duration, logDestination io.Writer) {
-	chain := chainservice.NewMockChainImpl()
+	chain := chainservice.NewMockChain()
 	chainServiceA := chainservice.NewMockChainService(chain, alice.Address())
 	chainServiceB := chainservice.NewMockChainService(chain, bob.Address())
 	chainServiceI := chainservice.NewMockChainService(chain, irene.Address())

--- a/client_test/virtualfund_largescale_integration_test.go
+++ b/client_test/virtualfund_largescale_integration_test.go
@@ -47,7 +47,7 @@ func TestLargeScaleVirtualFundIntegration(t *testing.T) {
 	logDestination := newLogWriter(logFile)
 
 	// Setup central services
-	chain := chainservice.NewMockChain()
+	chain := chainservice.NewMockChainService()
 	broker := messageservice.NewBroker()
 
 	// Setup singleton (instrumented) clients
@@ -73,7 +73,7 @@ func TestLargeScaleVirtualFundIntegration(t *testing.T) {
 	}
 
 	// Switch to instrumented clients
-	chain = chainservice.NewMockChain()
+	chain = chainservice.NewMockChainService()
 	broker = messageservice.NewBroker()
 	retrievalProvider = client.New(
 		messageservice.NewVectorClockTestMessageService(bob.Address(), broker, 0, vectorClockLogDir),

--- a/client_test/virtualfund_largescale_integration_test.go
+++ b/client_test/virtualfund_largescale_integration_test.go
@@ -47,7 +47,7 @@ func TestLargeScaleVirtualFundIntegration(t *testing.T) {
 	logDestination := newLogWriter(logFile)
 
 	// Setup central services
-	chain := chainservice.NewMockChainImpl()
+	chain := chainservice.NewMockChain()
 	chainServiceB := chainservice.NewMockChainService(chain, bob.Address())
 	chainServiceI := chainservice.NewMockChainService(chain, irene.Address())
 	broker := messageservice.NewBroker()

--- a/client_test/virtualfund_multi_party_test.go
+++ b/client_test/virtualfund_multi_party_test.go
@@ -19,7 +19,7 @@ func TestVirtualFundMultiParty(t *testing.T) {
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
-	chain := chainservice.NewMockChain()
+	chain := chainservice.NewMockChainService()
 	broker := messageservice.NewBroker()
 
 	clientAlice, _ := setupClient(alice.PrivateKey, chain, broker, logDestination, 0)

--- a/client_test/virtualfund_multi_party_test.go
+++ b/client_test/virtualfund_multi_party_test.go
@@ -19,7 +19,7 @@ func TestVirtualFundMultiParty(t *testing.T) {
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
-	chain := chainservice.NewMockChainImpl()
+	chain := chainservice.NewMockChain()
 	chainServiceA := chainservice.NewMockChainService(chain, alice.Address())
 	chainServiceBo := chainservice.NewMockChainService(chain, bob.Address())
 	chainServiceBr := chainservice.NewMockChainService(chain, brian.Address())

--- a/client_test/virtualfund_multi_party_test.go
+++ b/client_test/virtualfund_multi_party_test.go
@@ -19,13 +19,17 @@ func TestVirtualFundMultiParty(t *testing.T) {
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
-	chain := chainservice.NewMockChainService()
+	chain := chainservice.NewMockChainImpl()
+	chainServiceA := chainservice.NewMockChainService(chain, alice.Address())
+	chainServiceBo := chainservice.NewMockChainService(chain, bob.Address())
+	chainServiceBr := chainservice.NewMockChainService(chain, brian.Address())
+	chainServiceI := chainservice.NewMockChainService(chain, irene.Address())
 	broker := messageservice.NewBroker()
 
-	clientAlice, _ := setupClient(alice.PrivateKey, chain, broker, logDestination, 0)
-	clientBob, _ := setupClient(bob.PrivateKey, chain, broker, logDestination, 0)
-	clientBrian, _ := setupClient(brian.PrivateKey, chain, broker, logDestination, 0)
-	clientIrene, _ := setupClient(irene.PrivateKey, chain, broker, logDestination, 0)
+	clientAlice, _ := setupClient(alice.PrivateKey, chainServiceA, broker, logDestination, 0)
+	clientBob, _ := setupClient(bob.PrivateKey, chainServiceBo, broker, logDestination, 0)
+	clientBrian, _ := setupClient(brian.PrivateKey, chainServiceBr, broker, logDestination, 0)
+	clientIrene, _ := setupClient(irene.PrivateKey, chainServiceI, broker, logDestination, 0)
 
 	directlyFundALedgerChannel(t, clientAlice, clientIrene)
 	directlyFundALedgerChannel(t, clientIrene, clientBob)

--- a/client_test/virtualfund_simple_tcp_test.go
+++ b/client_test/virtualfund_simple_tcp_test.go
@@ -14,7 +14,7 @@ func TestVirtualFundWithSimpleTCPMessageService(t *testing.T) {
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
-	chain := chainservice.NewMockChainImpl()
+	chain := chainservice.NewMockChain()
 	chainServiceA := chainservice.NewMockChainService(chain, alice.Address())
 	chainServiceB := chainservice.NewMockChainService(chain, bob.Address())
 	chainServiceI := chainservice.NewMockChainService(chain, irene.Address())

--- a/client_test/virtualfund_simple_tcp_test.go
+++ b/client_test/virtualfund_simple_tcp_test.go
@@ -14,7 +14,7 @@ func TestVirtualFundWithSimpleTCPMessageService(t *testing.T) {
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
-	chain := chainservice.NewMockChain()
+	chain := chainservice.NewMockChainService()
 
 	peers := map[types.Address]string{
 		alice.Address(): "localhost:3005",

--- a/client_test/virtualfund_simple_tcp_test.go
+++ b/client_test/virtualfund_simple_tcp_test.go
@@ -14,7 +14,10 @@ func TestVirtualFundWithSimpleTCPMessageService(t *testing.T) {
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
-	chain := chainservice.NewMockChainService()
+	chain := chainservice.NewMockChainImpl()
+	chainServiceA := chainservice.NewMockChainService(chain, alice.Address())
+	chainServiceB := chainservice.NewMockChainService(chain, bob.Address())
+	chainServiceI := chainservice.NewMockChainService(chain, irene.Address())
 
 	peers := map[types.Address]string{
 		alice.Address(): "localhost:3005",
@@ -22,9 +25,9 @@ func TestVirtualFundWithSimpleTCPMessageService(t *testing.T) {
 		irene.Address(): "localhost:3007",
 	}
 
-	clientA, msgA := setupClientWithSimpleTCP(alice.PrivateKey, chain, peers, logDestination, 0)
-	clientB, msgB := setupClientWithSimpleTCP(bob.PrivateKey, chain, peers, logDestination, 0)
-	clientI, msgI := setupClientWithSimpleTCP(irene.PrivateKey, chain, peers, logDestination, 0)
+	clientA, msgA := setupClientWithSimpleTCP(alice.PrivateKey, chainServiceA, peers, logDestination, 0)
+	clientB, msgB := setupClientWithSimpleTCP(bob.PrivateKey, chainServiceB, peers, logDestination, 0)
+	clientI, msgI := setupClientWithSimpleTCP(irene.PrivateKey, chainServiceI, peers, logDestination, 0)
 	defer msgA.Close()
 	defer msgB.Close()
 	defer msgI.Close()

--- a/client_test/virtualfund_test.go
+++ b/client_test/virtualfund_test.go
@@ -49,7 +49,7 @@ func TestVirtualFundIntegration(t *testing.T) {
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
-	chain := chainservice.NewMockChain()
+	chain := chainservice.NewMockChainService()
 	broker := messageservice.NewBroker()
 
 	clientA, _ := setupClient(alice.PrivateKey, chain, broker, logDestination, 0)

--- a/client_test/virtualfund_test.go
+++ b/client_test/virtualfund_test.go
@@ -49,12 +49,15 @@ func TestVirtualFundIntegration(t *testing.T) {
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
-	chain := chainservice.NewMockChainService()
+	chain := chainservice.NewMockChainImpl()
+	chainServiceA := chainservice.NewMockChainService(chain, alice.Address())
+	chainServiceB := chainservice.NewMockChainService(chain, bob.Address())
+	chainServiceI := chainservice.NewMockChainService(chain, irene.Address())
 	broker := messageservice.NewBroker()
 
-	clientA, _ := setupClient(alice.PrivateKey, chain, broker, logDestination, 0)
-	clientB, _ := setupClient(bob.PrivateKey, chain, broker, logDestination, 0)
-	clientI, _ := setupClient(irene.PrivateKey, chain, broker, logDestination, 0)
+	clientA, _ := setupClient(alice.PrivateKey, chainServiceA, broker, logDestination, 0)
+	clientB, _ := setupClient(bob.PrivateKey, chainServiceB, broker, logDestination, 0)
+	clientI, _ := setupClient(irene.PrivateKey, chainServiceI, broker, logDestination, 0)
 
 	openVirtualChannels(t, clientA, clientB, clientI, 1)
 }

--- a/client_test/virtualfund_test.go
+++ b/client_test/virtualfund_test.go
@@ -49,7 +49,7 @@ func TestVirtualFundIntegration(t *testing.T) {
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
-	chain := chainservice.NewMockChainImpl()
+	chain := chainservice.NewMockChain()
 	chainServiceA := chainservice.NewMockChainService(chain, alice.Address())
 	chainServiceB := chainservice.NewMockChainService(chain, bob.Address())
 	chainServiceI := chainservice.NewMockChainService(chain, irene.Address())

--- a/client_test/virtualfund_with_message_delays_test.go
+++ b/client_test/virtualfund_with_message_delays_test.go
@@ -27,12 +27,15 @@ func TestVirtualFundWithMessageDelays(t *testing.T) {
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
-	chain := chainservice.NewMockChainService()
+	chain := chainservice.NewMockChainImpl()
+	chainServiceA := chainservice.NewMockChainService(chain, alice.Address())
+	chainServiceB := chainservice.NewMockChainService(chain, bob.Address())
+	chainServiceI := chainservice.NewMockChainService(chain, irene.Address())
 	broker := messageservice.NewBroker()
 
-	clientA, _ := setupClient(alice.PrivateKey, chain, broker, logDestination, MAX_MESSAGE_DELAY)
-	clientB, _ := setupClient(bob.PrivateKey, chain, broker, logDestination, MAX_MESSAGE_DELAY)
-	clientI, _ := setupClient(irene.PrivateKey, chain, broker, logDestination, MAX_MESSAGE_DELAY)
+	clientA, _ := setupClient(alice.PrivateKey, chainServiceA, broker, logDestination, MAX_MESSAGE_DELAY)
+	clientB, _ := setupClient(bob.PrivateKey, chainServiceB, broker, logDestination, MAX_MESSAGE_DELAY)
+	clientI, _ := setupClient(irene.PrivateKey, chainServiceI, broker, logDestination, MAX_MESSAGE_DELAY)
 
 	directlyFundALedgerChannel(t, clientA, clientI)
 	directlyFundALedgerChannel(t, clientI, clientB)

--- a/client_test/virtualfund_with_message_delays_test.go
+++ b/client_test/virtualfund_with_message_delays_test.go
@@ -27,7 +27,7 @@ func TestVirtualFundWithMessageDelays(t *testing.T) {
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
-	chain := chainservice.NewMockChain()
+	chain := chainservice.NewMockChainService()
 	broker := messageservice.NewBroker()
 
 	clientA, _ := setupClient(alice.PrivateKey, chain, broker, logDestination, MAX_MESSAGE_DELAY)

--- a/client_test/virtualfund_with_message_delays_test.go
+++ b/client_test/virtualfund_with_message_delays_test.go
@@ -27,7 +27,7 @@ func TestVirtualFundWithMessageDelays(t *testing.T) {
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
-	chain := chainservice.NewMockChainImpl()
+	chain := chainservice.NewMockChain()
 	chainServiceA := chainservice.NewMockChainService(chain, alice.Address())
 	chainServiceB := chainservice.NewMockChainService(chain, bob.Address())
 	chainServiceI := chainservice.NewMockChainService(chain, irene.Address())


### PR DESCRIPTION
Part of the work needed for https://github.com/statechannels/go-nitro/issues/790.

An implementation of the `ChainService` interface is used by the engine to submit transactions to a chain and receive events from the chain.

Previously, the `ChainService` included a subscription API to accommodate multiple engines using the same `ChainService`. This has been changed to:
- A single engine/client uses a single ChainService instance that is passed to the engine/client constructor. The instance should not be used by multiple engines.
- A `ChainService` has a reference to a shared state chain. In the case of `EthChainService`, the chain is an Ethereum chain (which can be a simulated chain, a testnet, or the mainnet). In the case of `MockChainService`, the chain is a `MockChain` (introduced in this PR).

Since this PR updates the `MockChainService` constructor, [go-nitro-testground](https://github.com/statechannels/go-nitro-testground/blob/0c6d670d05a1aacefc99e67dfbb4ec73e35cc94f/chain/syncer.go#L113) should be updated after this PR is merged.