### PR TITLE
Generalise protocols.virtualfund.ObjectiveRequest to n-hop

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -94,10 +94,10 @@ func (c *Client) ReceivedVouchers() <-chan payments.Voucher {
 }
 
 // CreateVirtualChannel creates a virtual channel with the counterParty using ledger channels with the intermediary.
-func (c *Client) CreateVirtualPaymentChannel(Intermediary, CounterParty types.Address, ChallengeDuration uint32, Outcome outcome.Exit) virtualfund.ObjectiveResponse {
+func (c *Client) CreateVirtualPaymentChannel(Intermediaries []types.Address, CounterParty types.Address, ChallengeDuration uint32, Outcome outcome.Exit) virtualfund.ObjectiveResponse {
 
 	objectiveRequest := virtualfund.ObjectiveRequest{
-		Intermediary:      Intermediary,
+		Intermediaries:    Intermediaries,
 		CounterParty:      CounterParty,
 		ChallengeDuration: ChallengeDuration,
 		Outcome:           Outcome,

--- a/client/client.go
+++ b/client/client.go
@@ -93,7 +93,8 @@ func (c *Client) ReceivedVouchers() <-chan payments.Voucher {
 	return c.receivedVouchers
 }
 
-// CreateVirtualChannel creates a virtual channel with the counterParty using ledger channels with the intermediary.
+// CreateVirtualChannel creates a virtual channel with the counterParty using ledger channels
+// with the supplied intermediaries.
 func (c *Client) CreateVirtualPaymentChannel(Intermediaries []types.Address, CounterParty types.Address, ChallengeDuration uint32, Outcome outcome.Exit) virtualfund.ObjectiveResponse {
 
 	objectiveRequest := virtualfund.ObjectiveRequest{

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -367,7 +367,8 @@ func (e *Engine) handleObjectiveRequest(or protocols.ObjectiveRequest) (EngineEv
 			return EngineEvent{}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 		}
 		// Only Alice or Bob care about registering the objective and keeping track of vouchers
-		if vfo.MyRole == payments.PAYEE_INDEX || vfo.MyRole == payments.PAYER_INDEX {
+		lastParticipant := uint(len(vfo.V.Participants) - 1)
+		if vfo.MyRole == lastParticipant || vfo.MyRole == payments.PAYER_INDEX {
 			err = e.registerPaymentChannel(vfo)
 			if err != nil {
 				return EngineEvent{}, fmt.Errorf("could not register channel with payment/receipt manager: %w", err)

--- a/client_test/directdefund_test.go
+++ b/client_test/directdefund_test.go
@@ -90,7 +90,7 @@ func TestDirectDefund(t *testing.T) {
 
 		// create & virtual channel between A and B through I
 		outcome := testdata.Outcomes.Create(alice.Address(), bob.Address(), 1, 1)
-		response := clientA.CreateVirtualPaymentChannel(irene.Address(), bob.Address(), 0, outcome)
+		response := clientA.CreateVirtualPaymentChannel([]types.Address{irene.Address()}, bob.Address(), 0, outcome)
 
 		waitTimeForCompletedObjectiveIds(t, &clientA, defaultTimeout, response.Id)
 

--- a/client_test/payment_with_p2p_ms_test.go
+++ b/client_test/payment_with_p2p_ms_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/store"
 	td "github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/types"
 )
 
 // setupClientWithP2PMessageService is a helper function that contructs a client and returns the new client and its store.
@@ -54,7 +55,12 @@ func TestPayments(t *testing.T) {
 	directlyFundALedgerChannel(t, clientA, clientI)
 	directlyFundALedgerChannel(t, clientI, clientB)
 	outcome := td.Outcomes.Create(alice.Address(), bob.Address(), 100, 100)
-	r := clientA.CreateVirtualPaymentChannel(irene.Address(), bob.Address(), 0, outcome)
+	r := clientA.CreateVirtualPaymentChannel(
+		[]types.Address{irene.Address()},
+		bob.Address(),
+		0,
+		outcome,
+	)
 
 	ids := []protocols.ObjectiveId{r.Id}
 

--- a/client_test/virtualdefund_test.go
+++ b/client_test/virtualdefund_test.go
@@ -176,7 +176,12 @@ func TestWhenVirtualDefundObjectiveIsRejected(t *testing.T) {
 	directlyFundALedgerChannel(t, clientB, clientI)
 
 	outcome := td.Outcomes.Create(alice.Address(), bob.Address(), 1, 1)
-	response := clientA.CreateVirtualPaymentChannel(irene.Address(), bob.Address(), 0, outcome)
+	response := clientA.CreateVirtualPaymentChannel(
+		[]types.Address{irene.Address()},
+		bob.Address(),
+		0,
+		outcome,
+	)
 
 	waitTimeForCompletedObjectiveIds(t, &clientA, time.Second, response.Id)
 	waitTimeForCompletedObjectiveIds(t, &clientB, time.Second, response.Id)

--- a/client_test/virtualfund_multi_party_test.go
+++ b/client_test/virtualfund_multi_party_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	td "github.com/statechannels/go-nitro/internal/testdata"
+	"github.com/statechannels/go-nitro/types"
 )
 
 // TestVirtualFundMultiParty tests the scenario where Alice creates virtual channels with Bob and Brian using Irene as the intermediary.
@@ -31,19 +32,27 @@ func TestVirtualFundMultiParty(t *testing.T) {
 	directlyFundALedgerChannel(t, clientIrene, clientBob)
 	directlyFundALedgerChannel(t, clientIrene, clientBrian)
 
-	id := clientAlice.CreateVirtualPaymentChannel(irene.Address(), bob.Address(), 0, td.Outcomes.Create(
-		alice.Address(),
+	id := clientAlice.CreateVirtualPaymentChannel(
+		[]types.Address{irene.Address()},
 		bob.Address(),
-		1,
-		1,
-	)).Id
+		0,
+		td.Outcomes.Create(
+			alice.Address(),
+			bob.Address(),
+			1,
+			1,
+		)).Id
 
-	id2 := clientAlice.CreateVirtualPaymentChannel(irene.Address(), brian.Address(), 0, td.Outcomes.Create(
-		alice.Address(),
+	id2 := clientAlice.CreateVirtualPaymentChannel(
+		[]types.Address{irene.Address()},
 		brian.Address(),
-		1,
-		1,
-	)).Id
+		0,
+		td.Outcomes.Create(
+			alice.Address(),
+			brian.Address(),
+			1,
+			1,
+		)).Id
 
 	waitTimeForCompletedObjectiveIds(t, &clientBob, defaultTimeout, id)
 	waitTimeForCompletedObjectiveIds(t, &clientBrian, defaultTimeout, id2)

--- a/client_test/virtualfund_test.go
+++ b/client_test/virtualfund_test.go
@@ -19,7 +19,12 @@ func openVirtualChannels(t *testing.T, clientA client.Client, clientB client.Cli
 	channelIds := make([]types.Destination, numOfChannels)
 	for i := 0; i < int(numOfChannels); i++ {
 		outcome := td.Outcomes.Create(alice.Address(), bob.Address(), 1, 1)
-		response := clientA.CreateVirtualPaymentChannel(irene.Address(), bob.Address(), 0, outcome)
+		response := clientA.CreateVirtualPaymentChannel(
+			[]types.Address{irene.Address()},
+			bob.Address(),
+			0,
+			outcome,
+		)
 
 		objectiveIds[i] = response.Id
 		channelIds[i] = response.ChannelId

--- a/client_test/virtualfund_with_message_delays_test.go
+++ b/client_test/virtualfund_with_message_delays_test.go
@@ -51,7 +51,7 @@ func createVirtualChannels(client client.Client, counterParty types.Address, int
 	ids := make([]protocols.ObjectiveId, amountOfChannels)
 	for i := uint(0); i < amountOfChannels; i++ {
 		outcome := td.Outcomes.Create(*client.Address, counterParty, 1, 1)
-		ids[i] = client.CreateVirtualPaymentChannel(intermediary, counterParty, 0, outcome).Id
+		ids[i] = client.CreateVirtualPaymentChannel([]types.Address{intermediary}, counterParty, 0, outcome).Id
 	}
 	return ids
 }

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -8,6 +8,7 @@ import (
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/protocols/directfund"
 	"github.com/statechannels/go-nitro/protocols/virtualfund"
+	"github.com/statechannels/go-nitro/types"
 )
 
 // objectiveCollection namespaces literal objectives, precomputed objectives, and
@@ -64,7 +65,7 @@ func genericVFO() virtualfund.Objective {
 	ts.Participants[2] = testactors.Bob.Address()
 
 	request := virtualfund.ObjectiveRequest{
-		Intermediary:      ts.Participants[1],
+		Intermediaries:    []types.Address{ts.Participants[1]},
 		CounterParty:      ts.Participants[2],
 		ChallengeDuration: ts.ChallengeDuration,
 		Outcome:           ts.Outcome,

--- a/payments/helpers.go
+++ b/payments/helpers.go
@@ -3,7 +3,6 @@ package payments
 import "github.com/statechannels/go-nitro/types"
 
 const PAYER_INDEX = 0
-const PAYEE_INDEX = 2
 
 // GetPayer returns the payer on a payment channel
 func GetPayer(participants []types.Address) types.Address {
@@ -12,5 +11,5 @@ func GetPayer(participants []types.Address) types.Address {
 
 // GetPayee returns the payee on a payment channel
 func GetPayee(participants []types.Address) types.Address {
-	return participants[PAYEE_INDEX]
+	return participants[len(participants)-1]
 }


### PR DESCRIPTION
towards #904 

This PR changes the public API of `go-nitro` in order to allow multi-hop virtualfund operations. The previous `CreateVirtualChannel` method received a single intermediary - the updated one receives a slice of them.

Recommending a review & merge of this PR and [the linked PR](https://github.com/statechannels/go-nitro-testground/pull/126) in `go-nitro-testground` independent of followup updates to the unit tests, so that CI can resume normal function ASAP.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] ~I have added tests that prove my fix is effective or that my feature works, if necessary~ Existing virtualfund unit tests work, and generalized versions incoming.
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [ ] I have assigned this PR to the appropriate GitHub Milestone
