### PR TITLE
Add Signal/Wait functions to Objective Request

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -113,7 +113,7 @@ func (c *Client) CreateVirtualPaymentChannel(Intermediaries []types.Address, Cou
 
 	// Send the event to the engine
 	c.engine.ObjectiveRequestsFromAPI <- objectiveRequest
-	<-objectiveRequest.ObjectiveStarted()
+	objectiveRequest.WaitForObjectiveToStart()
 	return objectiveRequest.Response(*c.Address, c.chainId)
 }
 
@@ -124,7 +124,7 @@ func (c *Client) CloseVirtualChannel(channelId types.Destination) protocols.Obje
 
 	// Send the event to the engine
 	c.engine.ObjectiveRequestsFromAPI <- objectiveRequest
-	<-objectiveRequest.ObjectiveStarted()
+	objectiveRequest.WaitForObjectiveToStart()
 	return objectiveRequest.Id(*c.Address, c.chainId)
 
 }
@@ -144,7 +144,7 @@ func (c *Client) CreateLedgerChannel(Counterparty types.Address, ChallengeDurati
 
 	// Send the event to the engine
 	c.engine.ObjectiveRequestsFromAPI <- objectiveRequest
-	<-objectiveRequest.ObjectiveStarted()
+	objectiveRequest.WaitForObjectiveToStart()
 	return objectiveRequest.Response(*c.Address, c.chainId)
 
 }
@@ -156,7 +156,7 @@ func (c *Client) CloseLedgerChannel(channelId types.Destination) protocols.Objec
 
 	// Send the event to the engine
 	c.engine.ObjectiveRequestsFromAPI <- objectiveRequest
