### PR TITLE
Test the n-hop virtual fund

### DIFF
--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -137,7 +137,14 @@ type Objective struct {
 
 // NewObjective creates a new virtual funding objective from a given request.
 func NewObjective(request ObjectiveRequest, preApprove bool, myAddress types.Address, getTwoPartyConsensusLedger GetTwoPartyConsensusLedgerFunction) (Objective, error) {
-	rightCC, ok := getTwoPartyConsensusLedger(request.Intermediaries[0])
+	var rightCC *consensus_channel.ConsensusChannel
+	ok := false
+
+	if len(request.Intermediaries) > 0 {
+		rightCC, ok = getTwoPartyConsensusLedger(request.Intermediaries[0])
+	} else {
+		rightCC, ok = getTwoPartyConsensusLedger(request.CounterParty)
+	}
 
 	if !ok {
 		return Objective{}, fmt.Errorf("could not find ledger for %s and %s", myAddress, request.Intermediaries[0])


### PR DESCRIPTION
Towards #904 

This PR
- modifies `vitualfund_test.go` to create 0, 1, and 2 hop virtually funded channels
- modifies `virtualfund.NewObjective()` to allow 0-hop funding (ie, persons with a ledger channel can use that channel to fund a virtual channel between them)


---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [ ] I have assigned this PR to the appropriate GitHub Milestone
