### PR TITLE
Use safesync.Map in test message service

### DIFF
--- a/client/engine/messageservice/test-messageservice.go
+++ b/client/engine/messageservice/test-messageservice.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/client/engine/store/safesync"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -28,28 +28,28 @@ type TestMessageService struct {
 	// connection with Peers:
 	fromPeers chan []byte // for receiving serialized messages from peers
 
-	broker Broker
+	broker *Broker
 }
 
 // A Broker manages a mapping from identifying address to a TestMessageService,
 // allowing messages sent from one message service to be directed to the intended
 // recipient
 type Broker struct {
-	services map[types.Address]TestMessageService
+	services safesync.Map[*TestMessageService]
 }
 
-func NewBroker() Broker {
+func NewBroker() *Broker {
 	b := Broker{
-		services: make(map[common.Address]TestMessageService),
+		services: safesync.Map[*TestMessageService]{},
 	}
 
-	return b
+	return &b
 }
 
 // NewTestMessageService returns a running TestMessageService
 // It accepts an address, a broker, and a max delay for messages.
 // Messages will be handled with a random delay between 0 and maxDelay
-func NewTestMessageService(address types.Address, broker Broker, maxDelay time.Duration) TestMessageService {
+func NewTestMessageService(address types.Address, broker *Broker, maxDelay time.Duration) TestMessageService {
 	tms := TestMessageService{
 		address:   address,
 		out:       make(chan protocols.Message, 5),
@@ -63,19 +63,19 @@ func NewTestMessageService(address types.Address, broker Broker, maxDelay time.D
 	return tms
 }
 
-func (t TestMessageService) Out() <-chan protocols.Message {
+func (t *TestMessageService) Out() <-chan protocols.Message {
 	return t.out
 }
 
 // dispatchMessage is responsible for dispatching a message to the appropriate peer message service.
 // If there is a mean delay it will wait a random amount of time(based on meanDelay) before sending the message.
-func (t TestMessageService) dispatchMessage(message protocols.Message) {
+func (t *TestMessageService) dispatchMessage(message protocols.Message) {
 	if t.maxDelay > 0 {
 		randomDelay := time.Duration(rand.Int63n(t.maxDelay.Nanoseconds()))
 		time.Sleep(randomDelay)
 	}
 
-	peer, ok := t.broker.services[message.To]
+	peer, ok := t.broker.services.Load(message.To.Hex())
 	if ok {
 		// To mimic a proper message service, we serialize and then
 		// deserialize the message
@@ -92,17 +92,17 @@ func (t TestMessageService) dispatchMessage(message protocols.Message) {
 }
 
 // connect registers the message service with the broker
-func (tms TestMessageService) connect(b Broker) {
-	b.services[tms.address] = tms
+func (tms *TestMessageService) connect(b *Broker) {
+	b.services.Store(tms.address.Hex(), tms)
 }
 
 // Send dispatches messages
-func (tms TestMessageService) Send(msg protocols.Message) {
+func (tms *TestMessageService) Send(msg protocols.Message) {
 	tms.dispatchMessage(msg)
 }
 
 // routeFromPeers listens for messages from peers, deserializes them and feeds them to the engine
-func (tms TestMessageService) routeFromPeers() {
+func (tms *TestMessageService) routeFromPeers() {
 	for message := range tms.fromPeers {
 		msg, err := protocols.DeserializeMessage(string(message))
 		if err != nil {

--- a/client_test/directfund_test.go
+++ b/client_test/directfund_test.go
@@ -52,7 +52,7 @@ func TestWhenObjectiveIsRejected(t *testing.T) {
 	{
 		messageservice := messageservice.NewTestMessageService(bob.Address(), broker, meanMessageDelay)
 		storeB = store.NewMemStore(bob.PrivateKey)
-		_ = client.New(messageservice, chainServiceB, storeB, logDestination, &RejectingPolicyMaker{}, nil)
+		_ = client.New(&messageservice, chainServiceB, storeB, logDestination, &RejectingPolicyMaker{}, nil)
 	}
 
 	outcome := testdata.Outcomes.Create(alice.Address(), bob.Address(), ledgerChannelDeposit, ledgerChannelDeposit)

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -126,11 +126,11 @@ func waitTimeForReceivedVoucher(t *testing.T, client *client.Client, timeout tim
 }
 
 // setupClient is a helper function that contructs a client and returns the new client and its store.
-func setupClient(pk []byte, chain chainservice.ChainService, msgBroker messageservice.Broker, logDestination io.Writer, meanMessageDelay time.Duration) (client.Client, store.Store) {
+func setupClient(pk []byte, chain chainservice.ChainService, msgBroker *messageservice.Broker, logDestination io.Writer, meanMessageDelay time.Duration) (client.Client, store.Store) {
 	myAddress := crypto.GetAddressFromSecretKeyBytes(pk)
 	messageservice := messageservice.NewTestMessageService(myAddress, msgBroker, meanMessageDelay)
 	storeA := store.NewMemStore(pk)
-	return client.New(messageservice, chain, storeA, logDestination, &engine.PermissivePolicy{}, nil), storeA
+	return client.New(&messageservice, chain, storeA, logDestination, &engine.PermissivePolicy{}, nil), storeA
 }
 
 func truncateLog(logFile string) {

--- a/client_test/virtualdefund_test.go
+++ b/client_test/virtualdefund_test.go
@@ -168,7 +168,7 @@ func TestWhenVirtualDefundObjectiveIsRejected(t *testing.T) {
 	{
 		messageservice := messageservice.NewTestMessageService(bob.Address(), broker, meanMessageDelay)
 		storeB = store.NewMemStore(bob.PrivateKey)
-		clientB = client.New(messageservice, chainServiceB, storeB, logDestination, &RejectingPolicyMaker{}, nil)
+		clientB = client.New(&messageservice, chainServiceB, storeB, logDestination, &RejectingPolicyMaker{}, nil)
 	}
 	clientI, storeI := setupClient(irene.PrivateKey, chainServiceI, broker, logDestination, meanMessageDelay)
 


### PR DESCRIPTION
This seems to allow us to send messages in go routines with the test message service, without tests failing. Under the hood, this change enables some locking in the message broker to avoid concurrent reads/writes to their peer lookup table. 