### PR TITLE
Expose `Client.WaitForObjectivesToComplete()`

### DIFF
--- a/client_test/directfund_test.go
+++ b/client_test/directfund_test.go
@@ -2,6 +2,7 @@
 package client_test // import "github.com/statechannels/go-nitro/client_test"
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -58,7 +59,7 @@ func TestWhenObjectiveIsRejected(t *testing.T) {
 	outcome := testdata.Outcomes.Create(alice.Address(), bob.Address(), ledgerChannelDeposit, ledgerChannelDeposit)
 	response := clientA.CreateLedgerChannel(bob.Address(), 0, outcome)
 
-	waitTimeForCompletedObjectiveIds(t, &clientA, time.Second, response.Id)
+	<-clientA.WaitForObjectivesToComplete(context.Background(), response.Id)
 
 	obj, _ := storeA.GetObjectiveById(response.Id)
 

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -32,7 +32,13 @@ func waitTimeForCompletedObjectiveIds(t *testing.T, client *client.Client, timeo
 	case <-time.After(timeout):
 		cancel()
 		incomplete := <-allDone
-		t.Fatalf("Objective ids %v failed to complete on client %s within %s", incomplete, client.Address, timeout)
+		ids := make([]protocols.ObjectiveId, len(incomplete))
+		i := 0
+		for k := range incomplete {
+			ids[i] = k
+			i++
+		}
+		t.Fatalf("Objective ids %s failed to complete on client %s within %s", ids, client.Address, timeout)
 	case <-allDone:
 		cancel()
 		return


### PR DESCRIPTION
While working on #936, it occurred to me that we make heavy use of a test utility `waitTimeForCompletedObjectiveIds` in our integration tests. There is currently nothing like this available to consumers of go-nitro, placing a burden on those consumers to write their own boilerplate for this. 



This PR adds such a method, which:
* does _not_ accept  an explicit timeout parameter, but instead accepts a `context` which may be cancelled
* is used to refactor the existing test utility, using a cancellable `context`
* is used by example in one place (only) of our tests, reducing the boilerplate for consumers. We should either
  - roll this out across all tests
  - revert the change if we want tests to really wait a certain amount of time for such calls to resolve


NOTE 
We rolled something similar in out testground monitor called a completion monitor. We could consider absorbing that into the go-nitro client instead of using this PR -- let's discuss and maybe take the best of both. 
https://github.com/statechannels/go-nitro-testground/blob/3df3fa6b1ee1efbbfa1d5cc9fc69532cde3d9860/utils/monitor.go#L22
