### PR TITLE
Add vouchers to message format

### DIFF
--- a/payments/payments_test.go
+++ b/payments/payments_test.go
@@ -1,11 +1,15 @@
 package payments
 
 import (
+	"fmt"
 	"math/big"
+	"path/filepath"
+	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/statechannels/go-nitro/internal/testactors"
-	. "github.com/statechannels/go-nitro/internal/testhelpers"
+
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -127,4 +131,44 @@ func TestPaymentManager(t *testing.T) {
 	_, err = receiptMgr.Receive(voucher)
 	Assert(t, err != nil, "expected an error")
 	Equals(t, twoPaymentsMade, getBalance(receiptMgr))
+}
+
+// TODO: This is a copy of the test helpers from github.com/statechannels/go-nitro/internal/testactors
+// We have a copy of them here to avoid an import cycle.
+
+// makeRed sets the colour to red when printed
+const makeRed = "\033[31m"
+
+// makeBlack sets the colour to black when printed.
+// as it is intended to be used at the end of a string, it also adds two linebreaks
+const makeBlack = "\033[39m\n\n"
+
+// Assert fails the test immediately if the condition is false.
+// If the assertion fails the formatted message will be output to the console.
+func Assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
+	if !condition {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf(makeRed+"%s:%d: "+msg+makeBlack, append([]interface{}{filepath.Base(file), line}, v...)...)
+		tb.FailNow()
+	}
+}
+
+// Ok fails the test immediately if an err is not nil.
+// If the error is not nil the message containing the error will be outputted to the console
+func Ok(tb testing.TB, err error) {
+	if err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf(makeRed+"%s:%d: unexpected error: %s"+makeBlack, filepath.Base(file), line, err.Error())
+		tb.FailNow()
+	}
+}
+
+// Equals fails the test if want is not deeply equal to got.
+// Equals uses reflect.DeepEqual to compare the two values.
+func Equals(tb testing.TB, want, got interface{}) {
+	if !reflect.DeepEqual(want, got) {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf(makeRed+"%s:%d:\n\n\texp: %#v\n\n\tgot: %#v"+makeBlack, filepath.Base(file), line, want, got)
+		tb.FailNow()
+	}
 }

--- a/payments/serde.go
+++ b/payments/serde.go
@@ -1,0 +1,40 @@
+package payments
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/types"
+)
+
+type jsonVoucher struct {
+	ChannelId types.Destination
+	Amount    *big.Int
+	Signature state.Signature
+}
+
+// MarshalJSON returns a JSON representation of the Voucher
+func (v Voucher) MarshalJSON() ([]byte, error) {
+	jsonV := jsonVoucher{
+		v.channelId, v.amount, v.signature,
+	}
+	return json.Marshal(jsonV)
+}
+
+// UnmarshalJSON populates the receiver with the
+// json-encoded data
+func (v *Voucher) UnmarshalJSON(data []byte) error {
+	var jsonV jsonVoucher
+	err := json.Unmarshal(data, &jsonV)
+	if err != nil {
+		return fmt.Errorf("error unmarshaling voucher data: %w", err)
+	}
+
+	v.channelId = jsonV.ChannelId
+	v.amount = jsonV.Amount
+	v.signature = jsonV.Signature
+
+	return nil
+}

--- a/payments/serde_test.go
+++ b/payments/serde_test.go
@@ -1,0 +1,45 @@
+package payments
+
+import (
+	"encoding/json"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/crypto"
+	"github.com/statechannels/go-nitro/types"
+)
+
+func TestSerde(t *testing.T) {
+	someVoucher := Voucher{types.Destination{1}, big.NewInt(2), crypto.Signature{
+		R: common.Hex2Bytes(`704b3afcc6e702102ca1af3f73cf3b37f3007f368c40e8b81ca823a65740a053`),
+		S: common.Hex2Bytes(`14040ad4c598dbb055a50430142a13518e1330b79d24eed86fcbdff1a7a95589`),
+		V: byte(0),
+	}}
+
+	someVoucherJson := `{"ChannelId":"0x0100000000000000000000000000000000000000000000000000000000000000","Amount":2,"Signature":{"R":"cEs6/MbnAhAsoa8/c887N/MAfzaMQOi4HKgjpldAoFM=","S":"FAQK1MWY27BVpQQwFCoTUY4TMLedJO7Yb8vf8aepVYk=","V":0}}`
+
+	t.Run("Marshalling", func(t *testing.T) {
+		got, err := json.Marshal(someVoucher)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != someVoucherJson {
+			t.Fatalf("incorrect json marshaling, expected %v got \n%v", someVoucherJson, string(got))
+		}
+	})
+
+	t.Run("Unmarshalling", func(t *testing.T) {
+		got := Voucher{}
+		err := json.Unmarshal([]byte(someVoucherJson), &got)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(got, someVoucher) {
+			t.Fatalf("incorrect json unmarshaling, expected \n%+v got \n%+v", someVoucher, got)
+		}
+	})
+}

