### PR TITLE
Fix some ledger proposal plumbing

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -88,6 +88,7 @@ func New(msg messageservice.MessageService, chain chainservice.ChainService, sto
 
 	e.store = store
 
+	e.fromLedger = make(chan consensus_channel.Proposal, 100)
 	// bind to inbound chans
 	e.ObjectiveRequestsFromAPI = make(chan protocols.ObjectiveRequest)
 	e.PaymentRequestsFromAPI = make(chan PaymentRequest)

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -82,6 +82,7 @@ func (se *SideEffects) Merge(other SideEffects) {
 
 	se.MessagesToSend = append(se.MessagesToSend, other.MessagesToSend...)
 	se.TransactionsToSubmit = append(se.TransactionsToSubmit, other.TransactionsToSubmit...)
+	se.ProposalsToProcess = append(se.ProposalsToProcess, other.ProposalsToProcess...)
 
 }
 

--- a/protocols/messages_test.go
+++ b/protocols/messages_test.go
@@ -40,6 +40,30 @@ func toPayload(p interface{}) []byte {
 	return b
 }
 
+func TestSideEffectsMerge(t *testing.T) {
+	original := &SideEffects{
+		MessagesToSend:       []Message{{To: types.Address{'a'}}},
+		TransactionsToSubmit: []ChainTransaction{},
+		ProposalsToProcess:   []consensus_channel.Proposal{removeProposal().Proposal},
+	}
+	toMerge := SideEffects{
+		MessagesToSend:       []Message{{To: types.Address{'b'}}},
+		TransactionsToSubmit: []ChainTransaction{},
+		ProposalsToProcess:   []consensus_channel.Proposal{addProposal().Proposal},
+	}
+
+	original.Merge(toMerge)
+
+	expected := &SideEffects{
+		MessagesToSend:       []Message{{To: types.Address{'a'}}, {To: types.Address{'b'}}},
+		TransactionsToSubmit: []ChainTransaction{},
+		ProposalsToProcess:   []consensus_channel.Proposal{removeProposal().Proposal, addProposal().Proposal},
+	}
+	if !reflect.DeepEqual(original, expected) {
+		t.Errorf("incorrect merge: got:\n%v\nwanted:\n%v", original, expected)
+	}
+}
+
 func TestMessage(t *testing.T) {
 	ss := state.NewSignedState(state.TestState)
 	msg := Message{


### PR DESCRIPTION
Right now a protocol can return a list of proposals to process in `sideEffects` This is used by a protocol to [queue up processing](https://github.com/statechannels/go-nitro/blob/e2df3ae7f32ce3c4c992a4fd11203e7a5031219f/protocols/virtualdefund/virtualdefund.go#L493) of other proposals that may now be unblocked because this protocol is done with the ledger.

However it looks like this isn't working correctly and the engine discards any`sideEffects.ProposalsToProcess`.

There were two problems:

1. `SideEffects.Merge` didn't merge `ProposalsToProcess`.  So when we attempted to merge the results we ended up dropping any `ProposalsToProcess`. I've added a small test for this and updated the merge function to include `ProposalsToProcess`.
2. We didn't instantiate a chan for `fromLedger` in the engine, which meant it was a nil chan. If we tried writing to it we'd end up blocking [forever](https://golangbyexample.com/send-receive-nil-channel-go/)

From running the integration tests it looks like they're is rarely a proposal queue which explains why this didn't cause test failures. (And even if a proposal is dropped from the queue its possible we'll receive a message from another peer that triggers a crank anyways)

I am slightly surprised this didn't show up testground runs more. Do we need to use a higher `jitter` value for more thorough message re-ordering?