### PR TITLE
Generalize `channel/virtual.go` to be n-hop

### DIFF
--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -305,7 +305,7 @@ func TestChannel(t *testing.T) {
 }
 
 func TestSingleHopVirtualChannel(t *testing.T) {
-	compareChannels := func(a, b *SingleHopVirtualChannel) string {
+	compareChannels := func(a, b *VirtualChannel) string {
 		return cmp.Diff(*a, *b, cmp.AllowUnexported(*a, big.Int{}, state.SignedState{}, Channel{}))
 	}
 
@@ -313,7 +313,7 @@ func TestSingleHopVirtualChannel(t *testing.T) {
 	s.Participants = append(s.Participants, s.Participants[0]) // ensure three participants
 	s.TurnNum = 0
 	testClone := func(t *testing.T) {
-		r, err := NewSingleHopVirtualChannel(s, 0)
+		r, err := NewVirtualChannel(s, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -332,7 +332,7 @@ func TestSingleHopVirtualChannel(t *testing.T) {
 			t.Error("Clone: modifying the clone should not modify the original")
 		}
 
-		var nilChannel *SingleHopVirtualChannel
+		var nilChannel *VirtualChannel
 		clone := nilChannel.Clone()
 		if clone != nil {
 			t.Fatal("Tried to clone a Channel via a nil pointer, but got something not nil")

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -304,7 +304,7 @@ func TestChannel(t *testing.T) {
 
 }
 
-func TestSingleHopVirtualChannel(t *testing.T) {
+func TestVirtualChannel(t *testing.T) {
 	compareChannels := func(a, b *VirtualChannel) string {
 		return cmp.Diff(*a, *b, cmp.AllowUnexported(*a, big.Int{}, state.SignedState{}, Channel{}))
 	}
@@ -339,7 +339,10 @@ func TestSingleHopVirtualChannel(t *testing.T) {
 		}
 
 	}
-	t.Run(`TestClone`, testClone)
+
+	t.Run(`TestClone SingleHop`, testClone)
+	s.Participants = append(s.Participants, s.Participants[1]) // add a fourth participant
+	t.Run(`TestClone DoubleHop`, testClone)
 }
 
 func TestSerde(t *testing.T) {

--- a/channel/virtual.go
+++ b/channel/virtual.go
@@ -12,17 +12,16 @@ type SingleHopVirtualChannel struct {
 
 // NewSingleHopVirtualChannel returns a new SingleHopVirtualChannel based on the supplied state.
 func NewSingleHopVirtualChannel(s state.State, myIndex uint) (*SingleHopVirtualChannel, error) {
-	if myIndex > 2 {
-		return &SingleHopVirtualChannel{}, errors.New("myIndex in a single hop virtual channel must be 0, 1, or 2")
+	if int(myIndex) >= len(s.Participants) {
+		return &SingleHopVirtualChannel{}, errors.New("myIndex not in range of the supplied participants")
 	}
-	if len(s.Participants) != 3 {
-		return &SingleHopVirtualChannel{}, errors.New("a single hop virtual channel must have exactly three participants")
-	}
+
 	for _, assetExit := range s.Outcome {
 		if len(assetExit.Allocations) != 2 {
-			return &SingleHopVirtualChannel{}, errors.New("a single hop virtual channel's initial state should only have two allocations")
+			return &SingleHopVirtualChannel{}, errors.New("a virtual channel's initial state should only have two allocations")
 		}
 	}
+
 	c, err := New(s, myIndex)
 
 	return &SingleHopVirtualChannel{*c}, err

--- a/channel/virtual.go
+++ b/channel/virtual.go
@@ -6,32 +6,36 @@ import (
 	"github.com/statechannels/go-nitro/channel/state"
 )
 
-type SingleHopVirtualChannel struct {
+type VirtualChannel struct {
 	Channel
 }
 
-// NewSingleHopVirtualChannel returns a new SingleHopVirtualChannel based on the supplied state.
-func NewSingleHopVirtualChannel(s state.State, myIndex uint) (*SingleHopVirtualChannel, error) {
+// NewVirtualChannel returns a new VirtualChannel based on the supplied state.
+//
+// Virtual channel protocol currently presumes exactly two "active" participants,
+// Alice and Bob (p[0] and p[last]). They should be the only destinations allocated
+// to in the supplied state's Outcome.
+func NewVirtualChannel(s state.State, myIndex uint) (*VirtualChannel, error) {
 	if int(myIndex) >= len(s.Participants) {
-		return &SingleHopVirtualChannel{}, errors.New("myIndex not in range of the supplied participants")
+		return &VirtualChannel{}, errors.New("myIndex not in range of the supplied participants")
 	}
 
 	for _, assetExit := range s.Outcome {
 		if len(assetExit.Allocations) != 2 {
-			return &SingleHopVirtualChannel{}, errors.New("a virtual channel's initial state should only have two allocations")
+			return &VirtualChannel{}, errors.New("a virtual channel's initial state should only have two allocations")
 		}
 	}
 
 	c, err := New(s, myIndex)
 
-	return &SingleHopVirtualChannel{*c}, err
+	return &VirtualChannel{*c}, err
 }
 
 // Clone returns a pointer to a new, deep copy of the receiver, or a nil pointer if the receiver is nil.
-func (v *SingleHopVirtualChannel) Clone() *SingleHopVirtualChannel {
+func (v *VirtualChannel) Clone() *VirtualChannel {
 	if v == nil {
 		return nil
 	}
-	w := SingleHopVirtualChannel{*v.Channel.Clone()}
+	w := VirtualChannel{*v.Channel.Clone()}
 	return &w
 }

--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -294,7 +294,7 @@ func (ms *MemStore) populateChannelData(obj protocols.Objective) error {
 		if err != nil {
 			return fmt.Errorf("error retrieving virtual channel data for objective %s: %w", id, err)
 		}
-		o.V = &channel.SingleHopVirtualChannel{Channel: v}
+		o.V = &channel.VirtualChannel{Channel: v}
 
 		zeroAddress := types.Destination{}
 

--- a/protocols/virtualfund/serde.go
+++ b/protocols/virtualfund/serde.go
@@ -132,7 +132,7 @@ func (o *Objective) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("failed to unmarshal the VirtualFundObjective: %w", err)
 	}
 
-	o.V = &channel.SingleHopVirtualChannel{}
+	o.V = &channel.VirtualChannel{}
 	o.V.Id = jsonVFO.V
 
 	o.ToMyLeft = &Connection{}

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -122,7 +122,7 @@ func (c *Connection) getExpectedGuarantee() consensus_channel.Guarantee {
 // Objective is a cache of data computed by reading from the store. It stores (potentially) infinite data.
 type Objective struct {
 	Status protocols.ObjectiveStatus
-	V      *channel.SingleHopVirtualChannel
+	V      *channel.VirtualChannel
 
 	ToMyLeft  *Connection
 	ToMyRight *Connection
@@ -194,7 +194,7 @@ func constructFromState(
 	}
 
 	// Initialize virtual channel
-	v, err := channel.NewSingleHopVirtualChannel(initialStateOfV, init.MyRole)
+	v, err := channel.NewVirtualChannel(initialStateOfV, init.MyRole)
 	if err != nil {
 		return Objective{}, err
 	}

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -172,7 +172,7 @@ func TestClone(t *testing.T) {
 	}
 }
 
-func cloneAndSignSetupStateByPeers(v channel.SingleHopVirtualChannel, myRole uint, prefund bool) *channel.SingleHopVirtualChannel {
+func cloneAndSignSetupStateByPeers(v channel.VirtualChannel, myRole uint, prefund bool) *channel.VirtualChannel {
 	withSigs := v.Clone()
 
 	var state state.State


### PR DESCRIPTION
Toward #904 

This PR:
- relaxes the `len(participants) == 3` check from the `SingleHopVirtualChannel` struct
- renames the struct `SingleHopVirtualChannel` > `VirtualChannel`
- expands the doccomment with the expectation that the target channel have two "active" participants (while allowing any number of funding participants)
- adds a 2-hop channel to the channel struct's `clone` test

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [ ] ~I have assigned this PR to the appropriate GitHub Milestone~
