### PR TITLE
Extend directfund test to cover ERC20 tokens

### DIFF
--- a/client_test/directdefund_test.go
+++ b/client_test/directdefund_test.go
@@ -52,7 +52,7 @@ func TestDirectDefund(t *testing.T) {
 
 	// test successful condition for setup / teadown of unused ledger channel
 	{
-		channelId := directlyFundALedgerChannel(t, clientA, clientB)
+		channelId := directlyFundALedgerChannel(t, clientA, clientB, types.Address{})
 		directlyDefundALedgerChannel(t, clientA, clientB, channelId)
 
 		// Ensure that we no longer have a consensus channel in the store

--- a/client_test/directfund_test.go
+++ b/client_test/directfund_test.go
@@ -2,11 +2,16 @@
 package client_test // import "github.com/statechannels/go-nitro/client_test"
 
 import (
+	"os"
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/go-cmp/cmp"
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
@@ -18,9 +23,10 @@ import (
 
 const ledgerChannelDeposit = 5_000_000
 
-func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.Client) types.Destination {
+func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.Client, asset common.Address) types.Destination {
 	// Set up an outcome that requires both participants to deposit
-	outcome := testdata.Outcomes.Create(*alpha.Address, *beta.Address, ledgerChannelDeposit, ledgerChannelDeposit)
+	outcome := testdata.Outcomes.Create(*alpha.Address, *beta.Address, ledgerChannelDeposit, ledgerChannelDeposit, asset)
+
 	response := alpha.CreateLedgerChannel(*beta.Address, 0, outcome)
 
 	waitTimeForCompletedObjectiveIds(t, &alpha, defaultTimeout, response.Id)
@@ -55,7 +61,7 @@ func TestWhenObjectiveIsRejected(t *testing.T) {
 		_ = client.New(messageservice, chainServiceB, storeB, logDestination, &RejectingPolicyMaker{}, nil)
 	}
 
-	outcome := testdata.Outcomes.Create(alice.Address(), bob.Address(), ledgerChannelDeposit, ledgerChannelDeposit)
+	outcome := testdata.Outcomes.Create(alice.Address(), bob.Address(), ledgerChannelDeposit, ledgerChannelDeposit, types.Address{})
 	response := clientA.CreateLedgerChannel(bob.Address(), 0, outcome)
 
 	waitTimeForCompletedObjectiveIds(t, &clientA, time.Second, response.Id)
@@ -75,73 +81,85 @@ func TestWhenObjectiveIsRejected(t *testing.T) {
 	}
 }
 
+// testDirectFundWithAsset returns a function which tests the direct fund flow with the supplied asset. It is designed to be used as a subtest.
+func testDirectFundWithAsset(asset common.Address, sim *backends.SimulatedBackend, bindings chainservice.Bindings, ethAccounts []*bind.TransactOpts, logDestination *os.File) func(t *testing.T) {
+	return func(t *testing.T) {
+
+		// Spawn a pair of chain services
+		chainA, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[0], logDestination)
+		if err != nil {
+			t.Fatal(err)
+		}
+		chainB, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[1], logDestination)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		broker := messageservice.NewBroker()
+
+		clientA, storeA := setupClient(alice.PrivateKey, chainA, broker, logDestination, 0)
+		clientB, storeB := setupClient(bob.PrivateKey, chainB, broker, logDestination, 0)
+
+		directlyFundALedgerChannel(t, clientA, clientB, asset)
+		want := testdata.Outcomes.Create(*clientA.Address, *clientB.Address, ledgerChannelDeposit, ledgerChannelDeposit, asset)
+
+		assertLedgerChannelInBothStoresWithOutcome := func(want outcome.Exit, storeA, storeB store.Store) {
+			for _, store := range []store.Store{storeA, storeB} {
+				var con *consensus_channel.ConsensusChannel
+				var ok bool
+
+				// each client fetches the ConsensusChannel by reference to their counterparty
+				if store.GetChannelSecretKey() == &alice.PrivateKey {
+					con, ok = store.GetConsensusChannel(*storeB.GetAddress())
+				} else {
+					con, ok = store.GetConsensusChannel(*storeA.GetAddress())
+				}
+
+				if !ok {
+					t.Fatalf("expected a consensus channel to have been created")
+				}
+				vars := con.ConsensusVars()
+				got := vars.Outcome.AsOutcome()
+
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Fatalf("expected outcome to be %v, got %v:\n %v", want, got, diff)
+				}
+				if vars.TurnNum != 1 {
+					t.Fatal("expected consensus turn number to be the post fund setup 1, received #$v", vars.TurnNum)
+				}
+				if con.Leader() != *storeA.GetAddress() {
+					t.Fatalf("Expected %v as leader, but got %v", *storeA.GetAddress(), con.Leader())
+				}
+
+				if !con.OnChainFunding.IsNonZero() {
+					t.Fatal("Expected nonzero on chain funding, but got zero")
+				}
+
+				if _, channelStillInStore := store.GetChannelById(con.Id); channelStillInStore {
+					t.Fatalf("Expected channel to have been destroyed in %v's store, but it was not", store.GetAddress())
+				}
+			}
+		}
+
+		assertLedgerChannelInBothStoresWithOutcome(want, storeA, storeB)
+
+	}
+}
+
 // TestDirectFund uses the geth simulated backend
 func TestDirectFund(t *testing.T) {
+
+	// Setup long-running chain
+	sim, bindings, ethAccounts, err := chainservice.SetupSimulatedBackend(2)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Setup logging
 	logFile := "test_direct_fund.log"
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
-	// Setup chain service
-	sim, bindings, ethAccounts, err := chainservice.SetupSimulatedBackend(2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	chainA, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[0], logDestination)
-	if err != nil {
-		t.Fatal(err)
-	}
-	chainB, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[1], logDestination)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// End chain service setup
-
-	broker := messageservice.NewBroker()
-
-	clientA, storeA := setupClient(alice.PrivateKey, chainA, broker, logDestination, 0)
-	clientB, storeB := setupClient(bob.PrivateKey, chainB, broker, logDestination, 0)
-
-	directlyFundALedgerChannel(t, clientA, clientB)
-
-	want := testdata.Outcomes.Create(*clientA.Address, *clientB.Address, ledgerChannelDeposit, ledgerChannelDeposit)
-	// Ensure that we create a consensus channel in the store
-	for _, store := range []store.Store{storeA, storeB} {
-		var con *consensus_channel.ConsensusChannel
-		var ok bool
-
-		// each client fetches the ConsensusChannel by reference to their counterparty
-		if store.GetChannelSecretKey() == &alice.PrivateKey {
-			con, ok = store.GetConsensusChannel(*clientB.Address)
-		} else {
-			con, ok = store.GetConsensusChannel(*clientA.Address)
-		}
-
-		if !ok {
-			t.Fatalf("expected a consensus channel to have been created")
-		}
-		vars := con.ConsensusVars()
-		got := vars.Outcome.AsOutcome()
-
-		if diff := cmp.Diff(want, got); diff != "" {
-			t.Fatalf("expected outcome to be %v, got %v:\n %v", want, got, diff)
-		}
-		if vars.TurnNum != 1 {
-			t.Fatal("expected consensus turn number to be the post fund setup 1, received #$v", vars.TurnNum)
-		}
-		if con.Leader() != *clientA.Address {
-			t.Fatalf("Expected %v as leader, but got %v", clientA.Address, con.Leader())
-		}
-
-		if !con.OnChainFunding.IsNonZero() {
-			t.Fatal("Expected nonzero on chain funding, but got zero")
-		}
-
-		if _, channelStillInStore := store.GetChannelById(con.Id); channelStillInStore {
-			t.Fatalf("Expected channel to have been destroyed in %v's store, but it was not", store.GetAddress())
-		}
-
-	}
-
+	t.Run("native-asset", testDirectFundWithAsset(common.Address{}, sim, bindings, ethAccounts, logDestination))
+	t.Run("ERC20-asset", testDirectFundWithAsset(bindings.Token.Address, sim, bindings, ethAccounts, logDestination))
 }