-	<-objectiveRequest.ObjectiveStarted()
+	objectiveRequest.WaitForObjectiveToStart()
 	return objectiveRequest.Id(*c.Address, c.chainId)
 
 }

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -365,7 +365,7 @@ func (e *Engine) handleObjectiveRequest(or protocols.ObjectiveRequest) (EngineEv
 	objectiveId := or.Id(myAddress, chainId)
 	e.logger.Printf("handling new objective request for %s", objectiveId)
 	e.metrics.RecordObjectiveStarted(objectiveId)
-
+	defer or.SignalObjectiveStarted()
 	switch request := or.(type) {
 
 	case virtualfund.ObjectiveRequest:

--- a/internal/testdata/objectives.go
+++ b/internal/testdata/objectives.go
@@ -67,14 +67,14 @@ func genericVFO() virtualfund.Objective {
 	ts.Participants[1] = testactors.Irene.Address()
 	ts.Participants[2] = testactors.Bob.Address()
 
-	request := virtualfund.ObjectiveRequest{
-		Intermediaries:    []types.Address{ts.Participants[1]},
-		CounterParty:      ts.Participants[2],
-		ChallengeDuration: ts.ChallengeDuration,
-		Outcome:           ts.Outcome,
-		Nonce:             ts.ChannelNonce,
-		AppDefinition:     ts.AppDefinition,
-	}
+	request := virtualfund.NewObjectiveRequest(
+		[]types.Address{ts.Participants[1]},
+		ts.Participants[2],
+		ts.ChallengeDuration,
+		ts.Outcome,
+		ts.ChannelNonce,
+		ts.AppDefinition,
+	)
 	ledgerPath := createLedgerPath([]testactors.Actor{
 		testactors.Alice,
 		testactors.Irene,

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -350,9 +350,9 @@ func (r ObjectiveRequest) SignalObjectiveStarted() {
 	r.objectiveStarted <- struct{}{}
 }
 
-// ObjectiveStarted returns a channel used to signal when the objective is started
-func (r ObjectiveRequest) ObjectiveStarted() <-chan struct{} {
-	return r.objectiveStarted
+// WaitForObjectiveToStart blocks until the objective starts
+func (r ObjectiveRequest) WaitForObjectiveToStart() {
+	<-r.objectiveStarted
 }
 
 // Id returns the objective id for the request.

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -333,7 +333,26 @@ func (o *Objective) clone() Objective {
 
 // ObjectiveRequest represents a request to create a new direct defund objective.
 type ObjectiveRequest struct {
-	ChannelId types.Destination
+	ChannelId        types.Destination
+	objectiveStarted chan struct{}
+}
+
+// NewObjectiveRequest creates a new ObjectiveRequest.
+func NewObjectiveRequest(channelId types.Destination) ObjectiveRequest {
+	return ObjectiveRequest{
+		ChannelId:        channelId,
+		objectiveStarted: make(chan struct{}),
+	}
+}
+
+// SignalObjectiveStarted is used by the engine to signal the objective has been started.
+func (r ObjectiveRequest) SignalObjectiveStarted() {
+	r.objectiveStarted <- struct{}{}
+}
+
+// ObjectiveStarted returns a channel used to signal when the objective is started
+func (r ObjectiveRequest) ObjectiveStarted() <-chan struct{} {
+	return r.objectiveStarted
 }
 
 // Id returns the objective id for the request.

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -347,7 +347,7 @@ func NewObjectiveRequest(channelId types.Destination) ObjectiveRequest {
 
 // SignalObjectiveStarted is used by the engine to signal the objective has been started.
 func (r ObjectiveRequest) SignalObjectiveStarted() {
-	r.objectiveStarted <- struct{}{}
+	close(r.objectiveStarted)
 }
 
 // WaitForObjectiveToStart blocks until the objective starts

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -148,9 +148,7 @@ func ConstructObjectiveFromPayload(
 	}
 
 	cId := s.ChannelId()
-	request := ObjectiveRequest{
-		ChannelId: cId,
-	}
+	request := NewObjectiveRequest(cId)
 	return NewObjective(request, preapprove, getConsensusChannel)
 }
 

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -75,7 +75,7 @@ func newTestObjective() (Objective, error) {
 	getConsensusChannel := func(id types.Destination) (channel *consensus_channel.ConsensusChannel, err error) {
 		return cc, nil
 	}
-	request := ObjectiveRequest{ChannelId: cc.Id}
+	request := NewObjectiveRequest(cc.Id)
 	// Assert that valid constructor args do not result in error
 	o, err := NewObjective(request, true, getConsensusChannel)
 	if err != nil {

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -474,7 +474,7 @@ func NewObjectiveRequest(
 
 // SignalObjectiveStarted is used by the engine to signal the objective has been started.
 func (r ObjectiveRequest) SignalObjectiveStarted() {
-	r.objectiveStarted <- struct{}{}
+	close(r.objectiveStarted)
 }
 
 // WaitForObjectiveToStart blocks until the objective starts

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -477,9 +477,9 @@ func (r ObjectiveRequest) SignalObjectiveStarted() {
 	r.objectiveStarted <- struct{}{}
 }
 
-// ObjectiveStarted returns a channel used to signal when the objective is started
-func (r ObjectiveRequest) ObjectiveStarted() <-chan struct{} {
-	return r.objectiveStarted
+// WaitForObjectiveToStart blocks until the objective starts
+func (r ObjectiveRequest) WaitForObjectiveToStart() {
+	<-r.objectiveStarted
 }
 
 // Id returns the objective id for the request.

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -451,6 +451,35 @@ type ObjectiveRequest struct {
 	AppDefinition     types.Address
 	AppData           types.Bytes
 	Nonce             uint64
+	objectiveStarted  chan struct{}
+}
+
+// NewObjectiveRequest creates a new ObjectiveRequest.
+func NewObjectiveRequest(
+	counterparty types.Address,
+	challengeDuration uint32,
+	outcome outcome.Exit,
+	nonce uint64,
+	appDefinition types.Address,
+) ObjectiveRequest {
+	return ObjectiveRequest{
+		CounterParty:      counterparty,
+		ChallengeDuration: challengeDuration,
+		Outcome:           outcome,
+		Nonce:             nonce,
+		AppDefinition:     appDefinition,
+		objectiveStarted:  make(chan struct{}),
+	}
+}
+
+// SignalObjectiveStarted is used by the engine to signal the objective has been started.
+func (r ObjectiveRequest) SignalObjectiveStarted() {
+	r.objectiveStarted <- struct{}{}
+}
+
+// ObjectiveStarted returns a channel used to signal when the objective is started
+func (r ObjectiveRequest) ObjectiveStarted() <-chan struct{} {
+	return r.objectiveStarted
 }
 
 // Id returns the objective id for the request.

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -58,13 +58,13 @@ func TestNew(t *testing.T) {
 	getByConsensus := func(id types.Address) (*consensus_channel.ConsensusChannel, bool) {
 		return nil, false
 	}
-	request := ObjectiveRequest{
-		CounterParty:      testState.Participants[1],
-		ChallengeDuration: testState.ChallengeDuration,
-		Outcome:           testState.Outcome,
-		AppDefinition:     testState.AppDefinition,
-		AppData:           testState.AppData,
-	}
+	request := NewObjectiveRequest(
+		testState.Participants[1],
+		testState.ChallengeDuration,
+		testState.Outcome,
+		0,
+		testState.AppDefinition,
+	)
 	// Assert that valid constructor args do not result in error
 	if _, err := NewObjective(request, false, testState.Participants[0], big.NewInt(TEST_CHAIN_ID), getByParticipant, getByConsensus); err != nil {
 		t.Error(err)

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -118,4 +118,6 @@ const (
 // ObjectiveRequest is a request to create a new objective.
 type ObjectiveRequest interface {
 	Id(types.Address, *big.Int) ObjectiveId
+	ObjectiveStarted() <-chan struct{}
+	SignalObjectiveStarted()
 }

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -118,6 +118,6 @@ const (
 // ObjectiveRequest is a request to create a new objective.
 type ObjectiveRequest interface {
 	Id(types.Address, *big.Int) ObjectiveId
-	ObjectiveStarted() <-chan struct{}
+	WaitForObjectiveToStart()
 	SignalObjectiveStarted()
 }

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -749,7 +749,7 @@ func (r ObjectiveRequest) SignalObjectiveStarted() {
 	r.objectiveStarted <- struct{}{}
 }
 
-// ObjectiveStarted returns a channel used to signal when the objective is started
-func (r ObjectiveRequest) ObjectiveStarted() <-chan struct{} {
-	return r.objectiveStarted
+// WaitForObjectiveToStart blocks until the objective starts
+func (r ObjectiveRequest) WaitForObjectiveToStart() {
+	<-r.objectiveStarted
 }

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -746,7 +746,7 @@ func validateFinalOutcome(vFixed state.FixedPart, initialOutcome outcome.SingleA
 
 // SignalObjectiveStarted is used by the engine to signal the objective has been started.
 func (r ObjectiveRequest) SignalObjectiveStarted() {
-	r.objectiveStarted <- struct{}{}
+	close(r.objectiveStarted)
 }
 
 // WaitForObjectiveToStart blocks until the objective starts

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -197,7 +197,7 @@ func ConstructObjectiveFromPayload(
 			return Objective{}, err
 		}
 		return NewObjective(
-			ObjectiveRequest{cId, make(chan struct{})},
+			NewObjectiveRequest(cId),
 			preapprove,
 			myAddress,
 			latestVoucherAmount,
@@ -227,7 +227,7 @@ func ConstructObjectiveFromPayload(
 		}
 
 		return NewObjective(
-			ObjectiveRequest{ss.ChannelId(), make(chan struct{})},
+			NewObjectiveRequest(ss.ChannelId()),
 			preapprove,
 			myAddress,
 			latestVoucherAmount,

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -36,9 +36,7 @@ func TestCrank(t *testing.T) {
 func TestInvalidUpdate(t *testing.T) {
 	data := generateTestData()
 	vId := data.vFinal.ChannelId()
-	request := ObjectiveRequest{
-		ChannelId: vId,
-	}
+	request := NewObjectiveRequest(vId)
 
 	getChannel, getConsensusChannel := generateStoreGetters(0, vId, data.vFinal)
 
@@ -68,10 +66,7 @@ func testUpdateAs(my ta.Actor) func(t *testing.T) {
 	return func(t *testing.T) {
 		data := generateTestData()
 		vId := data.vFinal.ChannelId()
-		request := ObjectiveRequest{
-			ChannelId: vId,
-		}
-
+		request := NewObjectiveRequest(vId)
 		getChannel, getConsensusChannel := generateStoreGetters(my.Role, vId, data.vInitial)
 
 		virtualDefund, err := NewObjective(request, false, my.Address(), nil, getChannel, getConsensusChannel)
@@ -101,9 +96,7 @@ func testCrankAs(my ta.Actor) func(t *testing.T) {
 	return func(t *testing.T) {
 		data := generateTestData()
 		vId := data.vFinal.ChannelId()
-		request := ObjectiveRequest{
-			ChannelId: vId,
-		}
+		request := NewObjectiveRequest(vId)
 
 		// If we're Alice we should have the latest payment amount
 		// Otherwise we have an older or no payment amount
@@ -215,9 +208,7 @@ func TestConstructObjectiveFromState(t *testing.T) {
 func TestApproveReject(t *testing.T) {
 	data := generateTestData()
 	vId := data.vFinal.ChannelId()
-	request := ObjectiveRequest{
-		ChannelId: vId,
-	}
+	request := NewObjectiveRequest(vId)
 
 	getChannel, getConsensusChannel := generateStoreGetters(0, vId, data.vInitial)
 

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -764,7 +764,7 @@ func (r ObjectiveRequest) Id(myAddress types.Address, chainId *big.Int) protocol
 
 // SignalObjectiveStarted is used by the engine to signal the objective has been started.
 func (r ObjectiveRequest) SignalObjectiveStarted() {
-	r.objectiveStarted <- struct{}{}
+	close(r.objectiveStarted)
 }
 
 // WaitForObjectiveToStart blocks until the objective starts

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -767,9 +767,9 @@ func (r ObjectiveRequest) SignalObjectiveStarted() {
 	r.objectiveStarted <- struct{}{}
 }
 
-// ObjectiveStarted returns a channel used to signal when the objective is started
-func (r ObjectiveRequest) ObjectiveStarted() <-chan struct{} {
-	return r.objectiveStarted
+// WaitForObjectiveToStart blocks until the objective starts
+func (r ObjectiveRequest) WaitForObjectiveToStart() {
+	<-r.objectiveStarted
 }
 
 // ObjectiveResponse is the type returned across the API in response to the ObjectiveRequest.

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -734,12 +734,42 @@ type ObjectiveRequest struct {
 	Outcome           outcome.Exit
 	Nonce             uint64
 	AppDefinition     types.Address
+	objectiveStarted  chan struct{}
+}
+
+// NewObjectiveRequest creates a new ObjectiveRequest.
+func NewObjectiveRequest(intermediaries []types.Address,
+	counterparty types.Address,
+	challengeDuration uint32,
+	outcome outcome.Exit,
+	nonce uint64,
+	appDefinition types.Address,
+) ObjectiveRequest {
+	return ObjectiveRequest{
+		Intermediaries:    intermediaries,
+		CounterParty:      counterparty,
+		ChallengeDuration: challengeDuration,
+		Outcome:           outcome,
+		Nonce:             nonce,
+		AppDefinition:     appDefinition,
+		objectiveStarted:  make(chan struct{}),
+	}
 }
 
 // Id returns the objective id for the request.
 func (r ObjectiveRequest) Id(myAddress types.Address, chainId *big.Int) protocols.ObjectiveId {
 	idStr := r.channelID(myAddress, chainId).String()
 	return protocols.ObjectiveId(ObjectivePrefix + idStr)
+}
+
+// SignalObjectiveStarted is used by the engine to signal the objective has been started.
+func (r ObjectiveRequest) SignalObjectiveStarted() {
+	r.objectiveStarted <- struct{}{}
+}
+
+// ObjectiveStarted returns a channel used to signal when the objective is started
+func (r ObjectiveRequest) ObjectiveStarted() <-chan struct{} {
+	return r.objectiveStarted
 }
 
 // ObjectiveResponse is the type returned across the API in response to the ObjectiveRequest.


### PR DESCRIPTION
Fixes #1026 

This PR adds Signal and Wait functions to `ObjectiveRequest` so the engine can alert the client API that the objective request has been processed and the objective has "started".

This means that any client API calls that create an objective will block until the objective has been created, cranked, and stored in the store. This ensures that querying the store after the API call returns will always contain the new objective.

The objective request interface has two new functions:
```
// ObjectiveRequest is a request to create a new objective.
type ObjectiveRequest interface {
	Id(types.Address, *big.Int) ObjectiveId
	WaitForObjectiveToStart()
	SignalObjectiveStarted()
}
```

`WaitForObjectiveToStart()` is called by the client API after submitting the objective request to the engine. It blocks until the engine calls `SignalObjectiveStarted()`.

I've also created constructor functions `NewObjectiveRequest` so we don't have to expose the chan we use for signalling.

