### PR TITLE
Ignore proposals for completed objectives

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -177,6 +177,10 @@ func (e *Engine) handleProposal(proposal consensus_channel.Proposal) (EngineEven
 	if err != nil {
 		return EngineEvent{}, err
 	}
+	if obj.GetStatus() == protocols.Completed {
+		e.logger.Printf("Ignoring proposal for complected objective  %s", obj.Id())
+		return EngineEvent{}, nil
+	}
 	return e.attemptProgress(obj)
 }
 


### PR DESCRIPTION
Fixes #1007 

It's possible that a proposal can get queued and by the time we get around to processing it the objective has already completed (since we would receive the proposal in other messages). This results in the `Objective not Approved` error since the objective status isn't `Approved` it's `Complete`. 

Similar to what we do when handling messages, we now return early if the objective is already complete when processing an objective.

I've been able to reproduce it by running the test a lot; `go test ./client_test -count=100 -shuffle=on` would normally catch it. After this change I've run `go test ./client_test -count=100 -shuffle=on` and not run into it.