### PR TITLE
fix: remove leader=left, follower=right assumption from `vars.Add()`

### DIFF
--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -485,9 +485,9 @@ func assertOneProposalSent(t *testing.T, ses protocols.SideEffects, sp consensus
 			sent := msg.LedgerProposals[0]
 			toAddress := to.Address()
 
-			Assert(t, len(ses.MessagesToSend[0].LedgerProposals) == 1, "exp: %+v\n\n\tgot%+v", sent.Proposal, sp.Proposal)
-			Assert(t, bytes.Equal(msg.To[:], toAddress[:]), "exp: %+v\n\n\tgot%+v", msg.To.String(), to.Address().String())
-			Assert(t, compareSignedProposals(sp, sent), "exp: %+v\n\n\tgot%+v", sp, sent)
+			Assert(t, len(ses.MessagesToSend[0].LedgerProposals) == 1, "exp: %+v\n\n\tgot: %+v", sent.Proposal, sp.Proposal)
+			Assert(t, bytes.Equal(msg.To[:], toAddress[:]), "exp: %+v\n\n\tgot: %+v", msg.To.String(), to.Address().String())
+			Assert(t, compareSignedProposals(sp, sent), "exp: %+v\n\n\tgot: %+v", sp, sent)
 			numProposals++
 		}
 	}

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -62,26 +62,26 @@ func newTestData() testData {
 
 	leaderLedgers := make(map[types.Destination]actorLedgers)
 	leaderLedgers[alice.Destination()] = actorLedgers{
-		right: prepareConsensusChannel(uint(consensus_channel.Leader), alice, p1),
+		right: prepareConsensusChannel(uint(consensus_channel.Leader), alice, p1, alice),
 	}
 	leaderLedgers[p1.Destination()] = actorLedgers{
-		left:  prepareConsensusChannel(uint(consensus_channel.Leader), p1, alice),
-		right: prepareConsensusChannel(uint(consensus_channel.Leader), p1, bob),
+		left:  prepareConsensusChannel(uint(consensus_channel.Leader), p1, alice, alice),
+		right: prepareConsensusChannel(uint(consensus_channel.Leader), p1, bob, p1),
 	}
 	leaderLedgers[bob.Destination()] = actorLedgers{
-		left: prepareConsensusChannel(uint(consensus_channel.Leader), bob, p1),
+		left: prepareConsensusChannel(uint(consensus_channel.Leader), bob, p1, p1),
 	}
 
 	followerLedgers := make(map[types.Destination]actorLedgers)
 	followerLedgers[alice.Destination()] = actorLedgers{
-		right: prepareConsensusChannel(uint(consensus_channel.Follower), alice, p1),
+		right: prepareConsensusChannel(uint(consensus_channel.Follower), alice, p1, alice),
 	}
 	followerLedgers[p1.Destination()] = actorLedgers{
-		left:  prepareConsensusChannel(uint(consensus_channel.Follower), alice, p1),
-		right: prepareConsensusChannel(uint(consensus_channel.Follower), p1, bob),
+		left:  prepareConsensusChannel(uint(consensus_channel.Follower), alice, p1, alice),
+		right: prepareConsensusChannel(uint(consensus_channel.Follower), p1, bob, p1),
 	}
 	followerLedgers[bob.Destination()] = actorLedgers{
-		left: prepareConsensusChannel(uint(consensus_channel.Follower), p1, bob),
+		left: prepareConsensusChannel(uint(consensus_channel.Follower), p1, bob, p1),
 	}
 
 	return testData{vPreFund, vPostFund, leaderLedgers, followerLedgers}

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -74,11 +74,11 @@ func newTestData() testData {
 
 	followerLedgers := make(map[types.Destination]actorLedgers)
 	followerLedgers[alice.Destination()] = actorLedgers{
-		right: prepareConsensusChannel(uint(consensus_channel.Follower), alice, p1, alice),
+		right: prepareConsensusChannel(uint(consensus_channel.Follower), p1, alice, alice),
 	}
 	followerLedgers[p1.Destination()] = actorLedgers{
 		left:  prepareConsensusChannel(uint(consensus_channel.Follower), alice, p1, alice),
-		right: prepareConsensusChannel(uint(consensus_channel.Follower), p1, bob, p1),
+		right: prepareConsensusChannel(uint(consensus_channel.Follower), bob, p1, p1),
 	}
 	followerLedgers[bob.Destination()] = actorLedgers{
 		left: prepareConsensusChannel(uint(consensus_channel.Follower), p1, bob, p1),

--- a/protocols/virtualfund/virtualfund_test.go
+++ b/protocols/virtualfund/virtualfund_test.go
@@ -46,7 +46,7 @@ func TestMarshalJSON(t *testing.T) {
 	ts := state.TestState
 	ts.TurnNum = channel.PreFundTurnNum
 
-	right := prepareConsensusChannel(1, alice, bob)
+	right := prepareConsensusChannel(1, alice, bob, alice)
 	vfo, err := constructFromState(
 		false,
 		vPreFund,


### PR DESCRIPTION
Towards #952 

This PR fixes a faulty assumption of consensuschannel.leader=left, consensuschannel.follower=right when adding a proposal to a ConsensusChannel.

Where this assumption was false, this would have the effect that participants would be contributing the other participant's share toward funding the guarantee. In a simplex channel (Alice pays Bob), the effect would be that the wrong participant contributes the asset.

This PR is now ready for review. The existing unit tests for virtualfund had been broken in specific way to allow for the previous bug. The adjusted test fails under the original implementation and passes under the fixed implementation.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [x] I have assigned this PR to the appropriate GitHub project
- [ ] I have assigned this PR to the appropriate GitHub Milestone
