### PR TITLE
Fix possible flicker in query test

### DIFF
--- a/client_test/query_test.go
+++ b/client_test/query_test.go
@@ -33,9 +33,16 @@ func TestQueryLedgerChannel(t *testing.T) {
 	res := aliceClient.CreateLedgerChannel(irene.Address(), 0, outcome)
 	ledgerId := res.ChannelId
 
-	// Irene might not have received the objective yet so we only check alice
-	checkLedgerChannel(t, ledgerId, outcome, query.Proposed, &aliceClient)
-
+	// It is possible the objective completes for Alice before we query it
+	// so the status could be either Proposed or Ready
+	// Irene may not have received the objective yet so we only check Alice
+	ledger, err := aliceClient.GetLedgerChannel(ledgerId)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ledger.Status != query.Proposed && ledger.Status != query.Ready {
+		t.Fatalf("Expected status to be Proposed or Ready but got %v", ledger.Status)
+	}
 	waitTimeForCompletedObjectiveIds(t, &aliceClient, defaultTimeout, res.Id)
 	waitTimeForCompletedObjectiveIds(t, &ireneClient, defaultTimeout, res.Id)
 

--- a/client_test/query_test.go
+++ b/client_test/query_test.go
@@ -50,9 +50,16 @@ func TestQueryLedgerChannel(t *testing.T) {
 
 	closeId := aliceClient.CloseLedgerChannel(ledgerId)
 
-	// Irene might not have received the objective yet so we only check alice
-	checkLedgerChannel(t, ledgerId, outcome, query.Closing, &aliceClient)
-
+	// It is possible the objective completes for Alice before we query it
+	// so the status could be either Closing or Complete
+	// Irene may not have received the objective yet so we only check Alice
+	ledger, err = aliceClient.GetLedgerChannel(ledgerId)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ledger.Status != query.Closing && ledger.Status != query.Complete {
+		t.Fatalf("Expected status to be Closing or Complete but got %v", ledger.Status)
+	}
 	waitTimeForCompletedObjectiveIds(t, &aliceClient, defaultTimeout, closeId)
 	waitTimeForCompletedObjectiveIds(t, &ireneClient, defaultTimeout, closeId)
 


### PR DESCRIPTION
We're seeing flickers on [CI for the query ledger channel test.](https://github.com/statechannels/go-nitro/actions/runs/4115238114/jobs/7103683401)

This is due to us asserting that the status of a ledger channel is `Proposed` after calling `CreateLedgerChannel`. However it's possible that the create ledger channel objective completes before we call the query function, since there's nothing blocking progress on the ledger channel once `CreateLedgerChannel` is called. This means that it's possible that we get get back a status of `Proposed` or `Ready` when calling query ledger channel immediately after creating it. It seems like this is more prevalent on CI, most likely due to constrained resources?

This PR updates the initial check after calling `CreateLedgerChannel` to check that the status is `Ready` **or** `Proposed` since either could be valid. 