--- a/client_test/payment_with_p2p_ms_test.go
+++ b/client_test/payment_with_p2p_ms_test.go
@@ -52,9 +52,9 @@ func TestPayments(t *testing.T) {
 	defer msgB.Close()
 	defer msgI.Close()
 
-	directlyFundALedgerChannel(t, clientA, clientI)
-	directlyFundALedgerChannel(t, clientI, clientB)
-	outcome := td.Outcomes.Create(alice.Address(), bob.Address(), 100, 100)
+	directlyFundALedgerChannel(t, clientA, clientI, types.Address{})
+	directlyFundALedgerChannel(t, clientI, clientB, types.Address{})
+	outcome := td.Outcomes.Create(alice.Address(), bob.Address(), 100, 100, types.Address{})
 	r := clientA.CreateVirtualPaymentChannel(
 		[]types.Address{irene.Address()},
 		bob.Address(),

--- a/client_test/virtualdefund_test.go
+++ b/client_test/virtualdefund_test.go
@@ -172,10 +172,10 @@ func TestWhenVirtualDefundObjectiveIsRejected(t *testing.T) {
 	}
 	clientI, storeI := setupClient(irene.PrivateKey, chainServiceI, broker, logDestination, meanMessageDelay)
 
-	directlyFundALedgerChannel(t, clientA, clientI)
-	directlyFundALedgerChannel(t, clientB, clientI)
+	directlyFundALedgerChannel(t, clientA, clientI, types.Address{})
+	directlyFundALedgerChannel(t, clientB, clientI, types.Address{})
 
-	outcome := td.Outcomes.Create(alice.Address(), bob.Address(), 1, 1)
+	outcome := td.Outcomes.Create(alice.Address(), bob.Address(), 1, 1, types.Address{})
 	response := clientA.CreateVirtualPaymentChannel(
 		[]types.Address{irene.Address()},
 		bob.Address(),

--- a/client_test/virtualfund_multi_party_test.go
+++ b/client_test/virtualfund_multi_party_test.go
@@ -28,9 +28,9 @@ func TestVirtualFundMultiParty(t *testing.T) {
 	clientBrian, _ := setupClient(brian.PrivateKey, chainServiceBr, broker, logDestination, 0)
 	clientIrene, _ := setupClient(irene.PrivateKey, chainServiceI, broker, logDestination, 0)
 
-	directlyFundALedgerChannel(t, clientAlice, clientIrene)
-	directlyFundALedgerChannel(t, clientIrene, clientBob)
-	directlyFundALedgerChannel(t, clientIrene, clientBrian)
+	directlyFundALedgerChannel(t, clientAlice, clientIrene, types.Address{})
+	directlyFundALedgerChannel(t, clientIrene, clientBob, types.Address{})
+	directlyFundALedgerChannel(t, clientIrene, clientBrian, types.Address{})
 
 	id := clientAlice.CreateVirtualPaymentChannel(
 		[]types.Address{irene.Address()},
@@ -41,6 +41,7 @@ func TestVirtualFundMultiParty(t *testing.T) {
 			bob.Address(),
 			1,
 			1,
+			types.Address{},
 		)).Id
 
 	id2 := clientAlice.CreateVirtualPaymentChannel(
@@ -52,6 +53,7 @@ func TestVirtualFundMultiParty(t *testing.T) {
 			brian.Address(),
 			1,
 			1,
+			types.Address{},
 		)).Id
 
 	waitTimeForCompletedObjectiveIds(t, &clientBob, defaultTimeout, id)

--- a/client_test/virtualfund_test.go
+++ b/client_test/virtualfund_test.go
@@ -12,13 +12,13 @@ import (
 )
 
 func openVirtualChannels(t *testing.T, clientA client.Client, clientB client.Client, clientI client.Client, numOfChannels uint) []types.Destination {
-	directlyFundALedgerChannel(t, clientA, clientI)
-	directlyFundALedgerChannel(t, clientI, clientB)
+	directlyFundALedgerChannel(t, clientA, clientI, types.Address{})
+	directlyFundALedgerChannel(t, clientI, clientB, types.Address{})
 
 	objectiveIds := make([]protocols.ObjectiveId, numOfChannels)
 	channelIds := make([]types.Destination, numOfChannels)
 	for i := 0; i < int(numOfChannels); i++ {
-		outcome := td.Outcomes.Create(alice.Address(), bob.Address(), 1, 1)
+		outcome := td.Outcomes.Create(alice.Address(), bob.Address(), 1, 1, types.Address{})
 		response := clientA.CreateVirtualPaymentChannel(
 			[]types.Address{irene.Address()},
 			bob.Address(),
@@ -69,7 +69,7 @@ func openN_HopVirtualChannels(t *testing.T, participants []client.Client, channe
 	// network is a line: A <-> B <-> C <-> D ... <-> X
 	for i, participant := range participants {
 		if i+1 < len(participants) {
-			directlyFundALedgerChannel(t, participant, participants[i+1])
+			directlyFundALedgerChannel(t, participant, participants[i+1], types.Address{})
 		}
 	}
 
@@ -85,7 +85,7 @@ func openN_HopVirtualChannels(t *testing.T, participants []client.Client, channe
 			intermediaries := counterparties[0:j]
 			intermediaryAddresses := clientsToAddresses(intermediaries)
 
-			outcome := td.Outcomes.Create(*alice.Address, *bob.Address, 1, 1)
+			outcome := td.Outcomes.Create(*alice.Address, *bob.Address, 1, 1, types.Address{})
 			response := alice.CreateVirtualPaymentChannel(
 				intermediaryAddresses,
 				*bob.Address,

--- a/client_test/virtualfund_with_message_delays_test.go
+++ b/client_test/virtualfund_with_message_delays_test.go
@@ -34,8 +34,8 @@ func TestVirtualFundWithMessageDelays(t *testing.T) {
 	clientB, _ := setupClient(bob.PrivateKey, chainServiceB, broker, logDestination, MAX_MESSAGE_DELAY)
 	clientI, _ := setupClient(irene.PrivateKey, chainServiceI, broker, logDestination, MAX_MESSAGE_DELAY)
 
-	directlyFundALedgerChannel(t, clientA, clientI)
-	directlyFundALedgerChannel(t, clientI, clientB)
+	directlyFundALedgerChannel(t, clientA, clientI, types.Address{})
+	directlyFundALedgerChannel(t, clientI, clientB, types.Address{})
 
 	ids := createVirtualChannels(clientA, bob.Address(), irene.Address(), 5)
 	waitTimeForCompletedObjectiveIds(t, &clientA, OBJECTIVE_TIMEOUT, ids...)
@@ -50,7 +50,7 @@ func TestVirtualFundWithMessageDelays(t *testing.T) {
 func createVirtualChannels(client client.Client, counterParty types.Address, intermediary types.Address, amountOfChannels uint) []protocols.ObjectiveId {
 	ids := make([]protocols.ObjectiveId, amountOfChannels)
 	for i := uint(0); i < amountOfChannels; i++ {
-		outcome := td.Outcomes.Create(*client.Address, counterParty, 1, 1)
+		outcome := td.Outcomes.Create(*client.Address, counterParty, 1, 1, types.Address{})
 		ids[i] = client.CreateVirtualPaymentChannel([]types.Address{intermediary}, counterParty, 0, outcome).Id
 	}
 	return ids

--- a/internal/testdata/states.go
+++ b/internal/testdata/states.go
@@ -17,9 +17,10 @@ type SimpleItem struct {
 }
 
 type outcomes struct {
-	// Create returns a simple outcome {a: aBalance, b: bBalance} in the
+	// Create returns a simple outcome {a: aBalance, b: bBalance} with the supplied
+	// erc20 token address as the asset. A zero address implies the
 	// zero-asset (chain-native token)
-	Create func(a, b types.Address, aBalance, bBalance uint) outcome.Exit
+	Create func(a, b types.Address, aBalance, bBalance uint, token common.Address) outcome.Exit
 	// CreateLongOutcome returns a simple outcome {addressOne: balanceOne ...} in the
 	// zero-asset (chain-native token)
 	// The outcome can be of arbitrary length, and is formed in order that the SimpleItems are provided
@@ -79,7 +80,7 @@ func createLedgerState(client, hub types.Address, clientBalance, hubBalance uint
 		client,
 		hub,
 	}
-	state.Outcome = Outcomes.Create(client, hub, clientBalance, hubBalance)
+	state.Outcome = Outcomes.Create(client, hub, clientBalance, hubBalance, common.Address{})
 	state.AppDefinition = types.Address{} // ledger channel running the consensus app
 	state.TurnNum = 0
 
@@ -87,9 +88,10 @@ func createLedgerState(client, hub types.Address, clientBalance, hubBalance uint
 }
 
 // createOutcome is a helper function to create a two-actor outcome
-func createOutcome(first types.Address, second types.Address, x, y uint) outcome.Exit {
+func createOutcome(first types.Address, second types.Address, x, y uint, asset common.Address) outcome.Exit {
 
 	return outcome.Exit{outcome.SingleAssetExit{
+		Asset: asset,
 		Allocations: outcome.Allocations{
 			outcome.Allocation{
 				Destination: types.AddressToDestination(first),


### PR DESCRIPTION
Changes:

* simulated backend distributed tokens to all accounts when it is setup
* the directfund test is repeated for native and then erc20 tokens.
* we do not yet currently support mixing of assets, this test just shows things work if we choose an asset and stick with it.


Towards https://github.com/statechannels/go-nitro/issues/1001