### PR TITLE
tidy up  `handleObjectiveRequest`

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -364,16 +364,16 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 // It will attempt to spawn a new, approved objective.
 func (e *Engine) handleObjectiveRequest(or protocols.ObjectiveRequest) (EngineEvent, error) {
 	defer e.metrics.RecordFunctionDuration()()
-
+	myAddress := *e.store.GetAddress()
+	objectiveId := or.Id(myAddress)
+	e.metrics.RecordObjectiveStarted(objectiveId)
 	switch request := or.(type) {
 
 	case virtualfund.ObjectiveRequest:
-		e.metrics.RecordObjectiveStarted(request.Id(*e.store.GetAddress()))
-		vfo, err := virtualfund.NewObjective(request, true, *e.store.GetAddress(), e.store.GetConsensusChannel)
+		vfo, err := virtualfund.NewObjective(request, true, myAddress, e.store.GetConsensusChannel)
 		if err != nil {
 			return EngineEvent{}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 		}
-
 		err = e.registerPaymentChannel(vfo)
 		if err != nil {
 			return EngineEvent{}, fmt.Errorf("could not register channel with payment/receipt manager: %w", err)
@@ -381,26 +381,25 @@ func (e *Engine) handleObjectiveRequest(or protocols.ObjectiveRequest) (EngineEv
 		return e.attemptProgress(&vfo)
 
 	case virtualdefund.ObjectiveRequest:
-		e.metrics.RecordObjectiveStarted(request.Id(*e.store.GetAddress()))
-		vdfo, err := virtualdefund.NewObjective(request, true, *e.store.GetAddress(), e.store.GetChannelById, e.store.GetConsensusChannel)
+		vdfo, err := virtualdefund.NewObjective(request, true, myAddress, e.store.GetChannelById, e.store.GetConsensusChannel)
 		if err != nil {
 			return EngineEvent{}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 		}
 		return e.attemptProgress(&vdfo)
 
 	case directfund.ObjectiveRequest:
-		e.metrics.RecordObjectiveStarted(request.Id(*e.store.GetAddress()))
-		dfo, err := directfund.NewObjective(request, true, *e.store.GetAddress(), e.store.GetChannelsByParticipant, e.store.GetConsensusChannel)
+		dfo, err := directfund.NewObjective(request, true, myAddress, e.store.GetChannelsByParticipant, e.store.GetConsensusChannel)
 		if err != nil {
 			return EngineEvent{}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 		}
 		return e.attemptProgress(&dfo)
 
 	case directdefund.ObjectiveRequest:
-		e.metrics.RecordObjectiveStarted(request.Id(*e.store.GetAddress()))
 		ddfo, err := directdefund.NewObjective(request, true, e.store.GetConsensusChannelById)
 		if err != nil {
-			return EngineEvent{FailedObjectives: []protocols.ObjectiveId{request.Id(*e.store.GetAddress())}}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
+			return EngineEvent{
+				FailedObjectives: []protocols.ObjectiveId{objectiveId},
+			}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 		}
 		// If ddfo creation was successful, destroy the consensus channel to prevent it being used (a Channel will now take over governance)
 		e.store.DestroyConsensusChannel(request.ChannelId)


### PR DESCRIPTION
- Breaks one long line up for readability
- computes `myAddress` and `objectiveId` "optimistically", before we know which type of objective request we are dealing with. I think this improves readability, but it does change the behaviour when we hit the `default` case. Before, we wouldn't have expended this work, now we will have done. I think it is safe to calculate the `objectiveId`, since the type system assures us that this method exists.