### PR TITLE
Log message summaries

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -357,6 +357,7 @@ func (e *Engine) handleObjectiveRequest(or protocols.ObjectiveRequest) (EngineEv
 	defer e.metrics.RecordFunctionDuration()()
 	myAddress := *e.store.GetAddress()
 	objectiveId := or.Id(myAddress)
+	e.logger.Printf("handling new objective request for %s", objectiveId)
 	e.metrics.RecordObjectiveStarted(objectiveId)
 	switch request := or.(type) {
 
@@ -557,7 +558,7 @@ func (e *Engine) getOrCreateObjective(p protocols.ObjectivePayload) (protocols.O
 		if err != nil {
 			return nil, fmt.Errorf("error setting objective in store: %w", err)
 		}
-		e.logger.Printf("Created new objective from  message %s", newObj.Id())
+		e.logger.Printf("Created new objective from message %s", newObj.Id())
 		return newObj, nil
 
 	} else {
@@ -567,6 +568,7 @@ func (e *Engine) getOrCreateObjective(p protocols.ObjectivePayload) (protocols.O
 
 // constructObjectiveFromMessage Constructs a new objective (of the appropriate concrete type) from the supplied payload.
 func (e *Engine) constructObjectiveFromMessage(id protocols.ObjectiveId, p protocols.ObjectivePayload) (protocols.Objective, error) {
+	e.logger.Printf("Constructing objective %s from message", id)
 	defer e.metrics.RecordFunctionDuration()()
 
 	switch {

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -446,7 +446,7 @@ func (e *Engine) executeSideEffects(sideEffects protocols.SideEffects) error {
 	defer e.metrics.RecordFunctionDuration()()
 
 	for _, message := range sideEffects.MessagesToSend {
-
+		e.logger.Printf("sending message %+v", message.Summarize())
 		e.msg.Send(message)
 	}
 	for _, tx := range sideEffects.TransactionsToSubmit {

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -193,7 +193,7 @@ func (e *Engine) handleProposal(proposal consensus_channel.Proposal) (EngineEven
 //   - attempts progress on related objectives which may have become unblocked.
 func (e *Engine) handleMessage(message protocols.Message) (EngineEvent, error) {
 	defer e.metrics.RecordFunctionDuration()()
-
+	e.logger.Printf("Handling incoming message: %+v", message.Summarize())
 	allCompleted := EngineEvent{}
 
 	for _, payload := range message.ObjectivePayloads {

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -181,8 +181,8 @@ type ObjectivePayloadSummary struct {
 
 // ProposalSummary is a summary of a proposal suitable for logging.
 type ProposalSummary struct {
+	ObjectiveId  string
 	LedgerId     string
-	TargetId     string
 	ProposalType string
 	TurnNum      uint64
 }
@@ -206,8 +206,8 @@ func (m Message) Summarize() MessageSummary {
 	s.ProposalSummaries = make([]ProposalSummary, len(m.LedgerProposals))
 	for i, p := range m.SortedProposals() {
 		s.ProposalSummaries[i] = ProposalSummary{
+			ObjectiveId:  string(GetProposalObjectiveId(p.Proposal)),
 			LedgerId:     p.ChannelID().String(),
-			TargetId:     p.Proposal.Target().String(),
 			TurnNum:      p.TurnNum,
 			ProposalType: string(p.Proposal.Type())}
 	}

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -159,3 +159,67 @@ func DeserializeMessage(s string) (Message, error) {
 
 	return msg, err
 }
+
+// MessageSummary is a summary of a message suitable for logging.
+type MessageSummary struct {
+	To               string
+	PayloadSummaries []ObjectivePayloadSummary
+
+	ProposalSummaries []ProposalSummary
+
+	Payments []PaymentSummary
+	// RejectedObjectives is a collection of objectives that have been rejected.
+	RejectedObjectives []string
+}
+
+// ObjectivePayloadSummary is a summary of an objective payload suitable for logging.
+type ObjectivePayloadSummary struct {
+	ObjectiveId     string
+	Type            string
+	PayloadDataSize int
+}
+
+// ProposalSummary is a summary of a proposal suitable for logging.
+type ProposalSummary struct {
+	LedgerId     string
+	TargetId     string
+	ProposalType string
+	TurnNum      uint64
+}
+
+// PaymentSummary is a summary of a payment voucher suitable for logging.
+type PaymentSummary struct {
+	Amount    uint64
+	ChannelId string
+}
+
+// Summarize returns a MessageSummary for the message that is suitable for logging
+func (m Message) Summarize() MessageSummary {
+	s := MessageSummary{}
+	s.To = m.To.String()
+
+	s.PayloadSummaries = make([]ObjectivePayloadSummary, len(m.ObjectivePayloads))
+	for i, p := range m.ObjectivePayloads {
+		s.PayloadSummaries[i] = ObjectivePayloadSummary{ObjectiveId: string(p.ObjectiveId), Type: string(p.Type), PayloadDataSize: len(p.PayloadData)}
+	}
+
+	s.ProposalSummaries = make([]ProposalSummary, len(m.LedgerProposals))
+	for i, p := range m.SortedProposals() {
+		s.ProposalSummaries[i] = ProposalSummary{
+			LedgerId:     p.ChannelID().String(),
+			TargetId:     p.Proposal.Target().String(),
+			TurnNum:      p.TurnNum,
+			ProposalType: string(p.Proposal.Type())}
+	}
+
+	s.Payments = make([]PaymentSummary, len(m.Payments))
+	for i, p := range m.Payments {
+		s.Payments[i] = PaymentSummary{Amount: p.Amount.Uint64(), ChannelId: p.ChannelId.String()}
+	}
+
+	s.RejectedObjectives = make([]string, len(m.RejectedObjectives))
+	for i, o := range m.RejectedObjectives {
+		s.RejectedObjectives[i] = string(o)
+	}
+	return s
+}


### PR DESCRIPTION
This PR re-introduces a summarize function so we can output a message summary to the log file. We use this to log message summaries for incoming and outgoing messages.

I added this locally to aid in debugging some testground stuff and figured the changes were helpful enough that they should be rolled into `main`.
