### PR TITLE
Setup Nightly Testground Run

### DIFF
--- a/.github/workflows/testground-nightly.yml
+++ b/.github/workflows/testground-nightly.yml
@@ -1,0 +1,47 @@
+name: Run Testground Nightly
+# TODO: Change this to run on a schedule
+on:
+  pull_request:
+# on:
+#   schedule:
+#     - cron:  '13 20 * * *'
+jobs:
+  run-testground-nightly:
+      runs-on: ubuntu-latest
+      container: iptestground/testground:edge
+      steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "^1.19.0"
+      # Get testground and our test plan code
+      - uses: actions/checkout@v3
+        with:
+         repository: 'statechannels/testground'
+         path: "code/testground"
+      - uses: actions/checkout@v3
+        with:
+          repository: 'statechannels/go-nitro-testground'
+          path: "code/go-nitro-testground"
+          ref: main
+
+      # Update our test plan so it uses the latest main of go-nitro
+      - name: Update Test Dependency
+        run: go get github.com/statechannels/go-nitro@main
+        working-directory: "code/go-nitro-testground"
+
+      - name: Import Test 
+        run:    testground plan import --from ./go-nitro-testground
+        working-directory: "code"
+
+      - name: Run 5 min Test 
+        run: | 
+         testground --endpoint=${{secrets.TG_SERVER_URL}}  run s --wait \
+         -p=go-nitro-testground -t=virtual-payment \
+         -b=docker:go -r=local:docker \
+         -tp=numOfHubs=1 -tp=numOfPayers=10 -tp=numOfPayees=1  -i=12 \
+         -tp=paymentTestDuration=300  -tp=concurrentPaymentJobs=10 \
+         --tp=networkLatency=15 --tp=networkJitter=2 \
+         --metadata-repo "${{github.repository}}" \
+         --metadata-branch "${{github.event.pull_request.head.ref}}" \
+         --metadata-commit "${{github.event.pull_request.head.sha}}"  | tee run.out
+          

--- a/.github/workflows/testground-nightly.yml
+++ b/.github/workflows/testground-nightly.yml
@@ -39,7 +39,7 @@ jobs:
          -tp=isNightly=true -p=go-nitro-testground -t=virtual-payment \
          -b=docker:go -r=local:docker \
          -tp=numOfHubs=1 -tp=numOfPayers=10 -tp=numOfPayees=1  -i=12 \
-         -tp=paymentTestDuration=300  -tp=concurrentPaymentJobs=10 \
+         -tp=paymentTestDuration=180  -tp=concurrentPaymentJobs=10 \
          --tp=networkLatency=15 --tp=networkJitter=2 \
          --metadata-repo "${{github.repository}}" \
          --metadata-branch "${{github.event.pull_request.head.ref}}" \

--- a/.github/workflows/testground-nightly.yml
+++ b/.github/workflows/testground-nightly.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run 5 min Test 
         run: | 
          testground --endpoint=${{secrets.TG_SERVER_URL}}  run s --wait \
-         -p=go-nitro-testground -t=virtual-payment \
+         -tp=isNightly=true -p=go-nitro-testground -t=virtual-payment \
          -b=docker:go -r=local:docker \
          -tp=numOfHubs=1 -tp=numOfPayers=10 -tp=numOfPayees=1  -i=12 \
          -tp=paymentTestDuration=300  -tp=concurrentPaymentJobs=10 \

--- a/.github/workflows/testground-nightly.yml
+++ b/.github/workflows/testground-nightly.yml
@@ -1,10 +1,8 @@
 name: Run Testground Nightly
-# TODO: Change this to run on a schedule
 on:
-  pull_request:
-# on:
-#   schedule:
-#     - cron:  '13 20 * * *'
+  schedule:
+    # Run at 05:00 UTC every day
+    - cron:  '0 5 * * *'
 jobs:
   run-testground-nightly:
       runs-on: ubuntu-latest

--- a/.github/workflows/testground-nightly.yml
+++ b/.github/workflows/testground-nightly.yml
@@ -31,7 +31,7 @@ jobs:
         run:    testground plan import --from ./go-nitro-testground
         working-directory: "code"
 
-      - name: Run 5 min Test 
+      - name: Run 3 min Test 
         run: | 
          testground --endpoint=${{secrets.TG_SERVER_URL}}  run s --wait \
          -tp=isNightly=true -p=go-nitro-testground -t=virtual-payment \

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run Test 
         run: | 
          testground --endpoint=${{secrets.TG_SERVER_URL}}  run s --wait \
-         -p=go-nitro-testground -t=virtual-payment \
+         -tp=isCI=true -p=go-nitro-testground -t=virtual-payment \
          -b=docker:go -r=local:docker \
          -tp=numOfHubs=1 -tp=numOfPayers=10 -tp=numOfPayees=1  -i=12 \
          -tp=paymentTestDuration=30  -tp=concurrentPaymentJobs=10 \


### PR DESCRIPTION
Towards https://github.com/statechannels/go-nitro-testground/issues/107

This PR adds a scheduled github workflow, that starts a testground run nightly at 5AM UTC.   Since this is only run nightly we run it for ~5~3 minutes (shortened to 3 min to avoid this [issue](https://github.com/statechannels/go-nitro-testground/issues/116)). 

To test the workflow I set the [nightly workflow to run on PR](https://github.com/statechannels/go-nitro/actions/runs/3177472243/jobs/5177949776) before switching to `schedule`. Only scheduled workflows in `main` are picked up, so we'll have to merge this to test the scheduling bit.

This PR also updates both testground workflows to set the `isCI`/`isNightly` flags in anticipation of https://github.com/statechannels/go-nitro-testground/pull/119. This will allow us to track stats of our nightly/ci testground runs over time. `testground` will ignore the parameters if they're not defined so this is safe to merge in before [the PR](https://github.com/statechannels/go-nitro-testground/pull/119).