### PR TITLE
Use public docker image to avoid building testground on CI

### DIFF
--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -21,7 +21,7 @@ jobs:
           path: "code/go-nitro-testground"
           ref: main
       
-      # Set up caching for docker (which testground uses) and go modules
+      # Set up caching for go modules
       - uses: actions/cache@v3
         with:
           path: |
@@ -30,22 +30,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: docker-cache-{hash}
-          restore-keys: |
-           docker-cache-
-
-      # # Build the testground daemon
-      # - name: Build
-      #   run: make goinstall docker-testground
-      #   working-directory: "code/testground"
-      # # Update our test plan so it uses the version of go-nitro from this workflow
-      # - name: Update Test Dependency
-      #   run: go get github.com/statechannels/go-nitro@${{github.event.pull_request.head.sha}}
-      #   working-directory: "code/go-nitro-testground"
-
+    
       - name: Import Test 
         run:    testground plan import --from ./go-nitro-testground
         working-directory: "code"

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   run-testground:
       runs-on: ubuntu-latest
+      container: iptestground/testground:edge
       steps:
       - uses: actions/setup-go@v3
         with:
@@ -36,14 +37,14 @@ jobs:
           restore-keys: |
            docker-cache-
 
-      # Build the testground daemon
-      - name: Build
-        run: make goinstall docker-testground
-        working-directory: "code/testground"
-      # Update our test plan so it uses the version of go-nitro from this workflow
-      - name: Update Test Dependency
-        run: go get github.com/statechannels/go-nitro@${{github.event.pull_request.head.sha}}
-        working-directory: "code/go-nitro-testground"
+      # # Build the testground daemon
+      # - name: Build
+      #   run: make goinstall docker-testground
+      #   working-directory: "code/testground"
+      # # Update our test plan so it uses the version of go-nitro from this workflow
+      # - name: Update Test Dependency
+      #   run: go get github.com/statechannels/go-nitro@${{github.event.pull_request.head.sha}}
+      #   working-directory: "code/go-nitro-testground"
 
       - name: Import Test 
         run:    testground plan import --from ./go-nitro-testground

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -21,16 +21,7 @@ jobs:
           path: "code/go-nitro-testground"
           ref: main
       
-      # Set up caching for go modules
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-    
+
       - name: Import Test 
         run:    testground plan import --from ./go-nitro-testground
         working-directory: "code"


### PR DESCRIPTION
It turns out you can just configure a github workflow job to run using a container. This means we can specify the public [testground image](https://hub.docker.com/r/iptestground/testground) instead of building `testground` ourselves and fooling around with docker caching.

Based on this PR I've seeing a reduction from [4 minutes](https://github.com/statechannels/go-nitro/actions/runs/3138567121/jobs/5098038931) to[ 2 minutes](https://github.com/statechannels/go-nitro/actions/runs/3138593404/jobs/5098094332) for the duration of the testground action. We also get to remove some docker caching and simplify our action 🎉 

