### PR TITLE
Handle proposals in sorted order

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -252,7 +252,7 @@ func (e *Engine) handleMessage(message protocols.Message) (EngineEvent, error) {
 
 	}
 
-	for _, entry := range message.LedgerProposals {
+	for _, entry := range message.SortedProposals() {
 		id := getProposalObjectiveId(entry.Proposal)
 		objective, err := e.store.GetObjectiveById(id)
 		if err != nil {


### PR DESCRIPTION
Fixes #885.

This updates `handleMessage` to consume the proposals in a sorted order (by channelId, and turn num) instead of whatever order they happen to be delivered in. I didn't really see a difference in performance with this chage.