### PR TITLE
Update CI to post link to dashboards

### DIFF
--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -31,6 +31,10 @@ jobs:
             ${{ runner.os }}-go-
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
+        with:
+          key: docker-cache-{hash}
+          restore-keys: |
+           docker-cache-
 
       # Build the testground daemon
       - name: Build

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -52,6 +52,8 @@ jobs:
       # Set the start time for the dashboard time range
       - name: Set Start Time
         id: set_start_time
+        # We add 40 seconds to the start time so the dashboard ignores startup when nothing is happening
+        # We multiply by 1000 to get the timestamp in MS which grafana expects
         run: | 
          echo "::set-output name=START_TIME_OFFSET::$(((`date '+%s'`+40)*1000))"
       # Run a short test using the wait flag so we block until it completes

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -52,10 +52,10 @@ jobs:
       # Set the start time for the dashboard time range
       - name: Set Start Time
         id: set_start_time
-        # We add 40 seconds to the start time so the dashboard ignores startup when nothing is happening
+        # We add 45 seconds to the start time so the dashboard ignores startup when nothing is happening
         # We multiply by 1000 to get the timestamp in MS which grafana expects
         run: | 
-         echo "::set-output name=START_TIME_OFFSET::$(((`date '+%s'`+40)*1000))"
+         echo "::set-output name=START_TIME_OFFSET::$(((`date '+%s'`+45)*1000))"
       # Run a short test using the wait flag so we block until it completes
       - name: Run Test 
         run: | 

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -91,9 +91,7 @@ jobs:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            # 🧪Testground Run🧪
-            ## Run Id
-            ${{steps.set_run_id.outputs.RUN_ID}}
+            # 🧪Testground Run ${{steps.set_run_id.outputs.RUN_ID}}🧪
             ## Grafana Dashboard Links
             - [Message Stats](http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
             - [Time to First Payment](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -63,9 +63,9 @@ jobs:
          -b=docker:go -r=local:docker \
          -tp=numOfHubs=2 -tp=numOfPayers=2 -tp=numOfPayees=2  -i=6 \
          -tp=paymentTestDuration=30  -tp=concurrentPaymentJobs=1 \
-          --metadata-repo "${{github.repository}}" \
-          --metadata-branch "${{github.event.pull_request.head.ref}}" \
-          --metadata-commit "${{github.event.pull_request.head.sha}}"  | tee run.out
+         --metadata-repo "${{github.repository}}" \
+         --metadata-branch "${{github.event.pull_request.head.ref}}" \
+         --metadata-commit "${{github.event.pull_request.head.sha}}"  | tee run.out
           
       # Parse the run id from the testground run output
       - name: Set Run Id

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -76,7 +76,11 @@ jobs:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            # Dashboard Links
+            # Testground Run ${{steps.get_id.outputs.RUN_ID}}
+            ## Grafana Dashboard Links
             [Message Stats](http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.get_id.outputs.RUN_ID}}&from=now-2m&to=now)
             [Time to First Payment](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.get_id.outputs.RUN_ID}}&from=now-2m&to=now)
