### PR TITLE
upgrade golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,8 +17,8 @@ jobs:
         uses: golangci/golangci-lint-action@v3.1.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.45.2
-      
+          version: v1.46.2
+
       - name: Run staticcheck # see: staticcheck.io
         uses: dominikh/staticcheck-action@v1.2.0
         with:


### PR DESCRIPTION
To upgrade locally, use

brew upgrade golangci-lint

