### PR TITLE
ignore netlify builds unless docs change

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ They work by allowing users to deposit their funds into a "layer 2" network whic
 
 The network benefits from significant advantages, however -- in a fraction of a second, a direct, private connection can be forged with anyone else in the network. Then, payments can be streamed incredibly fast: up to **hundreds of times per second**. What's more, there is no per-payment fee to cover (just a small fee per unit time for maintaining the connection).
 
-This is in sharp contrast to the experience of transacting publicly on a "layer 1" blockchain or even on a rollup chain. There, fees and latency apply to each and every action.
+This is in contrast to the experience of transacting publicly on a "layer 1" blockchain or even on a rollup chain. There, fees and latency apply to each and every action.
 
 ## What's on offer
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- docs"


### PR DESCRIPTION
See https://docs.netlify.com/configure-builds/ignore-builds/

This has been manually tested, and seems to work.