+            ## Testground Links
+            [Logs](http://34.168.92.245:8042/logs?task_id=${{steps.get_id.outputs.RUN_ID}})
+            [Output download](http://34.168.92.245:8042/outputs?run_id=${{steps.get_id.outputs.RUN_ID}})
           edit-mode: replace

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -59,7 +59,7 @@ jobs:
       # Run a short test using the wait flag so we block until it completes
       - name: Run Test 
         run: | 
-         testground --endpoint=http://34.168.92.245:8042  run s --wait \
+         testground --endpoint=$((secrets.TG_SERVER_URL))  run s --wait \
          -p=go-nitro-testground -t=virtual-payment \
          -b=docker:go -r=local:docker \
          -tp=numOfHubs=2 -tp=numOfPayers=2 -tp=numOfPayees=2  -i=6 \
@@ -94,8 +94,8 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             # 🧪 Testground Run for ${{github.event.pull_request.head.sha}} 
-            - [Message Stats Dashboard](http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME_OFFSET}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
-            - [Time to First Payment Dashboard](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME_OFFSET}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
-            - [Logs](http://34.168.92.245:8042/logs?task_id=${{steps.set_run_id.outputs.RUN_ID}})
-            - [Output download](http://34.168.92.245:8042/outputs?run_id=${{steps.set_run_id.outputs.RUN_ID}})
+            - [Message Stats Dashboard]($((secrets.TG_GRAFANA_URL))/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME_OFFSET}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
+            - [Time to First Payment Dashboard]($((secrets.TG_GRAFANA_URL))/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME_OFFSET}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
+            - [Logs]($((secrets.TG_SERVER_URL))logs?task_id=${{steps.set_run_id.outputs.RUN_ID}})
+            - [Output download]($((secrets.TG_SERVER_URL))/outputs?run_id=${{steps.set_run_id.outputs.RUN_ID}})
           edit-mode: append

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -53,8 +53,7 @@ jobs:
       - name: Set Start Time
         id: set_start_time
         run: | 
-         echo "::set-output name=START_TIME::$((`date '+%s'`*1000))"
-         echo "::set-output name=START_TIME_STRING::$(date "+%D %T")"
+         echo "::set-output name=START_TIME_OFFSET::$(((`date '+%s'`+40)*1000))"
       # Run a short test using the wait flag so we block until it completes
       - name: Run Test 
         run: | 
@@ -93,8 +92,8 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             # 🧪 Testground Run for ${{github.event.pull_request.head.sha}} 
-            - [Message Stats Dashboard](http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
-            - [Time to First Payment Dashboard](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
+            - [Message Stats Dashboard](http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME_OFFSET}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
+            - [Time to First Payment Dashboard](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME_OFFSET}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
             - [Logs](http://34.168.92.245:8042/logs?task_id=${{steps.set_run_id.outputs.RUN_ID}})
             - [Output download](http://34.168.92.245:8042/outputs?run_id=${{steps.set_run_id.outputs.RUN_ID}})
           edit-mode: append

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -92,7 +92,7 @@ jobs:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            # 🧪Testground Run at ${{steps.set_start_time.outputs.START_TIME_STRING}}
+            # 🧪Testground Run for ${{github.event.pull_request.head.sha}} 
             - [Message Stats Dashboard](http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
             - [Time to First Payment Dashboard](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
             - [Logs](http://34.168.92.245:8042/logs?task_id=${{steps.set_run_id.outputs.RUN_ID}})

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -92,7 +92,7 @@ jobs:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            # 🧪Testground Run for ${{github.event.pull_request.head.sha}} 
+            # 🧪 Testground Run for ${{github.event.pull_request.head.sha}} 
             - [Message Stats Dashboard](http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
             - [Time to First Payment Dashboard](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
             - [Logs](http://34.168.92.245:8042/logs?task_id=${{steps.set_run_id.outputs.RUN_ID}})

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -92,7 +92,7 @@ jobs:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            # 🧪Testground Run ${{steps.set_run_id.outputs.RUN_ID}} at ${{steps.set_start_time.outputs.START_TIME_STRING}} 🧪
+            # 🧪Testground Run at ${{steps.set_start_time.outputs.START_TIME_STRING}}
             - [Message Stats Dashboard](http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
             - [Time to First Payment Dashboard](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
             - [Logs](http://34.168.92.245:8042/logs?task_id=${{steps.set_run_id.outputs.RUN_ID}})

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -48,6 +48,11 @@ jobs:
       - name: Import Test 
         run:    testground plan import --from ./go-nitro-testground
         working-directory: "code"
+
+      - name: Set Start Time
+        id: set_start_time
+        run: | 
+         echo "::set-output name=START_TIME::$(date +%s)"
       # Run a short test using the wait flag so we block until it completes
       - name: Run Test 
         run: | 
@@ -63,8 +68,8 @@ jobs:
         id: get_id
         run: | 
          echo "::set-output name=RUN_ID::$(awk '/run is queued with ID/ {print $10}' <run.out)"
-      - name: Set Time
-        id: set_time
+      - name: Set Done Time
+        id: set_done_time
         run: | 
          echo "::set-output name=DONE_TIME::$(date +%s)"
       - name: Find dashboard links comment
@@ -84,8 +89,8 @@ jobs:
             ## Run Id
             ${{steps.get_id.outputs.RUN_ID}}
             ## Grafana Dashboard Links
-            - [Message Stats](http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.get_id.outputs.RUN_ID}}&from=${{steps.set_time.outputs.DONE_TIME}}-1m&to=${{steps.set_time.outputs.DONE_TIME}})
-            - [Time to First Payment](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.get_id.outputs.RUN_ID}}&from=${{steps.set_time.outputs.DONE_TIME}}-1m&to=${{steps.set_time.outputs.DONE_TIME}})
+            - [Message Stats](http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.get_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
+            - [Time to First Payment](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.get_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
             ## Testground Links
             - [Logs](http://34.168.92.245:8042/logs?task_id=${{steps.get_id.outputs.RUN_ID}})
             - [Output download](http://34.168.92.245:8042/outputs?run_id=${{steps.get_id.outputs.RUN_ID}})

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -58,6 +58,24 @@ jobs:
          -tp=paymentTestDuration=30  -tp=concurrentPaymentJobs=1 \
           --metadata-repo "${{github.repository}}" \
           --metadata-branch "${{github.event.pull_request.head.ref}}" \
-          --metadata-commit "${{github.event.pull_request.head.sha}}" 
-
-      
+          --metadata-commit "${{github.event.pull_request.head.sha}}"  | tee run.out
+      - name: Get Id
+        id: get_id
+        run: | 
+         echo "::set-output name=RUN_ID::$(awk '/run is queued with ID/ {print $10}' <run.out)"
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+         issue-number: ${{ github.event.pull_request.number }}
+         comment-author: 'github-actions[bot]'
+         body-includes: Dashboard Link
+      - name: Update comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Dashboard link
+            http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.get_id.outputs.RUN_ID}}&from=now-5m&to=now
+          edit-mode: replace

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -100,4 +100,4 @@ jobs:
             ## Testground Links
             - [Logs](http://34.168.92.245:8042/logs?task_id=${{steps.set_run_id.outputs.RUN_ID}})
             - [Output download](http://34.168.92.245:8042/outputs?run_id=${{steps.set_run_id.outputs.RUN_ID}})
-          edit-mode: replace
+          edit-mode: append

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -76,11 +76,13 @@ jobs:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            # Testground Run ${{steps.get_id.outputs.RUN_ID}}
+            # 🧪Testground Run🧪
+            ## Run Id
+            ${{steps.get_id.outputs.RUN_ID}}
             ## Grafana Dashboard Links
-            [Message Stats](http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.get_id.outputs.RUN_ID}}&from=now-2m&to=now)
-            [Time to First Payment](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.get_id.outputs.RUN_ID}}&from=now-2m&to=now)
+            - [Message Stats](http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.get_id.outputs.RUN_ID}}&from=now-2m&to=now)
+            - [Time to First Payment](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.get_id.outputs.RUN_ID}}&from=now-2m&to=now)
             ## Testground Links
-            [Logs](http://34.168.92.245:8042/logs?task_id=${{steps.get_id.outputs.RUN_ID}})
-            [Output download](http://34.168.92.245:8042/outputs?run_id=${{steps.get_id.outputs.RUN_ID}})
+            - [Logs](http://34.168.92.245:8042/logs?task_id=${{steps.get_id.outputs.RUN_ID}})
+            - [Output download](http://34.168.92.245:8042/outputs?run_id=${{steps.get_id.outputs.RUN_ID}})
           edit-mode: replace

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -63,6 +63,10 @@ jobs:
         id: get_id
         run: | 
          echo "::set-output name=RUN_ID::$(awk '/run is queued with ID/ {print $10}' <run.out)"
+      - name: Set Time
+        id: set_time
+        run: | 
+         echo "::set-output name=DONE_TIME::$(date +%s)"
       - name: Find dashboard links comment
         uses: peter-evans/find-comment@v2
         id: fc
@@ -80,8 +84,8 @@ jobs:
             ## Run Id
             ${{steps.get_id.outputs.RUN_ID}}
             ## Grafana Dashboard Links
-            - [Message Stats](http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.get_id.outputs.RUN_ID}}&from=now-2m&to=now)
-            - [Time to First Payment](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.get_id.outputs.RUN_ID}}&from=now-2m&to=now)
+            - [Message Stats](http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.get_id.outputs.RUN_ID}}&from=${{steps.set_time.outputs.DONE_TIME}}-1m&to=${{steps.set_time.outputs.DONE_TIME}})
+            - [Time to First Payment](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.get_id.outputs.RUN_ID}}&from=${{steps.set_time.outputs.DONE_TIME}}-1m&to=${{steps.set_time.outputs.DONE_TIME}})
             ## Testground Links
             - [Logs](http://34.168.92.245:8042/logs?task_id=${{steps.get_id.outputs.RUN_ID}})
             - [Output download](http://34.168.92.245:8042/outputs?run_id=${{steps.get_id.outputs.RUN_ID}})

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -63,19 +63,20 @@ jobs:
         id: get_id
         run: | 
          echo "::set-output name=RUN_ID::$(awk '/run is queued with ID/ {print $10}' <run.out)"
-      - name: Find Comment
+      - name: Find dashboard links comment
         uses: peter-evans/find-comment@v2
         id: fc
         with:
          issue-number: ${{ github.event.pull_request.number }}
          comment-author: 'github-actions[bot]'
-         body-includes: Dashboard Link
-      - name: Update comment
+         body-includes: Dashboard Links
+      - name: Update dashboard links comment
         uses: peter-evans/create-or-update-comment@v2
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Dashboard link
-            http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.get_id.outputs.RUN_ID}}&from=now-5m&to=now
+            # Dashboard Links
+            [Message Stats](http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.get_id.outputs.RUN_ID}}&from=now-2m&to=now)
+            [Time to First Payment](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.get_id.outputs.RUN_ID}}&from=now-2m&to=now)
           edit-mode: replace

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set Start Time
         id: set_start_time
         run: | 
-         echo "::set-output name=START_TIME::$(date +%s)"
+         echo "::set-output name=START_TIME::$((`date '+%s'`*1000))"
       # Run a short test using the wait flag so we block until it completes
       - name: Run Test 
         run: | 
@@ -71,7 +71,7 @@ jobs:
       - name: Set Done Time
         id: set_done_time
         run: | 
-         echo "::set-output name=DONE_TIME::$(date +%s)"
+         echo "::set-output name=DONE_TIME::$((`date '+%s'`*1000))"
       - name: Find dashboard links comment
         uses: peter-evans/find-comment@v2
         id: fc

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -93,10 +93,8 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             # 🧪Testground Run ${{steps.set_run_id.outputs.RUN_ID}} at ${{steps.set_start_time.outputs.START_TIME_STRING}} 🧪
-            ### Grafana Dashboard Links
-            - [Message Stats](http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
-            - [Time to First Payment](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
-            ### Testground Links
+            - [Message Stats Dashboard](http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
+            - [Time to First Payment Dashboard](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
             - [Logs](http://34.168.92.245:8042/logs?task_id=${{steps.set_run_id.outputs.RUN_ID}})
             - [Output download](http://34.168.92.245:8042/outputs?run_id=${{steps.set_run_id.outputs.RUN_ID}})
           edit-mode: append

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -54,6 +54,7 @@ jobs:
         id: set_start_time
         run: | 
          echo "::set-output name=START_TIME::$((`date '+%s'`*1000))"
+         echo "::set-output name=START_TIME_STRING::$(date "+%D %T")"
       # Run a short test using the wait flag so we block until it completes
       - name: Run Test 
         run: | 
@@ -91,11 +92,11 @@ jobs:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            # 🧪Testground Run ${{steps.set_run_id.outputs.RUN_ID}}🧪
-            ## Grafana Dashboard Links
+            # 🧪Testground Run ${{steps.set_run_id.outputs.RUN_ID}} at ${{steps.set_start_time.outputs.START_TIME_STRING}} 🧪
+            ### Grafana Dashboard Links
             - [Message Stats](http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
             - [Time to First Payment](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
-            ## Testground Links
+            ### Testground Links
             - [Logs](http://34.168.92.245:8042/logs?task_id=${{steps.set_run_id.outputs.RUN_ID}})
             - [Output download](http://34.168.92.245:8042/outputs?run_id=${{steps.set_run_id.outputs.RUN_ID}})
           edit-mode: append

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -49,6 +49,7 @@ jobs:
         run:    testground plan import --from ./go-nitro-testground
         working-directory: "code"
 
+      # Set the start time for the dashboard time range
       - name: Set Start Time
         id: set_start_time
         run: | 
@@ -64,34 +65,39 @@ jobs:
           --metadata-repo "${{github.repository}}" \
           --metadata-branch "${{github.event.pull_request.head.ref}}" \
           --metadata-commit "${{github.event.pull_request.head.sha}}"  | tee run.out
-      - name: Get Id
-        id: get_id
+          
+      # Parse the run id from the testground run output
+      - name: Set Run Id
+        id: set_run_id
         run: | 
          echo "::set-output name=RUN_ID::$(awk '/run is queued with ID/ {print $10}' <run.out)"
+      # Set the end time for the dashboard time range
       - name: Set Done Time
         id: set_done_time
         run: | 
          echo "::set-output name=DONE_TIME::$((`date '+%s'`*1000))"
+      
+      # Look for an existing comment from the bot and update it 
       - name: Find dashboard links comment
         uses: peter-evans/find-comment@v2
-        id: fc
+        id: find-comment
         with:
          issue-number: ${{ github.event.pull_request.number }}
          comment-author: 'github-actions[bot]'
-         body-includes: Dashboard Links
+         body-includes: Testground Run
       - name: Update dashboard links comment
         uses: peter-evans/create-or-update-comment@v2
         with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             # 🧪Testground Run🧪
             ## Run Id
-            ${{steps.get_id.outputs.RUN_ID}}
+            ${{steps.set_run_id.outputs.RUN_ID}}
             ## Grafana Dashboard Links
-            - [Message Stats](http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.get_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
-            - [Time to First Payment](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.get_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
+            - [Message Stats](http://34.168.92.245:3000/d/miulKz7Vk/message-stats?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
+            - [Time to First Payment](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&var-runId=${{steps.set_run_id.outputs.RUN_ID}}&from=${{steps.set_start_time.outputs.START_TIME}}&to=${{steps.set_done_time.outputs.DONE_TIME}})
             ## Testground Links
-            - [Logs](http://34.168.92.245:8042/logs?task_id=${{steps.get_id.outputs.RUN_ID}})
-            - [Output download](http://34.168.92.245:8042/outputs?run_id=${{steps.get_id.outputs.RUN_ID}})
+            - [Logs](http://34.168.92.245:8042/logs?task_id=${{steps.set_run_id.outputs.RUN_ID}})
+            - [Output download](http://34.168.92.245:8042/outputs?run_id=${{steps.set_run_id.outputs.RUN_ID}})
           edit-mode: replace


### PR DESCRIPTION
Fixes #894

Updates our CI to post a comment with links to grafana dashboards and logs for the testground run kicked off by the CI.

Right now I have it configured so CI will only use one comment on the PR. Each testground run is appended to the comment.

An example of the [comment](https://github.com/statechannels/go-nitro/pull/895#issuecomment-1256729528) can be found on this PR. **Note** during testing I've manually edited this comment which is why it doesn't show the test runs for every commit.

We capture timestamps before and after we run the `testground run` command which we use for the time ranges in the dashboard links.

