### PR TITLE
Update metadata to use right context vars

### DIFF
--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -53,7 +53,7 @@ jobs:
          -tp=numOfHubs=2 -tp=numOfPayers=2 -tp=numOfPayees=2  -i=6 \
          -tp=paymentTestDuration=30  -tp=concurrentPaymentJobs=1 \
           --metadata-repo "${{github.repository}}" \
-          --metadata-branch "${{github.ref}}" \
-          --metadata-commit "${{github.sha}}" 
+          --metadata-branch "${{github.event.pull_request.head.ref}}" \
+          --metadata-commit "${{github.event.pull_request.head.sha}}" 
 
       


### PR DESCRIPTION
Now that we're running on `pull_request` instead of `push` we need to use slightly different context vars. We did this for fetching `go-nitro` but not for the metadata we pass in.

This fixes the metadata args we pass into testground which means the link on the [task page](http://34.168.92.245:8042/tasks) should work correctly.