### PR TITLE
Convert FixedPart.ChallengeDuration to uint32

### DIFF
--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -210,7 +210,7 @@ func TestChannel(t *testing.T) {
 			},
 			ChannelNonce:      37140676581,
 			AppDefinition:     common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),
-			ChallengeDuration: big.NewInt(60),
+			ChallengeDuration: 60,
 			AppData:           []byte{},
 			Outcome:           state.TestOutcome,
 			TurnNum:           5,

--- a/channel/consensus_channel/helpers_test.go
+++ b/channel/consensus_channel/helpers_test.go
@@ -25,7 +25,7 @@ func fp() state.FixedPart {
 		Participants:      participants[:],
 		ChainId:           big.NewInt(9001),
 		ChannelNonce:      9001,
-		ChallengeDuration: big.NewInt(100),
+		ChallengeDuration: 100,
 	}
 }
 

--- a/channel/state/state.go
+++ b/channel/state/state.go
@@ -38,7 +38,7 @@ type (
 		Participants      []types.Address
 		ChannelNonce      uint64
 		AppDefinition     types.Address
-		ChallengeDuration *types.Uint256
+		ChallengeDuration uint64
 		AppData           types.Bytes
 		Outcome           outcome.Exit
 		TurnNum           uint64
@@ -51,7 +51,7 @@ type (
 		Participants      []types.Address
 		ChannelNonce      uint64
 		AppDefinition     types.Address
-		ChallengeDuration *types.Uint256
+		ChallengeDuration uint64
 	}
 
 	// VariablePart contains the subset of State data which can change with each state update.
@@ -90,7 +90,7 @@ func (fp FixedPart) ChannelId() types.Destination {
 		{Type: abi.Uint256},
 		{Type: abi.Address},
 		{Type: abi.Uint256},
-	}.Pack(fp.ChainId, fp.Participants, new(big.Int).SetUint64(fp.ChannelNonce), fp.AppDefinition, fp.ChallengeDuration)
+	}.Pack(fp.ChainId, fp.Participants, new(big.Int).SetUint64(fp.ChannelNonce), fp.AppDefinition, new(big.Int).SetUint64(fp.ChallengeDuration))
 
 	if err != nil {
 		panic(err)
@@ -169,7 +169,7 @@ func (s State) Equal(r State) bool {
 		equalParticipants(s.Participants, r.Participants) &&
 		s.ChannelNonce == r.ChannelNonce &&
 		bytes.Equal(s.AppDefinition.Bytes(), r.AppDefinition.Bytes()) &&
-		types.Equal(s.ChallengeDuration, r.ChallengeDuration) &&
+		s.ChallengeDuration == r.ChallengeDuration &&
 		bytes.Equal(s.AppData, r.AppData) &&
 		s.Outcome.Equal(r.Outcome) &&
 		s.TurnNum == r.TurnNum &&
@@ -183,7 +183,7 @@ func (f FixedPart) Clone() FixedPart {
 	clone.Participants = append(clone.Participants, f.Participants...)
 	clone.ChannelNonce = f.ChannelNonce
 	clone.AppDefinition = f.AppDefinition
-	clone.ChallengeDuration = new(big.Int).Set(f.ChallengeDuration)
+	clone.ChallengeDuration = f.ChallengeDuration
 	return clone
 }
 

--- a/channel/state/state.go
+++ b/channel/state/state.go
@@ -38,7 +38,7 @@ type (
 		Participants      []types.Address
 		ChannelNonce      uint64
 		AppDefinition     types.Address
-		ChallengeDuration uint64
+		ChallengeDuration uint32
 		AppData           types.Bytes
 		Outcome           outcome.Exit
 		TurnNum           uint64
@@ -51,7 +51,7 @@ type (
 		Participants      []types.Address
 		ChannelNonce      uint64
 		AppDefinition     types.Address
-		ChallengeDuration uint64
+		ChallengeDuration uint32
 	}
 
 	// VariablePart contains the subset of State data which can change with each state update.
@@ -90,7 +90,7 @@ func (fp FixedPart) ChannelId() types.Destination {
 		{Type: abi.Uint256},
 		{Type: abi.Address},
 		{Type: abi.Uint256},
-	}.Pack(fp.ChainId, fp.Participants, new(big.Int).SetUint64(fp.ChannelNonce), fp.AppDefinition, new(big.Int).SetUint64(fp.ChallengeDuration))
+	}.Pack(fp.ChainId, fp.Participants, new(big.Int).SetUint64(fp.ChannelNonce), fp.AppDefinition, new(big.Int).SetUint64(uint64(fp.ChallengeDuration)))
 
 	if err != nil {
 		panic(err)

--- a/channel/state/state_test.go
+++ b/channel/state/state_test.go
@@ -106,7 +106,7 @@ func TestEqual(t *testing.T) {
 		},
 		ChannelNonce:      37140676580,
 		AppDefinition:     common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),
-		ChallengeDuration: big.NewInt(60),
+		ChallengeDuration: 60,
 		AppData:           []byte{},
 		Outcome:           TestOutcome,
 		TurnNum:           5,

--- a/channel/state/test-fixtures.go
+++ b/channel/state/test-fixtures.go
@@ -34,7 +34,7 @@ var TestState = State{
 	},
 	ChannelNonce:      37140676580,
 	AppDefinition:     common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),
-	ChallengeDuration: big.NewInt(60),
+	ChallengeDuration: 60,
 	AppData:           []byte{},
 	Outcome:           TestOutcome,
 	TurnNum:           5,

--- a/client/engine/chainservice/adjudicator/challenge_test.go
+++ b/client/engine/chainservice/adjudicator/challenge_test.go
@@ -152,7 +152,7 @@ func TestChallenge(t *testing.T) {
 		}
 
 		// Generate expectation
-		expectedFinalizesAt := header.Time + s.ChallengeDuration
+		expectedFinalizesAt := header.Time + uint64(s.ChallengeDuration)
 		cId := s.ChannelId()
 		expectedOnChainStatus, err := generateStatus(s, expectedFinalizesAt)
 		if err != nil {

--- a/client/engine/chainservice/adjudicator/challenge_test.go
+++ b/client/engine/chainservice/adjudicator/challenge_test.go
@@ -99,7 +99,7 @@ func TestChallenge(t *testing.T) {
 			},
 			ChannelNonce:      37140676580,
 			AppDefinition:     consensusAppAddress,
-			ChallengeDuration: big.NewInt(60),
+			ChallengeDuration: 60,
 			AppData:           []byte{},
 			Outcome:           outcome.Exit{},
 			TurnNum:           turnNum,
@@ -128,7 +128,7 @@ func TestChallenge(t *testing.T) {
 		// Fire off a Challenge tx
 		tx, err := na.Challenge(
 			auth,
-			INitroTypesFixedPart(s.FixedPart()),
+			INitroTypesFixedPart(ConvertFixedPart(s.FixedPart())),
 			proof,
 			candidate,
 			ConvertSignature(challengerSig),
@@ -150,10 +150,9 @@ func TestChallenge(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		challengeTime := big.NewInt(int64(header.Time))
 
 		// Generate expectation
-		expectedFinalizesAt := big.NewInt(0).Add(challengeTime, s.ChallengeDuration)
+		expectedFinalizesAt := header.Time + s.ChallengeDuration
 		cId := s.ChannelId()
 		expectedOnChainStatus, err := generateStatus(s, expectedFinalizesAt)
 		if err != nil {

--- a/client/engine/chainservice/adjudicator/typeconversions.go
+++ b/client/engine/chainservice/adjudicator/typeconversions.go
@@ -14,7 +14,7 @@ func ConvertFixedPart(fp state.FixedPart) INitroTypesFixedPart {
 		Participants:      fp.Participants,
 		ChannelNonce:      fp.ChannelNonce,
 		AppDefinition:     fp.AppDefinition,
-		ChallengeDuration: new(big.Int).SetUint64(fp.ChallengeDuration),
+		ChallengeDuration: new(big.Int).SetUint64(uint64(fp.ChallengeDuration)),
 	}
 }
 

--- a/client/engine/chainservice/adjudicator/typeconversions.go
+++ b/client/engine/chainservice/adjudicator/typeconversions.go
@@ -8,6 +8,16 @@ import (
 	nc "github.com/statechannels/go-nitro/crypto"
 )
 
+func ConvertFixedPart(fp state.FixedPart) INitroTypesFixedPart {
+	return INitroTypesFixedPart{
+		ChainId:           fp.ChainId,
+		Participants:      fp.Participants,
+		ChannelNonce:      fp.ChannelNonce,
+		AppDefinition:     fp.AppDefinition,
+		ChallengeDuration: new(big.Int).SetUint64(fp.ChallengeDuration),
+	}
+}
+
 func ConvertVariablePart(vp state.VariablePart) INitroTypesVariablePart {
 	return INitroTypesVariablePart{
 		AppData: vp.AppData,

--- a/client/engine/chainservice/adjudicator/utils_test.go
+++ b/client/engine/chainservice/adjudicator/utils_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/statechannels/go-nitro/channel/state"
 )
 
-func generateStatus(state state.State, finalizesAt *big.Int) ([]byte, error) {
+func generateStatus(state state.State, finalizesAt uint64) ([]byte, error) {
 	turnNumBytes := big.NewInt(int64(state.TurnNum)).FillBytes(make([]byte, 6))
-	finalizesAtBytes := finalizesAt.FillBytes(make([]byte, 6))
+	finalizesAtBytes := new(big.Int).SetUint64(finalizesAt).FillBytes(make([]byte, 6))
 
 	stateHash, err := state.Hash()
 	if err != nil {

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -93,7 +93,7 @@ func (ecs *EthChainService) SendTransaction(tx protocols.ChainTransaction) error
 	case protocols.WithdrawAllTransaction:
 		state := tx.SignedState.State()
 		signatures := tx.SignedState.Signatures()
-		nitroFixedPart := NitroAdjudicator.INitroTypesFixedPart(state.FixedPart())
+		nitroFixedPart := NitroAdjudicator.INitroTypesFixedPart(NitroAdjudicator.ConvertFixedPart(state.FixedPart()))
 		nitroVariablePart := NitroAdjudicator.ConvertVariablePart(state.VariablePart())
 		nitroSignatures := []NitroAdjudicator.INitroTypesSignature{NitroAdjudicator.ConvertSignature(signatures[0]), NitroAdjudicator.ConvertSignature(signatures[1])}
 		proof := make([]NitroAdjudicator.INitroTypesSignedVariablePart, 0)

--- a/client/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/client/engine/chainservice/simulated_backend_chainservice_test.go
@@ -107,7 +107,7 @@ func TestConcludeSimulatedBackendChainService(t *testing.T) {
 		},
 		ChannelNonce:      37140676580,
 		AppDefinition:     bindings.ConsensusApp.Address,
-		ChallengeDuration: &big.Int{},
+		ChallengeDuration: 0,
 		AppData:           []byte{},
 		Outcome:           concludeOutcome,
 		TurnNum:           uint64(2),

--- a/client_test/directdefund_test.go
+++ b/client_test/directdefund_test.go
@@ -2,7 +2,6 @@
 package client_test // import "github.com/statechannels/go-nitro/client_test"
 
 import (
-	"math/big"
 	"math/rand"
 	"testing"
 	"time"
@@ -99,7 +98,7 @@ func TestDirectDefund(t *testing.T) {
 			Outcome:           outcome,
 			AppDefinition:     types.Address{},
 			AppData:           types.Bytes{},
-			ChallengeDuration: big.NewInt(0),
+			ChallengeDuration: 0,
 			Nonce:             rand.Uint64(),
 		}
 		response := clientA.CreateVirtualChannel(request)

--- a/client_test/directfund_test.go
+++ b/client_test/directfund_test.go
@@ -2,7 +2,6 @@
 package client_test // import "github.com/statechannels/go-nitro/client_test"
 
 import (
-	"math/big"
 	"math/rand"
 	"testing"
 	"time"
@@ -28,7 +27,7 @@ func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.C
 	request := directfund.ObjectiveRequestForConsensusApp{
 		CounterParty:      *beta.Address,
 		Outcome:           outcome,
-		ChallengeDuration: big.NewInt(0),
+		ChallengeDuration: 0,
 		Nonce:             rand.Uint64(),
 	}
 	response := alpha.CreateLedgerChannel(request)
@@ -70,7 +69,7 @@ func TestWhenObjectiveIsRejected(t *testing.T) {
 	request := directfund.ObjectiveRequestForConsensusApp{
 		CounterParty:      bob.Address(),
 		Outcome:           outcome,
-		ChallengeDuration: big.NewInt(0),
+		ChallengeDuration: 0,
 		Nonce:             rand.Uint64(),
 	}
 

--- a/client_test/payment_test.go
+++ b/client_test/payment_test.go
@@ -47,7 +47,7 @@ func TestPayments(t *testing.T) {
 		Outcome:           outcome,
 		AppDefinition:     types.Address{},
 		AppData:           types.Bytes{},
-		ChallengeDuration: big.NewInt(0),
+		ChallengeDuration: 0,
 		Nonce:             rand.Uint64(),
 	}
 

--- a/client_test/virtualdefund_test.go
+++ b/client_test/virtualdefund_test.go
@@ -184,7 +184,7 @@ func TestWhenVirtualDefundObjectiveIsRejected(t *testing.T) {
 		Outcome:           outcome,
 		AppDefinition:     types.Address{},
 		AppData:           types.Bytes{},
-		ChallengeDuration: big.NewInt(0),
+		ChallengeDuration: 0,
 		Nonce:             rand.Uint64(),
 	}
 	response := clientA.CreateVirtualChannel(request)

--- a/client_test/virtualfund_multi_party_test.go
+++ b/client_test/virtualfund_multi_party_test.go
@@ -1,7 +1,6 @@
 package client_test
 
 import (
-	"math/big"
 	"math/rand"
 	"testing"
 
@@ -45,7 +44,7 @@ func TestVirtualFundMultiParty(t *testing.T) {
 		),
 		AppDefinition:     types.Address{},
 		AppData:           types.Bytes{},
-		ChallengeDuration: big.NewInt(0),
+		ChallengeDuration: 0,
 		Nonce:             rand.Uint64(),
 	}
 	withBrianRequest := virtualfund.ObjectiveRequest{
@@ -59,7 +58,7 @@ func TestVirtualFundMultiParty(t *testing.T) {
 		),
 		AppDefinition:     types.Address{},
 		AppData:           types.Bytes{},
-		ChallengeDuration: big.NewInt(0),
+		ChallengeDuration: 0,
 		Nonce:             rand.Uint64(),
 	}
 	id := clientAlice.CreateVirtualChannel(withBobRequest).Id

--- a/client_test/virtualfund_test.go
+++ b/client_test/virtualfund_test.go
@@ -1,7 +1,6 @@
 package client_test
 
 import (
-	"math/big"
 	"math/rand"
 	"testing"
 
@@ -28,7 +27,7 @@ func openVirtualChannels(t *testing.T, clientA client.Client, clientB client.Cli
 			Outcome:           outcome,
 			AppDefinition:     types.Address{},
 			AppData:           types.Bytes{},
-			ChallengeDuration: big.NewInt(0),
+			ChallengeDuration: 0,
 			Nonce:             rand.Uint64(),
 		}
 		response := clientA.CreateVirtualChannel(request)

--- a/client_test/virtualfund_with_message_delays_test.go
+++ b/client_test/virtualfund_with_message_delays_test.go
@@ -1,7 +1,6 @@
 package client_test
 
 import (
-	"math/big"
 	"math/rand"
 	"testing"
 	"time"
@@ -61,7 +60,7 @@ func createVirtualChannels(client client.Client, counterParty types.Address, int
 			Outcome:           outcome,
 			AppDefinition:     types.Address{},
 			AppData:           types.Bytes{},
-			ChallengeDuration: big.NewInt(0),
+			ChallengeDuration: 0,
 			Nonce:             rand.Uint64(),
 		}
 

--- a/internal/testdata/states.go
+++ b/internal/testdata/states.go
@@ -48,7 +48,7 @@ var testVirtualState = state.State{
 	},
 	ChannelNonce:      1234789,
 	AppDefinition:     someAppDefinition,
-	ChallengeDuration: big.NewInt(60),
+	ChallengeDuration: 60,
 	AppData:           []byte{},
 	Outcome: Outcomes.CreateLongOutcome(
 		SimpleItem{testactors.Alice.Destination(), 6},
@@ -66,7 +66,7 @@ var testState = state.State{
 	},
 	ChannelNonce:      37140676580,
 	AppDefinition:     someAppDefinition,
-	ChallengeDuration: big.NewInt(60),
+	ChallengeDuration: 60,
 	AppData:           []byte{},
 	Outcome:           testOutcome,
 	TurnNum:           5,

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -26,7 +26,7 @@ var testState = state.State{
 	Participants:      []types.Address{alice.Address(), bob.Address()},
 	ChannelNonce:      37140676580,
 	AppDefinition:     common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),
-	ChallengeDuration: big.NewInt(60),
+	ChallengeDuration: 60,
 	AppData:           []byte{},
 	Outcome: outcome.Exit{
 		outcome.SingleAssetExit{

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -447,7 +447,7 @@ func IsDirectFundObjective(id protocols.ObjectiveId) bool {
 // There is no AppDefinition, since we currently only support full consensus rules for direct channels.
 type ObjectiveRequestForConsensusApp struct {
 	CounterParty      types.Address
-	ChallengeDuration *types.Uint256
+	ChallengeDuration uint64
 	Outcome           outcome.Exit
 	Nonce             uint64
 }

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -447,7 +447,7 @@ func IsDirectFundObjective(id protocols.ObjectiveId) bool {
 // There is no AppDefinition, since we currently only support full consensus rules for direct channels.
 type ObjectiveRequestForConsensusApp struct {
 	CounterParty      types.Address
-	ChallengeDuration uint64
+	ChallengeDuration uint32
 	Outcome           outcome.Exit
 	Nonce             uint64
 }

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -26,7 +26,7 @@ var testState = state.State{
 	Participants:      []types.Address{alice.Address(), bob.Address()},
 	ChannelNonce:      37140676580,
 	AppDefinition:     common.HexToAddress(`0x5e29E5Ab8EF33F050c7cc10B5a0456D975C5F88d`),
-	ChallengeDuration: big.NewInt(60),
+	ChallengeDuration: 60,
 	AppData:           []byte{},
 	Outcome: outcome.Exit{
 		outcome.SingleAssetExit{

--- a/protocols/virtualdefund/helpers_test.go
+++ b/protocols/virtualdefund/helpers_test.go
@@ -79,7 +79,7 @@ func prepareConsensusChannel(role uint, left, right ta.Actor, guarantees ...cons
 		Participants:      []types.Address{left.Address(), right.Address()},
 		ChannelNonce:      0,
 		AppDefinition:     types.Address{},
-		ChallengeDuration: big.NewInt(45),
+		ChallengeDuration: 45,
 	}
 
 	leftBal := consensus_channel.NewBalance(left.Destination(), big.NewInt(0))
@@ -255,7 +255,7 @@ func generateTestData() testdata {
 		Participants:      []types.Address{alice.Address(), irene.Address(), bob.Address()}, // A single hop virtual channel
 		ChannelNonce:      0,
 		AppDefinition:     types.Address{},
-		ChallengeDuration: big.NewInt(45),
+		ChallengeDuration: 45,
 	}
 
 	finalAliceAmount := uint(6)

--- a/protocols/virtualfund/helpers_test.go
+++ b/protocols/virtualfund/helpers_test.go
@@ -28,7 +28,7 @@ func prepareConsensusChannelHelper(role uint, leader, follower testactors.Actor,
 		Participants:      []types.Address{leader.Address(), follower.Address()},
 		ChannelNonce:      0,
 		AppDefinition:     types.Address{},
-		ChallengeDuration: big.NewInt(45),
+		ChallengeDuration: 45,
 	}
 
 	leaderBal := consensus_channel.NewBalance(leader.Destination(), big.NewInt(int64(leftBalance)))

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -705,7 +705,7 @@ type ObjectiveRequest struct {
 	CounterParty      types.Address
 	AppDefinition     types.Address
 	AppData           types.Bytes
-	ChallengeDuration *types.Uint256
+	ChallengeDuration uint64
 	Outcome           outcome.Exit
 	Nonce             uint64
 }

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -705,7 +705,7 @@ type ObjectiveRequest struct {
 	CounterParty      types.Address
 	AppDefinition     types.Address
 	AppData           types.Bytes
-	ChallengeDuration uint64
+	ChallengeDuration uint32
 	Outcome           outcome.Exit
 	Nonce             uint64
 }

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -40,7 +40,7 @@ func newTestData() testData {
 		Participants:      []types.Address{alice.Address(), p1.Address(), bob.Address()},
 		ChannelNonce:      0,
 		AppDefinition:     types.Address{},
-		ChallengeDuration: big.NewInt(45),
+		ChallengeDuration: 45,
 		AppData:           []byte{},
 		Outcome: outcome.Exit{outcome.SingleAssetExit{
 			Allocations: outcome.Allocations{

--- a/protocols/virtualfund/virtualfund_test.go
+++ b/protocols/virtualfund/virtualfund_test.go
@@ -25,7 +25,7 @@ func TestMarshalJSON(t *testing.T) {
 		Participants:      []types.Address{alice.Address(), p1.Address(), bob.Address()}, // A single hop virtual channel
 		ChannelNonce:      0,
 		AppDefinition:     types.Address{},
-		ChallengeDuration: big.NewInt(45),
+		ChallengeDuration: 45,
 		AppData:           []byte{},
 		Outcome: outcome.Exit{outcome.SingleAssetExit{
 			Allocations: outcome.Allocations{


### PR DESCRIPTION
In Solidity contracts, ChallengeDuration type is `uint48`. This PR changes the type of ChallengeDuration from `big.Int` to `uint64` on golang. While golang `uint64` will not guard against overflowing the Solidity type, we should favor primitive types over structs when a struct provides no other significant advantages.