### PR TITLE
Generlise virtualdefund to be n-hop

### DIFF
--- a/protocols/virtualdefund/serde.go
+++ b/protocols/virtualdefund/serde.go
@@ -18,7 +18,7 @@ type jsonObjective struct {
 	VFixed         state.FixedPart
 	InitialOutcome outcome.SingleAssetExit
 	FinalOutcome   outcome.SingleAssetExit
-	Signatures     [3]state.Signature
+	Signatures     []state.Signature
 
 	ToMyLeft             []byte
 	ToMyRight            []byte

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -266,9 +266,8 @@ func (o *Objective) finalState() state.State {
 
 // Id returns the objective id.
 func (o *Objective) Id() protocols.ObjectiveId {
-	vId := o.VFixed.ChannelId() //TODO: Handle error
-	return protocols.ObjectiveId(ObjectivePrefix + vId.String())
-
+	id := o.VId().String()
+	return protocols.ObjectiveId(ObjectivePrefix + id)
 }
 
 // Approve returns an approved copy of the objective.
@@ -296,8 +295,7 @@ func (o *Objective) Reject() (protocols.Objective, protocols.SideEffects) {
 
 // OwnsChannel returns the channel that the objective is funding.
 func (o *Objective) OwnsChannel() types.Destination {
-	vId := o.VFixed.ChannelId()
-	return vId
+	return o.VId()
 }
 
 // GetStatus returns the status of the objective.
@@ -503,9 +501,7 @@ func (o *Objective) updateLedgerToRemoveGuarantee(ledger *consensus_channel.Cons
 
 // VId returns the channel id of the virtual channel.
 func (o *Objective) VId() types.Destination {
-	vId := o.VFixed.ChannelId()
-
-	return vId
+	return o.VFixed.ChannelId()
 }
 
 // signedBy returns whether we have a valid signature for the given participant

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -388,7 +388,7 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 		return &updated, sideEffects, WaitingForSignedFinal, nil
 	}
 
-	if !updated.isAlice() && !updated.isLeftDefunded() {
+	if !updated.isAlice() && !updated.leftHasDefunded() {
 		ledgerSideEffects, err := updated.updateLedgerToRemoveGuarantee(updated.ToMyLeft, secretKey)
 		if err != nil {
 			return o, protocols.SideEffects{}, WaitingForNothing, fmt.Errorf("error updating ledger funding: %w", err)
@@ -396,7 +396,7 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 		sideEffects.Merge(ledgerSideEffects)
 	}
 
-	if !updated.isBob() && !updated.isRightDefunded() {
+	if !updated.isBob() && !updated.rightHasDefunded() {
 		ledgerSideEffects, err := updated.updateLedgerToRemoveGuarantee(updated.ToMyRight, secretKey)
 		if err != nil {
 			return o, protocols.SideEffects{}, WaitingForNothing, fmt.Errorf("error updating ledger funding: %w", err)
@@ -404,7 +404,7 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 		sideEffects.Merge(ledgerSideEffects)
 	}
 
-	if fullyDefunded := updated.isLeftDefunded() && updated.isRightDefunded(); !fullyDefunded {
+	if fullyDefunded := updated.leftHasDefunded() && updated.rightHasDefunded(); !fullyDefunded {
 		return &updated, sideEffects, WaitingForCompleteLedgerDefunding, nil
 	}
 
@@ -503,9 +503,11 @@ func (o *Objective) signedByMe() bool {
 
 }
 
-// isRightDefunded returns whether the ledger channel ToMyRight has been defunded
-// If ToMyRight==nil then we return true
-func (o *Objective) isRightDefunded() bool {
+// rightHasDefunded returns whether the ledger channel ToMyRight has removed
+// its funding for the target channel.
+//
+// If ToMyRight==nil then we return true.
+func (o *Objective) rightHasDefunded() bool {
 	if o.ToMyRight == nil {
 		return true
 	}
@@ -514,9 +516,11 @@ func (o *Objective) isRightDefunded() bool {
 	return !included
 }
 
-// isLeftDefunded returns whether the ledger channel ToMyLeft has been defunded
-// If ToMyLeft==nil then we return true
-func (o *Objective) isLeftDefunded() bool {
+// leftHasDefunded returns whether the ledger channel ToMyLeft has removed
+// its funding for the target channel.
+//
+// If ToMyLeft==nil then we return true.
+func (o *Objective) leftHasDefunded() bool {
 	if o.ToMyLeft == nil {
 		return true
 	}

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -430,6 +430,10 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 
 // fullySigned returns whether we have a signature from every partciapant.
 func (o *Objective) fullySigned() bool {
+	if len(o.Signatures) != len(o.VFixed.Participants) {
+		return false
+	}
+
 	for _, sig := range o.Signatures {
 		if isZero(sig) {
 			return false

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -363,7 +363,7 @@ func (o *Objective) hasFinalStateFromAlice() bool {
 	return !o.FinalOutcome.Equal(outcome.SingleAssetExit{})
 }
 
-// Crank inspects the extended state and declares a list of Effects to be executed
+// Crank inspects the extended state and declares a list of Effects to be executed.
 func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.SideEffects, protocols.WaitingFor, error) {
 	updated := o.clone()
 	sideEffects := protocols.SideEffects{}
@@ -430,7 +430,7 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 
 }
 
-// fullySigned returns whether we have a signature from every partciapant
+// fullySigned returns whether we have a signature from every partciapant.
 func (o *Objective) fullySigned() bool {
 	for _, sig := range o.Signatures {
 		if isZero(sig) {
@@ -513,10 +513,9 @@ func (o *Objective) signedBy(participant uint) bool {
 	return !isZero(o.Signatures[participant])
 }
 
-// signedByMe returns whether the current participant has signed the final state
+// signedByMe returns whether the current participant has signed the final state.
 func (o *Objective) signedByMe() bool {
 	return o.signedBy(o.MyRole)
-
 }
 
 // rightHasDefunded returns whether the ledger channel ToMyRight has removed
@@ -545,8 +544,8 @@ func (o *Objective) leftHasDefunded() bool {
 	return !included
 }
 
-// validateSignature returns whether the given signature is valid for the given participant
-// If a signature is invalid an error will be returned containing the reason
+// validateSignature returns whether the given signature is valid for the given participant.
+// If a signature is invalid an error will be returned containing the reason.
 func (o *Objective) validateSignature(sig state.Signature, participantIndex uint) (bool, error) {
 	if participantIndex >= uint(len(o.VFixed.Participants)) {
 		return false, fmt.Errorf("participant index %d is out of bounds", participantIndex)

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -487,7 +487,7 @@ func (o *Objective) updateLedgerToRemoveGuarantee(ledger *consensus_channel.Cons
 
 // VId returns the channel id of the virtual channel.
 func (o *Objective) VId() types.Destination {
-	vId := o.VFixed.ChannelId() // TODO Deal with error
+	vId := o.VFixed.ChannelId()
 
 	return vId
 }

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -289,18 +289,18 @@ func (o *Objective) GetStatus() protocols.ObjectiveStatus {
 	return o.Status
 }
 
-// Relable returns related channels that need to be stored along with the objective.
+// Related returns channels that need to be stored along with the objective.
 func (o *Objective) Related() []protocols.Storable {
-	relatable := []protocols.Storable{}
+	related := []protocols.Storable{}
 
 	if o.ToMyLeft != nil {
-		relatable = append(relatable, o.ToMyLeft)
+		related = append(related, o.ToMyLeft)
 	}
 
 	if o.ToMyRight != nil {
-		relatable = append(relatable, o.ToMyRight)
+		related = append(related, o.ToMyRight)
 	}
-	return relatable
+	return related
 }
 
 // Clone returns a deep copy of the receiver.

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -202,7 +202,7 @@ func TestConstructObjectiveFromState(t *testing.T) {
 		InitialOutcome:       data.vInitial.Outcome[0],
 		FinalOutcome:         data.vFinal.Outcome[0],
 		VFixed:               data.vFinal.FixedPart(),
-		Signatures:           [3]state.Signature{},
+		Signatures:           make([]state.Signature, 3),
 		ToMyLeft:             left,
 		ToMyRight:            right,
 		MinimumPaymentAmount: big.NewInt(int64(data.paid)),


### PR DESCRIPTION
towards #904 

This is similar to work in #906, and follows #916 as well.

It relaxes the `len(Participants) == 3` assumption from `protocols.virtualdefund`. Tested against existing unit tests.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] ~I have added tests that prove my fix is effective or that my feature works, if necessary~
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [ ] I have assigned this PR to the appropriate GitHub Milestone
