### PR TITLE
Logging cleanup

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -149,8 +149,10 @@ func (e *Engine) Run() {
 
 		// Handle errors
 		if err != nil {
-			e.logger.Panic().Err(err).Msgf("%s, error in run loop", e.store.GetAddress())
+			e.logger.Err(err).Msgf("%s, error in run loop", e.store.GetAddress())
+
 			// TODO do not panic if in production.
+			panic(err)
 			// TODO report errors back to the consuming application
 		}
 

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -686,9 +686,9 @@ const (
 func (e *Engine) logMessage(msg protocols.Message, direction messageDirection) {
 
 	if direction == Incoming {
-		e.logger.Printf("Receiving message %+v", msg.Summarize())
+		e.logger.Trace().EmbedObject(msg.Summarize()).Msg("Received message")
 	} else {
-		e.logger.Printf("Sending message %+v", msg.Summarize())
+		e.logger.Trace().EmbedObject(msg.Summarize()).Msg("Sending message")
 	}
 }
 

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -26,6 +26,7 @@ func createLogger(logDestination *os.File, clientName, rpcRole string) zerolog.L
 
 func TestRpcClient(t *testing.T) {
 	logFile := "test_rpc_client.log"
+	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
 	chain := chainservice.NewMockChain()

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -25,7 +25,8 @@ func createLogger(logDestination *os.File, clientName, rpcRole string) zerolog.L
 }
 
 func TestRpcClient(t *testing.T) {
-	logDestination := newLogWriter("test_rpc_client.log")
+	logFile := "test_rpc_client.log"
+	logDestination := newLogWriter(logFile)
 
 	chain := chainservice.NewMockChain()
 	chainServiceA := chainservice.NewMockChainService(chain, alice.Address())
@@ -36,9 +37,9 @@ func TestRpcClient(t *testing.T) {
 	}
 	chainServiceI := chainservice.NewMockChainService(chain, irene.Address())
 
-	clientA, msgA := setupClientWithP2PMessageService(alice.PrivateKey, 3005, chainServiceA, createLogger(logDestination, "alice", ""))
-	clientB, msgB := setupClientWithP2PMessageService(bob.PrivateKey, 3006, chainServiceB, createLogger(logDestination, "bob", ""))
-	clientI, msgI := setupClientWithP2PMessageService(irene.PrivateKey, 3007, chainServiceI, createLogger(logDestination, "irene", ""))
+	clientA, msgA := setupClientWithP2PMessageService(alice.PrivateKey, 3005, chainServiceA, logDestination)
+	clientB, msgB := setupClientWithP2PMessageService(bob.PrivateKey, 3006, chainServiceB, logDestination)
+	clientI, msgI := setupClientWithP2PMessageService(irene.PrivateKey, 3007, chainServiceI, logDestination)
 	peers := []p2pms.PeerInfo{
 		{Id: msgA.Id(), IpAddress: "127.0.0.1", Port: 3005, Address: alice.Address()},
 		{Id: msgB.Id(), IpAddress: "127.0.0.1", Port: 3006, Address: bob.Address()},

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -211,10 +211,10 @@ type PaymentSummaries []PaymentSummary
 
 func (m MessageSummary) MarshalZerologObject(e *zerolog.Event) {
 	e.Str("To", m.To).
-		Array("PayloadSummaries", ObjectivePayloadSummaries(m.PayloadSummaries)).
-		Array("ProposalSummaries", ProposalSummaries(m.ProposalSummaries)).
-		Array("Payments", PaymentSummaries(m.Payments)).
-		Array("RejectedObjectives", RejectedIds(m.RejectedObjectives))
+		Array("PayloadSummaries", m.PayloadSummaries).
+		Array("ProposalSummaries", (m.ProposalSummaries)).
+		Array("Payments", m.Payments).
+		Array("RejectedObjectives", m.RejectedObjectives)
 
 }
 func (o ObjectivePayloadSummaries) MarshalZerologArray(a *zerolog.Array) {


### PR DESCRIPTION
Performs some cleanup of how we log stuff using `zerologger` so the log file is easily parsible by `JQ`.
<img width="1118" alt="image" src="https://user-images.githubusercontent.com/1620336/217353356-8e35d7d4-39ae-4436-9a07-97e0cf727334.png">

# Changes
- The message summary implements the `MarshalZerologObject` which means the message summaries gets nicely serialized out to a JSON entry in the log.
- The engine constructs it's own logger, so instead of passing in a logger (and getting nested entries) we now just pass the log file name into the engine.
- We now truncate the log file at the start of the RPC test
- We now call `panic` with the error we run into the engine, so the error will be visible in the console when the test fails

