### PR TITLE
replace filecoinnonce method with ethNonce

### DIFF
--- a/client/engine/chainservice/fevm_test.go
+++ b/client/engine/chainservice/fevm_test.go
@@ -49,10 +49,14 @@ func TestFevm(t *testing.T) {
 
 	del, err := filecoinAddress.NewDelegatedAddress(10, crypto.PubkeyToAddress(pk.PublicKey).Bytes())
 
+	want := "t410for64b7cich4ktkekidsea2lo7jdrbb7ppzyclzi"
+	if del.String() != want {
+		t.Fatalf("incorrect delegated address, got %s wanted %s", del, want)
+	}
 	if err != nil {
 		t.Fatalf("could not get address")
 	}
-	nonce, err := fvmNonce(del)
+	nonce, err := ethNonce(crypto.PubkeyToAddress(pk.PublicKey))
 	if err != nil {
 		t.Fatalf("could not get nonce")
 	}

--- a/client_test/directfund_fevm_test.go
+++ b/client_test/directfund_fevm_test.go
@@ -19,6 +19,7 @@ func TestFevmDirectFund(t *testing.T) {
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 	const pkString = "716b7161580785bc96a4344eb52d23131aea0caf42a52dcf9f8aee9eef9dc3cd"
+
 	// Setup chain service
 	pk, _ := crypto.HexToECDSA(pkString)
 	chainA := chainservice.NewFevmChainService(pk)


### PR DESCRIPTION
This is a small step on the way to making the fevm chain service a pure eth chain service. Wallaby test net now supports nonce queries using the ethereum API. 