### PR TITLE
Small refactor of metrics

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -114,30 +114,26 @@ func (e *Engine) Run() {
 		var err error
 		select {
 		case apiEvent := <-e.FromAPI:
-			e.metrics.RecordDuration("handle_api_event", func() {
-				e.metrics.RecordQueueLength("incoming_api_events", len(e.fromMsg))
-				res, err = e.handleAPIEvent(apiEvent)
 
-				if errors.Is(err, directdefund.ErrNotEmpty) {
-					// communicate failure to client & swallow error
-					e.toApi <- res
-					err = nil
-				}
-			})
+			e.metrics.RecordQueueLength("incoming_api_events", len(e.fromMsg))
+			res, err = e.handleAPIEvent(apiEvent)
+
+			if errors.Is(err, directdefund.ErrNotEmpty) {
+				// communicate failure to client & swallow error
+				e.toApi <- res
+				err = nil
+			}
+
 		case chainEvent := <-e.fromChain:
 			e.metrics.RecordQueueLength("incoming_chain_events", len(e.fromMsg))
-			e.metrics.RecordDuration("handle_chain_event", func() {
-				res, err = e.handleChainEvent(chainEvent)
-			})
+
+			res, err = e.handleChainEvent(chainEvent)
+
 		case message := <-e.fromMsg:
 			e.metrics.RecordQueueLength("incoming_messages", len(e.fromMsg))
-			e.metrics.RecordDuration("handle_message", func() {
-				res, err = e.handleMessage(message)
-			})
+			res, err = e.handleMessage(message)
 		case proposal := <-e.fromLedger:
-			e.metrics.RecordDuration("handle_proposal", func() {
-				res, err = e.handleProposal(proposal)
-			})
+			res, err = e.handleProposal(proposal)
 		}
 
 		// Handle errors
@@ -163,6 +159,8 @@ func (e *Engine) Run() {
 // a running ledger channel by pulling its corresponding objective
 // from the store and attempting progress.
 func (e *Engine) handleProposal(proposal consensus_channel.Proposal) (ObjectiveChangeEvent, error) {
+	defer e.metrics.RecordFunctionDuration()()
+
 	id := getProposalObjectiveId(proposal)
 	obj, err := e.store.GetObjectiveById(id)
 	if err != nil {
@@ -178,6 +176,8 @@ func (e *Engine) handleProposal(proposal consensus_channel.Proposal) (ObjectiveC
 //   - attempts progress on the target Objective,
 //   - attempts progress on related objectives which may have become unblocked.
 func (e *Engine) handleMessage(message protocols.Message) (ObjectiveChangeEvent, error) {
+	defer e.metrics.RecordFunctionDuration()()
+
 	e.logger.Printf("Handling inbound message %+v", protocols.SummarizeMessage(message))
 	allCompleted := ObjectiveChangeEvent{}
 
@@ -310,6 +310,7 @@ func (e *Engine) handleMessage(message protocols.Message) (ObjectiveChangeEvent,
 //   - generates an updated objective, and
 //   - attempts progress.
 func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (ObjectiveChangeEvent, error) {
+	defer e.metrics.RecordFunctionDuration()()
 	e.logger.Printf("handling chain event %v", chainEvent)
 	objective, ok := e.store.GetObjectiveByChannelId(chainEvent.ChannelID())
 	if !ok {
@@ -336,6 +337,7 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (ObjectiveChang
 //   - Reject an existing objective (if not null)
 //   - Approve an existing objective (if not null)
 func (e *Engine) handleAPIEvent(apiEvent APIEvent) (ObjectiveChangeEvent, error) {
+	defer e.metrics.RecordFunctionDuration()()
 	if apiEvent.ObjectiveToSpawn != nil {
 
 		switch request := (apiEvent.ObjectiveToSpawn).(type) {
@@ -386,6 +388,8 @@ func (e *Engine) handleAPIEvent(apiEvent APIEvent) (ObjectiveChangeEvent, error)
 
 // executeSideEffects executes the SideEffects declared by cranking an Objective
 func (e *Engine) executeSideEffects(sideEffects protocols.SideEffects) error {
+	defer e.metrics.RecordFunctionDuration()()
+
 	for _, message := range sideEffects.MessagesToSend {
 
 		e.logger.Printf("Sending message %+v", protocols.SummarizeMessage(message))
@@ -413,15 +417,14 @@ func (e *Engine) executeSideEffects(sideEffects protocols.SideEffects) error {
 //  4. It executes any side effects that were declared during cranking
 //  5. It updates progress metadata in the store
 func (e *Engine) attemptProgress(objective protocols.Objective) (outgoing ObjectiveChangeEvent, err error) {
+	defer e.metrics.RecordFunctionDuration()()
 
 	secretKey := e.store.GetChannelSecretKey()
 	var crankedObjective protocols.Objective
 	var sideEffects protocols.SideEffects
 	var waitingFor protocols.WaitingFor
 
-	e.metrics.RecordDuration("crank", func() {
-		crankedObjective, sideEffects, waitingFor, err = objective.Crank(secretKey)
-	})
+	crankedObjective, sideEffects, waitingFor, err = objective.Crank(secretKey)
 
 	if err != nil {
 		return
@@ -454,6 +457,8 @@ func (e *Engine) attemptProgress(objective protocols.Objective) (outgoing Object
 //
 // The associated Channel will remain in the store.
 func (e Engine) spawnConsensusChannelIfDirectFundObjective(crankedObjective protocols.Objective) error {
+	defer e.metrics.RecordFunctionDuration()()
+
 	if dfo, isDfo := crankedObjective.(*directfund.Objective); isDfo {
 		c, err := dfo.CreateConsensusChannel()
 		if err != nil {
@@ -471,7 +476,8 @@ func (e Engine) spawnConsensusChannelIfDirectFundObjective(crankedObjective prot
 
 // getOrCreateObjective retrieves the objective from the store. if the objective does not exist, it creates the objective using the supplied signed state, and stores it in the store
 func (e *Engine) getOrCreateObjective(id protocols.ObjectiveId, ss state.SignedState) (protocols.Objective, error) {
-
+	defer e.metrics.RecordFunctionDuration()()
+	
 	objective, err := e.store.GetObjectiveById(id)
 
 	if err == nil {
@@ -497,6 +503,7 @@ func (e *Engine) getOrCreateObjective(id protocols.ObjectiveId, ss state.SignedS
 
 // constructObjectiveFromMessage Constructs a new objective (of the appropriate concrete type) from the supplied message.
 func (e *Engine) constructObjectiveFromMessage(id protocols.ObjectiveId, ss state.SignedState) (protocols.Objective, error) {
+	defer e.metrics.RecordFunctionDuration()()
 
 	switch {
 	case directfund.IsDirectFundObjective(id):

--- a/client/engine/metrics.go
+++ b/client/engine/metrics.go
@@ -78,7 +78,7 @@ func NewMetricsRecorder(me types.Address, metrics MetricsApi) *MetricsRecorder {
 	}
 }
 
-// RecordMessageReceived records the duration of the function
+// RecordFunctionDuration records the duration of the function
 // It should be called at the start of the function like so  `defer e.metrics.RecordFunctionDuration()()`
 func (o *MetricsRecorder) RecordFunctionDuration() func() {
 	start := time.Now()
@@ -86,10 +86,10 @@ func (o *MetricsRecorder) RecordFunctionDuration() func() {
 
 		elapsed := time.Since(start)
 
-		// Skip this function, and fetch the PC  for its parent.
+		// Skip this function, and fetch the PC for its parent.
 		pc, _, _, _ := runtime.Caller(1)
 
-		// Retrieve a function object this functions parent.
+		// Retrieve a function object this function's parent.
 		funcObj := runtime.FuncForPC(pc)
 
 		// Use a regex to strip out the module path

--- a/client/engine/metrics.go
+++ b/client/engine/metrics.go
@@ -25,16 +25,6 @@ type MetricsApi interface {
 	//   requests_received,tag1=value1,tag2=value2,tag3=value3
 	RecordPoint(name string, value float64)
 
-	// Counter creates a measurement of counter type. The returned type is an
-	// alias of go-metrics' Counter type. Refer to godocs there for details.
-	//
-	// The format of the metric name is a comma-separated list, where the first
-	// element is the metric name, and optionally, an unbounded list of
-	// key-value pairs. Example:
-	//
-	//   requests_received,tag1=value1,tag2=value2,tag3=value3
-	Counter(name string) metrics.Counter
-
 	// Timer creates a measurement of timer type.
 	// The returned type is an alias of go-metrics' Timer type. Refer to
 	// godocs there for details.
@@ -60,10 +50,6 @@ type MetricsApi interface {
 
 // NewNoOpMetrics returns a MetricsApi that does nothing.
 type NoOpMetrics struct{}
-
-func (n *NoOpMetrics) Counter(name string) metrics.Counter {
-	return metrics.NilCounter{}
-}
 
 func (n *NoOpMetrics) Timer(name string) metrics.Timer {
 	return metrics.NilTimer{}
@@ -118,7 +104,6 @@ func (o *MetricsRecorder) RecordFunctionDuration() func() {
 // RecordObjectiveStarted records metrics about the start of an objective
 // This should be called when an objective is first created
 func (o *MetricsRecorder) RecordObjectiveStarted(id protocols.ObjectiveId) {
-	o.metrics.Counter(o.addMyAddress("active_objective_count")).Inc(1)
 	o.startTimes[id] = time.Now()
 }
 
@@ -132,8 +117,6 @@ func (o *MetricsRecorder) RecordObjectiveCompleted(id protocols.ObjectiveId) {
 
 	timer := o.metrics.Timer(o.addMyAddress("objective_complete_time") + fmt.Sprintf(",type=%s", oType))
 	timer.Update(elapsed)
-	o.metrics.Counter(o.addMyAddress("objective_complete_count")).Inc(1)
-	o.metrics.Counter(o.addMyAddress("active_objective_count")).Dec(1)
 
 	delete(o.startTimes, id)
 


### PR DESCRIPTION
Fixes https://github.com/statechannels/go-nitro/issues/781

Based on some feedback from @kerzhner I've made a few small changes to how we record metrics in the wallet:
- Instead of wrapping a function with `e.metrics.RecordDuration` to record the duration `e.metrics.RecordFunctionDuration()()` can now be called at the start of the function. See https://stackoverflow.com/a/45766707/13280122
- I've corrected some of the queue length metrics being recorded and put them in one place so they're all reported with the same frequency
- I've removed `Counters` as they didn't function as I had thought. It looks like the counters get reset (I believe when the counter metric info is recorded to influxdb) so the active/completed objective counts didn't make sense