### PR TITLE
Fix, improve error messages in `engine.constructObjectiveFromMessage()`

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -581,17 +581,17 @@ func (e *Engine) constructObjectiveFromMessage(id protocols.ObjectiveId, p proto
 	case virtualfund.IsVirtualFundObjective(id):
 		vfo, err := virtualfund.ConstructObjectiveFromPayload(p, false, *e.store.GetAddress(), e.store.GetConsensusChannel)
 		if err != nil {
-			return &virtualfund.Objective{}, fmt.Errorf("could not create virtual fund objective from message: %w", err)
+			return &virtualfund.Objective{}, fmt.Errorf("could not create virtual fund objective from message.\n\ttarget objective: %s\n\terr: %w", id, err)
 		}
 		err = e.registerPaymentChannel(vfo)
 		if err != nil {
-			return &virtualfund.Objective{}, fmt.Errorf("could not register channel with payment/receipt manager: %w", err)
+			return &virtualfund.Objective{}, fmt.Errorf("could not register channel with payment/receipt manager.\n\ttarget channel: %s\n\terr: %w", id, err)
 		}
 		return &vfo, nil
 	case virtualdefund.IsVirtualDefundObjective(id):
 		vId, err := virtualdefund.GetVirtualChannelFromObjectiveId(id)
 		if err != nil {
-			return &virtualdefund.Objective{}, fmt.Errorf("could not determine virtual channel id: %w", err)
+			return &virtualdefund.Objective{}, fmt.Errorf("could not determine virtual channel id from objective %s: %w", id, err)
 		}
 		minAmount := big.NewInt(0)
 		if e.vm.ChannelRegistered(vId) {
@@ -601,13 +601,13 @@ func (e *Engine) constructObjectiveFromMessage(id protocols.ObjectiveId, p proto
 
 		vdfo, err := virtualdefund.ConstructObjectiveFromPayload(p, false, *e.store.GetAddress(), e.store.GetChannelById, e.store.GetConsensusChannel, minAmount)
 		if err != nil {
-			return &virtualfund.Objective{}, fmt.Errorf("could not create virtual defund objective from message: %w", err)
+			return &virtualfund.Objective{}, fmt.Errorf("could not create virtual defund objective from message.\n\ttarget objective: %s\n\terr: %w", id, err)
 		}
 		return &vdfo, nil
 	case directdefund.IsDirectDefundObjective(id):
 		ddfo, err := directdefund.ConstructObjectiveFromPayload(p, false, e.store.GetConsensusChannelById)
 		if err != nil {
-			return &directdefund.Objective{}, fmt.Errorf("could not create direct defund objective from message: %w", err)
+			return &directdefund.Objective{}, fmt.Errorf("could not create direct defund objective from message.\n\ttarget objective: %s\n\terr: %w", id, err)
 		}
 		return &ddfo, nil
 

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -601,7 +601,7 @@ func (e *Engine) constructObjectiveFromMessage(id protocols.ObjectiveId, p proto
 
 		vdfo, err := virtualdefund.ConstructObjectiveFromPayload(p, false, *e.store.GetAddress(), e.store.GetChannelById, e.store.GetConsensusChannel, minAmount)
 		if err != nil {
-			return &virtualfund.Objective{}, fmt.Errorf("could not create virtual fund objective from message: %w", err)
+			return &virtualfund.Objective{}, fmt.Errorf("could not create virtual defund objective from message: %w", err)
 		}
 		return &vdfo, nil
 	case directdefund.IsDirectDefundObjective(id):

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -581,7 +581,7 @@ func (e *Engine) constructObjectiveFromMessage(id protocols.ObjectiveId, p proto
 	case virtualfund.IsVirtualFundObjective(id):
 		vfo, err := virtualfund.ConstructObjectiveFromPayload(p, false, *e.store.GetAddress(), e.store.GetConsensusChannel)
 		if err != nil {
-			return &virtualfund.Objective{}, fmt.Errorf("could not create virtual fund objective from message.\n\ttarget objective: %s\n\terr: %w", id, err)
+			return &virtualfund.Objective{}, fromMsgErr(id, err)
 		}
 		err = e.registerPaymentChannel(vfo)
 		if err != nil {
@@ -601,13 +601,13 @@ func (e *Engine) constructObjectiveFromMessage(id protocols.ObjectiveId, p proto
 
 		vdfo, err := virtualdefund.ConstructObjectiveFromPayload(p, false, *e.store.GetAddress(), e.store.GetChannelById, e.store.GetConsensusChannel, minAmount)
 		if err != nil {
-			return &virtualfund.Objective{}, fmt.Errorf("could not create virtual defund objective from message.\n\ttarget objective: %s\n\terr: %w", id, err)
+			return &virtualfund.Objective{}, fromMsgErr(id, err)
 		}
 		return &vdfo, nil
 	case directdefund.IsDirectDefundObjective(id):
 		ddfo, err := directdefund.ConstructObjectiveFromPayload(p, false, e.store.GetConsensusChannelById)
 		if err != nil {
-			return &directdefund.Objective{}, fmt.Errorf("could not create direct defund objective from message.\n\ttarget objective: %s\n\terr: %w", id, err)
+			return &directdefund.Objective{}, fromMsgErr(id, err)
 		}
 		return &ddfo, nil
 
@@ -615,6 +615,12 @@ func (e *Engine) constructObjectiveFromMessage(id protocols.ObjectiveId, p proto
 		return &directfund.Objective{}, errors.New("cannot handle unimplemented objective type")
 	}
 
+}
+
+// fromMsgErr wraps errors from objective construction functions and
+// returns an error bundled with the objectiveID
+func fromMsgErr(id protocols.ObjectiveId, err error) error {
+	return fmt.Errorf("could not create objective from message.\n\ttarget objective: %s\n\terr: %w", id, err)
 }
 
 // getProposalObjectiveId returns the objectiveId for a proposal.


### PR DESCRIPTION
Related to https://github.com/statechannels/go-nitro-testground/issues/134 (or, at least, to the debugging of this issue)

PR:
- fixes an error message that declared a virtualfund had failed when in fact a virtualdefund had failed
- augments the error messages to include the ID of the failed objectives
- adds a small helper function to standardize these error messages

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] ~I have added tests that prove my fix is effective or that my feature works, if necessary~
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [ ] ~I have assigned this PR to the appropriate GitHub Milestone~
