### PR TITLE
clarify status on virtual funding protocols

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,8 +35,8 @@ The following roadmap gives an idea of the various packages that compose the `go
 ├── protocols ✅               # functional core of the go-nitro client
 │   ├── direct-fund ✅         # fund a channel on-chain
 │   ├── direct-defund ✅       # defund a channel on-chain
-│   ├── virtual-fund ✅        # fund a channel off-chain through one or more intermediaries
-│   └── virtual-defund ✅      # defund a channel off-chain through one or more intermediaries
+│   ├── virtual-fund ✅ 🚧     # fund a channel off-chain through one (✅) or more (🚧) intermediaries
+│   └── virtual-defund ✅ 🚧   # defund a channel off-chain through one (✅) or more (🚧) intermediaries
 └── types ✅                   # basic types and utility methods
 ```
 


### PR DESCRIPTION
Previous bullet point indicated that multi-hop VFO and DFO were completed, but this isn't the case. Single-hop is hardcoded as part of the [`virtualfund.ObjectiveRequest`](https://github.com/statechannels/go-nitro/blob/069cd9e0b39a1b33e77bcc2715220d6a7e6243df/protocols/virtualfund/virtualfund.go#L672) struct:

```
type ObjectiveRequest struct {
	Intermediary      types.Address
	CounterParty      types.Address
	AppDefinition     types.Address
	AppData           types.Bytes
	ChallengeDuration *types.Uint256
	Outcome           outcome.Exit
	Nonce             int64
}
```

---
