### PR TITLE
Reduce resub interval

### DIFF
--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -40,9 +40,9 @@ type EthChainService struct {
 
 // RESUB_INTERVAL is how often we resubscribe to log events.
 // We do this to avoid https://github.com/ethereum/go-ethereum/issues/23845
-// We use 4:30 as the default filter timeout is 5 minutes.
+// We use 2.5 minutes as the default filter timeout is 5 minutes.
 // See https://github.com/ethereum/go-ethereum/blob/e14164d516600e9ac66f9060892e078f5c076229/eth/filters/filter_system.go#L43
-const RESUB_INTERVAL = 4*time.Minute + 30*time.Second
+const RESUB_INTERVAL = 2*time.Minute + 30*time.Second
 
 // NewEthChainService constructs a chain service that submits transactions to a NitroAdjudicator
 // and listens to events from an eventSource


### PR DESCRIPTION
It looks like we're still seeing failures in testground runs. I suspect this might be due to this [change](https://github.com/statechannels/go-nitro/pull/922/commits/b196845d8e4ac1496e47bca4e9e1d0415eeb1441) where I increased the duration before we resubscribe.

I was able to run 10 minute tests previously on that PR so I suspect that 4 minutes and 30 seconds is too long. The duration of the subscription is handled internally by the harhat/geth,  but the resub interval is handled by our client. So I suspect the hardhat/geth 5 minute timer expired before our client side 4 minute 30 second timer did.

This PR reduces the resub interval to 2.5 minutes (which is half of the default timeout of 5 minutes).

TODO:
- [x] Show a 10 minute run with this change. http://34.168.92.245:8042/logs?task_id=cd0budgnr2gtv8be0of0