### PR TITLE
Fix chain service polling in batches

### DIFF
--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -298,7 +298,7 @@ func (ecs *EthChainService) fetchLogsFromChain(from *big.Int, to *big.Int) ([]et
 
 	// Big.ints make it hard to parse but this is the condition:
 	// toBlock - fromBlock > MAX_QUERY_BLOCK_RANGE
-	for big.NewInt(0).Sub(toBlock, from).Cmp(big.NewInt(MAX_QUERY_BLOCK_RANGE)) > 0 {
+	for big.NewInt(0).Sub(toBlock, fromBlock).Cmp(big.NewInt(MAX_QUERY_BLOCK_RANGE)) > 0 {
 
 		nextBlock := big.NewInt(0).Add(fromBlock, big.NewInt(MAX_QUERY_BLOCK_RANGE))
 

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -305,7 +305,7 @@ func (ecs *EthChainService) fetchLogsFromChain(from *big.Int, to *big.Int) ([]et
 		query := ethereum.FilterQuery{
 			Addresses: []common.Address{ecs.naAddress},
 			FromBlock: fromBlock,
-			ToBlock:   toBlock,
+			ToBlock:   nextBlock,
 		}
 
 		fetchedLogs, err := ecs.chain.FilterLogs(context.Background(), query)


### PR DESCRIPTION
Fixes two errors with batched log polling in the chain service.

- We were using the original parameter passed into the function instead of `fromBlock` which gets updated.
- We were using the final `toBlock` instead of `nextBlock` in our query,.


TODO:
Figure out a way to test this.