--- a/payments/vouchers.go
+++ b/payments/vouchers.go
@@ -11,7 +11,7 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-func (v Voucher) hash() (types.Bytes32, error) {
+func (v *Voucher) hash() (types.Bytes32, error) {
 	encoded, err := abi.Arguments{
 		{Type: nitroAbi.Destination},
 		{Type: nitroAbi.Uint256},
@@ -40,7 +40,7 @@ func (v *Voucher) sign(pk []byte) error {
 	return nil
 }
 
-func (v Voucher) recoverSigner() (types.Address, error) {
+func (v *Voucher) recoverSigner() (types.Address, error) {
 	h, error := v.hash()
 	if error != nil {
 		return types.Address{}, error
@@ -48,16 +48,16 @@ func (v Voucher) recoverSigner() (types.Address, error) {
 	return nitroCrypto.RecoverEthereumMessageSigner(h[:], v.signature)
 }
 
-// Equal returns true if the two vouchers have the same channel id, amount and signaturesß
-func (v Voucher) Equal(other Voucher) bool {
+// Equal returns true if the two vouchers have the same channel id, amount and signatures
+func (v *Voucher) Equal(other *Voucher) bool {
 	return v.channelId == other.channelId && v.amount.Cmp(other.amount) == 0 && v.signature.Equal(other.signature)
 }
 
 // NewVoucher constructs a voucher with the given channel id and amount
-func NewVoucher(channelId types.Destination, amount *big.Int) Voucher {
+func NewVoucher(channelId types.Destination, amount *big.Int) *Voucher {
 	v := Voucher{
 		channelId: channelId,
 		amount:    amount,
 	}
-	return v
+	return &v
 }

--- a/payments/vouchers.go
+++ b/payments/vouchers.go
@@ -2,6 +2,7 @@ package payments
 
 import (
 	"fmt"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -45,4 +46,18 @@ func (v Voucher) recoverSigner() (types.Address, error) {
 		return types.Address{}, error
 	}
 	return nitroCrypto.RecoverEthereumMessageSigner(h[:], v.signature)
+}
+
+// Equal returns true if the two vouchers have the same channel id, amount and signaturesß
+func (v Voucher) Equal(other Voucher) bool {
+	return v.channelId == other.channelId && v.amount.Cmp(other.amount) == 0 && v.signature.Equal(other.signature)
+}
+
+// NewVoucher constructs a voucher with the given channel id and amount
+func NewVoucher(channelId types.Destination, amount *big.Int) Voucher {
+	v := Voucher{
+		channelId: channelId,
+		amount:    amount,
+	}
+	return v
 }

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/internal/testhelpers"
+	"github.com/statechannels/go-nitro/payments"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -126,7 +127,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func compareSideEffect(a, b protocols.SideEffects) string {
-	return cmp.Diff(a, b, cmp.AllowUnexported(a, state.SignedState{}, consensus_channel.Add{}, consensus_channel.Remove{}, consensus_channel.Guarantee{}, protocols.Message{}))
+	return cmp.Diff(a, b, cmp.AllowUnexported(a, state.SignedState{}, consensus_channel.Add{}, consensus_channel.Remove{}, consensus_channel.Guarantee{}, protocols.Message{}, payments.Voucher{}))
 }
 
 func TestCrankAlice(t *testing.T) {

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/internal/testhelpers"
+	"github.com/statechannels/go-nitro/payments"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -182,7 +183,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func compareSideEffect(a, b protocols.SideEffects) string {
-	return cmp.Diff(a, b, cmp.AllowUnexported(a, state.SignedState{}, consensus_channel.Add{}, consensus_channel.Guarantee{}, consensus_channel.Remove{}, protocols.Message{}))
+	return cmp.Diff(a, b, cmp.AllowUnexported(a, state.SignedState{}, consensus_channel.Add{}, consensus_channel.Guarantee{}, consensus_channel.Remove{}, protocols.Message{}, payments.Voucher{}))
 }
 
 func TestCrank(t *testing.T) {

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -56,7 +56,7 @@ func (p messagePayload) hasRejection() bool {
 
 // hasVoucher returns true if the payload contains a voucher.
 func (p messagePayload) hasVoucher() bool {
-	return !p.Voucher.Equal(payments.Voucher{})
+	return !(&p.Voucher).Equal(&payments.Voucher{})
 }
 
 // Type returns the type of the payload, either a SignedProposal or SignedState.

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -356,6 +356,21 @@ func CreateRejectionNoticeMessage(oId ObjectiveId, recipients ...types.Address) 
 	return messages
 }
 
+// CreateVoucherMessage returns a signed voucher message for each of the recipients provided.
+func CreateVoucherMessage(voucher payments.Voucher, recipients ...types.Address) []Message {
+	messages := make([]Message, len(recipients))
+	for i, recipient := range recipients {
+		payload := messagePayload{
+			Voucher: voucher,
+		}
+		payloads := []messagePayload{payload}
+		messages[i] = Message{To: recipient, payloads: payloads}
+
+	}
+
+	return messages
+}
+
 // getProposalObjectiveId returns the objectiveId for a proposal.
 func getProposalObjectiveId(p consensus_channel.Proposal) ObjectiveId {
 	switch p.Type() {

--- a/protocols/messages_test.go
+++ b/protocols/messages_test.go
@@ -49,7 +49,7 @@ func TestMessage(t *testing.T) {
 
 			{
 
-				Voucher: payments.NewVoucher(types.Destination{'d'}, big.NewInt(123)),
+				Voucher: *payments.NewVoucher(types.Destination{'d'}, big.NewInt(123)),
 			},
 		},
 	}

--- a/protocols/messages_test.go
+++ b/protocols/messages_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/payments"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -45,11 +46,16 @@ func TestMessage(t *testing.T) {
 				ObjectiveId:    `say-hello-to-my-little-friend3`,
 				SignedProposal: removeProposal(),
 			},
+
+			{
+
+				Voucher: payments.NewVoucher(types.Destination{'d'}, big.NewInt(123)),
+			},
 		},
 	}
 
 	msgString :=
-		`{"To":"0x6100000000000000000000000000000000000000","Payloads":[{"ObjectiveId":"say-hello-to-my-little-friend","SignedState":{"State":{"ChainId":9001,"Participants":["0xf5a1bb5607c9d079e46d1b3dc33f257d937b43bd","0x760bf27cd45036a6c486802d30b5d90cffbe31fe"],"ChannelNonce":37140676580,"AppDefinition":"0x5e29e5ab8ef33f050c7cc10b5a0456d975c5f88d","ChallengeDuration":60,"AppData":"","Outcome":[{"Asset":"0x0000000000000000000000000000000000000000","Metadata":null,"Allocations":[{"Destination":"0x000000000000000000000000f5a1bb5607c9d079e46d1b3dc33f257d937b43bd","Amount":5,"AllocationType":0,"Metadata":null},{"Destination":"0x000000000000000000000000ee18ff1575055691009aa246ae608132c57a422c","Amount":5,"AllocationType":0,"Metadata":null}]}],"TurnNum":5,"IsFinal":false},"Sigs":{}}},{"ObjectiveId":"say-hello-to-my-little-friend2","SignedProposal":{"R":null,"S":null,"V":0,"Proposal":{"LedgerID":"0x6c00000000000000000000000000000000000000000000000000000000000000","ToAdd":{"Guarantee":{"Amount":1,"Target":"0x6100000000000000000000000000000000000000000000000000000000000000","Left":"0x6200000000000000000000000000000000000000000000000000000000000000","Right":"0x6300000000000000000000000000000000000000000000000000000000000000"},"LeftDeposit":1},"ToRemove":{"Target":"0x0000000000000000000000000000000000000000000000000000000000000000","LeftAmount":null}},"TurnNum":0}},{"ObjectiveId":"say-hello-to-my-little-friend3","SignedProposal":{"R":null,"S":null,"V":0,"Proposal":{"LedgerID":"0x6c00000000000000000000000000000000000000000000000000000000000000","ToAdd":{"Guarantee":{"Amount":null,"Target":"0x0000000000000000000000000000000000000000000000000000000000000000","Left":"0x0000000000000000000000000000000000000000000000000000000000000000","Right":"0x0000000000000000000000000000000000000000000000000000000000000000"},"LeftDeposit":null},"ToRemove":{"Target":"0x6100000000000000000000000000000000000000000000000000000000000000","LeftAmount":1}},"TurnNum":0}}]}`
+		`{"To":"0x6100000000000000000000000000000000000000","Payloads":[{"ObjectiveId":"say-hello-to-my-little-friend","SignedState":{"State":{"ChainId":9001,"Participants":["0xf5a1bb5607c9d079e46d1b3dc33f257d937b43bd","0x760bf27cd45036a6c486802d30b5d90cffbe31fe"],"ChannelNonce":37140676580,"AppDefinition":"0x5e29e5ab8ef33f050c7cc10b5a0456d975c5f88d","ChallengeDuration":60,"AppData":"","Outcome":[{"Asset":"0x0000000000000000000000000000000000000000","Metadata":null,"Allocations":[{"Destination":"0x000000000000000000000000f5a1bb5607c9d079e46d1b3dc33f257d937b43bd","Amount":5,"AllocationType":0,"Metadata":null},{"Destination":"0x000000000000000000000000ee18ff1575055691009aa246ae608132c57a422c","Amount":5,"AllocationType":0,"Metadata":null}]}],"TurnNum":5,"IsFinal":false},"Sigs":{}}},{"ObjectiveId":"say-hello-to-my-little-friend2","SignedProposal":{"R":null,"S":null,"V":0,"Proposal":{"LedgerID":"0x6c00000000000000000000000000000000000000000000000000000000000000","ToAdd":{"Guarantee":{"Amount":1,"Target":"0x6100000000000000000000000000000000000000000000000000000000000000","Left":"0x6200000000000000000000000000000000000000000000000000000000000000","Right":"0x6300000000000000000000000000000000000000000000000000000000000000"},"LeftDeposit":1},"ToRemove":{"Target":"0x0000000000000000000000000000000000000000000000000000000000000000","LeftAmount":null}},"TurnNum":0}},{"ObjectiveId":"say-hello-to-my-little-friend3","SignedProposal":{"R":null,"S":null,"V":0,"Proposal":{"LedgerID":"0x6c00000000000000000000000000000000000000000000000000000000000000","ToAdd":{"Guarantee":{"Amount":null,"Target":"0x0000000000000000000000000000000000000000000000000000000000000000","Left":"0x0000000000000000000000000000000000000000000000000000000000000000","Right":"0x0000000000000000000000000000000000000000000000000000000000000000"},"LeftDeposit":null},"ToRemove":{"Target":"0x6100000000000000000000000000000000000000000000000000000000000000","LeftAmount":1}},"TurnNum":0}},{"ObjectiveId":"","Voucher":{"ChannelId":"0x6400000000000000000000000000000000000000000000000000000000000000","Amount":123,"Signature":{"R":null,"S":null,"V":0}}}]}`
 
 	t.Run(`serialize`, func(t *testing.T) {
 		got, err := msg.Serialize()


### PR DESCRIPTION
Fixes #823 

This adds support for transmitting vouchers across the wire using our existing message format. 

- Adds basic serde and test for `payment.Voucher` 
- Adds `payment.Voucher`s to the message format and extends the message test.