### PR TITLE
Use a zerolog logger in engine and chain service

### DIFF
--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -65,7 +65,8 @@ func NewEthChainService(chain ethChain, na *NitroAdjudicator.NitroAdjudicator,
 	naAddress, caAddress, vpaAddress common.Address, txSigner *bind.TransactOpts, logDestination io.Writer) (*EthChainService, error) {
 
 	logging.ConfigureZeroLogger()
-	logger := zerolog.New(logDestination).With().Timestamp().Str("txSigner", txSigner.From.String()).Caller().Logger()
+
+	logger := zerolog.New(logDestination).With().Timestamp().Str("txSigner:", txSigner.From.String()[0:8]).Caller().Logger()
 
 	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
 	ecs := EthChainService{chain, na, naAddress, caAddress, vpaAddress, txSigner, make(chan Event, 10), logger}

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rs/zerolog"
 	NitroAdjudicator "github.com/statechannels/go-nitro/client/engine/chainservice/adjudicator"
 	Token "github.com/statechannels/go-nitro/client/engine/chainservice/erc20"
+	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 
@@ -63,7 +64,7 @@ const RESUB_INTERVAL = 2*time.Minute + 30*time.Second
 func NewEthChainService(chain ethChain, na *NitroAdjudicator.NitroAdjudicator,
 	naAddress, caAddress, vpaAddress common.Address, txSigner *bind.TransactOpts, logDestination io.Writer) (*EthChainService, error) {
 
-	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	logging.ConfigureZeroLogger()
 	logger := zerolog.New(logDestination).With().Timestamp().Str("txSigner", txSigner.From.String()).Caller().Logger()
 
 	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -273,7 +273,7 @@ func (ecs *EthChainService) subscribeForLogs(ctx context.Context) {
 			if sErr != nil {
 				ecs.fatalError(err)
 			}
-			ecs.logger.Println("resubscribed to filtered logs")
+			ecs.logger.Print("resubscribed to filtered logs")
 
 		case <-time.After(RESUB_INTERVAL):
 			// Due to https://github.com/ethereum/go-ethereum/issues/23845 we can't rely on a long running subscription.

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -66,7 +66,7 @@ func NewEthChainService(chain ethChain, na *NitroAdjudicator.NitroAdjudicator,
 
 	logging.ConfigureZeroLogger()
 
-	logger := zerolog.New(logDestination).With().Timestamp().Str("txSigner:", txSigner.From.String()[0:8]).Caller().Logger()
+	logger := zerolog.New(logDestination).With().Timestamp().Str("txSigner", txSigner.From.String()[0:8]).Caller().Logger()
 
 	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
 	ecs := EthChainService{chain, na, naAddress, caAddress, vpaAddress, txSigner, make(chan Event, 10), logger}

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -178,9 +178,9 @@ func (ecs *EthChainService) fatalF(format string, v ...any) {
 	// Print to STDOUT in case we're using a noop logger
 	fmt.Println(fmt.Errorf(format, v...))
 
-	ecs.logger.Printf(format, v...)
+	ecs.logger.Fatal().Msgf(format, v...)
 
-	// Manually panic
+	// Manually panic in case we're using a logger that doesn't call exit(1)
 	panic(fmt.Errorf(format, v...))
 
 }

--- a/client/engine/chainservice/simulated_backend_chainservice.go
+++ b/client/engine/chainservice/simulated_backend_chainservice.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"log"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -12,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/rs/zerolog"
 	NitroAdjudicator "github.com/statechannels/go-nitro/client/engine/chainservice/adjudicator"
 	ConsensusApp "github.com/statechannels/go-nitro/client/engine/chainservice/consensusapp"
 	Token "github.com/statechannels/go-nitro/client/engine/chainservice/erc20"
@@ -63,8 +63,9 @@ type SimulatedBackendChainService struct {
 func newPollingSimulatedBackendChainService(sim SimulatedChain, bindings Bindings,
 	txSigner *bind.TransactOpts, logDestination io.Writer) (ChainService, error) {
 
-	logPrefix := "chainservice " + txSigner.From.String() + ": "
-	logger := log.New(logDestination, logPrefix, log.Lmicroseconds|log.Lshortfile)
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	logger := zerolog.New(logDestination).With().Timestamp().Str("txSigner", txSigner.From.String()).Caller().Logger()
+
 	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
 	ecs := EthChainService{sim,
 		bindings.Adjudicator.Contract,

--- a/client/engine/chainservice/simulated_backend_chainservice.go
+++ b/client/engine/chainservice/simulated_backend_chainservice.go
@@ -65,7 +65,7 @@ func newPollingSimulatedBackendChainService(sim SimulatedChain, bindings Binding
 	txSigner *bind.TransactOpts, logDestination io.Writer) (ChainService, error) {
 
 	logging.ConfigureZeroLogger()
-	logger := zerolog.New(logDestination).With().Timestamp().Str("txSigner", txSigner.From.String()).Caller().Logger()
+	logger := zerolog.New(logDestination).With().Timestamp().Str("txSigner:", txSigner.From.String()[0:8]).Caller().Logger()
 
 	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
 	ecs := EthChainService{sim,

--- a/client/engine/chainservice/simulated_backend_chainservice.go
+++ b/client/engine/chainservice/simulated_backend_chainservice.go
@@ -65,7 +65,7 @@ func newPollingSimulatedBackendChainService(sim SimulatedChain, bindings Binding
 	txSigner *bind.TransactOpts, logDestination io.Writer) (ChainService, error) {
 
 	logging.ConfigureZeroLogger()
-	logger := zerolog.New(logDestination).With().Timestamp().Str("txSigner:", txSigner.From.String()[0:8]).Caller().Logger()
+	logger := zerolog.New(logDestination).With().Timestamp().Str("txSigner", txSigner.From.String()[0:8]).Caller().Logger()
 
 	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
 	ecs := EthChainService{sim,

--- a/client/engine/chainservice/simulated_backend_chainservice.go
+++ b/client/engine/chainservice/simulated_backend_chainservice.go
@@ -16,6 +16,7 @@ import (
 	ConsensusApp "github.com/statechannels/go-nitro/client/engine/chainservice/consensusapp"
 	Token "github.com/statechannels/go-nitro/client/engine/chainservice/erc20"
 	VirtualPaymentApp "github.com/statechannels/go-nitro/client/engine/chainservice/virtualpaymentapp"
+	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -63,7 +64,7 @@ type SimulatedBackendChainService struct {
 func newPollingSimulatedBackendChainService(sim SimulatedChain, bindings Bindings,
 	txSigner *bind.TransactOpts, logDestination io.Writer) (ChainService, error) {
 
-	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	logging.ConfigureZeroLogger()
 	logger := zerolog.New(logDestination).With().Timestamp().Str("txSigner", txSigner.From.String()).Caller().Logger()
 
 	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -109,7 +109,7 @@ func New(vm *payments.VoucherManager, msg messageservice.MessageService, chain c
 
 	e.vm = vm
 
-	e.logger.Println("Constructed Engine")
+	e.logger.Print("Constructed Engine")
 
 	if metricsApi == nil {
 		metricsApi = &NoOpMetrics{}
@@ -149,7 +149,8 @@ func (e *Engine) Run() {
 
 		// Handle errors
 		if err != nil {
-			e.logger.Panic(fmt.Errorf("%s, error in run loop: %w", e.store.GetAddress(), err))
+			e.logger.Err(fmt.Errorf("%s, error in run loop: %w", e.store.GetAddress(), err))
+			e.logger.Panic()
 			// TODO do not panic if in production.
 			// TODO report errors back to the consuming application
 		}

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -149,8 +149,7 @@ func (e *Engine) Run() {
 
 		// Handle errors
 		if err != nil {
-			e.logger.Err(fmt.Errorf("%s, error in run loop: %w", e.store.GetAddress(), err))
-			e.logger.Panic()
+			e.logger.Panic().Err(err).Msgf("%s, error in run loop", e.store.GetAddress())
 			// TODO do not panic if in production.
 			// TODO report errors back to the consuming application
 		}

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -12,6 +12,7 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	"github.com/statechannels/go-nitro/client/engine/store"
+	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/payments"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/protocols/directdefund"
@@ -101,8 +102,7 @@ func New(vm *payments.VoucherManager, msg messageservice.MessageService, chain c
 
 	e.toApi = make(chan EngineEvent, 100)
 
-	// initialize a Logger
-	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	logging.ConfigureZeroLogger()
 	e.logger = zerolog.New(logDestination).With().Timestamp().Str("address", e.store.GetAddress().String()[0:8]).Caller().Logger()
 
 	e.policymaker = policymaker

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -104,7 +104,6 @@ func New(vm *payments.VoucherManager, msg messageservice.MessageService, chain c
 	// initialize a Logger
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	e.logger = zerolog.New(logDestination).With().Timestamp().Str("address", e.store.GetAddress().String()[0:8]).Caller().Logger()
-	zerolog.SetGlobalLevel(zerolog.ErrorLevel)
 
 	e.policymaker = policymaker
 

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -103,7 +103,7 @@ func New(vm *payments.VoucherManager, msg messageservice.MessageService, chain c
 	e.toApi = make(chan EngineEvent, 100)
 
 	logging.ConfigureZeroLogger()
-	e.logger = zerolog.New(logDestination).With().Timestamp().Str("address", e.store.GetAddress().String()[0:8]).Caller().Logger()
+	e.logger = zerolog.New(logDestination).With().Timestamp().Str("engine", e.store.GetAddress().String()[0:8]).Caller().Logger()
 
 	e.policymaker = policymaker
 

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"math/big"
 
+	"github.com/rs/zerolog"
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
@@ -52,7 +52,7 @@ type Engine struct {
 	store       store.Store // A Store for persisting and restoring important data
 	policymaker PolicyMaker // A PolicyMaker decides whether to approve or reject objectives
 
-	logger *log.Logger
+	logger zerolog.Logger
 
 	metrics *MetricsRecorder
 
@@ -102,8 +102,8 @@ func New(vm *payments.VoucherManager, msg messageservice.MessageService, chain c
 	e.toApi = make(chan EngineEvent, 100)
 
 	// initialize a Logger
-	logPrefix := e.store.GetAddress().String()[0:8] + ": "
-	e.logger = log.New(logDestination, logPrefix, log.Lmicroseconds|log.Lshortfile)
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	e.logger = zerolog.New(logDestination).With().Timestamp().Str("address", e.store.GetAddress().String()[0:8]).Caller().Logger()
 
 	e.policymaker = policymaker
 

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -104,6 +104,7 @@ func New(vm *payments.VoucherManager, msg messageservice.MessageService, chain c
 	// initialize a Logger
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	e.logger = zerolog.New(logDestination).With().Timestamp().Str("address", e.store.GetAddress().String()[0:8]).Caller().Logger()
+	zerolog.SetGlobalLevel(zerolog.ErrorLevel)
 
 	e.policymaker = policymaker
 

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,25 @@
+package logging
+
+import (
+	"strconv"
+
+	"github.com/rs/zerolog"
+)
+
+func ConfigureZeroLogger() {
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	zerolog.TimestampFieldName = "t"
+	zerolog.LevelFieldName = "l"
+	zerolog.MessageFieldName = "m"
+	zerolog.CallerMarshalFunc = func(pc uintptr, file string, line int) string {
+		short := file
+		for i := len(file) - 1; i > 0; i-- {
+			if file[i] == '/' {
+				short = file[i+1:]
+				break
+			}
+		}
+		file = short
+		return file + ":" + strconv.Itoa(line)
+	}
+}


### PR DESCRIPTION
This is a super easy change, and I'm interested to see if it has an impact on our performance in testground. 

There are other justifications to make this switch, such as the ability to set log levels and to be able to more-easily parse the logs.

Example output in `/artifacts/test_direct_fund.log`

```json
{"l":"debug","txSigner:":"0x9e3F65","t":1675079708,"caller":"eth_chainservice.go:74","m":"Notifications are supported by the chain. Using notifications to listen for events."}
{"l":"debug","txSigner:":"0x9112B1","t":1675079708,"caller":"eth_chainservice.go:74","m":"Notifications are supported by the chain. Using notifications to listen for events."}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:112","m":"Constructed Engine"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:112","m":"Constructed Engine"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:368","m":"handling new objective request for DirectFunding-0xb9eed3fb2e6ee2a8aafaa14165be8fdc4233a32730a26791f31ff3db369ad938"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:513","m":"Objective DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374 is WaitingForCompletePrefund"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:692","m":"Sending message {To:0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 PayloadSummaries:[{ObjectiveId:DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374 Type:SignedStatePayload PayloadDataSize:774}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:690","m":"Receiving message {To:0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 PayloadSummaries:[{ObjectiveId:DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374 Type:SignedStatePayload PayloadDataSize:774}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:592","m":"Constructing objective DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374 from message"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:582","m":"Created new objective from message DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:207","m":"Policymaker is &{}"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:513","m":"Objective DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374 is WaitingForMyTurnToFund"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:692","m":"Sending message {To:0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE PayloadSummaries:[{ObjectiveId:DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374 Type:SignedStatePayload PayloadDataSize:774}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:690","m":"Receiving message {To:0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE PayloadSummaries:[{ObjectiveId:DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374 Type:SignedStatePayload PayloadDataSize:774}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:513","m":"Objective DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374 is WaitingForCompleteFunding"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:474","m":"Sending chain transaction for channel 0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:335","m":"handling chain event {{[105 186 118 229 116 196 79 241 196 237 79 177 187 177 107 228 159 172 139 199 120 54 99 190 130 181 37 58 39 64 163 116] 2} {0x0000000000000000000000000000000000000000 5000000} 5000000}"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:335","m":"handling chain event {{[105 186 118 229 116 196 79 241 196 237 79 177 187 177 107 228 159 172 139 199 120 54 99 190 130 181 37 58 39 64 163 116] 2} {0x0000000000000000000000000000000000000000 5000000} 5000000}"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:513","m":"Objective DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374 is WaitingForCompleteFunding"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:474","m":"Sending chain transaction for channel 0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:513","m":"Objective DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374 is WaitingForCompleteFunding"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:335","m":"handling chain event {{[105 186 118 229 116 196 79 241 196 237 79 177 187 177 107 228 159 172 139 199 120 54 99 190 130 181 37 58 39 64 163 116] 3} {0x0000000000000000000000000000000000000000 5000000} 10000000}"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:335","m":"handling chain event {{[105 186 118 229 116 196 79 241 196 237 79 177 187 177 107 228 159 172 139 199 120 54 99 190 130 181 37 58 39 64 163 116] 3} {0x0000000000000000000000000000000000000000 5000000} 10000000}"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:513","m":"Objective DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374 is WaitingForCompletePostFund"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:692","m":"Sending message {To:0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 PayloadSummaries:[{ObjectiveId:DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374 Type:SignedStatePayload PayloadDataSize:774}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:513","m":"Objective DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374 is WaitingForCompletePostFund"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:692","m":"Sending message {To:0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE PayloadSummaries:[{ObjectiveId:DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374 Type:SignedStatePayload PayloadDataSize:774}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:690","m":"Receiving message {To:0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 PayloadSummaries:[{ObjectiveId:DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374 Type:SignedStatePayload PayloadDataSize:774}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:690","m":"Receiving message {To:0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE PayloadSummaries:[{ObjectiveId:DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374 Type:SignedStatePayload PayloadDataSize:774}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:513","m":"Objective DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374 is WaitingForNothing"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:513","m":"Objective DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374 is WaitingForNothing"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:161","m":"Objective DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374 is complete & returned to API"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:161","m":"Objective DirectFunding-0x69ba76e574c44ff1c4ed4fb1bbb16be49fac8bc7783663be82b5253a2740a374 is complete & returned to API"}
{"l":"debug","txSigner:":"0x9e3F65","t":1675079708,"caller":"eth_chainservice.go:74","m":"Notifications are supported by the chain. Using notifications to listen for events."}
{"l":"debug","txSigner:":"0x9112B1","t":1675079708,"caller":"eth_chainservice.go:74","m":"Notifications are supported by the chain. Using notifications to listen for events."}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:112","m":"Constructed Engine"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:112","m":"Constructed Engine"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:368","m":"handling new objective request for DirectFunding-0xc5fd7aa06f2ea0e0b2669a631589e32eb8200a2f6c00e22acc39196491bbb87b"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:513","m":"Objective DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548 is WaitingForCompletePrefund"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:692","m":"Sending message {To:0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 PayloadSummaries:[{ObjectiveId:DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548 Type:SignedStatePayload PayloadDataSize:775}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:690","m":"Receiving message {To:0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 PayloadSummaries:[{ObjectiveId:DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548 Type:SignedStatePayload PayloadDataSize:775}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:592","m":"Constructing objective DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548 from message"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:582","m":"Created new objective from message DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:207","m":"Policymaker is &{}"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:513","m":"Objective DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548 is WaitingForMyTurnToFund"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:692","m":"Sending message {To:0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE PayloadSummaries:[{ObjectiveId:DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548 Type:SignedStatePayload PayloadDataSize:775}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:690","m":"Receiving message {To:0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE PayloadSummaries:[{ObjectiveId:DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548 Type:SignedStatePayload PayloadDataSize:775}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:513","m":"Objective DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548 is WaitingForCompleteFunding"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:474","m":"Sending chain transaction for channel 0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:335","m":"handling chain event {{[37 138 62 50 28 17 221 10 211 101 210 194 190 220 219 94 225 17 166 6 109 84 85 215 5 156 44 75 126 195 133 72] 4} {0x9f66B6b641F487d7c57846d7e6C6eB9d5A09556E 5000000} 5000000}"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:335","m":"handling chain event {{[37 138 62 50 28 17 221 10 211 101 210 194 190 220 219 94 225 17 166 6 109 84 85 215 5 156 44 75 126 195 133 72] 4} {0x9f66B6b641F487d7c57846d7e6C6eB9d5A09556E 5000000} 5000000}"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:335","m":"handling chain event {{[37 138 62 50 28 17 221 10 211 101 210 194 190 220 219 94 225 17 166 6 109 84 85 215 5 156 44 75 126 195 133 72] 4} {0x9f66B6b641F487d7c57846d7e6C6eB9d5A09556E 5000000} 5000000}"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:335","m":"handling chain event {{[37 138 62 50 28 17 221 10 211 101 210 194 190 220 219 94 225 17 166 6 109 84 85 215 5 156 44 75 126 195 133 72] 4} {0x9f66B6b641F487d7c57846d7e6C6eB9d5A09556E 5000000} 5000000}"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:513","m":"Objective DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548 is WaitingForCompleteFunding"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:474","m":"Sending chain transaction for channel 0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:513","m":"Objective DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548 is WaitingForCompleteFunding"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:335","m":"handling chain event {{[37 138 62 50 28 17 221 10 211 101 210 194 190 220 219 94 225 17 166 6 109 84 85 215 5 156 44 75 126 195 133 72] 5} {0x9f66B6b641F487d7c57846d7e6C6eB9d5A09556E 5000000} 10000000}"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:335","m":"handling chain event {{[37 138 62 50 28 17 221 10 211 101 210 194 190 220 219 94 225 17 166 6 109 84 85 215 5 156 44 75 126 195 133 72] 5} {0x9f66B6b641F487d7c57846d7e6C6eB9d5A09556E 5000000} 10000000}"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:335","m":"handling chain event {{[37 138 62 50 28 17 221 10 211 101 210 194 190 220 219 94 225 17 166 6 109 84 85 215 5 156 44 75 126 195 133 72] 5} {0x9f66B6b641F487d7c57846d7e6C6eB9d5A09556E 5000000} 10000000}"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:335","m":"handling chain event {{[37 138 62 50 28 17 221 10 211 101 210 194 190 220 219 94 225 17 166 6 109 84 85 215 5 156 44 75 126 195 133 72] 5} {0x9f66B6b641F487d7c57846d7e6C6eB9d5A09556E 5000000} 10000000}"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:513","m":"Objective DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548 is WaitingForCompletePostFund"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:692","m":"Sending message {To:0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 PayloadSummaries:[{ObjectiveId:DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548 Type:SignedStatePayload PayloadDataSize:775}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:513","m":"Objective DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548 is WaitingForCompletePostFund"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:692","m":"Sending message {To:0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE PayloadSummaries:[{ObjectiveId:DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548 Type:SignedStatePayload PayloadDataSize:775}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:690","m":"Receiving message {To:0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 PayloadSummaries:[{ObjectiveId:DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548 Type:SignedStatePayload PayloadDataSize:775}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:690","m":"Receiving message {To:0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE PayloadSummaries:[{ObjectiveId:DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548 Type:SignedStatePayload PayloadDataSize:775}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:513","m":"Objective DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548 is WaitingForNothing"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:513","m":"Objective DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548 is WaitingForNothing"}
{"l":"debug","engine":"0xBBB676","t":1675079708,"caller":"engine.go:161","m":"Objective DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548 is complete & returned to API"}
{"l":"debug","engine":"0xAAA662","t":1675079708,"caller":"engine.go:161","m":"Objective DirectFunding-0x258a3e321c11dd0ad365d2c2bedcdb5ee111a6066d5455d7059c2c4b7ec38548 is complete & returned to API"}

```
Compared with existing: 

```log
chainservice 0xED15705E3A5573f3483012286cda21f739d41E64: 11:58:35.863442 eth_chainservice.go:71: Notifications are supported by the chain. Using notifications to listen for events.
chainservice 0x1EDA41c1733ed9891183D90014A80700edD218eE: 11:58:35.863550 eth_chainservice.go:71: Notifications are supported by the chain. Using notifications to listen for events.
0xAAA662: 11:58:35.863705 engine.go:112: Constructed Engine
0xBBB676: 11:58:35.863864 engine.go:112: Constructed Engine
0xAAA662: 11:58:35.863928 engine.go:367: handling new objective request for DirectFunding-0x24c722d6aeb745d60723b9042513302ddf27edea18f27fe83f92e605e9118670
0xAAA662: 11:58:35.864428 engine.go:512: Objective DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad is WaitingForCompletePrefund
0xAAA662: 11:58:35.864575 engine.go:691: Sending message {To:0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 PayloadSummaries:[{ObjectiveId:DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad Type:SignedStatePayload PayloadDataSize:775}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}
0xBBB676: 11:58:35.864713 engine.go:689: Receiving message {To:0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 PayloadSummaries:[{ObjectiveId:DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad Type:SignedStatePayload PayloadDataSize:775}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}
0xBBB676: 11:58:35.864723 engine.go:591: Constructing objective DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad from message
0xBBB676: 11:58:35.864838 engine.go:581: Created new objective from message DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad
0xBBB676: 11:58:35.864858 engine.go:206: Policymaker is &{}
0xBBB676: 11:58:35.865364 engine.go:512: Objective DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad is WaitingForMyTurnToFund
0xBBB676: 11:58:35.865444 engine.go:691: Sending message {To:0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE PayloadSummaries:[{ObjectiveId:DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad Type:SignedStatePayload PayloadDataSize:775}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}
0xAAA662: 11:58:35.865575 engine.go:689: Receiving message {To:0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE PayloadSummaries:[{ObjectiveId:DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad Type:SignedStatePayload PayloadDataSize:775}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}
0xAAA662: 11:58:35.865834 engine.go:512: Objective DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad is WaitingForCompleteFunding
0xAAA662: 11:58:35.865848 engine.go:473: Sending chain transaction for channel 0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad
0xBBB676: 11:58:35.867689 engine.go:334: handling chain event {{[40 251 52 209 46 146 29 130 15 31 119 131 210 82 4 94 158 137 36 143 224 102 181 140 244 189 198 143 30 51 79 173] 2} {0x0000000000000000000000000000000000000000 5000000} 5000000}
0xAAA662: 11:58:35.867810 engine.go:334: handling chain event {{[40 251 52 209 46 146 29 130 15 31 119 131 210 82 4 94 158 137 36 143 224 102 181 140 244 189 198 143 30 51 79 173] 2} {0x0000000000000000000000000000000000000000 5000000} 5000000}
0xBBB676: 11:58:35.867896 engine.go:512: Objective DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad is WaitingForCompleteFunding
0xBBB676: 11:58:35.867912 engine.go:473: Sending chain transaction for channel 0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad
0xAAA662: 11:58:35.867979 engine.go:512: Objective DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad is WaitingForCompleteFunding
0xAAA662: 11:58:35.869794 engine.go:334: handling chain event {{[40 251 52 209 46 146 29 130 15 31 119 131 210 82 4 94 158 137 36 143 224 102 181 140 244 189 198 143 30 51 79 173] 3} {0x0000000000000000000000000000000000000000 5000000} 10000000}
0xBBB676: 11:58:35.869934 engine.go:334: handling chain event {{[40 251 52 209 46 146 29 130 15 31 119 131 210 82 4 94 158 137 36 143 224 102 181 140 244 189 198 143 30 51 79 173] 3} {0x0000000000000000000000000000000000000000 5000000} 10000000}
0xAAA662: 11:58:35.870328 engine.go:512: Objective DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad is WaitingForCompletePostFund
0xBBB676: 11:58:35.870384 engine.go:512: Objective DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad is WaitingForCompletePostFund
0xAAA662: 11:58:35.870397 engine.go:691: Sending message {To:0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 PayloadSummaries:[{ObjectiveId:DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad Type:SignedStatePayload PayloadDataSize:775}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}
0xBBB676: 11:58:35.870421 engine.go:691: Sending message {To:0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE PayloadSummaries:[{ObjectiveId:DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad Type:SignedStatePayload PayloadDataSize:775}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}
0xBBB676: 11:58:35.870485 engine.go:689: Receiving message {To:0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 PayloadSummaries:[{ObjectiveId:DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad Type:SignedStatePayload PayloadDataSize:775}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}
0xAAA662: 11:58:35.870503 engine.go:689: Receiving message {To:0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE PayloadSummaries:[{ObjectiveId:DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad Type:SignedStatePayload PayloadDataSize:775}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}
0xBBB676: 11:58:35.870771 engine.go:512: Objective DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad is WaitingForNothing
0xAAA662: 11:58:35.870794 engine.go:512: Objective DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad is WaitingForNothing
0xBBB676: 11:58:35.871051 engine.go:160: Objective DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad is complete & returned to API
0xAAA662: 11:58:35.871059 engine.go:160: Objective DirectFunding-0x28fb34d12e921d820f1f7783d252045e9e89248fe066b58cf4bdc68f1e334fad is complete & returned to API
chainservice 0xED15705E3A5573f3483012286cda21f739d41E64: 11:58:35.871426 eth_chainservice.go:71: Notifications are supported by the chain. Using notifications to listen for events.
chainservice 0x1EDA41c1733ed9891183D90014A80700edD218eE: 11:58:35.871446 eth_chainservice.go:71: Notifications are supported by the chain. Using notifications to listen for events.
0xAAA662: 11:58:35.871623 engine.go:112: Constructed Engine
0xBBB676: 11:58:35.871845 engine.go:112: Constructed Engine
0xAAA662: 11:58:35.871932 engine.go:367: handling new objective request for DirectFunding-0xf45cb32e2192c00f50c9f116bea9b2b94f7a929acee4f9a266a69f0cf8ec5a1d
0xAAA662: 11:58:35.872433 engine.go:512: Objective DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68 is WaitingForCompletePrefund
0xAAA662: 11:58:35.872611 engine.go:691: Sending message {To:0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 PayloadSummaries:[{ObjectiveId:DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68 Type:SignedStatePayload PayloadDataSize:774}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}
0xBBB676: 11:58:35.872821 engine.go:689: Receiving message {To:0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 PayloadSummaries:[{ObjectiveId:DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68 Type:SignedStatePayload PayloadDataSize:774}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}
0xBBB676: 11:58:35.872834 engine.go:591: Constructing objective DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68 from message
0xBBB676: 11:58:35.872970 engine.go:581: Created new objective from message DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68
0xBBB676: 11:58:35.873006 engine.go:206: Policymaker is &{}
0xBBB676: 11:58:35.873526 engine.go:512: Objective DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68 is WaitingForMyTurnToFund
0xBBB676: 11:58:35.873633 engine.go:691: Sending message {To:0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE PayloadSummaries:[{ObjectiveId:DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68 Type:SignedStatePayload PayloadDataSize:774}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}
0xAAA662: 11:58:35.873848 engine.go:689: Receiving message {To:0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE PayloadSummaries:[{ObjectiveId:DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68 Type:SignedStatePayload PayloadDataSize:774}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}
0xAAA662: 11:58:35.874253 engine.go:512: Objective DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68 is WaitingForCompleteFunding
0xAAA662: 11:58:35.874273 engine.go:473: Sending chain transaction for channel 0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68
0xAAA662: 11:58:35.878383 engine.go:334: handling chain event {{[10 67 20 160 168 211 205 238 115 126 206 103 194 212 59 186 146 252 166 182 35 120 233 20 244 169 97 237 121 136 139 104] 4} {0x9777CDF0b7c384Aa011E77c578fE2E9c23d1884e 5000000} 5000000}
0xBBB676: 11:58:35.878417 engine.go:334: handling chain event {{[10 67 20 160 168 211 205 238 115 126 206 103 194 212 59 186 146 252 166 182 35 120 233 20 244 169 97 237 121 136 139 104] 4} {0x9777CDF0b7c384Aa011E77c578fE2E9c23d1884e 5000000} 5000000}
0xBBB676: 11:58:35.878490 engine.go:334: handling chain event {{[10 67 20 160 168 211 205 238 115 126 206 103 194 212 59 186 146 252 166 182 35 120 233 20 244 169 97 237 121 136 139 104] 4} {0x9777CDF0b7c384Aa011E77c578fE2E9c23d1884e 5000000} 5000000}
0xAAA662: 11:58:35.878547 engine.go:334: handling chain event {{[10 67 20 160 168 211 205 238 115 126 206 103 194 212 59 186 146 252 166 182 35 120 233 20 244 169 97 237 121 136 139 104] 4} {0x9777CDF0b7c384Aa011E77c578fE2E9c23d1884e 5000000} 5000000}
0xBBB676: 11:58:35.878685 engine.go:512: Objective DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68 is WaitingForCompleteFunding
0xBBB676: 11:58:35.878708 engine.go:473: Sending chain transaction for channel 0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68
0xAAA662: 11:58:35.878710 engine.go:512: Objective DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68 is WaitingForCompleteFunding
0xAAA662: 11:58:35.882859 engine.go:334: handling chain event {{[10 67 20 160 168 211 205 238 115 126 206 103 194 212 59 186 146 252 166 182 35 120 233 20 244 169 97 237 121 136 139 104] 5} {0x9777CDF0b7c384Aa011E77c578fE2E9c23d1884e 5000000} 10000000}
0xAAA662: 11:58:35.882885 engine.go:334: handling chain event {{[10 67 20 160 168 211 205 238 115 126 206 103 194 212 59 186 146 252 166 182 35 120 233 20 244 169 97 237 121 136 139 104] 5} {0x9777CDF0b7c384Aa011E77c578fE2E9c23d1884e 5000000} 10000000}
0xBBB676: 11:58:35.882880 engine.go:334: handling chain event {{[10 67 20 160 168 211 205 238 115 126 206 103 194 212 59 186 146 252 166 182 35 120 233 20 244 169 97 237 121 136 139 104] 5} {0x9777CDF0b7c384Aa011E77c578fE2E9c23d1884e 5000000} 10000000}
0xBBB676: 11:58:35.883168 engine.go:334: handling chain event {{[10 67 20 160 168 211 205 238 115 126 206 103 194 212 59 186 146 252 166 182 35 120 233 20 244 169 97 237 121 136 139 104] 5} {0x9777CDF0b7c384Aa011E77c578fE2E9c23d1884e 5000000} 10000000}
0xAAA662: 11:58:35.883501 engine.go:512: Objective DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68 is WaitingForCompletePostFund
0xAAA662: 11:58:35.883556 engine.go:691: Sending message {To:0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 PayloadSummaries:[{ObjectiveId:DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68 Type:SignedStatePayload PayloadDataSize:774}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}
0xBBB676: 11:58:35.883649 engine.go:512: Objective DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68 is WaitingForCompletePostFund
0xBBB676: 11:58:35.883712 engine.go:691: Sending message {To:0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE PayloadSummaries:[{ObjectiveId:DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68 Type:SignedStatePayload PayloadDataSize:774}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}
0xBBB676: 11:58:35.883788 engine.go:689: Receiving message {To:0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94 PayloadSummaries:[{ObjectiveId:DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68 Type:SignedStatePayload PayloadDataSize:774}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}
0xAAA662: 11:58:35.883844 engine.go:689: Receiving message {To:0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE PayloadSummaries:[{ObjectiveId:DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68 Type:SignedStatePayload PayloadDataSize:774}] ProposalSummaries:[] Payments:[] RejectedObjectives:[]}
0xAAA662: 11:58:35.884943 engine.go:512: Objective DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68 is WaitingForNothing
0xBBB676: 11:58:35.885031 engine.go:512: Objective DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68 is WaitingForNothing
0xAAA662: 11:58:35.885721 engine.go:160: Objective DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68 is complete & returned to API
0xBBB676: 11:58:35.885919 engine.go:160: Objective DirectFunding-0x0a4314a0a8d3cdee737ece67c2d43bba92fca6b62378e914f4a961ed79888b68 is complete & returned to API

```

I didn't notice any performance change with this logger, in the end. We might want to run this through testground with 0 latency / jitter to get a better idea of the performance aspect.