### PR TITLE
Make the `client` responsible for nonce management

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -4,6 +4,7 @@ package client // import "github.com/statechannels/go-nitro/client"
 import (
 	"io"
 	"math/big"
+	"math/rand"
 
 	"github.com/statechannels/go-nitro/client/engine"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
@@ -92,7 +93,13 @@ func (c *Client) ReceivedVouchers() <-chan payments.Voucher {
 }
 
 // CreateVirtualChannel creates a virtual channel with the counterParty using ledger channels with the intermediary.
-func (c *Client) CreateVirtualChannel(objectiveRequest virtualfund.ObjectiveRequest) virtualfund.ObjectiveResponse {
+func (c *Client) CreateVirtualChannel(request virtualfund.ObjectiveRequestForVirtualPaymentApp) virtualfund.ObjectiveResponse {
+
+	objectiveRequest := virtualfund.ObjectiveRequest{
+		ObjectiveRequestForVirtualPaymentApp: request,
+		Nonce:                                rand.Uint64(),
+		// AppDefinition implicitly zero TODO https://github.com/statechannels/go-nitro/issues/839
+	}
 
 	// Send the event to the engine
 	c.engine.ObjectiveRequestsFromAPI <- objectiveRequest
@@ -121,7 +128,8 @@ func (c *Client) CreateLedgerChannel(request directfund.ObjectiveRequestForConse
 	objectiveRequest := directfund.ObjectiveRequest{
 		ObjectiveRequestForConsensusApp: request,
 		AppDefinition:                   c.engine.GetConsensusAppAddress(),
-		// Appdata implicitly zero
+		Nonce:                           rand.Uint64(),
+		// Appdata implicitly zero TODO https://github.com/statechannels/go-nitro/issues/839
 	}
 
 	// Send the event to the engine

--- a/client/client.go
+++ b/client/client.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"math/rand"
 
+	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client/engine"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
@@ -93,11 +94,14 @@ func (c *Client) ReceivedVouchers() <-chan payments.Voucher {
 }
 
 // CreateVirtualChannel creates a virtual channel with the counterParty using ledger channels with the intermediary.
-func (c *Client) CreateVirtualChannel(request virtualfund.ObjectiveRequestForVirtualPaymentApp) virtualfund.ObjectiveResponse {
+func (c *Client) CreateVirtualPaymentChannel(Intermediary, CounterParty types.Address, ChallengeDuration uint32, Outcome outcome.Exit) virtualfund.ObjectiveResponse {
 
 	objectiveRequest := virtualfund.ObjectiveRequest{
-		ObjectiveRequestForVirtualPaymentApp: request,
-		Nonce:                                rand.Uint64(),
+		Intermediary:      Intermediary,
+		CounterParty:      CounterParty,
+		ChallengeDuration: ChallengeDuration,
+		Outcome:           Outcome,
+		Nonce:             rand.Uint64(),
 		// AppDefinition implicitly zero TODO https://github.com/statechannels/go-nitro/issues/839
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -127,13 +127,15 @@ func (c *Client) CloseVirtualChannel(channelId types.Destination) protocols.Obje
 
 // CreateLedgerChannel creates a directly funded ledger channel with the given counterparty.
 // The channel will run under full consensus rules (it is not possible to provide a custom AppDefinition or AppData).
-func (c *Client) CreateLedgerChannel(request directfund.ObjectiveRequestForConsensusApp) directfund.ObjectiveResponse {
+func (c *Client) CreateLedgerChannel(Counterparty types.Address, ChallengeDuration uint32, outcome outcome.Exit) directfund.ObjectiveResponse {
 
 	objectiveRequest := directfund.ObjectiveRequest{
-		ObjectiveRequestForConsensusApp: request,
-		AppDefinition:                   c.engine.GetConsensusAppAddress(),
-		Nonce:                           rand.Uint64(),
-		// Appdata implicitly zero TODO https://github.com/statechannels/go-nitro/issues/839
+		CounterParty:      Counterparty,
+		ChallengeDuration: ChallengeDuration,
+		Outcome:           outcome,
+		AppDefinition:     c.engine.GetConsensusAppAddress(),
+		Nonce:             rand.Uint64(),
+		// Appdata implicitly zero
 	}
 
 	// Send the event to the engine

--- a/client_test/directdefund_test.go
+++ b/client_test/directdefund_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/store"
 	"github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols"
-	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -91,14 +90,7 @@ func TestDirectDefund(t *testing.T) {
 
 		// create & virtual channel between A and B through I
 		outcome := testdata.Outcomes.Create(alice.Address(), bob.Address(), 1, 1)
-		request := virtualfund.ObjectiveRequestForVirtualPaymentApp{
-			CounterParty:      bob.Address(),
-			Intermediary:      irene.Address(),
-			Outcome:           outcome,
-			ChallengeDuration: 0,
-		}
-
-		response := clientA.CreateVirtualChannel(request)
+		response := clientA.CreateVirtualPaymentChannel(irene.Address(), bob.Address(), 0, outcome)
 
 		waitTimeForCompletedObjectiveIds(t, &clientA, defaultTimeout, response.Id)
 

--- a/client_test/directdefund_test.go
+++ b/client_test/directdefund_test.go
@@ -2,7 +2,6 @@
 package client_test // import "github.com/statechannels/go-nitro/client_test"
 
 import (
-	"math/rand"
 	"testing"
 	"time"
 
@@ -92,15 +91,13 @@ func TestDirectDefund(t *testing.T) {
 
 		// create & virtual channel between A and B through I
 		outcome := testdata.Outcomes.Create(alice.Address(), bob.Address(), 1, 1)
-		request := virtualfund.ObjectiveRequest{
+		request := virtualfund.ObjectiveRequestForVirtualPaymentApp{
 			CounterParty:      bob.Address(),
 			Intermediary:      irene.Address(),
 			Outcome:           outcome,
-			AppDefinition:     types.Address{},
-			AppData:           types.Bytes{},
 			ChallengeDuration: 0,
-			Nonce:             rand.Uint64(),
 		}
+
 		response := clientA.CreateVirtualChannel(request)
 
 		waitTimeForCompletedObjectiveIds(t, &clientA, defaultTimeout, response.Id)

--- a/client_test/directfund_test.go
+++ b/client_test/directfund_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/store"
 	"github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols"
-	"github.com/statechannels/go-nitro/protocols/directfund"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -22,13 +21,7 @@ const ledgerChannelDeposit = 5_000_000
 func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.Client) types.Destination {
 	// Set up an outcome that requires both participants to deposit
 	outcome := testdata.Outcomes.Create(*alpha.Address, *beta.Address, ledgerChannelDeposit, ledgerChannelDeposit)
-
-	request := directfund.ObjectiveRequestForConsensusApp{
-		CounterParty:      *beta.Address,
-		Outcome:           outcome,
-		ChallengeDuration: 0,
-	}
-	response := alpha.CreateLedgerChannel(request)
+	response := alpha.CreateLedgerChannel(*beta.Address, 0, outcome)
 
 	waitTimeForCompletedObjectiveIds(t, &alpha, defaultTimeout, response.Id)
 	waitTimeForCompletedObjectiveIds(t, &beta, defaultTimeout, response.Id)
@@ -63,14 +56,7 @@ func TestWhenObjectiveIsRejected(t *testing.T) {
 	}
 
 	outcome := testdata.Outcomes.Create(alice.Address(), bob.Address(), ledgerChannelDeposit, ledgerChannelDeposit)
-
-	request := directfund.ObjectiveRequestForConsensusApp{
-		CounterParty:      bob.Address(),
-		Outcome:           outcome,
-		ChallengeDuration: 0,
-	}
-
-	response := clientA.CreateLedgerChannel(request)
+	response := clientA.CreateLedgerChannel(bob.Address(), 0, outcome)
 
 	waitTimeForCompletedObjectiveIds(t, &clientA, time.Second, response.Id)
 

--- a/client_test/directfund_test.go
+++ b/client_test/directfund_test.go
@@ -2,7 +2,6 @@
 package client_test // import "github.com/statechannels/go-nitro/client_test"
 
 import (
-	"math/rand"
 	"testing"
 	"time"
 
@@ -28,7 +27,6 @@ func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.C
 		CounterParty:      *beta.Address,
 		Outcome:           outcome,
 		ChallengeDuration: 0,
-		Nonce:             rand.Uint64(),
 	}
 	response := alpha.CreateLedgerChannel(request)
 
@@ -70,7 +68,6 @@ func TestWhenObjectiveIsRejected(t *testing.T) {
 		CounterParty:      bob.Address(),
 		Outcome:           outcome,
 		ChallengeDuration: 0,
-		Nonce:             rand.Uint64(),
 	}
 
 	response := clientA.CreateLedgerChannel(request)

--- a/client_test/payment_test.go
+++ b/client_test/payment_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	td "github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols"
-	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -39,15 +38,7 @@ func TestPayments(t *testing.T) {
 	directlyFundALedgerChannel(t, clientA, clientI)
 	directlyFundALedgerChannel(t, clientI, clientB)
 	outcome := td.Outcomes.Create(alice.Address(), bob.Address(), 100, 100)
-	request := virtualfund.ObjectiveRequestForVirtualPaymentApp{
-
-		CounterParty:      bob.Address(),
-		Intermediary:      irene.Address(),
-		Outcome:           outcome,
-		ChallengeDuration: 0,
-	}
-
-	r := clientA.CreateVirtualChannel(request)
+	r := clientA.CreateVirtualPaymentChannel(irene.Address(), bob.Address(), 0, outcome)
 
 	ids := []protocols.ObjectiveId{r.Id}
 

--- a/client_test/payment_test.go
+++ b/client_test/payment_test.go
@@ -2,7 +2,6 @@ package client_test
 
 import (
 	"math/big"
-	"math/rand"
 	"testing"
 
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
@@ -40,15 +39,12 @@ func TestPayments(t *testing.T) {
 	directlyFundALedgerChannel(t, clientA, clientI)
 	directlyFundALedgerChannel(t, clientI, clientB)
 	outcome := td.Outcomes.Create(alice.Address(), bob.Address(), 100, 100)
-	request := virtualfund.ObjectiveRequest{
+	request := virtualfund.ObjectiveRequestForVirtualPaymentApp{
 
 		CounterParty:      bob.Address(),
 		Intermediary:      irene.Address(),
 		Outcome:           outcome,
-		AppDefinition:     types.Address{},
-		AppData:           types.Bytes{},
 		ChallengeDuration: 0,
-		Nonce:             rand.Uint64(),
 	}
 
 	r := clientA.CreateVirtualChannel(request)

--- a/client_test/virtualdefund_test.go
+++ b/client_test/virtualdefund_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -178,14 +177,11 @@ func TestWhenVirtualDefundObjectiveIsRejected(t *testing.T) {
 	directlyFundALedgerChannel(t, clientB, clientI)
 
 	outcome := td.Outcomes.Create(alice.Address(), bob.Address(), 1, 1)
-	request := virtualfund.ObjectiveRequest{
+	request := virtualfund.ObjectiveRequestForVirtualPaymentApp{
 		CounterParty:      bob.Address(),
 		Intermediary:      irene.Address(),
 		Outcome:           outcome,
-		AppDefinition:     types.Address{},
-		AppData:           types.Bytes{},
 		ChallengeDuration: 0,
-		Nonce:             rand.Uint64(),
 	}
 	response := clientA.CreateVirtualChannel(request)
 

--- a/client_test/virtualdefund_test.go
+++ b/client_test/virtualdefund_test.go
@@ -18,7 +18,6 @@ import (
 	td "github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/protocols/virtualdefund"
-	"github.com/statechannels/go-nitro/protocols/virtualfund"
 
 	"github.com/statechannels/go-nitro/types"
 )
@@ -177,13 +176,7 @@ func TestWhenVirtualDefundObjectiveIsRejected(t *testing.T) {
 	directlyFundALedgerChannel(t, clientB, clientI)
 
 	outcome := td.Outcomes.Create(alice.Address(), bob.Address(), 1, 1)
-	request := virtualfund.ObjectiveRequestForVirtualPaymentApp{
-		CounterParty:      bob.Address(),
-		Intermediary:      irene.Address(),
-		Outcome:           outcome,
-		ChallengeDuration: 0,
-	}
-	response := clientA.CreateVirtualChannel(request)
+	response := clientA.CreateVirtualPaymentChannel(irene.Address(), bob.Address(), 0, outcome)
 
 	waitTimeForCompletedObjectiveIds(t, &clientA, time.Second, response.Id)
 	waitTimeForCompletedObjectiveIds(t, &clientB, time.Second, response.Id)

--- a/client_test/virtualfund_multi_party_test.go
+++ b/client_test/virtualfund_multi_party_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	td "github.com/statechannels/go-nitro/internal/testdata"
-	"github.com/statechannels/go-nitro/protocols/virtualfund"
 )
 
 // TestVirtualFundMultiParty tests the scenario where Alice creates virtual channels with Bob and Brian using Irene as the intermediary.
@@ -31,30 +30,20 @@ func TestVirtualFundMultiParty(t *testing.T) {
 	directlyFundALedgerChannel(t, clientAlice, clientIrene)
 	directlyFundALedgerChannel(t, clientIrene, clientBob)
 	directlyFundALedgerChannel(t, clientIrene, clientBrian)
-	withBobRequest := virtualfund.ObjectiveRequestForVirtualPaymentApp{
-		CounterParty: bob.Address(),
-		Intermediary: irene.Address(),
-		Outcome: td.Outcomes.Create(
-			alice.Address(),
-			bob.Address(),
-			1,
-			1,
-		),
-		ChallengeDuration: 0,
-	}
-	withBrianRequest := virtualfund.ObjectiveRequestForVirtualPaymentApp{
-		CounterParty: brian.Address(),
-		Intermediary: irene.Address(),
-		Outcome: td.Outcomes.Create(
-			alice.Address(),
-			brian.Address(),
-			1,
-			1,
-		),
-		ChallengeDuration: 0,
-	}
-	id := clientAlice.CreateVirtualChannel(withBobRequest).Id
-	id2 := clientAlice.CreateVirtualChannel(withBrianRequest).Id
+
+	id := clientAlice.CreateVirtualPaymentChannel(irene.Address(), bob.Address(), 0, td.Outcomes.Create(
+		alice.Address(),
+		bob.Address(),
+		1,
+		1,
+	)).Id
+
+	id2 := clientAlice.CreateVirtualPaymentChannel(irene.Address(), brian.Address(), 0, td.Outcomes.Create(
+		alice.Address(),
+		brian.Address(),
+		1,
+		1,
+	)).Id
 
 	waitTimeForCompletedObjectiveIds(t, &clientBob, defaultTimeout, id)
 	waitTimeForCompletedObjectiveIds(t, &clientBrian, defaultTimeout, id2)

--- a/client_test/virtualfund_multi_party_test.go
+++ b/client_test/virtualfund_multi_party_test.go
@@ -1,14 +1,12 @@
 package client_test
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	td "github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols/virtualfund"
-	"github.com/statechannels/go-nitro/types"
 )
 
 // TestVirtualFundMultiParty tests the scenario where Alice creates virtual channels with Bob and Brian using Irene as the intermediary.
@@ -33,7 +31,7 @@ func TestVirtualFundMultiParty(t *testing.T) {
 	directlyFundALedgerChannel(t, clientAlice, clientIrene)
 	directlyFundALedgerChannel(t, clientIrene, clientBob)
 	directlyFundALedgerChannel(t, clientIrene, clientBrian)
-	withBobRequest := virtualfund.ObjectiveRequest{
+	withBobRequest := virtualfund.ObjectiveRequestForVirtualPaymentApp{
 		CounterParty: bob.Address(),
 		Intermediary: irene.Address(),
 		Outcome: td.Outcomes.Create(
@@ -42,12 +40,9 @@ func TestVirtualFundMultiParty(t *testing.T) {
 			1,
 			1,
 		),
-		AppDefinition:     types.Address{},
-		AppData:           types.Bytes{},
 		ChallengeDuration: 0,
-		Nonce:             rand.Uint64(),
 	}
-	withBrianRequest := virtualfund.ObjectiveRequest{
+	withBrianRequest := virtualfund.ObjectiveRequestForVirtualPaymentApp{
 		CounterParty: brian.Address(),
 		Intermediary: irene.Address(),
 		Outcome: td.Outcomes.Create(
@@ -56,10 +51,7 @@ func TestVirtualFundMultiParty(t *testing.T) {
 			1,
 			1,
 		),
-		AppDefinition:     types.Address{},
-		AppData:           types.Bytes{},
 		ChallengeDuration: 0,
-		Nonce:             rand.Uint64(),
 	}
 	id := clientAlice.CreateVirtualChannel(withBobRequest).Id
 	id2 := clientAlice.CreateVirtualChannel(withBrianRequest).Id

--- a/client_test/virtualfund_test.go
+++ b/client_test/virtualfund_test.go
@@ -1,7 +1,6 @@
 package client_test
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/statechannels/go-nitro/client"
@@ -21,14 +20,11 @@ func openVirtualChannels(t *testing.T, clientA client.Client, clientB client.Cli
 	channelIds := make([]types.Destination, numOfChannels)
 	for i := 0; i < int(numOfChannels); i++ {
 		outcome := td.Outcomes.Create(alice.Address(), bob.Address(), 1, 1)
-		request := virtualfund.ObjectiveRequest{
+		request := virtualfund.ObjectiveRequestForVirtualPaymentApp{
 			CounterParty:      bob.Address(),
 			Intermediary:      irene.Address(),
 			Outcome:           outcome,
-			AppDefinition:     types.Address{},
-			AppData:           types.Bytes{},
 			ChallengeDuration: 0,
-			Nonce:             rand.Uint64(),
 		}
 		response := clientA.CreateVirtualChannel(request)
 		objectiveIds[i] = response.Id

--- a/client_test/virtualfund_test.go
+++ b/client_test/virtualfund_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	td "github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols"
-	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -20,13 +19,8 @@ func openVirtualChannels(t *testing.T, clientA client.Client, clientB client.Cli
 	channelIds := make([]types.Destination, numOfChannels)
 	for i := 0; i < int(numOfChannels); i++ {
 		outcome := td.Outcomes.Create(alice.Address(), bob.Address(), 1, 1)
-		request := virtualfund.ObjectiveRequestForVirtualPaymentApp{
-			CounterParty:      bob.Address(),
-			Intermediary:      irene.Address(),
-			Outcome:           outcome,
-			ChallengeDuration: 0,
-		}
-		response := clientA.CreateVirtualChannel(request)
+		response := clientA.CreateVirtualPaymentChannel(irene.Address(), bob.Address(), 0, outcome)
+
 		objectiveIds[i] = response.Id
 		channelIds[i] = response.ChannelId
 	}

--- a/client_test/virtualfund_with_message_delays_test.go
+++ b/client_test/virtualfund_with_message_delays_test.go
@@ -1,7 +1,6 @@
 package client_test
 
 import (
-	"math/rand"
 	"testing"
 	"time"
 
@@ -53,15 +52,12 @@ func createVirtualChannels(client client.Client, counterParty types.Address, int
 	ids := make([]protocols.ObjectiveId, amountOfChannels)
 	for i := uint(0); i < amountOfChannels; i++ {
 		outcome := td.Outcomes.Create(*client.Address, counterParty, 1, 1)
-		request := virtualfund.ObjectiveRequest{
+		request := virtualfund.ObjectiveRequestForVirtualPaymentApp{
 
 			CounterParty:      counterParty,
 			Intermediary:      intermediary,
 			Outcome:           outcome,
-			AppDefinition:     types.Address{},
-			AppData:           types.Bytes{},
 			ChallengeDuration: 0,
-			Nonce:             rand.Uint64(),
 		}
 
 		ids[i] = client.CreateVirtualChannel(request).Id

--- a/client_test/virtualfund_with_message_delays_test.go
+++ b/client_test/virtualfund_with_message_delays_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	td "github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols"
-	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -52,15 +51,7 @@ func createVirtualChannels(client client.Client, counterParty types.Address, int
 	ids := make([]protocols.ObjectiveId, amountOfChannels)
 	for i := uint(0); i < amountOfChannels; i++ {
 		outcome := td.Outcomes.Create(*client.Address, counterParty, 1, 1)
-		request := virtualfund.ObjectiveRequestForVirtualPaymentApp{
-
-			CounterParty:      counterParty,
-			Intermediary:      intermediary,
-			Outcome:           outcome,
-			ChallengeDuration: 0,
-		}
-
-		ids[i] = client.CreateVirtualChannel(request).Id
+		ids[i] = client.CreateVirtualPaymentChannel(intermediary, counterParty, 0, outcome).Id
 	}
 	return ids
 }

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -64,14 +64,12 @@ func genericVFO() virtualfund.Objective {
 	ts.Participants[2] = testactors.Bob.Address()
 
 	request := virtualfund.ObjectiveRequest{
-		virtualfund.ObjectiveRequestForVirtualPaymentApp{
-			Intermediary:      ts.Participants[1],
-			CounterParty:      ts.Participants[2],
-			ChallengeDuration: ts.ChallengeDuration,
-			Outcome:           ts.Outcome,
-		},
-		ts.ChannelNonce,
-		ts.AppDefinition,
+		Intermediary:      ts.Participants[1],
+		CounterParty:      ts.Participants[2],
+		ChallengeDuration: ts.ChallengeDuration,
+		Outcome:           ts.Outcome,
+		Nonce:             ts.ChannelNonce,
+		AppDefinition:     ts.AppDefinition,
 	}
 	ledgerPath := createLedgerPath([]testactors.Actor{
 		testactors.Alice,

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -64,15 +64,15 @@ func genericVFO() virtualfund.Objective {
 	ts.Participants[2] = testactors.Bob.Address()
 
 	request := virtualfund.ObjectiveRequest{
-		ts.Participants[1],
-		ts.Participants[2],
-		ts.AppDefinition,
-		ts.AppData,
-		ts.ChallengeDuration,
-		ts.Outcome,
+		virtualfund.ObjectiveRequestForVirtualPaymentApp{
+			Intermediary:      ts.Participants[1],
+			CounterParty:      ts.Participants[2],
+			ChallengeDuration: ts.ChallengeDuration,
+			Outcome:           ts.Outcome,
+		},
 		ts.ChannelNonce,
+		ts.AppDefinition,
 	}
-
 	ledgerPath := createLedgerPath([]testactors.Actor{
 		testactors.Alice,
 		testactors.Irene,

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -443,21 +443,14 @@ func IsDirectFundObjective(id protocols.ObjectiveId) bool {
 	return strings.HasPrefix(string(id), ObjectivePrefix)
 }
 
-// ObjectiveRequestForConsensusApp represents a request to create a new direct funding objective.
-// There is no AppDefinition, since we currently only support full consensus rules for direct channels.
-// There is no Nonce, since the client fills this in.
-type ObjectiveRequestForConsensusApp struct {
+// ObjectiveRequest represents a request to create a new direct funding objective.
+type ObjectiveRequest struct {
 	CounterParty      types.Address
 	ChallengeDuration uint32
 	Outcome           outcome.Exit
-}
-
-// ObjectiveRequest represents a request to create a new direct funding objective.
-type ObjectiveRequest struct {
-	ObjectiveRequestForConsensusApp
-	AppDefinition types.Address
-	AppData       types.Bytes
-	Nonce         uint64
+	AppDefinition     types.Address
+	AppData           types.Bytes
+	Nonce             uint64
 }
 
 // Id returns the objective id for the request.

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -445,11 +445,11 @@ func IsDirectFundObjective(id protocols.ObjectiveId) bool {
 
 // ObjectiveRequestForConsensusApp represents a request to create a new direct funding objective.
 // There is no AppDefinition, since we currently only support full consensus rules for direct channels.
+// There is no Nonce, since the client fills this in.
 type ObjectiveRequestForConsensusApp struct {
 	CounterParty      types.Address
 	ChallengeDuration uint32
 	Outcome           outcome.Exit
-	Nonce             uint64
 }
 
 // ObjectiveRequest represents a request to create a new direct funding objective.
@@ -457,6 +457,7 @@ type ObjectiveRequest struct {
 	ObjectiveRequestForConsensusApp
 	AppDefinition types.Address
 	AppData       types.Bytes
+	Nonce         uint64
 }
 
 // Id returns the objective id for the request.

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -57,13 +57,11 @@ func TestNew(t *testing.T) {
 		return nil, false
 	}
 	request := ObjectiveRequest{
-		ObjectiveRequestForConsensusApp: ObjectiveRequestForConsensusApp{
-			CounterParty:      testState.Participants[1],
-			ChallengeDuration: testState.ChallengeDuration,
-			Outcome:           testState.Outcome,
-		},
-		AppDefinition: testState.AppDefinition,
-		AppData:       testState.AppData,
+		CounterParty:      testState.Participants[1],
+		ChallengeDuration: testState.ChallengeDuration,
+		Outcome:           testState.Outcome,
+		AppDefinition:     testState.AppDefinition,
+		AppData:           testState.AppData,
 	}
 	// Assert that valid constructor args do not result in error
 	if _, err := NewObjective(request, false, testState.Participants[0], getByParticipant, getByConsensus); err != nil {

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -61,7 +61,6 @@ func TestNew(t *testing.T) {
 			CounterParty:      testState.Participants[1],
 			ChallengeDuration: testState.ChallengeDuration,
 			Outcome:           testState.Outcome,
-			Nonce:             0,
 		},
 		AppDefinition: testState.AppDefinition,
 		AppData:       testState.AppData,

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -698,21 +698,14 @@ func (o *Objective) updateLedgerWithGuarantee(ledgerConnection Connection, sk *[
 	return sideEffects, nil
 }
 
-// ObjectiveRequestForVirtualPaymentApp represents a request to create a new virtual funding objective.
-// There is no AppDefinition, since we currently only support full consensus rules for direct channels.
-// There is no Nonce, since the client fills this in.
-type ObjectiveRequestForVirtualPaymentApp struct {
+// ObjectiveRequest represents a request to create a new virtual funding objective.
+type ObjectiveRequest struct {
 	Intermediary      types.Address
 	CounterParty      types.Address
 	ChallengeDuration uint32
 	Outcome           outcome.Exit
-}
-
-// ObjectiveRequest represents a request to create a new virtual funding objective.
-type ObjectiveRequest struct {
-	ObjectiveRequestForVirtualPaymentApp
-	Nonce         uint64
-	AppDefinition types.Address
+	Nonce             uint64
+	AppDefinition     types.Address
 }
 
 // Id returns the objective id for the request.

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -150,7 +150,6 @@ func NewObjective(request ObjectiveRequest, preApprove bool, myAddress types.Add
 			Participants:      []types.Address{myAddress, request.Intermediary, request.CounterParty},
 			ChannelNonce:      request.Nonce,
 			ChallengeDuration: request.ChallengeDuration,
-			AppData:           request.AppData,
 			Outcome:           request.Outcome,
 			TurnNum:           0,
 			IsFinal:           false,
@@ -699,15 +698,21 @@ func (o *Objective) updateLedgerWithGuarantee(ledgerConnection Connection, sk *[
 	return sideEffects, nil
 }
 
-// ObjectiveRequest represents a request to create a new virtual funding objective.
-type ObjectiveRequest struct {
+// ObjectiveRequestForVirtualPaymentApp represents a request to create a new virtual funding objective.
+// There is no AppDefinition, since we currently only support full consensus rules for direct channels.
+// There is no Nonce, since the client fills this in.
+type ObjectiveRequestForVirtualPaymentApp struct {
 	Intermediary      types.Address
 	CounterParty      types.Address
-	AppDefinition     types.Address
-	AppData           types.Bytes
 	ChallengeDuration uint32
 	Outcome           outcome.Exit
-	Nonce             uint64
+}
+
+// ObjectiveRequest represents a request to create a new virtual funding objective.
+type ObjectiveRequest struct {
+	ObjectiveRequestForVirtualPaymentApp
+	Nonce         uint64
+	AppDefinition types.Address
 }
 
 // Id returns the objective id for the request.


### PR DESCRIPTION
(Recommend commit-by-commit review)

This is a significant change to the `go-nitro` client APi. 

It is no longer necessary / possible to provide an `AppDefinition`, `AppData` or `Nonce` for a channel. 

`AppDefinition` -- this is set to the deployed contract address for ledger channels, and shortly something similar will happen for virtual channels #839.

`AppData` - neither channel type currently supported has any app data.

`Nonce` - this is now being generated in the client, avoiding the need for the consuming application to worry about it.  We are using random nonces for now, and aren't doing any checks against previously-used nonces at the current time. 