### PR TITLE
Stop swallowing ErrNotEmpty Error

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -136,12 +136,6 @@ func (e *Engine) Run() {
 		select {
 		case or := <-e.ObjectiveRequestsFromAPI:
 			res, err = e.handleObjectiveRequest(or)
-
-			if errors.Is(err, directdefund.ErrNotEmpty) {
-				// communicate failure to client & swallow error
-				e.toApi <- res
-				err = nil
-			}
 		case pr := <-e.PaymentRequestsFromAPI:
 			err = e.handlePaymentRequest(pr)
 		case chainEvent := <-e.fromChain:


### PR DESCRIPTION
Per our [discussion](https://github.com/statechannels/go-nitro/issues/883#issuecomment-1255272825) on #883 we decided to stop swallowing the `ErrNotEmpty`.

This PR implements that change.