### PR TITLE
Add Close Ledger to RPC API

### DIFF
--- a/client/rpc/client.go
+++ b/client/rpc/client.go
@@ -38,18 +38,7 @@ func NewRpcClient(rpcServerUrl string, myAddress types.Address, chainId *big.Int
 
 	nc, err := nats.Connect(rpcServerUrl)
 	handleError(err)
-	trp := natstrans.NewNatsTransport(nc, []string{
-		fmt.Sprintf("nitro.%s",
-			serde.DirectFundRequestMethod),
-		fmt.Sprintf("nitro.%s",
-			serde.DirectDefundRequestMethod),
-		fmt.Sprintf("nitro.%s",
-			serde.VirtualFundRequestMethod),
-		fmt.Sprintf("nitro.%s",
-			serde.VirtualDefundRequestMethod),
-		fmt.Sprintf("nitro.%s",
-			serde.PayRequestMethod),
-	})
+	trp := natstrans.NewNatsTransport(nc, getTopics())
 
 	con, err := trp.PollConnection()
 	handleError(err)

--- a/client/rpc/server.go
+++ b/client/rpc/server.go
@@ -62,7 +62,7 @@ func (rs *RpcServer) registerHandlers() {
 	rs.nts.RegisterRequestHandler(network.DirectFundRequestMethod, func(data []byte) {
 		rs.nts.Logger.Trace().Msgf("Rpc server received request: %+v", data)
 
-		rpcRequest := serde.JsonRpcDirectFundRequest{}
+		rpcRequest := serde.JsonRpcRequest[directfund.ObjectiveRequest]{}
 		err := json.Unmarshal(data, &rpcRequest)
 		if err != nil {
 			panic("could not unmarshal direct fund objective request")
@@ -71,17 +71,17 @@ func (rs *RpcServer) registerHandlers() {
 		// todo: objective request is redefined so that it has a valid objectiveStarted channel.
 		// 	Should find a better way to accomplish this.
 		objectiveRequestWithChan := directfund.NewObjectiveRequest(
-			rpcRequest.ObjectiveRequest.CounterParty,
-			rpcRequest.ObjectiveRequest.ChallengeDuration,
-			rpcRequest.ObjectiveRequest.Outcome,
-			rpcRequest.ObjectiveRequest.Nonce,
-			rpcRequest.ObjectiveRequest.AppDefinition,
+			rpcRequest.Params.CounterParty,
+			rpcRequest.Params.ChallengeDuration,
+			rpcRequest.Params.Outcome,
+			rpcRequest.Params.Nonce,
+			rpcRequest.Params.AppDefinition,
 		)
 
 		rs.client.IncomingObjectiveRequests() <- objectiveRequestWithChan
 
-		objRes := rpcRequest.ObjectiveRequest.Response(*rs.client.Address, rs.chainId)
-		msg := serde.NewDirectFundResponseMessage(rpcRequest.Id, objRes)
+		objRes := rpcRequest.Params.Response(*rs.client.Address, rs.chainId)
+		msg := serde.NewJsonRpcResponse(rpcRequest.Id, objRes)
 		messageData, err := json.Marshal(msg)
 		if err != nil {
 			panic("Could not marshal direct fund response message")

--- a/client/rpc/server.go
+++ b/client/rpc/server.go
@@ -116,7 +116,7 @@ func (rs *RpcServer) registerHandlers() {
 
 		rs.client.IncomingObjectiveRequests() <- objectiveRequestWithChan
 
-		objRes := rpcRequest.Params.Id(*rs.client.Address, rs.client.ChainId)
+		objRes := rpcRequest.Params.Id(*rs.client.Address, rs.chainId)
 		msg := serde.NewJsonRpcResponse(rpcRequest.Id, objRes)
 		messageData, err := json.Marshal(msg)
 		if err != nil {

--- a/client/rpc/server.go
+++ b/client/rpc/server.go
@@ -2,7 +2,6 @@ package rpc
 
 import (
 	"encoding/json"
-	"fmt"
 	"math/big"
 
 	"github.com/nats-io/nats-server/v2/server"
@@ -43,18 +42,7 @@ func NewRpcServer(nitroClient *nitro.Client, chainId *big.Int, logger zerolog.Lo
 	nc, err := nats.Connect(ns.ClientURL())
 	handleError(err)
 
-	trp := natstrans.NewNatsTransport(nc, []string{
-		fmt.Sprintf("nitro.%s",
-			serde.DirectFundRequestMethod),
-		fmt.Sprintf("nitro.%s",
-			serde.DirectDefundRequestMethod),
-		fmt.Sprintf("nitro.%s",
-			serde.VirtualFundRequestMethod),
-		fmt.Sprintf("nitro.%s",
-			serde.VirtualDefundRequestMethod),
-		fmt.Sprintf("nitro.%s",
-			serde.PayRequestMethod),
-	})
+	trp := natstrans.NewNatsTransport(nc, getTopics())
 
 	con, err := trp.PollConnection()
 	handleError(err)

--- a/client/rpc/util.go
+++ b/client/rpc/util.go
@@ -1,0 +1,24 @@
+package rpc
+
+import (
+	"fmt"
+
+	"github.com/statechannels/go-nitro/network/serde"
+)
+
+// getTopics returns a list of topics that the client/server should subscribe to.
+func getTopics() []string {
+
+	return []string{
+		fmt.Sprintf("nitro.%s",
+			serde.DirectFundRequestMethod),
+		fmt.Sprintf("nitro.%s",
+			serde.DirectDefundRequestMethod),
+		fmt.Sprintf("nitro.%s",
+			serde.VirtualFundRequestMethod),
+		fmt.Sprintf("nitro.%s",
+			serde.VirtualDefundRequestMethod),
+		fmt.Sprintf("nitro.%s",
+			serde.PayRequestMethod),
+	}
+}

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -64,4 +64,10 @@ func TestRpcClient(t *testing.T) {
 
 	waitTimeForCompletedObjectiveIds(t, &clientA, defaultTimeout, res.Id)
 	waitTimeForCompletedObjectiveIds(t, &clientB, defaultTimeout, res.Id)
+
+	closeId := rpcClientA.CloseLedger(res.ChannelId)
+
+	waitTimeForCompletedObjectiveIds(t, &clientA, defaultTimeout, closeId)
+	waitTimeForCompletedObjectiveIds(t, &clientB, defaultTimeout, closeId)
+
 }

--- a/network/serde/jsonrpc.go
+++ b/network/serde/jsonrpc.go
@@ -11,6 +11,16 @@ import (
 	"github.com/statechannels/go-nitro/protocols/virtualfund"
 )
 
+type RequestMethod string
+
+const (
+	DirectFundRequestMethod    RequestMethod = "direct_fund"
+	DirectDefundRequestMethod  RequestMethod = "direct_defund"
+	VirtualFundRequestMethod   RequestMethod = "virtual_fund"
+	VirtualDefundRequestMethod RequestMethod = "virtual_defund"
+	PayRequestMethod           RequestMethod = "pay"
+)
+
 const JsonRpcVersion = "2.0"
 
 type MessageType int8
@@ -21,22 +31,13 @@ const (
 	TypeError    MessageType = 3
 )
 
-type MethodType string
-
-const (
-	DirectFund    MethodType = "direct_fund"
-	DirectDefund  MethodType = "direct_defund"
-	VirtualFund   MethodType = "virtual_fund"
-	VirtualDefund MethodType = "virtual_defund"
-)
-
 type JsonRpcRequestResponse struct {
-	Jsonrpc string      `json:"jsonrpc"`
-	Id      uint64      `json:"id"`
-	Method  string      `json:"method"`
-	Params  interface{} `json:"params"`
-	Result  interface{} `json:"result"`
-	Error   interface{} `json:"error"`
+	Jsonrpc string        `json:"jsonrpc"`
+	Id      uint64        `json:"id"`
+	Method  RequestMethod `json:"method"`
+	Params  interface{}   `json:"params"`
+	Result  interface{}   `json:"result"`
+	Error   interface{}   `json:"error"`
 }
 type RequestPayload interface {
 	directfund.ObjectiveRequest | directdefund.ObjectiveRequest | virtualfund.ObjectiveRequest | virtualdefund.ObjectiveRequest
@@ -57,7 +58,7 @@ type JsonRpcResponse[T ResponsePayload] struct {
 	Error   interface{} `json:"error"`
 }
 
-func NewJsonRpcRequest[T RequestPayload](requestId uint64, method MethodType, objectiveRequest T) *JsonRpcRequest[T] {
+func NewJsonRpcRequest[T RequestPayload](requestId uint64, method RequestMethod, objectiveRequest T) *JsonRpcRequest[T] {
 
 	return &JsonRpcRequest[T]{
 		Jsonrpc: JsonRpcVersion,

--- a/network/serde/jsonrpc.go
+++ b/network/serde/jsonrpc.go
@@ -4,7 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/statechannels/go-nitro/protocols"
+	"github.com/statechannels/go-nitro/protocols/directdefund"
 	"github.com/statechannels/go-nitro/protocols/directfund"
+	"github.com/statechannels/go-nitro/protocols/virtualdefund"
+	"github.com/statechannels/go-nitro/protocols/virtualfund"
 )
 
 const JsonRpcVersion = "2.0"
@@ -17,19 +21,14 @@ const (
 	TypeError    MessageType = 3
 )
 
-type JsonRpcRequest struct {
-	Jsonrpc string      `json:"jsonrpc"`
-	Id      uint64      `json:"id"`
-	Method  string      `json:"method"`
-	Params  interface{} `json:"params"`
-}
+type MethodType string
 
-type JsonRpcResponse struct {
-	Jsonrpc string      `json:"jsonrpc"`
-	Id      uint64      `json:"id"`
-	Result  interface{} `json:"result"`
-	Error   interface{} `json:"error"`
-}
+const (
+	DirectFund    MethodType = "direct_fund"
+	DirectDefund  MethodType = "direct_defund"
+	VirtualFund   MethodType = "virtual_fund"
+	VirtualDefund MethodType = "virtual_defund"
+)
 
 type JsonRpcRequestResponse struct {
 	Jsonrpc string      `json:"jsonrpc"`
@@ -39,38 +38,41 @@ type JsonRpcRequestResponse struct {
 	Result  interface{} `json:"result"`
 	Error   interface{} `json:"error"`
 }
-
-type JsonRpcDirectFundRequest struct {
-	Jsonrpc          string                      `json:"jsonrpc"`
-	Id               uint64                      `json:"id"`
-	Method           string                      `json:"method"`
-	ObjectiveRequest directfund.ObjectiveRequest `json:"params"`
+type RequestPayload interface {
+	directfund.ObjectiveRequest | directdefund.ObjectiveRequest | virtualfund.ObjectiveRequest | virtualdefund.ObjectiveRequest
+}
+type JsonRpcRequest[T RequestPayload] struct {
+	Jsonrpc string `json:"jsonrpc"`
+	Id      uint64 `json:"id"`
+	Method  string `json:"method"`
+	Params  T      `json:"params"`
+}
+type ResponsePayload interface {
+	directfund.ObjectiveResponse | protocols.ObjectiveId | virtualfund.ObjectiveResponse
+}
+type JsonRpcResponse[T ResponsePayload] struct {
+	Jsonrpc string      `json:"jsonrpc"`
+	Id      uint64      `json:"id"`
+	Result  T           `json:"result"`
+	Error   interface{} `json:"error"`
 }
 
-type JsonRpcDirectFundResponse struct {
-	Jsonrpc           string                       `json:"jsonrpc"`
-	Id                uint64                       `json:"id"`
-	ObjectiveResponse directfund.ObjectiveResponse `json:"result"`
-	Error             interface{}                  `json:"error"`
-}
+func NewJsonRpcRequest[T RequestPayload](requestId uint64, method MethodType, objectiveRequest T) *JsonRpcRequest[T] {
 
-type JsonRpc struct{}
-
-func NewDirectFundRequestMessage(requestId uint64, objectiveRequest directfund.ObjectiveRequest) *JsonRpcDirectFundRequest {
-	return &JsonRpcDirectFundRequest{
-		Jsonrpc:          JsonRpcVersion,
-		Id:               requestId,
-		Method:           "direct_fund",
-		ObjectiveRequest: objectiveRequest,
+	return &JsonRpcRequest[T]{
+		Jsonrpc: JsonRpcVersion,
+		Id:      requestId,
+		Method:  string(method),
+		Params:  objectiveRequest,
 	}
 }
 
-func NewDirectFundResponseMessage(requestId uint64, objectiveResponse directfund.ObjectiveResponse) *JsonRpcDirectFundResponse {
-	return &JsonRpcDirectFundResponse{
-		Jsonrpc:           JsonRpcVersion,
-		Id:                requestId,
-		ObjectiveResponse: objectiveResponse,
-		Error:             nil,
+func NewJsonRpcResponse[T ResponsePayload](requestId uint64, objectiveResponse T) *JsonRpcResponse[T] {
+	return &JsonRpcResponse[T]{
+		Jsonrpc: JsonRpcVersion,
+		Id:      requestId,
+		Result:  objectiveResponse,
+		Error:   nil,
 	}
 }
 

--- a/network/service.go
+++ b/network/service.go
@@ -10,20 +10,13 @@ import (
 	"github.com/statechannels/go-nitro/network/transport"
 )
 
-const (
-	DirectFundRequestMethod    = "direct_fund"
-	DirectDefundRequestMethod  = "direct_defund"
-	VirtualFundRequestMethod   = "virtual_fund"
-	VirtualDefundRequestMethod = "virtual_defund"
-)
-
 type NetworkService struct {
 	Logger     zerolog.Logger
 	Connection transport.Connection
 
-	handlerRequest sync.Map
-	handlerError   sync.Map
-	responseHander func([]byte)
+	handlerRequest  sync.Map
+	handlerError    sync.Map
+	responseHandler func(uint64, []byte)
 }
 
 func NewNetworkService(con transport.Connection) *NetworkService {
@@ -36,33 +29,32 @@ func NewNetworkService(con transport.Connection) *NetworkService {
 	return p
 }
 
-func (p *NetworkService) RegisterRequestHandler(method string, handler func([]byte)) {
-	p.handlerRequest.Store(method, handler)
-	p.Logger.Trace().Str("method", method).Msg("registered request handler")
+func (p *NetworkService) RegisterRequestHandler(method serde.RequestMethod, handler func(uint64, []byte)) {
+	p.handlerRequest.Store(string(method), handler)
+	p.Logger.Trace().Str("method", string(method)).Msg("registered request handler")
 }
 
-func (p *NetworkService) UnregisterRequestHandler(method string) {
-	p.handlerRequest.Delete(method)
-	p.Logger.Trace().Str("method", method).Msg("unregistered request handler")
+func (p *NetworkService) UnregisterRequestHandler(method serde.RequestMethod) {
+	p.handlerRequest.Delete(string(method))
+	p.Logger.Trace().Str("method", string(method)).Msg("unregistered request handler")
 }
 
-func (p *NetworkService) RegisterErrorHandler(method string, handler func([]byte)) {
-	p.handlerError.Store(method, handler)
-	p.Logger.Trace().Str("method", method).Msg("registered error handler")
+func (p *NetworkService) RegisterErrorHandler(method serde.RequestMethod, handler func(uint64, []byte)) {
+	p.handlerError.Store(string(method), handler)
+	p.Logger.Trace().Str("method", string(method)).Msg("registered error handler")
 }
 
-func (p *NetworkService) UnregisterErrorHandler(method string) {
-	p.handlerError.Delete(method)
-	p.Logger.Trace().Str("method", method).Msg("unregistered error handler")
+func (p *NetworkService) UnregisterErrorHandler(method serde.RequestMethod) {
+	p.handlerError.Delete(string(method))
+	p.Logger.Trace().Str("method", string(method)).Msg("unregistered error handler")
 }
 
-func (p *NetworkService) RegisterResponseHandler(handler func([]byte)) {
-	p.responseHander = handler
+func (p *NetworkService) RegisterResponseHandler(handler func(uint64, []byte)) {
+	p.responseHandler = handler
 	p.Logger.Trace().Msg("registered response handler")
 }
-
 func (p *NetworkService) UnregisterResponseHandler() {
-	p.responseHander = nil
+	p.responseHandler = nil
 	p.Logger.Trace().Msg("unregistered response handler")
 }
 
@@ -83,7 +75,6 @@ func (p *NetworkService) handleMessages() {
 		}
 
 		msg, messageType, err := serde.Deserialize(data)
-
 		if err != nil {
 			p.Logger.Error().Err(err).Msg("failed to deserialize message")
 			return
@@ -92,7 +83,7 @@ func (p *NetworkService) handleMessages() {
 		// NOTE: we do not hande messages in a separate goroutine
 		// to ensure that messages are handled in the order they are received
 		// and to avoid inconsistencies in the state of the peer
-		p.handleMessage(msg.Method, messageType, data)
+		p.handleMessage(msg.Id, msg.Method, messageType, data)
 	}
 }
 
@@ -106,21 +97,21 @@ func (p *NetworkService) SendMessage(method string, data []byte) {
 		Msg("sent message")
 }
 
-func (p *NetworkService) getHandler(method string, messageType serde.MessageType) func([]byte) {
+func (p *NetworkService) getHandler(method string, messageType serde.MessageType) func(uint64, []byte) {
 	switch messageType {
 	case serde.TypeRequest:
 		function, ok := p.handlerRequest.Load(method)
 		if ok {
-			return function.(func([]byte))
+			return function.(func(uint64, []byte))
 		}
 
 	case serde.TypeResponse:
-		return p.responseHander
+		return p.responseHandler
 
 	case serde.TypeError:
 		function, ok := p.handlerError.Load(method)
 		if ok {
-			return function.(func([]byte))
+			return function.(func(uint64, []byte))
 		}
 	}
 	// TODO: case handlerPublicEvent
@@ -129,21 +120,23 @@ func (p *NetworkService) getHandler(method string, messageType serde.MessageType
 	return nil
 }
 
-func (p *NetworkService) handleMessage(method string, messageType serde.MessageType, data []byte) {
+func (p *NetworkService) handleMessage(id uint64, method serde.RequestMethod, messageType serde.MessageType, data []byte) {
 	p.Logger.Trace().
-		Str("method", method).
+		Str("method", string(method)).
+		Uint64("id", id).
 		Msg("received message")
 
-	h := p.getHandler(method, messageType)
+	h := p.getHandler(string(method), messageType)
 
 	if h == nil {
 		p.Logger.Error().
-			Str("method", method).
+			Str("method", string(method)).
+			Uint64("id", id).
 			Msg("missing handler")
 		return
 	}
 
-	h(data)
+	h(id, data)
 }
 
 func (p *NetworkService) Close() {


### PR DESCRIPTION
Adds the `CloseLedger` function to the RPC client which triggers an RPC call to the RPC server to start `direct_defunding`.

I've introduced some generic request/response structs that I think this should make adding the remaining API calls easier. 

The test has been updated to call `CloseLedger` and wait for the objective to close.