### PR TITLE
Experiment with running handlers in go routines

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -147,17 +147,18 @@ func (e *Engine) Run() {
 		e.metrics.RecordQueueLength("messages_queue", len(e.fromMsg))
 		e.metrics.RecordQueueLength("proposal_queue", len(e.fromLedger))
 
+		// TODO the engine cannot currently cope with running handlers asynchronously, so we omit the "go" keyword from most of them:
 		select {
 		case or := <-e.ObjectiveRequestsFromAPI:
 			go runAsync(e.handleObjectiveRequest, or, e.fromHandlers)
 		case pr := <-e.PaymentRequestsFromAPI:
-			go runAsync(e.handlePaymentRequest, pr, e.fromHandlers)
+			runAsync(e.handlePaymentRequest, pr, e.fromHandlers)
 		case chainEvent := <-e.fromChain:
-			go runAsync(e.handleChainEvent, chainEvent, e.fromHandlers)
+			runAsync(e.handleChainEvent, chainEvent, e.fromHandlers)
 		case message := <-e.fromMsg:
-			runAsync(e.handleMessage, message, e.fromHandlers) // TODO run this in a goroutine
+			runAsync(e.handleMessage, message, e.fromHandlers)
 		case proposal := <-e.fromLedger:
-			go runAsync(e.handleProposal, proposal, e.fromHandlers)
+			runAsync(e.handleProposal, proposal, e.fromHandlers)
 		}
 
 	}

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -207,13 +207,6 @@ func (e *Engine) handleProposal(proposal consensus_channel.Proposal) (EngineEven
 	return e.attemptProgress(obj)
 }
 
-// handleMessageAsync is an async wrapper for e.handleMessage; the return value is sent on the e.fromHandlers chan.
-
-func (e *Engine) handleMessageAsync(message protocols.Message) {
-	res, err := e.handleMessage(message)
-	e.fromHandlers <- HandlerReturnValue{res, err}
-}
-
 // handleMessage handles a Message from a peer go-nitro Wallet.
 // It:
 //   - reads an objective from the store,

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -157,7 +157,7 @@ func (e *Engine) Run() {
 		case message := <-e.fromMsg:
 			runAsync(e.handleMessage, message, e.fromHandlers) // TODO run this in a goroutine
 		case proposal := <-e.fromLedger:
-			runAsync(e.handleProposal, proposal, e.fromHandlers)
+			go runAsync(e.handleProposal, proposal, e.fromHandlers)
 		}
 
 	}

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -153,7 +153,7 @@ func (e *Engine) Run() {
 		case pr := <-e.PaymentRequestsFromAPI:
 			go runAsync(e.handlePaymentRequest, pr, e.fromHandlers)
 		case chainEvent := <-e.fromChain:
-			runAsync(e.handleChainEvent, chainEvent, e.fromHandlers)
+			go runAsync(e.handleChainEvent, chainEvent, e.fromHandlers)
 		case message := <-e.fromMsg:
 			runAsync(e.handleMessage, message, e.fromHandlers) // TODO run this in a goroutine
 		case proposal := <-e.fromLedger:

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -151,7 +151,7 @@ func (e *Engine) Run() {
 		case or := <-e.ObjectiveRequestsFromAPI:
 			go runAsync(e.handleObjectiveRequest, or, e.fromHandlers)
 		case pr := <-e.PaymentRequestsFromAPI:
-			runAsync(e.handlePaymentRequest, pr, e.fromHandlers)
+			go runAsync(e.handlePaymentRequest, pr, e.fromHandlers)
 		case chainEvent := <-e.fromChain:
 			runAsync(e.handleChainEvent, chainEvent, e.fromHandlers)
 		case message := <-e.fromMsg:

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -135,7 +135,6 @@ func (e *Engine) ToApi() <-chan EngineEvent {
 func run[p any](h func(p) (EngineEvent, error), args p, c chan HandlerReturnValue) {
 	res, err := h(args)
 	c <- HandlerReturnValue{res, err}
-	return
 }
 
 // Run kicks of an infinite loop that waits for communications on the supplied channels, and handles them accordingly


### PR DESCRIPTION
This PR is just an experiment with greater concurrency inside the engine. Theory being, the engine can get to work on the next request without blocking on the current one completing.

So far I didn't see any improvements. In fact we probably expect things to go wrong more frequently with this approach.
Doing a similar refactor with the message handler might be more likely to enable a busy hub to deal with things more efficiently.

Sharing so we can road test https://github.com/statechannels/go-nitro/pull/891 with it.