### PR TITLE
Concurrent test

### DIFF
--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -67,9 +67,8 @@ func TestRpcClient(t *testing.T) {
 	assert.Regexp(t, "DirectFunding.0x.*", res.Id)
 
 	waitTimeForCompletedObjectiveIds(t, &clientA, defaultTimeout, res.Id)
-	waitTimeForCompletedObjectiveIds(t, &clientI, defaultTimeout, res.Id)
 	waitTimeForCompletedObjectiveIds(t, &clientB, defaultTimeout, bobResponse.Id)
-	waitTimeForCompletedObjectiveIds(t, &clientI, defaultTimeout, bobResponse.Id)
+	waitTimeForCompletedObjectiveIds(t, &clientI, defaultTimeout, res.Id, bobResponse.Id)
 
 	vRes := rpcClientA.CreateVirtual(
 		[]types.Address{irene.Address()},

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -61,14 +61,13 @@ func TestRpcClient(t *testing.T) {
 	defer rpcClientA.Close()
 
 	res := rpcClientA.CreateLedger(irene.Address(), 100, testdata.Outcomes.Create(alice.Address(), irene.Address(), 100, 100, types.Address{}))
+	bobResponse := clientB.CreateLedgerChannel(irene.Address(), 100, testdata.Outcomes.Create(bob.Address(), irene.Address(), 100, 100, types.Address{}))
 
 	// Quick sanity check that we're getting a valid objective id
 	assert.Regexp(t, "DirectFunding.0x.*", res.Id)
+
 	waitTimeForCompletedObjectiveIds(t, &clientA, defaultTimeout, res.Id)
 	waitTimeForCompletedObjectiveIds(t, &clientI, defaultTimeout, res.Id)
-
-	bobResponse := clientB.CreateLedgerChannel(irene.Address(), 100, testdata.Outcomes.Create(bob.Address(), irene.Address(), 100, 100, types.Address{}))
-
 	waitTimeForCompletedObjectiveIds(t, &clientB, defaultTimeout, bobResponse.Id)
 	waitTimeForCompletedObjectiveIds(t, &clientI, defaultTimeout, bobResponse.Id)
 


### PR DESCRIPTION
Fixes #1105 

Previously we would wait for Irene's ledger objectives to complete by two separate calls to `waitTimeForCompletedObjectiveIds`. However `waitTimeForCompletedObjectiveIds` will greedily read any completed objectives from the client, even if it's not the objective it's waiting for. This means that the first call to `waitTimeForCompletedObjectiveIds` could consume both completed objectives, causing the second call to block forever.

To resolve this we now make one call to `waitTimeForCompletedObjectiveIds` and pass in both objective ids we're interested in. This means we'll never "drop" a completed objective id.