### PR TITLE
docs: configure edit links to target `main` branch

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: Nitro State Channel Framework
 strict: true
 repo_url: https://github.com/statechannels/go-nitro
+edit_url: blob/main/docs/
 theme:
   name: material
   palette:


### PR DESCRIPTION
Previously, the `edit` links on the docs went to a 404. On inspection, the links were pointing to the correct spot, except that the target branch was `master` instead of `main`. This fixes that.
