### PR TITLE
Update tesground test to use PR commit

### DIFF
--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -21,6 +21,10 @@ jobs:
           path: "code/go-nitro-testground"
           ref: main
       
+      # Update our test plan so it uses the version of go-nitro from this workflow
+      - name: Update Test Dependency
+        run: go get github.com/statechannels/go-nitro@${{github.event.pull_request.head.sha}}
+        working-directory: "code/go-nitro-testground"
 
       - name: Import Test 
         run:    testground plan import --from ./go-nitro-testground


### PR DESCRIPTION
It looks like I accidentally removed a line in #903. So the GH action testground runs were using whatever `go-nitro-testground`'s dependency is instead of running the test using the PR commit.

This PR fixes this by adding back the `go get` command that fetches `go-nitro` at the given PR.

