### PR TITLE
Implement virtual defunding per ADR

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -101,7 +101,7 @@ func (c *Client) CreateVirtualChannel(objectiveRequest virtualfund.ObjectiveRequ
 }
 
 // CloseVirtualChannel attempts to close and defund the given virtually funded channel.
-func (c *Client) CloseVirtualChannel(channelId types.Destination, paidToBob *big.Int) protocols.ObjectiveId {
+func (c *Client) CloseVirtualChannel(channelId types.Destination) protocols.ObjectiveId {
 
 	objectiveRequest := virtualdefund.ObjectiveRequest{
 		ChannelId: channelId,

--- a/client/client.go
+++ b/client/client.go
@@ -105,7 +105,6 @@ func (c *Client) CloseVirtualChannel(channelId types.Destination, paidToBob *big
 
 	objectiveRequest := virtualdefund.ObjectiveRequest{
 		ChannelId: channelId,
-		PaidToBob: paidToBob,
 	}
 
 	// Send the event to the engine

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -577,7 +577,7 @@ func (e *Engine) constructObjectiveFromMessage(id protocols.ObjectiveId, p proto
 		}
 		return &vfo, nil
 	case virtualdefund.IsVirtualDefundObjective(id):
-		vId, err := virtualdefund.GetVirtualChannelFromId(id)
+		vId, err := virtualdefund.GetVirtualChannelFromObjectiveId(id)
 		if err != nil {
 			return &virtualdefund.Objective{}, fmt.Errorf("could not determine virtual channel id: %w", err)
 		}

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -583,7 +583,7 @@ func (e *Engine) constructObjectiveFromMessage(id protocols.ObjectiveId, p proto
 		}
 		bal, err := e.vm.Balance(vId)
 		if err != nil {
-			return &virtualdefund.Objective{}, fmt.Errorf("could determine voucher balance: %w", err)
+			return &virtualdefund.Objective{}, fmt.Errorf("could not determine voucher balance: %w", err)
 		}
 		vdfo, err := virtualdefund.ConstructObjectiveFromPayload(p, false, *e.store.GetAddress(), e.store.GetChannelById, e.store.GetConsensusChannel, bal.Paid)
 		if err != nil {

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -365,18 +365,26 @@ func (e *Engine) handleObjectiveRequest(or protocols.ObjectiveRequest) (EngineEv
 		if err != nil {
 			return EngineEvent{}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 		}
-		err = e.registerPaymentChannel(vfo)
+		// Only Alice or Bob care about registering the objective and keeping track of vouchers
+		if vfo.MyRole == payments.PAYEE_INDEX || vfo.MyRole == payments.PAYER_INDEX {
+			err = e.registerPaymentChannel(vfo)
+			if err != nil {
+				return EngineEvent{}, fmt.Errorf("could not register channel with payment/receipt manager: %w", err)
+			}
+		}
+
 		if err != nil {
 			return EngineEvent{}, fmt.Errorf("could not register channel with payment/receipt manager: %w", err)
 		}
 		return e.attemptProgress(&vfo)
 
 	case virtualdefund.ObjectiveRequest:
-		bal, err := e.vm.Balance(request.ChannelId)
-		if err != nil {
-			return EngineEvent{}, fmt.Errorf("handleAPIEvent: Failed trying to get latest voucher balance %+v: %w", request, err)
+		minAmount := big.NewInt(0)
+		if e.vm.ChannelRegistered(request.ChannelId) {
+			bal, _ := e.vm.Balance(request.ChannelId)
+			minAmount = bal.Paid
 		}
-		vdfo, err := virtualdefund.NewObjective(request, true, myAddress, bal.Paid, e.store.GetChannelById, e.store.GetConsensusChannel)
+		vdfo, err := virtualdefund.NewObjective(request, true, myAddress, minAmount, e.store.GetChannelById, e.store.GetConsensusChannel)
 		if err != nil {
 			return EngineEvent{}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 		}
@@ -581,11 +589,13 @@ func (e *Engine) constructObjectiveFromMessage(id protocols.ObjectiveId, p proto
 		if err != nil {
 			return &virtualdefund.Objective{}, fmt.Errorf("could not determine virtual channel id: %w", err)
 		}
-		bal, err := e.vm.Balance(vId)
-		if err != nil {
-			return &virtualdefund.Objective{}, fmt.Errorf("could not determine voucher balance: %w", err)
+		minAmount := big.NewInt(0)
+		if e.vm.ChannelRegistered(vId) {
+			bal, _ := e.vm.Balance(vId)
+			minAmount = bal.Paid
 		}
-		vdfo, err := virtualdefund.ConstructObjectiveFromPayload(p, false, *e.store.GetAddress(), e.store.GetChannelById, e.store.GetConsensusChannel, bal.Paid)
+
+		vdfo, err := virtualdefund.ConstructObjectiveFromPayload(p, false, *e.store.GetAddress(), e.store.GetChannelById, e.store.GetConsensusChannel, minAmount)
 		if err != nil {
 			return &virtualfund.Objective{}, fmt.Errorf("could not create virtual fund objective from message: %w", err)
 		}

--- a/client_test/virtualdefund_test.go
+++ b/client_test/virtualdefund_test.go
@@ -77,11 +77,11 @@ func runVirtualDefundIntegrationTestAs(t *testing.T, closer types.Address, messa
 	for i := 0; i < len(cIds); i++ {
 		switch closer {
 		case alice.Address():
-			ids[i] = clientA.CloseVirtualChannel(cIds[i], big.NewInt(int64(paidToBob)))
+			ids[i] = clientA.CloseVirtualChannel(cIds[i])
 		case bob.Address():
-			ids[i] = clientB.CloseVirtualChannel(cIds[i], big.NewInt(int64(paidToBob)))
+			ids[i] = clientB.CloseVirtualChannel(cIds[i])
 		case irene.Address():
-			ids[i] = clientI.CloseVirtualChannel(cIds[i], big.NewInt(int64(paidToBob)))
+			ids[i] = clientI.CloseVirtualChannel(cIds[i])
 		}
 
 	}

--- a/client_test/virtualdefund_test.go
+++ b/client_test/virtualdefund_test.go
@@ -65,7 +65,9 @@ func runVirtualDefundIntegrationTest(t *testing.T, messageDelay time.Duration, o
 	totalPaidToBob := paidToBob * numOfVirtualChannels
 
 	cIds := openVirtualChannels(t, clientA, clientB, clientI, numOfVirtualChannels)
-
+	for i := 0; i < len(cIds); i++ {
+		clientA.Pay(cIds[i], big.NewInt(int64(paidToBob)))
+	}
 	ids := make([]protocols.ObjectiveId, len(cIds))
 	for i := 0; i < len(cIds); i++ {
 		ids[i] = clientA.CloseVirtualChannel(cIds[i], big.NewInt(int64(paidToBob)))

--- a/client_test/virtualdefund_test.go
+++ b/client_test/virtualdefund_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	"github.com/statechannels/go-nitro/client/engine/store"
+	"github.com/statechannels/go-nitro/internal/testactors"
 	td "github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/protocols/virtualdefund"
@@ -29,8 +30,12 @@ func TestVirtualDefundIntegration(t *testing.T) {
 	logFile := "test_virtual_defund.log"
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
-	runVirtualDefundIntegrationTest(t, 0, defaultTimeout, logDestination)
+	for _, closer := range []testactors.Actor{alice, irene, bob} {
+		t.Run(fmt.Sprintf("TestVirtualDefundIntegration_as_%s", closer.Name), func(t *testing.T) {
+			runVirtualDefundIntegrationTestAs(t, closer.Address(), 0, defaultTimeout, logDestination)
 
+		})
+	}
 }
 
 func TestVirtualDefundIntegrationWithMessageDelay(t *testing.T) {
@@ -44,12 +49,12 @@ func TestVirtualDefundIntegrationWithMessageDelay(t *testing.T) {
 	// Since we are delaying messages we allow for enough time to complete the objective
 	const OBJECTIVE_TIMEOUT = time.Second * 2
 
-	runVirtualDefundIntegrationTest(t, MAX_MESSAGE_DELAY, OBJECTIVE_TIMEOUT, logDestination)
+	runVirtualDefundIntegrationTestAs(t, alice.Address(), MAX_MESSAGE_DELAY, OBJECTIVE_TIMEOUT, logDestination)
 
 }
 
-// runVirtualDefundIntegrationTest runs a virtual defund integration test using the provided message delay, objective timeout and log destination
-func runVirtualDefundIntegrationTest(t *testing.T, messageDelay time.Duration, objectiveTimeout time.Duration, logDestination io.Writer) {
+// runVirtualDefundIntegrationTestAs runs a virtual defund integration test using the provided message delay, objective timeout and log destination
+func runVirtualDefundIntegrationTestAs(t *testing.T, closer types.Address, messageDelay time.Duration, objectiveTimeout time.Duration, logDestination io.Writer) {
 	chain := chainservice.NewMockChain()
 	chainServiceA := chainservice.NewMockChainService(chain, alice.Address())
 	chainServiceB := chainservice.NewMockChainService(chain, bob.Address())
@@ -70,7 +75,14 @@ func runVirtualDefundIntegrationTest(t *testing.T, messageDelay time.Duration, o
 	}
 	ids := make([]protocols.ObjectiveId, len(cIds))
 	for i := 0; i < len(cIds); i++ {
-		ids[i] = clientA.CloseVirtualChannel(cIds[i], big.NewInt(int64(paidToBob)))
+		switch closer {
+		case alice.Address():
+			ids[i] = clientA.CloseVirtualChannel(cIds[i], big.NewInt(int64(paidToBob)))
+		case bob.Address():
+			ids[i] = clientB.CloseVirtualChannel(cIds[i], big.NewInt(int64(paidToBob)))
+		case irene.Address():
+			ids[i] = clientI.CloseVirtualChannel(cIds[i], big.NewInt(int64(paidToBob)))
+		}
 
 	}
 	waitTimeForCompletedObjectiveIds(t, &clientA, objectiveTimeout, ids...)

--- a/internal/testhelpers/testhelpers.go
+++ b/internal/testhelpers/testhelpers.go
@@ -74,7 +74,7 @@ func AssertStateSentTo(t *testing.T, ses protocols.SideEffects, expected state.S
 		toAddress := to.Address()
 		if bytes.Equal(msg.To[:], toAddress[:]) {
 			for _, op := range msg.ObjectivePayloads {
-				Equals(t, op.PayloadData, b)
+				Equals(t, string(op.PayloadData), string(b))
 			}
 		}
 	}

--- a/payments/voucher_manager.go
+++ b/payments/voucher_manager.go
@@ -118,6 +118,13 @@ func (vm *VoucherManager) Receive(voucher Voucher) (*big.Int, error) {
 	return received, nil
 }
 
+// ChannelRegistered returns  whether a channel has been registered with the voucher manager or not
+func (vm *VoucherManager) ChannelRegistered(channelId types.Destination) bool {
+	_, ok := vm.channels[channelId]
+	return ok
+
+}
+
 // Balance returns the balance of the channel
 func (vm *VoucherManager) Balance(channelId types.Destination) (Balance, error) {
 	data, ok := vm.channels[channelId]

--- a/protocols/virtualdefund/serde.go
+++ b/protocols/virtualdefund/serde.go
@@ -14,15 +14,16 @@ import (
 // jsonObjective replaces the virtualfund Objective's channel pointers
 // with the channel's respective IDs, making jsonObjective suitable for serialization
 type jsonObjective struct {
-	Status           protocols.ObjectiveStatus
-	VFixed           state.FixedPart
-	InitialOutcome   outcome.SingleAssetExit
-	Signatures       [3]state.Signature
-	PaidToBob        *big.Int
-	ToMyLeft         []byte
-	ToMyRight        []byte
-	MinPaymentAmount *big.Int
-	MyRole           uint
+	Status         protocols.ObjectiveStatus
+	VFixed         state.FixedPart
+	InitialOutcome outcome.SingleAssetExit
+	FinalOutcome   outcome.SingleAssetExit
+	Signatures     [3]state.Signature
+
+	ToMyLeft             []byte
+	ToMyRight            []byte
+	MinimumPaymentAmount *big.Int
+	MyRole               uint
 }
 
 // MarshalJSON returns a JSON representation of the VirtualDefundObjective
@@ -52,15 +53,15 @@ func (o Objective) MarshalJSON() ([]byte, error) {
 	}
 
 	jsonVFO := jsonObjective{
-		Status:           o.Status,
-		VFixed:           o.VFixed,
-		Signatures:       o.Signatures,
-		PaidToBob:        o.PaidToBob,
-		InitialOutcome:   o.InitialOutcome,
-		ToMyLeft:         left,
-		ToMyRight:        right,
-		MyRole:           o.MyRole,
-		MinPaymentAmount: o.MinPaymentAmount,
+		Status:               o.Status,
+		VFixed:               o.VFixed,
+		Signatures:           o.Signatures,
+		FinalOutcome:         o.FinalOutcome,
+		InitialOutcome:       o.InitialOutcome,
+		ToMyLeft:             left,
+		ToMyRight:            right,
+		MyRole:               o.MyRole,
+		MinimumPaymentAmount: o.MinimumPaymentAmount,
 	}
 	return json.Marshal(jsonVFO)
 }
@@ -92,8 +93,8 @@ func (o *Objective) UnmarshalJSON(data []byte) error {
 	o.Signatures = jsonVFO.Signatures
 	o.InitialOutcome = jsonVFO.InitialOutcome
 	o.VFixed = jsonVFO.VFixed
-	o.PaidToBob = jsonVFO.PaidToBob
-	o.MinPaymentAmount = jsonVFO.MinPaymentAmount
+	o.FinalOutcome = jsonVFO.FinalOutcome
+	o.MinimumPaymentAmount = jsonVFO.MinimumPaymentAmount
 
 	return nil
 }

--- a/protocols/virtualdefund/serde.go
+++ b/protocols/virtualdefund/serde.go
@@ -14,15 +14,15 @@ import (
 // jsonObjective replaces the virtualfund Objective's channel pointers
 // with the channel's respective IDs, making jsonObjective suitable for serialization
 type jsonObjective struct {
-	Status         protocols.ObjectiveStatus
-	VFixed         state.FixedPart
-	InitialOutcome outcome.SingleAssetExit
-	Signatures     [3]state.Signature
-	PaidToBob      *big.Int
-	ToMyLeft       []byte
-	ToMyRight      []byte
-
-	MyRole uint
+	Status           protocols.ObjectiveStatus
+	VFixed           state.FixedPart
+	InitialOutcome   outcome.SingleAssetExit
+	Signatures       [3]state.Signature
+	PaidToBob        *big.Int
+	ToMyLeft         []byte
+	ToMyRight        []byte
+	MinPaymentAmount *big.Int
+	MyRole           uint
 }
 
 // MarshalJSON returns a JSON representation of the VirtualDefundObjective
@@ -52,14 +52,15 @@ func (o Objective) MarshalJSON() ([]byte, error) {
 	}
 
 	jsonVFO := jsonObjective{
-		Status:         o.Status,
-		VFixed:         o.VFixed,
-		Signatures:     o.Signatures,
-		PaidToBob:      o.PaidToBob,
-		InitialOutcome: o.InitialOutcome,
-		ToMyLeft:       left,
-		ToMyRight:      right,
-		MyRole:         o.MyRole,
+		Status:           o.Status,
+		VFixed:           o.VFixed,
+		Signatures:       o.Signatures,
+		PaidToBob:        o.PaidToBob,
+		InitialOutcome:   o.InitialOutcome,
+		ToMyLeft:         left,
+		ToMyRight:        right,
+		MyRole:           o.MyRole,
+		MinPaymentAmount: o.MinPaymentAmount,
 	}
 	return json.Marshal(jsonVFO)
 }
@@ -92,6 +93,7 @@ func (o *Objective) UnmarshalJSON(data []byte) error {
 	o.InitialOutcome = jsonVFO.InitialOutcome
 	o.VFixed = jsonVFO.VFixed
 	o.PaidToBob = jsonVFO.PaidToBob
+	o.MinPaymentAmount = jsonVFO.MinPaymentAmount
 
 	return nil
 }

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -38,7 +38,7 @@ type Objective struct {
 	// InitialOutcome is the initial outcome of the virtual channel
 	InitialOutcome outcome.SingleAssetExit
 
-	// FinalOutCome is the final outcome of the virtual channel from Alice
+	// FinalOutcome is the final outcome of the virtual channel from Alice
 	FinalOutcome outcome.SingleAssetExit
 
 	// MinimumPaymentAmount is the latest payment amount we have received from Alice before starting defunding.

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -368,7 +368,7 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 	// If we don't know the amount yet we send a message to alice to request it
 	if !updated.isAlice() && updated.PaidToBob == nil {
 		alice := o.VFixed.Participants[0]
-		messages := protocols.CreateObjectivePayloadMessage(updated.Id(), o.MyRole, RequestDefundPayload, alice)
+		messages := protocols.CreateObjectivePayloadMessage(updated.Id(), o.VId(), RequestDefundPayload, alice)
 		sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, messages...)
 		return &updated, sideEffects, WaitingForAmountFromAlice, nil
 	}
@@ -561,7 +561,7 @@ func getSignedStatePayload(b []byte) (state.SignedState, error) {
 	return ss, nil
 }
 
-// getRequestDefundPayload takes in a serialized signed state payload and returns the deserialized SignedState.
+// getRequestDefundPayload takes in a serialized channel id payload and returns the deserialized channel id.
 func getRequestDefundPayload(b []byte) (types.Destination, error) {
 	cId := types.Destination{}
 	err := json.Unmarshal(b, &cId)

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -678,8 +678,8 @@ func (r ObjectiveRequest) Id(types.Address) protocols.ObjectiveId {
 	return protocols.ObjectiveId(ObjectivePrefix + r.ChannelId.String())
 }
 
-// GetVirtualChannelFromId gets the virtual channel id from the objective id.
-func GetVirtualChannelFromId(id protocols.ObjectiveId) (types.Destination, error) {
+// GetVirtualChannelFromObjectiveId gets the virtual channel id from the objective id.
+func GetVirtualChannelFromObjectiveId(id protocols.ObjectiveId) (types.Destination, error) {
 	if !strings.HasPrefix(string(id), ObjectivePrefix) {
 		return types.Destination{}, fmt.Errorf("id %s does not have prefix %s", id, ObjectivePrefix)
 	}

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -138,7 +138,7 @@ func NewObjective(request ObjectiveRequest,
 	}
 
 	finalOutcome := outcome.SingleAssetExit{}
-	// Since is Alice is responsible for issuing vouchers she always has the largest payment amount
+	// Since Alice is responsible for issuing vouchers she always has the largest payment amount
 	// This means she can just set her FinalOutcomeFromAlice based on the largest voucher amount she has sent
 	if myAddress == alice {
 

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -122,7 +122,7 @@ func testCrankAs(my ta.Actor) func(t *testing.T) {
 		updated := updatedObj.(*Objective)
 
 		if my.Role != 0 {
-			testhelpers.Equals(t, se.MessagesToSend[0].ObjectiveMessages[0].Type, FinalStateRequestPayload)
+			testhelpers.Equals(t, se.MessagesToSend[0].ObjectivePayloads[0].Type, FinalStateRequestPayload)
 			testhelpers.Equals(t, waitingFor, WaitingForFinalStateFromAlice)
 
 			// mimic Alice sending the final state by setting PaidToBob to the paid value

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -126,7 +126,7 @@ func testCrankAs(my ta.Actor) func(t *testing.T) {
 			testhelpers.Equals(t, waitingFor, WaitingForFinalStateFromAlice)
 
 			// mimic Alice sending the final state by setting PaidToBob to the paid value
-			updated.PaidToBob = big.NewInt(int64(data.paid))
+			updated.FinalOutcome = data.vFinal.Outcome[0]
 			updatedObj, se, waitingFor, err = updated.Crank(&my.PrivateKey)
 			testhelpers.Ok(t, err)
 			updated = updatedObj.(*Objective)
@@ -196,15 +196,16 @@ func TestConstructObjectiveFromState(t *testing.T) {
 		t.Fatal(err)
 	}
 	left, right := generateLedgers(alice.Role, vId)
+
 	want := Objective{
-		Status:           protocols.Approved,
-		InitialOutcome:   data.vInitial.Outcome[0],
-		PaidToBob:        big.NewInt(int64(data.paid)),
-		VFixed:           data.vFinal.FixedPart(),
-		Signatures:       [3]state.Signature{},
-		ToMyLeft:         left,
-		ToMyRight:        right,
-		MinPaymentAmount: big.NewInt(int64(data.paid)),
+		Status:               protocols.Approved,
+		InitialOutcome:       data.vInitial.Outcome[0],
+		FinalOutcome:         data.vFinal.Outcome[0],
+		VFixed:               data.vFinal.FixedPart(),
+		Signatures:           [3]state.Signature{},
+		ToMyLeft:             left,
+		ToMyRight:            right,
+		MinimumPaymentAmount: big.NewInt(int64(data.paid)),
 	}
 	if diff := cmp.Diff(want, got, cmp.AllowUnexported(big.Int{}, consensus_channel.ConsensusChannel{}, consensus_channel.LedgerOutcome{}, consensus_channel.Guarantee{})); diff != "" {
 		t.Errorf("objective mismatch (-want +got):\n%s", diff)

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -122,8 +122,8 @@ func testCrankAs(my ta.Actor) func(t *testing.T) {
 		updated := updatedObj.(*Objective)
 
 		if my.Role != 0 {
-			testhelpers.Equals(t, se.MessagesToSend[0].ObjectiveMessages[0].Type, RequestDefundPayload)
-			testhelpers.Equals(t, waitingFor, WaitingForAmountFromAlice)
+			testhelpers.Equals(t, se.MessagesToSend[0].ObjectiveMessages[0].Type, FinalStateRequestPayload)
+			testhelpers.Equals(t, waitingFor, WaitingForFinalStateFromAlice)
 
 			// mimic Alice sending the final state by setting PaidToBob to the paid value
 			updated.PaidToBob = big.NewInt(int64(data.paid))

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -122,7 +122,7 @@ func testCrankAs(my ta.Actor) func(t *testing.T) {
 		updated := updatedObj.(*Objective)
 
 		if my.Role != 0 {
-			testhelpers.Equals(t, se.MessagesToSend[0].ObjectivePayloads[0].Type, FinalStateRequestPayload)
+			testhelpers.Equals(t, se.MessagesToSend[0].ObjectivePayloads[0].Type, RequestFinalStatePayload)
 			testhelpers.Equals(t, waitingFor, WaitingForFinalStateFromAlice)
 
 			// mimic Alice sending the final state by setting PaidToBob to the paid value


### PR DESCRIPTION
This roughly implements the virtual defunding protocol as specified in the [ADR](https://github.com/statechannels/go-nitro/pull/863).  When Bob or Irene triggers virtual defunding the protocol will send a `FinalStateRequestPayload` message to Alice requesting the final state.

Note that this implementation differs slightly from the ADR around signature communication. In the ADR Alice sends her signed state to Bob and then Bob forwards to Alice. In this implementation Alice simply broadcasts her signed state to all participants.  See https://github.com/statechannels/go-nitro/pull/863#discussion_r966444821 


The virtual defunding objective struct has two new fields on it:
```go

	// FinalOutcome is the final outcome of the virtual channel from Alice
	FinalOutcome outcome.SingleAssetExit

	// MinimumPaymentAmount is the latest payment amount we have received from Alice before starting defunding.
	// This is set by Bob so he can ensure he receives the latest amount from any vouchers he's received.
	// If this is not set then virtual defunding will accept any final outcome from Alice.
	MinimumPaymentAmount *big.Int

``` 

`FinalOutcome` is the outcome of the final state signed by Alice. For Bob and Irene this starts as `outcome.SingleAssetExit{}` and gets populated when Alice sends her signed final state.

`MinimumPaymentAmount` is the minimum payment amount Bob expects to receive. This gets set to the latest voucher Bob has whenever he starts virtual defunding. When Bob receives a final state from Alice he makes sure the payment amount is at least `MinimumPaymentAmount`.

The virtual defund protocol has a new `waitingFor` state `	WaitingForFinalStateFromAlice`. Bob and Irene enter this if before they have received the final state from Alice.

The virtual defunding integration test has been modified with two important changes:
- It calls `clientA.Pay` to actually send a payment to Bob.
- It tests all participants calling `client*.Close` not just Alice

