### PR TITLE
Upgrade to go 1.19

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,19 +12,19 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3
         with:
-          go-version: "^1.18.0"
+          go-version: "^1.19.0"
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.1.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.46.2
+          version: v1.48.0
 
       - name: Run staticcheck # see: staticcheck.io
         uses: dominikh/staticcheck-action@v1.2.0
         with:
           version: "2022.1.2"
           install-go: false
-          min-go-version: 1.18
+          min-go-version: 1.19
 
       - name: Build
         run: go build -v ./...

--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -442,9 +442,9 @@ func (o *LedgerOutcome) includes(g Guarantee) bool {
 // FromExit creates a new LedgerOutcome from the given SingleAssetExit.
 //
 // It makes the following assumptions about the exit:
-//  - The first alloction entry is for the ledger leader
-//  - The second alloction entry is for the ledger follower
-//  - All other allocations are guarantees
+//   - The first alloction entry is for the ledger leader
+//   - The second alloction entry is for the ledger follower
+//   - All other allocations are guarantees
 func FromExit(sae outcome.SingleAssetExit) (LedgerOutcome, error) {
 
 	var (
@@ -478,9 +478,9 @@ func FromExit(sae outcome.SingleAssetExit) (LedgerOutcome, error) {
 }
 
 // AsOutcome converts a LedgerOutcome to an on-chain exit according to the following convention:
-//  - the "leader" balance is first
-//  - the "follower" balance is second
-//  - guarantees follow, sorted according to their target destinations
+//   - the "leader" balance is first
+//   - the "follower" balance is second
+//   - guarantees follow, sorted according to their target destinations
 func (o *LedgerOutcome) AsOutcome() outcome.Exit {
 	// The first items are [leader, follower] balances
 	allocations := outcome.Allocations{o.leader.AsAllocation(), o.follower.AsAllocation()}
@@ -746,14 +746,14 @@ func (vars *Vars) HandleProposal(p Proposal) error {
 }
 
 // Add mutates Vars by
-//  - increasing the turn number by 1
-//  - including the guarantee
-//  - adjusting balances accordingly
+//   - increasing the turn number by 1
+//   - including the guarantee
+//   - adjusting balances accordingly
 //
 // An error is returned if:
-//  - the turn number is not incremented
-//  - the balances are incorrectly adjusted, or the deposits are too large
-//  - the guarantee is already included in vars.Outcome
+//   - the turn number is not incremented
+//   - the balances are incorrectly adjusted, or the deposits are too large
+//   - the guarantee is already included in vars.Outcome
 //
 // If an error is returned, the original vars is not mutated.
 func (vars *Vars) Add(p Add) error {
@@ -794,14 +794,14 @@ func (vars *Vars) Add(p Add) error {
 }
 
 // Remove mutates Vars by
-//  - increasing the turn number by 1
-//  - removing the guarantee for the Target channel
-//  - adjusting balances accordingly based on LeftAmount and RightAmount
+//   - increasing the turn number by 1
+//   - removing the guarantee for the Target channel
+//   - adjusting balances accordingly based on LeftAmount and RightAmount
 //
 // An error is returned if:
-//  - the turn number is not incremented
-//  - a guarantee is not found for the target
-//  - the amounts are too large for the guarantee amount
+//   - the turn number is not incremented
+//   - a guarantee is not found for the target
+//   - the amounts are too large for the guarantee amount
 //
 // If an error is returned, the original vars is not mutated.
 func (vars *Vars) Remove(p Remove) error {

--- a/channel/consensus_channel/helpers_test.go
+++ b/channel/consensus_channel/helpers_test.go
@@ -51,9 +51,9 @@ func makeOutcome(leader, follower Balance, guarantees ...Guarantee) LedgerOutcom
 }
 
 // ledgerOutcome constructs the LedgerOutcome with items
-//  - alice: 200,
-//  - bob: 300,
-//  - guarantee(target: 1, left: alice, right: bob, amount: 5)
+//   - alice: 200,
+//   - bob: 300,
+//   - guarantee(target: 1, left: alice, right: bob, amount: 5)
 func ledgerOutcome() LedgerOutcome {
 	return makeOutcome(
 		allocation(alice, aBal),

--- a/channel/consensus_channel/leader_channel.go
+++ b/channel/consensus_channel/leader_channel.go
@@ -53,15 +53,15 @@ func (c *ConsensusChannel) Propose(proposal Proposal, sk []byte) (SignedProposal
 // the proposal queue until it finds the countersigned proposal.
 //
 // If this proposal was signed by the Follower:
-//  - the consensus state is updated with the supplied proposal
-//  - the proposal queue is trimmed
+//   - the consensus state is updated with the supplied proposal
+//   - the proposal queue is trimmed
 //
 // If the countersupplied is stale (ie. proposal.TurnNum <= c.current.TurnNum) then
 // their proposal is ignored.
 //
 // An error is returned if:
-//  - the countersupplied proposal is not found
-//  - or if it is found but not correctly signed by the Follower
+//   - the countersupplied proposal is not found
+//   - or if it is found but not correctly signed by the Follower
 func (c *ConsensusChannel) leaderReceive(countersigned SignedProposal) error {
 	if c.MyIndex != Leader {
 		return ErrNotLeader

--- a/channel/state/signedstate.go
+++ b/channel/state/signedstate.go
@@ -23,8 +23,8 @@ func NewSignedState(s State) SignedState {
 // AddSignature adds a participant's signature to the SignedState.
 //
 // An error is returned if
-//  - the signer is not a participant, or
-//  - OR the signature was already stored
+//   - the signer is not a participant, or
+//   - OR the signature was already stored
 func (ss SignedState) AddSignature(sig Signature) error {
 	signer, err := ss.state.RecoverSigner(sig)
 	if err != nil {

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -173,10 +173,10 @@ func (e *Engine) handleProposal(proposal consensus_channel.Proposal) (ObjectiveC
 
 // handleMessage handles a Message from a peer go-nitro Wallet.
 // It:
-//  - reads an objective from the store,
-//  - generates an updated objective,
-//  - attempts progress on the target Objective,
-//  - attempts progress on related objectives which may have become unblocked.
+//   - reads an objective from the store,
+//   - generates an updated objective,
+//   - attempts progress on the target Objective,
+//   - attempts progress on related objectives which may have become unblocked.
 func (e *Engine) handleMessage(message protocols.Message) (ObjectiveChangeEvent, error) {
 	e.logger.Printf("Handling inbound message %+v", protocols.SummarizeMessage(message))
 	allCompleted := ObjectiveChangeEvent{}
@@ -306,9 +306,9 @@ func (e *Engine) handleMessage(message protocols.Message) (ObjectiveChangeEvent,
 
 // handleChainEvent handles a Chain Event from the blockchain.
 // It:
-//  - reads an objective from the store,
-//  - generates an updated objective, and
-//  - attempts progress.
+//   - reads an objective from the store,
+//   - generates an updated objective, and
+//   - attempts progress.
 func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (ObjectiveChangeEvent, error) {
 	e.logger.Printf("handling chain event %v", chainEvent)
 	objective, ok := e.store.GetObjectiveByChannelId(chainEvent.ChannelID())
@@ -332,9 +332,9 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (ObjectiveChang
 
 // handleAPIEvent handles an API Event (triggered by a client API call).
 // It will attempt to perform all of the following:
-//  - Spawn a new, approved objective (if not null)
-//  - Reject an existing objective (if not null)
-//  - Approve an existing objective (if not null)
+//   - Spawn a new, approved objective (if not null)
+//   - Reject an existing objective (if not null)
+//   - Approve an existing objective (if not null)
 func (e *Engine) handleAPIEvent(apiEvent APIEvent) (ObjectiveChangeEvent, error) {
 	if apiEvent.ObjectiveToSpawn != nil {
 
@@ -407,11 +407,11 @@ func (e *Engine) executeSideEffects(sideEffects protocols.SideEffects) error {
 
 // attemptProgress takes a "live" objective in memory and performs the following actions:
 //
-// 	1. It pulls the secret key from the store
-// 	2. It cranks the objective with that key
-// 	3. It commits the cranked objective to the store
-// 	4. It executes any side effects that were declared during cranking
-// 	5. It updates progress metadata in the store
+//  1. It pulls the secret key from the store
+//  2. It cranks the objective with that key
+//  3. It commits the cranked objective to the store
+//  4. It executes any side effects that were declared during cranking
+//  5. It updates progress metadata in the store
 func (e *Engine) attemptProgress(objective protocols.Objective) (outgoing ObjectiveChangeEvent, err error) {
 
 	secretKey := e.store.GetChannelSecretKey()

--- a/client_test/virtualfund_largescale_integration_test.go
+++ b/client_test/virtualfund_largescale_integration_test.go
@@ -3,7 +3,6 @@ package client_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
@@ -140,14 +139,14 @@ func combineLogs(t *testing.T, logDir string, combinedLogsFilename string, RP cl
 
 	// we want RP leftmost
 	// we want PH immediately to the right of RP
-	input, err := ioutil.ReadFile(path.Join(logDir, RP.Address.String()+"-Log.txt"))
+	input, err := os.ReadFile(path.Join(logDir, RP.Address.String()+"-Log.txt"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	os.Remove(path.Join(logDir, RP.Address.String()+"-Log.txt"))
 	output += string(input)
 	output += "\n"
-	input, err = ioutil.ReadFile(path.Join(logDir, PH.Address.String()+"-Log.txt"))
+	input, err = os.ReadFile(path.Join(logDir, PH.Address.String()+"-Log.txt"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +154,7 @@ func combineLogs(t *testing.T, logDir string, combinedLogsFilename string, RP cl
 	output += string(input)
 	output += "\n"
 	for i := range retrievalClients {
-		input, err := ioutil.ReadFile(path.Join(logDir, retrievalClients[i].Address.String()+"-Log.txt"))
+		input, err := os.ReadFile(path.Join(logDir, retrievalClients[i].Address.String()+"-Log.txt"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -163,7 +162,7 @@ func combineLogs(t *testing.T, logDir string, combinedLogsFilename string, RP cl
 		output += string(input)
 	}
 
-	if err = ioutil.WriteFile(path.Join(logDir, combinedLogsFilename), []byte(output), 0666); err != nil {
+	if err = os.WriteFile(path.Join(logDir, combinedLogsFilename), []byte(output), 0666); err != nil {
 		t.Fatal(err)
 	}
 
@@ -171,7 +170,7 @@ func combineLogs(t *testing.T, logDir string, combinedLogsFilename string, RP cl
 
 // prettify replaces addresses and destinations using the supplied prettyPrintDict
 func prettify(t *testing.T, logDir string, combinedLogsFilename string, prettyPrintDict *safesync.Map[string]) {
-	input, err := ioutil.ReadFile(path.Join(logDir, combinedLogsFilename))
+	input, err := os.ReadFile(path.Join(logDir, combinedLogsFilename))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +182,7 @@ func prettify(t *testing.T, logDir string, combinedLogsFilename string, prettyPr
 	}
 	prettyPrintDict.Range(replaceFun)
 
-	if err = ioutil.WriteFile(path.Join(logDir, combinedLogsFilename)+"_pretty", []byte(output), 0666); err != nil {
+	if err = os.WriteFile(path.Join(logDir, combinedLogsFilename)+"_pretty", []byte(output), 0666); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/client_test/virtualfund_with_message_delays_test.go
+++ b/client_test/virtualfund_with_message_delays_test.go
@@ -48,6 +48,7 @@ func TestVirtualFundWithMessageDelays(t *testing.T) {
 }
 
 // createVirtualChannels creates a number of virtual channels between the given parties and returns the objective ids.
+//
 //nolint:unused // unused due to skipped test
 func createVirtualChannels(client client.Client, counterParty types.Address, intermediary types.Address, amountOfChannels uint) []protocols.ObjectiveId {
 	ids := make([]protocols.ObjectiveId, amountOfChannels)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/statechannels/go-nitro
 
-go 1.18
+go 1.19
 
 require (
 	github.com/DistributedClocks/GoVector v0.0.0-20210402100930-db949c81a0af

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -31,7 +31,8 @@ type vfoCollection struct {
 // objective generating utility functions
 //
 // eg, a test wanting an Irene-Ivan ledger creation objective could import via
-//     testdata.Objectives.twopartyledgers.irene_ivan
+//
+//	testdata.Objectives.twopartyledgers.irene_ivan
 var Objectives objectiveCollection = objectiveCollection{
 	Directfund: dfoCollection{
 		GenericDFO: genericDFO,

--- a/protocols/directdefund/serde.go
+++ b/protocols/directdefund/serde.go
@@ -18,10 +18,8 @@ type jsonObjective struct {
 }
 
 // MarshalJSON returns a JSON representation of the DirectDefundObjective
-//
 // NOTE: Marshal -> Unmarshal is a lossy process. All channel data
-//
-//	(other than Id) from the field C is discarded
+// (other than Id) from the field C is discarded
 func (o Objective) MarshalJSON() ([]byte, error) {
 	jsonDDFO := jsonObjective{
 		o.Status,
@@ -35,10 +33,8 @@ func (o Objective) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON populates the calling DirectDefundObjective with the
 // json-encoded data
-//
 // NOTE: Marshal -> Unmarshal is a lossy process. All channel data
-//
-//	(other than Id) from the field C is discarded
+// (other than Id) from the field C is discarded
 func (o *Objective) UnmarshalJSON(data []byte) error {
 	if string(data) == "null" {
 		return nil

--- a/protocols/directdefund/serde.go
+++ b/protocols/directdefund/serde.go
@@ -20,7 +20,8 @@ type jsonObjective struct {
 // MarshalJSON returns a JSON representation of the DirectDefundObjective
 //
 // NOTE: Marshal -> Unmarshal is a lossy process. All channel data
-//       (other than Id) from the field C is discarded
+//
+//	(other than Id) from the field C is discarded
 func (o Objective) MarshalJSON() ([]byte, error) {
 	jsonDDFO := jsonObjective{
 		o.Status,
@@ -36,7 +37,8 @@ func (o Objective) MarshalJSON() ([]byte, error) {
 // json-encoded data
 //
 // NOTE: Marshal -> Unmarshal is a lossy process. All channel data
-//       (other than Id) from the field C is discarded
+//
+//	(other than Id) from the field C is discarded
 func (o *Objective) UnmarshalJSON(data []byte) error {
 	if string(data) == "null" {
 		return nil

--- a/protocols/directfund/serde.go
+++ b/protocols/directfund/serde.go
@@ -22,10 +22,8 @@ type jsonObjective struct {
 }
 
 // MarshalJSON returns a JSON representation of the DirectFundObjective
-//
 // NOTE: Marshal -> Unmarshal is a lossy process. All channel data
-//
-//	(other than Id) from the field C is discarded
+// (other than Id) from the field C is discarded
 func (o Objective) MarshalJSON() ([]byte, error) {
 	jsonDFO := jsonObjective{
 		o.Status,
@@ -41,10 +39,8 @@ func (o Objective) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON populates the calling DirectFundObjective with the
 // json-encoded data
-//
 // NOTE: Marshal -> Unmarshal is a lossy process. All channel data
-//
-//	(other than Id) from the field C is discarded
+// (other than Id) from the field C is discarded
 func (o *Objective) UnmarshalJSON(data []byte) error {
 	if string(data) == "null" {
 		return nil

--- a/protocols/directfund/serde.go
+++ b/protocols/directfund/serde.go
@@ -24,7 +24,8 @@ type jsonObjective struct {
 // MarshalJSON returns a JSON representation of the DirectFundObjective
 //
 // NOTE: Marshal -> Unmarshal is a lossy process. All channel data
-//       (other than Id) from the field C is discarded
+//
+//	(other than Id) from the field C is discarded
 func (o Objective) MarshalJSON() ([]byte, error) {
 	jsonDFO := jsonObjective{
 		o.Status,
@@ -42,7 +43,8 @@ func (o Objective) MarshalJSON() ([]byte, error) {
 // json-encoded data
 //
 // NOTE: Marshal -> Unmarshal is a lossy process. All channel data
-//       (other than Id) from the field C is discarded
+//
+//	(other than Id) from the field C is discarded
 func (o *Objective) UnmarshalJSON(data []byte) error {
 	if string(data) == "null" {
 		return nil

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -78,11 +78,11 @@ type Storable interface {
 
 // Objective is the interface for off-chain protocols.
 // The lifecycle of an objective is as follows:
-// 	* It is initialized by a single client (passing in various parameters). It is implicitly approved by that client. It is communicated to the other clients.
-// 	* It is stored and then approved or rejected by the other clients
-// 	* It is updated with external information arriving to the client
-// 	* After each update, it is cranked. This generates side effects and other metadata
-// 	* The metadata will eventually indicate that the Objective has stalled OR the Objective has completed successfully
+//   - It is initialized by a single client (passing in various parameters). It is implicitly approved by that client. It is communicated to the other clients.
+//   - It is stored and then approved or rejected by the other clients
+//   - It is updated with external information arriving to the client
+//   - After each update, it is cranked. This generates side effects and other metadata
+//   - The metadata will eventually indicate that the Objective has stalled OR the Objective has completed successfully
 type Objective interface {
 	Id() ObjectiveId
 

--- a/protocols/virtualdefund/helpers_test.go
+++ b/protocols/virtualdefund/helpers_test.go
@@ -70,9 +70,9 @@ func generateGuarantee(left, right ta.Actor, vId types.Destination) consensus_ch
 }
 
 // prepareConsensusChannel prepares a consensus channel with a consensus outcome
-//  - allocating 0 to left
-//  - allocating 0 to right
-//  - including the given guarantees
+//   - allocating 0 to left
+//   - allocating 0 to right
+//   - including the given guarantees
 func prepareConsensusChannel(role uint, left, right ta.Actor, guarantees ...consensus_channel.Guarantee) *consensus_channel.ConsensusChannel {
 	fp := state.FixedPart{
 		ChainId:           big.NewInt(9001),

--- a/protocols/virtualfund/helpers_test.go
+++ b/protocols/virtualfund/helpers_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 // prepareConsensusChannel prepares a consensus channel with a consensus outcome
-//  - allocating 6 to leader
-//  - allocating 4 to follower
-//  - including the given guarantees
+//   - allocating 6 to leader
+//   - allocating 4 to follower
+//   - including the given guarantees
 func prepareConsensusChannel(role uint, leader, follower testactors.Actor, guarantees ...consensus_channel.Guarantee) *consensus_channel.ConsensusChannel {
 	return prepareConsensusChannelHelper(role, leader, follower, 6, 4, 1, guarantees...)
 }

--- a/protocols/virtualfund/serde.go
+++ b/protocols/virtualfund/serde.go
@@ -20,7 +20,8 @@ type jsonConnection struct {
 // MarshalJSON returns a JSON representation of the Connection
 //
 // NOTE: Marshal -> Unmarshal is a lossy process. All channel data
-//       other than the ID is dropped
+//
+//	other than the ID is dropped
 func (c Connection) MarshalJSON() ([]byte, error) {
 	jsonC := jsonConnection{c.Channel.Id, c.GuaranteeInfo}
 	bytes, err := json.Marshal(jsonC)
@@ -36,7 +37,8 @@ func (c Connection) MarshalJSON() ([]byte, error) {
 // json-encoded data
 //
 // NOTE: Marshal -> Unmarshal is a lossy process. All channel data from
-//       (other than Id) is discarded
+//
+//	(other than Id) is discarded
 func (c *Connection) UnmarshalJSON(data []byte) error {
 	c.Channel = &consensus_channel.ConsensusChannel{}
 
@@ -78,7 +80,8 @@ type jsonObjective struct {
 // MarshalJSON returns a JSON representation of the VirtualFundObjective
 //
 // NOTE: Marshal -> Unmarshal is a lossy process. All channel data from
-//       the virtual and ledger channels (other than Ids) is discarded
+//
+//	the virtual and ledger channels (other than Ids) is discarded
 func (o Objective) MarshalJSON() ([]byte, error) {
 	var left []byte
 	var right []byte
@@ -121,7 +124,8 @@ func (o Objective) MarshalJSON() ([]byte, error) {
 // json-encoded data
 //
 // NOTE: Marshal -> Unmarshal is a lossy process. All channel data from
-//       the virtual and ledger channels (other than Ids) is discarded
+//
+//	the virtual and ledger channels (other than Ids) is discarded
 func (o *Objective) UnmarshalJSON(data []byte) error {
 	if string(data) == "null" {
 		return nil

--- a/protocols/virtualfund/serde.go
+++ b/protocols/virtualfund/serde.go
@@ -18,10 +18,8 @@ type jsonConnection struct {
 }
 
 // MarshalJSON returns a JSON representation of the Connection
-//
 // NOTE: Marshal -> Unmarshal is a lossy process. All channel data
-//
-//	other than the ID is dropped
+// other than the ID is dropped
 func (c Connection) MarshalJSON() ([]byte, error) {
 	jsonC := jsonConnection{c.Channel.Id, c.GuaranteeInfo}
 	bytes, err := json.Marshal(jsonC)
@@ -78,10 +76,8 @@ type jsonObjective struct {
 }
 
 // MarshalJSON returns a JSON representation of the VirtualFundObjective
-//
 // NOTE: Marshal -> Unmarshal is a lossy process. All channel data from
-//
-//	the virtual and ledger channels (other than Ids) is discarded
+// the virtual and ledger channels (other than Ids) is discarded
 func (o Objective) MarshalJSON() ([]byte, error) {
 	var left []byte
 	var right []byte

--- a/types/types.go
+++ b/types/types.go
@@ -15,8 +15,8 @@ type Bytes32 = common.Hash
 
 // Destination represents a payable address in go-nitro. In a state channel network,
 // payable address are either:
-//  - Internal: a 32-byte nitro channel ID, or
-//  - External: a blockchain account or contract address, left-padded with 0s
+//   - Internal: a 32-byte nitro channel ID, or
+//   - External: a blockchain account or contract address, left-padded with 0s
 type Destination Bytes32
 
 // An arbitrary length byte slice


### PR DESCRIPTION
Fixes #819 

Upgrades `go-nitro` to 1.19. 

Previously our CI could use go 1.19 (since we specify version range `^1.18.0`) but the linter version we used (`v1.46.2`) did not support go 1.19. 

This PR updates go-nitro to use go 1.19 and the linter to use a version that supports go 1.19.