### PR TITLE
Trigger testground run from CI

### DIFF
--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           repository: 'statechannels/go-nitro-testground'
           path: "code/go-nitro-testground"
-          ref: update-to-main #TODO Remove when https://github.com/statechannels/go-nitro-testground/pull/103 is merged
+          ref: main
       
       # Set up caching for docker (which testground uses) and go modules
       - uses: actions/cache@v3

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -51,6 +51,9 @@ jobs:
          -p=go-nitro-testground -t=virtual-payment \
          -b=docker:go -r=local:docker \
          -tp=numOfHubs=2 -tp=numOfPayers=2 -tp=numOfPayees=2  -i=6 \
-         -tp=paymentTestDuration=60  -tp=concurrentPaymentJobs=1
+         -tp=paymentTestDuration=60  -tp=concurrentPaymentJobs=1 \
+          --metadata-repo "${{github.repository}}" \
+          --metadata-branch "${{github.ref_name}}" \
+          --metadata-commit "${{github.sha}}" 
 
       

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -1,7 +1,7 @@
 name: Run Testground
 
 on:
-  push:
+  pull_request:
 jobs:
   run-testground:
       runs-on: ubuntu-latest
@@ -38,7 +38,7 @@ jobs:
         working-directory: "code/testground"
       # Update our test plan so it uses the version of go-nitro from this workflow
       - name: Update Test Dependency
-        run: go get github.com/statechannels/go-nitro@${{github.sha}}
+        run: go get github.com/statechannels/go-nitro@${{github.event.pull_request.head.sha}}
         working-directory: "code/go-nitro-testground"
 
       - name: Import Test 
@@ -53,7 +53,7 @@ jobs:
          -tp=numOfHubs=2 -tp=numOfPayers=2 -tp=numOfPayees=2  -i=6 \
          -tp=paymentTestDuration=60  -tp=concurrentPaymentJobs=1 \
           --metadata-repo "${{github.repository}}" \
-          --metadata-branch "${{github.ref_name}}" \
+          --metadata-branch "${{github.ref}}" \
           --metadata-commit "${{github.sha}}" 
 
       

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -51,7 +51,7 @@ jobs:
          -p=go-nitro-testground -t=virtual-payment \
          -b=docker:go -r=local:docker \
          -tp=numOfHubs=2 -tp=numOfPayers=2 -tp=numOfPayees=2  -i=6 \
-         -tp=paymentTestDuration=60  -tp=concurrentPaymentJobs=1 \
+         -tp=paymentTestDuration=30  -tp=concurrentPaymentJobs=1 \
           --metadata-repo "${{github.repository}}" \
           --metadata-branch "${{github.ref}}" \
           --metadata-commit "${{github.sha}}" 

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -1,0 +1,53 @@
+name: Run Testground
+
+on:
+  push:
+    branches: ['**'] # TODO: Restrict this to main
+jobs:
+  run-testground:
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "^1.19.0"
+      # Get testground and our test plan code
+      - uses: actions/checkout@v3
+        with:
+         repository: 'statechannels/testground'
+         path: "code/testground"
+      - uses: actions/checkout@v3
+        with:
+          repository: 'statechannels/go-nitro-testground'
+          path: "code/go-nitro-testground"
+          ref: update-to-main #TODO Remove when https://github.com/statechannels/go-nitro-testground/pull/103 is merged
+      
+      # Set up caching for docker (which testground uses) and go modules
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: true
+
+      # Build the testground daemon
+      - name: Build
+        run: make install
+        working-directory: "code/testground"
+      # Update our test plan so it uses the version of go-nitro from this workflow
+      - name: Update Test Dependency
+        run: go get github.com/statechannels/go-nitro@${{github.sha}}
+        working-directory: "code/go-nitro-testground"
+
+      - name: Import Test 
+        run:    testground plan import --from ./go-nitro-testground
+        working-directory: "code"
+      # Run a short test using the wait flag so we block until it completes
+      - name: Run Test 
+      # TODO: Multiline text
+        run:   testground --endpoint=http://34.168.92.245:8042  run s --wait -p=go-nitro-testground -t=virtual-payment -b=docker:go -r=local:docker -tp=numOfHubs=2 -tp=numOfPayers=2 -tp=numOfPayees=2  -i=6 -tp=paymentTestDuration=60  -tp=concurrentPaymentJobs=1
+
+      

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -34,7 +34,7 @@ jobs:
 
       # Build the testground daemon
       - name: Build
-        run: make install
+        run: make goinstall docker-testground
         working-directory: "code/testground"
       # Update our test plan so it uses the version of go-nitro from this workflow
       - name: Update Test Dependency

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -2,7 +2,6 @@ name: Run Testground
 
 on:
   push:
-    branches: ['**'] # TODO: Restrict this to main
 jobs:
   run-testground:
       runs-on: ubuntu-latest

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -46,7 +46,11 @@ jobs:
         working-directory: "code"
       # Run a short test using the wait flag so we block until it completes
       - name: Run Test 
-      # TODO: Multiline text
-        run:   testground --endpoint=http://34.168.92.245:8042  run s --wait -p=go-nitro-testground -t=virtual-payment -b=docker:go -r=local:docker -tp=numOfHubs=2 -tp=numOfPayers=2 -tp=numOfPayees=2  -i=6 -tp=paymentTestDuration=60  -tp=concurrentPaymentJobs=1
+        run: | 
+         testground --endpoint=http://34.168.92.245:8042  run s --wait \
+         -p=go-nitro-testground -t=virtual-payment \
+         -b=docker:go -r=local:docker \
+         -tp=numOfHubs=2 -tp=numOfPayers=2 -tp=numOfPayees=2  -i=6 \
+         -tp=paymentTestDuration=60  -tp=concurrentPaymentJobs=1
 
       


### PR DESCRIPTION
Adds a job to our github actions that runs a short testground run using the given commit. The test case is run remotely on our testground runner cloud vm, so the load on the CI shouldn't be too bad.

We run a 60 second test with 6 instances:
```bash
 testground --endpoint=http://34.168.92.245:8042  run s --wait -p=go-nitro-testground -t=virtual-payment -b=docker:go -r=local:docker -tp=numOfHubs=2 -tp=numOfPayers=2 -tp=numOfPayees=2  -i=6 -tp=paymentTestDuration=60  -tp=concurrentPaymentJobs=1
```
We use the `--wait` flag so the the github action blocks and only returns success when the test run is done.

Even though the test case is handled in the cloud vm we still need a local install of `testground` to send the test case to the cloud vm. This means we need to build testground (which is just a docker image underneath the hood). To help speed that up we use the `docker-layer-caching` action.

## TODO
- [ ] It would be nice if we could output a link to the dashboards 
- [ ] Decide how long / large test run to perform
- [ ] Decide when we should trigger this GH action 