### PR TITLE
Introduce API to allow querying for channel info

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -183,6 +183,30 @@ func (c Channel) PostFundComplete() bool {
 	return c.SignedStateForTurnNum[PostFundTurnNum].HasAllSignatures()
 }
 
+// FinalSignedByMe returns true if the calling client has signed the post fund setup state, false otherwise.
+func (c Channel) FinalSignedByMe() bool {
+	for _, ss := range c.SignedStateForTurnNum {
+		if ss.HasSignatureForParticipant(c.MyIndex) && ss.State().IsFinal {
+			return true
+		}
+	}
+	return false
+}
+
+// FinalCompleted() returns true if I have a complete set of signatures on a final state, false otherwise.
+func (c Channel) FinalCompleted() bool {
+	if c.latestSupportedStateTurnNum == MaxTurnNum {
+		return false
+	}
+
+	return c.SignedStateForTurnNum[c.latestSupportedStateTurnNum].State().IsFinal
+}
+
+// HasSupportedState returns true if the channel has a supported state, false otherwise.
+func (c Channel) HasSupportedState() bool {
+	return c.latestSupportedStateTurnNum != MaxTurnNum
+}
+
 // LatestSupportedState returns the latest supported state. A state is supported if it is signed
 // by all participants.
 func (c Channel) LatestSupportedState() (state.State, error) {

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -193,7 +193,7 @@ func (c Channel) FinalSignedByMe() bool {
 	return false
 }
 
-// FinalCompleted() returns true if I have a complete set of signatures on a final state, false otherwise.
+// FinalCompleted returns true if I have a complete set of signatures on a final state, false otherwise.
 func (c Channel) FinalCompleted() bool {
 	if c.latestSupportedStateTurnNum == MaxTurnNum {
 		return false

--- a/client/client.go
+++ b/client/client.go
@@ -185,5 +185,5 @@ func (c *Client) GetPaymentChannel(id types.Destination) (PaymentChannelInfo, er
 // GetLedgerChannel returns the ledger channel with the given id.
 // If no ledger channel exists with the given id an error is returned.
 func (c *Client) GetLedgerChannel(id types.Destination) (LedgerChannelInfo, error) {
-	return GetLedgerChannelInfo(id, c.store)
+	return getLedgerChannelInfo(id, c.store)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -173,7 +173,7 @@ func (c *Client) Pay(channelId types.Destination, amount *big.Int) {
 	c.engine.PaymentRequestsFromAPI <- engine.PaymentRequest{ChannelId: channelId, Amount: amount}
 }
 
-// GetPaymentChannel returns the ledger channel with the given id.
+// GetPaymentChannel returns the payment channel with the given id.
 // If no ledger channel exists with the given id an error is returned.
 func (c *Client) GetPaymentChannel(id types.Destination) (query.PaymentChannelInfo, error) {
 

--- a/client/client.go
+++ b/client/client.go
@@ -2,7 +2,6 @@
 package client // import "github.com/statechannels/go-nitro/client"
 
 import (
-	"errors"
 	"io"
 	"math/big"
 	"math/rand"
@@ -174,12 +173,8 @@ func (c *Client) Pay(channelId types.Destination, amount *big.Int) {
 // GetPaymentChannel returns the ledger channel with the given id.
 // If no ledger channel exists with the given id an error is returned.
 func (c *Client) GetPaymentChannel(id types.Destination) (PaymentChannelInfo, error) {
-	res, ok := c.store.GetChannelById(id)
-	if !ok {
-		return PaymentChannelInfo{}, errors.New("channel not found")
-	}
 
-	return getPaymentChannelInfo(res), nil
+	return getPaymentChannelInfo(id, c.store)
 }
 
 // GetLedgerChannel returns the ledger channel with the given id.

--- a/client/client.go
+++ b/client/client.go
@@ -7,7 +7,6 @@ import (
 	"math/big"
 	"math/rand"
 
-	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client/engine"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
@@ -181,51 +180,6 @@ func (c *Client) GetPaymentChannel(id types.Destination) (PaymentChannelInfo, er
 	return getPaymentChannelInfo(res), nil
 }
 
-// getPaymentChannelStatus returns the status of the channel
-func getPaymentChannelStatus(c *channel.Channel) ChannelStatus {
-	if c.FinalSignedByMe() {
-		if c.FinalCompleted() {
-			return Complete
-		}
-		return Closing
-	}
-	if !c.PostFundComplete() {
-		return Proposed
-	}
-
-	return Ready
-}
-
-func getPaymentChannelBalance(c *channel.Channel) PaymentChannelBalance {
-
-	latest := c.PreFundState()
-	if c.HasSupportedState() {
-
-		supported, _ := c.LatestSupportedState()
-		latest = supported
-	}
-
-	numParticipants := len(latest.Participants)
-	// TODO: We assume single asset outcomes
-	outcome := latest.Outcome[0]
-	asset := outcome.Asset
-	payer := latest.Participants[0]
-	payee := latest.Participants[numParticipants-1]
-	paidSoFar := outcome.Allocations[1].Amount
-	remaining := outcome.Allocations[0].Amount
-	return PaymentChannelBalance{
-		AssetAddress:   asset,
-		Payer:          payer,
-		Payee:          payee,
-		PaidSoFar:      paidSoFar,
-		RemainingFunds: remaining,
-	}
-}
-
-func getPaymentChannelInfo(channel *channel.Channel) PaymentChannelInfo {
-	return PaymentChannelInfo{
-		ID:      channel.Id,
-		Status:  getPaymentChannelStatus(channel),
-		Balance: getPaymentChannelBalance(channel),
-	}
+func (c *Client) GetLedgerChannel(id types.Destination) (LedgerChannelInfo, error) {
+	return GetLedgerChannelInfo(id, c.store)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	"github.com/statechannels/go-nitro/client/engine/store"
+	"github.com/statechannels/go-nitro/client/query"
 	"github.com/statechannels/go-nitro/payments"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/protocols/directdefund"
@@ -174,13 +175,13 @@ func (c *Client) Pay(channelId types.Destination, amount *big.Int) {
 
 // GetPaymentChannel returns the ledger channel with the given id.
 // If no ledger channel exists with the given id an error is returned.
-func (c *Client) GetPaymentChannel(id types.Destination) (PaymentChannelInfo, error) {
+func (c *Client) GetPaymentChannel(id types.Destination) (query.PaymentChannelInfo, error) {
 
-	return getPaymentChannelInfo(id, c.store, c.vm)
+	return query.GetPaymentChannelInfo(id, c.store, c.vm)
 }
 
 // GetLedgerChannel returns the ledger channel with the given id.
 // If no ledger channel exists with the given id an error is returned.
-func (c *Client) GetLedgerChannel(id types.Destination) (LedgerChannelInfo, error) {
-	return getLedgerChannelInfo(id, c.store)
+func (c *Client) GetLedgerChannel(id types.Destination) (query.LedgerChannelInfo, error) {
+	return query.GetLedgerChannelInfo(id, c.store)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -171,6 +171,8 @@ func (c *Client) Pay(channelId types.Destination, amount *big.Int) {
 	c.engine.PaymentRequestsFromAPI <- engine.PaymentRequest{ChannelId: channelId, Amount: amount}
 }
 
+// GetPaymentChannel returns the ledger channel with the given id.
+// If no ledger channel exists with the given id an error is returned.
 func (c *Client) GetPaymentChannel(id types.Destination) (PaymentChannelInfo, error) {
 	res, ok := c.store.GetChannelById(id)
 	if !ok {
@@ -180,6 +182,8 @@ func (c *Client) GetPaymentChannel(id types.Destination) (PaymentChannelInfo, er
 	return getPaymentChannelInfo(res), nil
 }
 
+// GetLedgerChannel returns the ledger channel with the given id.
+// If no ledger channel exists with the given id an error is returned.
 func (c *Client) GetLedgerChannel(id types.Destination) (LedgerChannelInfo, error) {
 	return GetLedgerChannelInfo(id, c.store)
 }

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -83,7 +83,7 @@ type CompletedObjectiveEvent struct {
 type Response struct{}
 
 // NewEngine is the constructor for an Engine
-func New(msg messageservice.MessageService, chain chainservice.ChainService, store store.Store, logDestination io.Writer, policymaker PolicyMaker, metricsApi MetricsApi) Engine {
+func New(vm *payments.VoucherManager, msg messageservice.MessageService, chain chainservice.ChainService, store store.Store, logDestination io.Writer, policymaker PolicyMaker, metricsApi MetricsApi) Engine {
 	e := Engine{}
 
 	e.store = store
@@ -107,7 +107,7 @@ func New(msg messageservice.MessageService, chain chainservice.ChainService, sto
 
 	e.policymaker = policymaker
 
-	e.vm = payments.NewVoucherManager(*store.GetAddress())
+	e.vm = vm
 
 	e.logger.Println("Constructed Engine")
 

--- a/client/query.go
+++ b/client/query.go
@@ -3,6 +3,9 @@ package client
 import (
 	"math/big"
 
+	"github.com/statechannels/go-nitro/channel"
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/client/engine/store"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -12,6 +15,68 @@ const Proposed ChannelStatus = "Proposed"
 const Ready ChannelStatus = "Ready"
 const Closing ChannelStatus = "Closing"
 const Complete ChannelStatus = "Complete"
+
+type PaymentChannelBalance struct {
+	AssetAddress   types.Address
+	Payee          types.Address
+	Payer          types.Address
+	PaidSoFar      *big.Int
+	RemainingFunds *big.Int
+}
+type PaymentChannelInfo struct {
+	ID      types.Destination
+	Status  ChannelStatus
+	Balance PaymentChannelBalance
+}
+
+// getStatusFromChannel returns the status of the channel
+func getStatusFromChannel(c *channel.Channel) ChannelStatus {
+	if c.FinalSignedByMe() {
+		if c.FinalCompleted() {
+			return Complete
+		}
+		return Closing
+	}
+	if !c.PostFundComplete() {
+		return Proposed
+	}
+
+	return Ready
+}
+
+func getPaymentChannelBalance(c *channel.Channel) PaymentChannelBalance {
+
+	latest := c.PreFundState()
+	if c.HasSupportedState() {
+
+		supported, _ := c.LatestSupportedState()
+		latest = supported
+	}
+
+	numParticipants := len(latest.Participants)
+	// TODO: We assume single asset outcomes
+	outcome := latest.Outcome[0]
+	asset := outcome.Asset
+	payer := latest.Participants[0]
+	payee := latest.Participants[numParticipants-1]
+	paidSoFar := outcome.Allocations[1].Amount
+	remaining := outcome.Allocations[0].Amount
+	return PaymentChannelBalance{
+		AssetAddress:   asset,
+		Payer:          payer,
+		Payee:          payee,
+		PaidSoFar:      paidSoFar,
+		RemainingFunds: remaining,
+	}
+}
+
+func getPaymentChannelInfo(channel *channel.Channel) PaymentChannelInfo {
+	return PaymentChannelInfo{
+		ID:      channel.Id,
+		Status:  getStatusFromChannel(channel),
+		Balance: getPaymentChannelBalance(channel),
+	}
+}
 
 type LedgerChannelInfo struct {
 	ID      types.Destination
@@ -26,17 +91,55 @@ type LedgerChannelBalance struct {
 	ClientBalance *big.Int
 }
 
-type PaymentChannelBalance struct {
-	AssetAddress   types.Address
-	Payee          types.Address
-	Payer          types.Address
-	PaidSoFar      *big.Int
-	RemainingFunds *big.Int
+func getLatest(channel *channel.Channel) state.State {
+	if channel.HasSupportedState() {
+		supported, _ := channel.LatestSupportedState()
+		return supported
+	}
+	return channel.PreFundState()
 }
-type PaymentChannelInfo struct {
-	ID      types.Destination
-	Status  ChannelStatus
-	Balance PaymentChannelBalance
+func getBalanceFromState(latest state.State) LedgerChannelBalance {
+
+	// TODO: We assume single asset outcomes
+	outcome := latest.Outcome[0]
+	asset := outcome.Asset
+	client := latest.Participants[0]
+	clientBalance := outcome.Allocations[0].Amount
+	hub := latest.Participants[1]
+	hubBalance := outcome.Allocations[1].Amount
+
+	return LedgerChannelBalance{
+		AssetAddress:  asset,
+		Hub:           hub,
+		Client:        client,
+		HubBalance:    hubBalance,
+		ClientBalance: clientBalance,
+	}
+}
+
+func GetLedgerChannelInfo(id types.Destination, store store.Store) (LedgerChannelInfo, error) {
+	c, ok := store.GetChannelById(id)
+	if ok {
+
+		return LedgerChannelInfo{
+			ID:      c.Id,
+			Status:  getStatusFromChannel(c),
+			Balance: getBalanceFromState(getLatest(c)),
+		}, nil
+	}
+
+	con, err := store.GetConsensusChannelById(id)
+	if err != nil {
+		return LedgerChannelInfo{}, err
+	}
+
+	latest := con.ConsensusVars().AsState(con.FixedPart())
+	return LedgerChannelInfo{
+		ID:      con.Id,
+		Status:  Ready,
+		Balance: getBalanceFromState(latest),
+	}, nil
+
 }
 
 type NitroQuery interface {

--- a/client/query.go
+++ b/client/query.go
@@ -33,6 +33,7 @@ type PaymentChannelInfo struct {
 	Balance PaymentChannelBalance
 }
 
+// TODO: This doesn't work for virtual defunding, since we store values directly on the objective
 // getStatusFromChannel returns the status of the channel
 func getStatusFromChannel(c *channel.Channel) ChannelStatus {
 	if c.FinalSignedByMe() {

--- a/client/query.go
+++ b/client/query.go
@@ -128,9 +128,9 @@ func getLedgerBalanceFromState(latest state.State) LedgerChannelBalance {
 	}
 }
 
-// GetLedgerChannelInfo returns the LedgerChannelInfo for the given channel
+// getLedgerChannelInfo returns the LedgerChannelInfo for the given channel
 // It does this by querying the provided store
-func GetLedgerChannelInfo(id types.Destination, store store.Store) (LedgerChannelInfo, error) {
+func getLedgerChannelInfo(id types.Destination, store store.Store) (LedgerChannelInfo, error) {
 	c, ok := store.GetChannelById(id)
 	if ok {
 

--- a/client/query.go
+++ b/client/query.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"math/big"
+
+	"github.com/statechannels/go-nitro/types"
+)
+
+type ChannelStatus string
+
+const Proposed ChannelStatus = "Proposed"
+const Ready ChannelStatus = "Ready"
+const Closing ChannelStatus = "Closing"
+const Complete ChannelStatus = "Complete"
+
+type LedgerChannelInfo struct {
+	ID      types.Destination
+	Status  ChannelStatus
+	Balance LedgerChannelBalance
+}
+type LedgerChannelBalance struct {
+	AssetAddress  types.Address
+	Hub           types.Address
+	Client        types.Address
+	HubBalance    *big.Int
+	ClientBalance *big.Int
+}
+
+type PaymentChannelBalance struct {
+	AssetAddress   types.Address
+	Payee          types.Address
+	Payer          types.Address
+	PaidSoFar      *big.Int
+	RemainingFunds *big.Int
+}
+type PaymentChannelInfo struct {
+	ID      types.Destination
+	Status  ChannelStatus
+	Balance PaymentChannelBalance
+}
+
+type NitroQuery interface {
+	// GetPaymentChannelByReceiver returns the first payment found channel with the given receiver.
+	// If no payment channel exists nil is returned.
+	GetPaymentChannelByReceiver(receiver types.Address) PaymentChannelInfo
+	// GetLedgerChannelByHub returns the first ledger channel found with the given hub.
+	// If no ledger channel exists nil is returned.
+	GetLedgerChannelByHub(Hub types.Address) LedgerChannelInfo
+	// GetLedgerChannel returnns the ledger channel for the given id.
+	// If no ledger channel exists nil is returned.
+	GetLedgerChannel(id types.Destination) LedgerChannelInfo
+	// GetPaymentChannel returnns the ledger channel for the given id.
+	// If no ledger channel exists nil is returned.
+	GetPaymentChannel(id types.Destination) PaymentChannelInfo
+}

--- a/client/query/query.go
+++ b/client/query/query.go
@@ -27,6 +27,7 @@ func getStatusFromChannel(c *channel.Channel) ChannelStatus {
 	return Ready
 }
 
+// getPaymentChannelBalance generates a PaymentChannelBalance from the given participants and outcome
 func getPaymentChannelBalance(participants []types.Address, outcome outcome.Exit) PaymentChannelBalance {
 
 	numParticipants := len(participants)
@@ -59,7 +60,7 @@ func getLatestSupported(channel *channel.Channel) state.State {
 // getLedgerBalanceFromState returns the balance of the ledger channel from the given state
 func getLedgerBalanceFromState(latest state.State) LedgerChannelBalance {
 
-	// TODO: We assume single asset outcomes
+	// TODO: We assume single asset outcomesch
 	outcome := latest.Outcome[0]
 	asset := outcome.Asset
 	client := latest.Participants[0]

--- a/client/query/query.go
+++ b/client/query/query.go
@@ -46,7 +46,8 @@ func getPaymentChannelBalance(participants []types.Address, outcome outcome.Exit
 	}
 }
 
-// getLatestSupported returns the latest supported state of the channel or the prefund state if no supported state exists
+// getLatestSupported returns the latest supported state of the channel
+// or the prefund state if no supported state exists
 func getLatestSupported(channel *channel.Channel) state.State {
 	if channel.HasSupportedState() {
 		supported, _ := channel.LatestSupportedState()
@@ -75,6 +76,8 @@ func getLedgerBalanceFromState(latest state.State) LedgerChannelBalance {
 	}
 }
 
+// GetPaymentChannelInfo returns the PaymentChannelInfo for the given channel
+// It does this by querying the provided store and voucher manager
 func GetPaymentChannelInfo(id types.Destination, store store.Store, vm *payments.VoucherManager) (PaymentChannelInfo, error) {
 
 	// This is slightly awkward but if the virtual defunding objective is complete it won't come back if we query by channel id
@@ -83,7 +86,8 @@ func GetPaymentChannelInfo(id types.Destination, store store.Store, vm *payments
 	fetchedDefund, err := store.GetObjectiveById(virtualDefundId)
 	isVirtualDefund := err == nil
 
-	// Since virtual defunding stores all state updates on the objective instead of the store we need to manually check the objective
+	// Since virtual defunding stores all state updates on the objective
+	// instead of the store we need to manually check the objective
 	if isVirtualDefund {
 		defund := fetchedDefund.(*virtualdefund.Objective)
 		status := Closing
@@ -91,6 +95,7 @@ func GetPaymentChannelInfo(id types.Destination, store store.Store, vm *payments
 		if defund.Status == protocols.Completed {
 			status = Complete
 		}
+
 		return PaymentChannelInfo{
 			ID:      id,
 			Status:  status,
@@ -99,9 +104,9 @@ func GetPaymentChannelInfo(id types.Destination, store store.Store, vm *payments
 	}
 
 	// Otherwise we can just check the store
-	c, ok := store.GetChannelById(id)
+	c, channelFound := store.GetChannelById(id)
 
-	if ok {
+	if channelFound {
 		status := getStatusFromChannel(c)
 		balance := getPaymentChannelBalance(c.Participants, getLatestSupported(c).Outcome)
 

--- a/client/query/query.go
+++ b/client/query/query.go
@@ -1,8 +1,7 @@
-package client
+package query
 
 import (
 	"fmt"
-	"math/big"
 
 	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/state"
@@ -13,30 +12,6 @@ import (
 	"github.com/statechannels/go-nitro/protocols/virtualdefund"
 	"github.com/statechannels/go-nitro/types"
 )
-
-type ChannelStatus string
-
-// TODO: Think through statuses
-const Proposed ChannelStatus = "Proposed"
-const Ready ChannelStatus = "Ready"
-const Closing ChannelStatus = "Closing"
-const Complete ChannelStatus = "Complete"
-
-// PaymentChannelBalance contains the balance of a uni-directional payment channel
-type PaymentChannelBalance struct {
-	AssetAddress   types.Address
-	Payee          types.Address
-	Payer          types.Address
-	PaidSoFar      *big.Int
-	RemainingFunds *big.Int
-}
-
-// PaymentChannelInfo contains balance and status info about a payment channel
-type PaymentChannelInfo struct {
-	ID      types.Destination
-	Status  ChannelStatus
-	Balance PaymentChannelBalance
-}
 
 // getStatusFromChannel returns the status of the channel
 func getStatusFromChannel(c *channel.Channel) ChannelStatus {
@@ -49,7 +24,6 @@ func getStatusFromChannel(c *channel.Channel) ChannelStatus {
 	if !c.PostFundComplete() {
 		return Proposed
 	}
-
 	return Ready
 }
 
@@ -70,22 +44,6 @@ func getPaymentChannelBalance(participants []types.Address, outcome outcome.Exit
 		PaidSoFar:      paidSoFar,
 		RemainingFunds: remaining,
 	}
-}
-
-// LedgerChannelInfo contains balance and status info about a ledger channel
-type LedgerChannelInfo struct {
-	ID      types.Destination
-	Status  ChannelStatus
-	Balance LedgerChannelBalance
-}
-
-// LedgerChannelBalance contains the balance of a ledger channel
-type LedgerChannelBalance struct {
-	AssetAddress  types.Address
-	Hub           types.Address
-	Client        types.Address
-	HubBalance    *big.Int
-	ClientBalance *big.Int
 }
 
 // getLatestSupported returns the latest supported state of the channel or the prefund state if no supported state exists
@@ -117,7 +75,7 @@ func getLedgerBalanceFromState(latest state.State) LedgerChannelBalance {
 	}
 }
 
-func getPaymentChannelInfo(id types.Destination, store store.Store, vm *payments.VoucherManager) (PaymentChannelInfo, error) {
+func GetPaymentChannelInfo(id types.Destination, store store.Store, vm *payments.VoucherManager) (PaymentChannelInfo, error) {
 
 	// This is slightly awkward but if the virtual defunding objective is complete it won't come back if we query by channel id
 	// We manually construct the objective id and query by that
@@ -167,9 +125,9 @@ func getPaymentChannelInfo(id types.Destination, store store.Store, vm *payments
 
 }
 
-// getLedgerChannelInfo returns the LedgerChannelInfo for the given channel
+// GetLedgerChannelInfo returns the LedgerChannelInfo for the given channel
 // It does this by querying the provided store
-func getLedgerChannelInfo(id types.Destination, store store.Store) (LedgerChannelInfo, error) {
+func GetLedgerChannelInfo(id types.Destination, store store.Store) (LedgerChannelInfo, error) {
 	c, ok := store.GetChannelById(id)
 	if ok {
 

--- a/client/query/query.go
+++ b/client/query/query.go
@@ -60,7 +60,7 @@ func getLatestSupported(channel *channel.Channel) state.State {
 // getLedgerBalanceFromState returns the balance of the ledger channel from the given state
 func getLedgerBalanceFromState(latest state.State) LedgerChannelBalance {
 
-	// TODO: We assume single asset outcomesch
+	// TODO: We assume single asset outcomes
 	outcome := latest.Outcome[0]
 	asset := outcome.Asset
 	client := latest.Participants[0]

--- a/client/query/types.go
+++ b/client/query/types.go
@@ -1,0 +1,47 @@
+package query
+
+import (
+	"math/big"
+
+	"github.com/statechannels/go-nitro/types"
+)
+
+type ChannelStatus string
+
+// TODO: Think through statuses
+const Proposed ChannelStatus = "Proposed"
+const Ready ChannelStatus = "Ready"
+const Closing ChannelStatus = "Closing"
+const Complete ChannelStatus = "Complete"
+
+// PaymentChannelBalance contains the balance of a uni-directional payment channel
+type PaymentChannelBalance struct {
+	AssetAddress   types.Address
+	Payee          types.Address
+	Payer          types.Address
+	PaidSoFar      *big.Int
+	RemainingFunds *big.Int
+}
+
+// PaymentChannelInfo contains balance and status info about a payment channel
+type PaymentChannelInfo struct {
+	ID      types.Destination
+	Status  ChannelStatus
+	Balance PaymentChannelBalance
+}
+
+// LedgerChannelInfo contains balance and status info about a ledger channel
+type LedgerChannelInfo struct {
+	ID      types.Destination
+	Status  ChannelStatus
+	Balance LedgerChannelBalance
+}
+
+// LedgerChannelBalance contains the balance of a ledger channel
+type LedgerChannelBalance struct {
+	AssetAddress  types.Address
+	Hub           types.Address
+	Client        types.Address
+	HubBalance    *big.Int
+	ClientBalance *big.Int
+}

--- a/client_test/query_test.go
+++ b/client_test/query_test.go
@@ -104,14 +104,16 @@ func TestPaymentChannelLifecycle(t *testing.T) {
 	checkPaymentChannel(t, res.ChannelId, o, client.Ready, &aliceClient, &bobClient)
 
 	aliceClient.Pay(res.ChannelId, big.NewInt(1))
-	// TODO: Test voucher query API once implemented
 
-	closeId := aliceClient.CloseVirtualChannel(res.ChannelId)
 	updatedOutcome := td.Outcomes.Create(alice.Address(),
 		bob.Address(),
 		1,
 		1,
 		types.Address{})
+	checkPaymentChannel(t, res.ChannelId, updatedOutcome, client.Ready, &aliceClient, &bobClient)
+
+	closeId := aliceClient.CloseVirtualChannel(res.ChannelId)
+
 	checkPaymentChannel(t, res.ChannelId, updatedOutcome, client.Closing, &aliceClient)
 
 	waitTimeForCompletedObjectiveIds(t, &aliceClient, defaultTimeout, closeId)

--- a/client_test/query_test.go
+++ b/client_test/query_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	"github.com/statechannels/go-nitro/internal/testdata"
-	td "github.com/statechannels/go-nitro/internal/testdata"
+
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -74,7 +74,7 @@ func TestPaymentChannelLifecycle(t *testing.T) {
 	directlyFundALedgerChannel(t, aliceClient, ireneClient, types.Address{})
 	directlyFundALedgerChannel(t, bobClient, ireneClient, types.Address{})
 
-	o := td.Outcomes.Create(
+	o := testdata.Outcomes.Create(
 		alice.Address(),
 		bob.Address(),
 		2,
@@ -86,7 +86,7 @@ func TestPaymentChannelLifecycle(t *testing.T) {
 		[]types.Address{*ireneClient.Address},
 		bob.Address(),
 		0,
-		td.Outcomes.Create(
+		testdata.Outcomes.Create(
 			alice.Address(),
 			bob.Address(),
 			2,
@@ -105,7 +105,7 @@ func TestPaymentChannelLifecycle(t *testing.T) {
 
 	aliceClient.Pay(res.ChannelId, big.NewInt(1))
 
-	updatedOutcome := td.Outcomes.Create(alice.Address(),
+	updatedOutcome := testdata.Outcomes.Create(alice.Address(),
 		bob.Address(),
 		1,
 		1,

--- a/client_test/query_test.go
+++ b/client_test/query_test.go
@@ -5,14 +5,56 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
+	"github.com/statechannels/go-nitro/internal/testdata"
 	td "github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/types"
 )
 
 const default_ledger_funding = 5_000_000
+
+func TestLedgerLifecycle(t *testing.T) {
+
+	logFile := "test_ledger_lifecycle.log"
+	truncateLog(logFile)
+	logDestination := newLogWriter(logFile)
+
+	chain := chainservice.NewMockChain()
+	chainServiceA := chainservice.NewMockChainService(chain, alice.Address())
+	chainServiceI := chainservice.NewMockChainService(chain, irene.Address())
+	broker := messageservice.NewBroker()
+
+	aliceClient, _ := setupClient(alice.PrivateKey, chainServiceA, broker, logDestination, 0)
+	ireneClient, _ := setupClient(irene.PrivateKey, chainServiceI, broker, logDestination, 0)
+
+	// Set up an outcome that requires both participants to deposit
+	outcome := testdata.Outcomes.Create(alice.Address(), irene.Address(), 7, 3, types.Address{})
+
+	res := aliceClient.CreateLedgerChannel(irene.Address(), 0, outcome)
+	ledgerId := res.ChannelId
+
+	// Irene might not have received the objective yet so we only check alice
+	checkLedgerChannel(t, ledgerId, outcome, client.Proposed, &aliceClient)
+
+	waitTimeForCompletedObjectiveIds(t, &aliceClient, defaultTimeout, res.Id)
+	waitTimeForCompletedObjectiveIds(t, &ireneClient, defaultTimeout, res.Id)
+
+	checkLedgerChannel(t, ledgerId, outcome, client.Ready, &aliceClient, &ireneClient)
+
+	closeId := aliceClient.CloseLedgerChannel(ledgerId)
+
+	// Irene might not have received the objective yet so we only check alice
+	checkLedgerChannel(t, ledgerId, outcome, client.Closing, &aliceClient)
+
+	waitTimeForCompletedObjectiveIds(t, &aliceClient, defaultTimeout, closeId)
+	waitTimeForCompletedObjectiveIds(t, &ireneClient, defaultTimeout, closeId)
+
+	checkLedgerChannel(t, ledgerId, outcome, client.Complete, &aliceClient, &ireneClient)
+
+}
 
 func TestQueryPaymentChannels(t *testing.T) {
 
@@ -85,4 +127,37 @@ func TestQueryPaymentChannels(t *testing.T) {
 		t.Fatalf("Query diff mismatch (-want +got):\n%s", diff)
 	}
 
+}
+
+// expectedInfo constructs a LedgerChannelInfo so we can easily compare it to the result of GetLedgerChannel
+func expectedInfo(id types.Destination, outcome outcome.Exit, status client.ChannelStatus) client.LedgerChannelInfo {
+	clientAdd, _ := outcome[0].Allocations[0].Destination.ToAddress()
+	hubAdd, _ := outcome[0].Allocations[1].Destination.ToAddress()
+
+	return client.LedgerChannelInfo{
+		ID:     id,
+		Status: status,
+		Balance: client.LedgerChannelBalance{
+			AssetAddress:  types.Address{},
+			Hub:           hubAdd,
+			Client:        clientAdd,
+			ClientBalance: outcome[0].Allocations[0].Amount,
+			HubBalance:    outcome[0].Allocations[1].Amount,
+		}}
+}
+
+// checkLedgerChannel checks that the ledger channel has the expected outcome and status
+// It will fail if the channel does not exist
+func checkLedgerChannel(t *testing.T, ledgerId types.Destination, o outcome.Exit, status client.ChannelStatus, clients ...*client.Client) {
+
+	for _, c := range clients {
+		expected := expectedInfo(ledgerId, o, status)
+		ledger, err := c.GetLedgerChannel(ledgerId)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(expected, ledger, cmp.AllowUnexported(big.Int{})); diff != "" {
+			t.Fatalf("Query diff mismatch (-want +got):\n%s", diff)
+		}
+	}
 }

--- a/client_test/query_test.go
+++ b/client_test/query_test.go
@@ -104,12 +104,13 @@ func TestPaymentChannelLifecycle(t *testing.T) {
 	checkPaymentChannel(t, res.ChannelId, o, client.Ready, &aliceClient, &bobClient)
 
 	aliceClient.Pay(res.ChannelId, big.NewInt(1))
-
+	<-bobClient.ReceivedVouchers()
 	updatedOutcome := testdata.Outcomes.Create(alice.Address(),
 		bob.Address(),
 		1,
 		1,
 		types.Address{})
+
 	checkPaymentChannel(t, res.ChannelId, updatedOutcome, client.Ready, &aliceClient, &bobClient)
 
 	closeId := aliceClient.CloseVirtualChannel(res.ChannelId)

--- a/client_test/query_test.go
+++ b/client_test/query_test.go
@@ -1,0 +1,66 @@
+package client_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/statechannels/go-nitro/client"
+	"github.com/statechannels/go-nitro/client/engine/chainservice"
+	"github.com/statechannels/go-nitro/client/engine/messageservice"
+	td "github.com/statechannels/go-nitro/internal/testdata"
+	"github.com/statechannels/go-nitro/types"
+)
+
+func TestQueryPaymentChannels(t *testing.T) {
+
+	// Setup logging
+	logFile := "test_query.log"
+	truncateLog(logFile)
+	logDestination := newLogWriter(logFile)
+
+	chain := chainservice.NewMockChain()
+	chainServiceA := chainservice.NewMockChainService(chain, alice.Address())
+	chainServiceB := chainservice.NewMockChainService(chain, bob.Address())
+	chainServiceI := chainservice.NewMockChainService(chain, irene.Address())
+	broker := messageservice.NewBroker()
+
+	clientA, _ := setupClient(alice.PrivateKey, chainServiceA, broker, logDestination, 0)
+	irene, _ := setupClient(irene.PrivateKey, chainServiceI, broker, logDestination, 0)
+	clientB, _ := setupClient(bob.PrivateKey, chainServiceB, broker, logDestination, 0)
+	directlyFundALedgerChannel(t, clientA, irene, types.Address{})
+	directlyFundALedgerChannel(t, clientB, irene, types.Address{})
+
+	id := clientA.CreateVirtualPaymentChannel(
+		[]types.Address{*irene.Address},
+		bob.Address(),
+		0,
+		td.Outcomes.Create(
+			alice.Address(),
+			bob.Address(),
+			2,
+			0,
+			types.Address{},
+		)).ChannelId
+
+	res, err := clientA.GetPaymentChannel(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := client.PaymentChannelInfo{
+		ID:     id,
+		Status: client.Proposed,
+		Balance: client.PaymentChannelBalance{
+			AssetAddress:   types.Address{},
+			Payee:          *clientB.Address,
+			Payer:          *clientA.Address,
+			PaidSoFar:      big.NewInt(0),
+			RemainingFunds: big.NewInt(2),
+		}}
+
+	if diff := cmp.Diff(expected, res, cmp.AllowUnexported(big.Int{})); diff != "" {
+		t.Fatalf("Query diff mismatch (-want +got):\n%s", diff)
+	}
+
+}

--- a/client_test/query_test.go
+++ b/client_test/query_test.go
@@ -107,17 +107,18 @@ func TestPaymentChannelLifecycle(t *testing.T) {
 	// TODO: Test voucher query API once implemented
 
 	closeId := aliceClient.CloseVirtualChannel(res.ChannelId)
-
-	// TODO: This doesn't work for virtual defunding, since we store values directly on the objective
-	// This means the channel struct in the store will be stale
-	//checkPaymentChannel(t, res.ChannelId, o, client.Closing, &aliceClient)
+	updatedOutcome := td.Outcomes.Create(alice.Address(),
+		bob.Address(),
+		1,
+		1,
+		types.Address{})
+	checkPaymentChannel(t, res.ChannelId, updatedOutcome, client.Closing, &aliceClient)
 
 	waitTimeForCompletedObjectiveIds(t, &aliceClient, defaultTimeout, closeId)
 	waitTimeForCompletedObjectiveIds(t, &bobClient, defaultTimeout, closeId)
 	waitTimeForCompletedObjectiveIds(t, &ireneClient, defaultTimeout, closeId)
-	// TODO: This doesn't work for virtual defunding, since we store values directly on the objective
-	// This means the channel struct in the store will be stale
-	// checkPaymentChannel(t, res.ChannelId, o, client.Complete, &aliceClient, &bobClient, &ireneClient)
+
+	checkPaymentChannel(t, res.ChannelId, updatedOutcome, client.Complete, &aliceClient, &bobClient, &ireneClient)
 }
 
 // expectedPaymentInfo constructs a LedgerChannelInfo so we can easily compare it to the result of GetPaymentChannel

--- a/client_test/query_test.go
+++ b/client_test/query_test.go
@@ -4,9 +4,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
-	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	"github.com/statechannels/go-nitro/client/query"
@@ -15,9 +13,9 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-func TestLedgerLifecycle(t *testing.T) {
+func TestQueryLedgerChannel(t *testing.T) {
 
-	logFile := "test_ledger_lifecycle.log"
+	logFile := "test_query_ledger_channel.log"
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
@@ -55,10 +53,10 @@ func TestLedgerLifecycle(t *testing.T) {
 
 }
 
-func TestPaymentChannelLifecycle(t *testing.T) {
+func TestQueryPaymentChannel(t *testing.T) {
 
 	// Setup logging
-	logFile := "test_payment_lifecycle.log"
+	logFile := "test_query_payment_channel.log"
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
@@ -140,53 +138,4 @@ func expectedPaymentInfo(id types.Destination, outcome outcome.Exit, status quer
 			RemainingFunds: outcome[0].Allocations[0].Amount,
 			PaidSoFar:      outcome[0].Allocations[1].Amount,
 		}}
-}
-
-// checkPaymentChannel checks that the ledger channel has the expected outcome and status
-// It will fail if the channel does not exist
-func checkPaymentChannel(t *testing.T, id types.Destination, o outcome.Exit, status query.ChannelStatus, clients ...*client.Client) {
-
-	for _, c := range clients {
-		expected := expectedPaymentInfo(id, o, status)
-		ledger, err := c.GetPaymentChannel(id)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if diff := cmp.Diff(expected, ledger, cmp.AllowUnexported(big.Int{})); diff != "" {
-			t.Fatalf("Payment channel diff mismatch (-want +got):\n%s", diff)
-		}
-	}
-}
-
-// expectedLedgerInfo constructs a LedgerChannelInfo so we can easily compare it to the result of GetLedgerChannel
-func expectedLedgerInfo(id types.Destination, outcome outcome.Exit, status query.ChannelStatus) query.LedgerChannelInfo {
-	clientAdd, _ := outcome[0].Allocations[0].Destination.ToAddress()
-	hubAdd, _ := outcome[0].Allocations[1].Destination.ToAddress()
-
-	return query.LedgerChannelInfo{
-		ID:     id,
-		Status: status,
-		Balance: query.LedgerChannelBalance{
-			AssetAddress:  types.Address{},
-			Hub:           hubAdd,
-			Client:        clientAdd,
-			ClientBalance: outcome[0].Allocations[0].Amount,
-			HubBalance:    outcome[0].Allocations[1].Amount,
-		}}
-}
-
-// checkLedgerChannel checks that the ledger channel has the expected outcome and status
-// It will fail if the channel does not exist
-func checkLedgerChannel(t *testing.T, ledgerId types.Destination, o outcome.Exit, status query.ChannelStatus, clients ...*client.Client) {
-
-	for _, c := range clients {
-		expected := expectedLedgerInfo(ledgerId, o, status)
-		ledger, err := c.GetLedgerChannel(ledgerId)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if diff := cmp.Diff(expected, ledger, cmp.AllowUnexported(big.Int{})); diff != "" {
-			t.Fatalf("Ledger diff mismatch (-want +got):\n%s", diff)
-		}
-	}
 }


### PR DESCRIPTION
This adds two key functions to the client API to allow querying channel information:
1. `GetPaymentChannel(id types.Destination) (PaymentChannelInfo, error)`
2. `GetLedgerChannel(id types.Destination) (LedgerChannelInfo, error)`

The `PaymentChannelInfo` and `LedgerChannelInfo` proxies contain information about the status and funding of the channels.

To test these functions there is a new integration tests that run a ledger channel and virtual channel through their lifecycle and use the new API functions to check the status/outcome.

Most of this functionality has been added in a new `query` package, a subpackage of `client`