### PR TITLE
EXPERIMENTAL: allow hubs to exit virtualfund early

### DIFF
--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -458,7 +458,11 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 		sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, messages...)
 	}
 
-	if !updated.V.PostFundComplete() {
+	// Alice and Bob need a complete post fund round to know V is fully funded.
+	// EXPERIMENTAL: Intermediaries do not require the complete post fund, so we allow them to finish the protocol early.
+	// If they need to recover funds, they can force V to close by challenging with the pre fund state.
+	// Alice and Bob may counter-challenge with a postfund state plus a redemption state.
+	if !updated.V.PostFundComplete() && (updated.isAlice() || updated.isBob()) {
 		return &updated, sideEffects, WaitingForCompletePostFund, nil
 	}
 

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -265,7 +265,7 @@ func TestCrankAsAlice(t *testing.T) {
 	sp := consensus_channel.SignedProposal{Proposal: p, Signature: consensusStateSignatures(alice, p1, o.ToMyRight.getExpectedGuarantee())[0], TurnNum: 2}
 	Ok(t, err)
 	assertOneProposalSent(t, effects, sp, p1)
-	Equals(t, waitingFor, WaitingForCompleteFunding)
+	Equals(t, waitingFor, WaitingForFundingAssurance)
 
 	// Check idempotency
 	emptySideEffects := protocols.SideEffects{}
@@ -273,7 +273,7 @@ func TestCrankAsAlice(t *testing.T) {
 	o = oObj.(*Objective)
 	Ok(t, err)
 	Equals(t, effects, emptySideEffects)
-	Equals(t, waitingFor, WaitingForCompleteFunding)
+	Equals(t, waitingFor, WaitingForFundingAssurance)
 
 	// If Alice had received a signed counterproposal, she should proceed to postFundSetup
 	sp = consensus_channel.SignedProposal{Proposal: p, Signature: consensusStateSignatures(alice, p1, o.ToMyRight.getExpectedGuarantee())[1], TurnNum: 2}
@@ -346,14 +346,14 @@ func TestCrankAsBob(t *testing.T) {
 	emptySideEffects := protocols.SideEffects{}
 	Ok(t, err)
 	Equals(t, effects, emptySideEffects)
-	Equals(t, waitingFor, WaitingForCompleteFunding)
+	Equals(t, waitingFor, WaitingForFundingAssurance)
 
 	// Check idempotency
 	oObj, effects, waitingFor, err = o.Crank(&my.PrivateKey)
 	o = oObj.(*Objective)
 	Ok(t, err)
 	Equals(t, effects, emptySideEffects)
-	Equals(t, waitingFor, WaitingForCompleteFunding)
+	Equals(t, waitingFor, WaitingForFundingAssurance)
 
 	// If Bob had received a signed counterproposal, he should proceed to postFundSetup
 	p := consensus_channel.NewAddProposal(o.ToMyLeft.Channel.Id, o.ToMyLeft.getExpectedGuarantee(), big.NewInt(6))
@@ -429,7 +429,7 @@ func TestCrankAsP1(t *testing.T) {
 	sp := consensus_channel.SignedProposal{Proposal: p, Signature: consensusStateSignatures(p1, alice, o.ToMyLeft.getExpectedGuarantee())[0], TurnNum: 2}
 	Ok(t, err)
 	assertOneProposalSent(t, effects, sp, alice)
-	Equals(t, waitingFor, WaitingForCompleteFunding)
+	Equals(t, waitingFor, WaitingForFundingAssurance)
 
 	// Check idempotency
 	emptySideEffects := protocols.SideEffects{}
@@ -437,7 +437,7 @@ func TestCrankAsP1(t *testing.T) {
 	o = oObj.(*Objective)
 	Ok(t, err)
 	Equals(t, effects, emptySideEffects)
-	Equals(t, waitingFor, WaitingForCompleteFunding)
+	Equals(t, waitingFor, WaitingForFundingAssurance)
 
 	// If P1 had received a signed counterproposal, she should proceed to postFundSetup
 	p = consensus_channel.NewAddProposal(o.ToMyLeft.Channel.Id, o.ToMyLeft.getExpectedGuarantee(), big.NewInt(6))
@@ -457,7 +457,7 @@ func TestCrankAsP1(t *testing.T) {
 	Ok(t, err)
 
 	// We need to receive a proposal from Bob before funding is completed!
-	Equals(t, waitingFor, WaitingForCompleteFunding)
+	Equals(t, waitingFor, WaitingForFundingAssurance)
 	Equals(t, effects, emptySideEffects)
 }
 


### PR DESCRIPTION
I wanted to try this out to see affects on performance.

I'm 80% sure that it is safe for intermediaries to exit the virtualfund protocol without having a full set of post fund signatures. To be discussed / confirmed. 

If you click through to the dashboards, this change drastically reduces the time taken for the hub to complete virtual funding (10s down to 2s, so an 80% reduction). The effects on the other participants (which are probably more important) are less dramatic. About 20% reduction in time to first payment. 
