### PR TITLE
Use random 64 bit integers for nonces in RPC client

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -35,7 +35,6 @@ func NewRpcClient(rpcServerUrl string, myAddress types.Address, chainId *big.Int
 	nc, err := nats.Connect(rpcServerUrl)
 	handleError(err)
 	con := natstrans.NewNatsConnection(nc)
-
 	c := &RpcClient{con, myAddress, chainId, logger}
 	return c
 }
@@ -47,7 +46,7 @@ func (rc *RpcClient) CreateVirtual(intermediaries []types.Address, counterparty 
 		counterparty,
 		100,
 		outcome,
-		uint64(rand.Float64()), // TODO: Since numeric fields get converted to a float64 in transit we need to prevent overflow
+		rand.Uint64(),
 		common.Address{})
 
 	return waitForRequest[virtualfund.ObjectiveRequest, virtualfund.ObjectiveResponse](rc, objReq)
@@ -67,7 +66,7 @@ func (rc *RpcClient) CreateLedger(counterparty types.Address, ChallengeDuration 
 		counterparty,
 		100,
 		outcome,
-		uint64(rand.Float64()), // TODO: Since numeric fields get converted to a float64 in transit we need to prevent overflow
+		rand.Uint64(),
 		common.Address{})
 
 	return waitForRequest[directfund.ObjectiveRequest, directfund.ObjectiveResponse](rc, objReq)

--- a/rpc/serde/serde_test.go
+++ b/rpc/serde/serde_test.go
@@ -5,44 +5,54 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols/directfund"
 )
 
+var someRequest JsonRpcRequest[directfund.ObjectiveRequest] = JsonRpcRequest[directfund.ObjectiveRequest]{
+	Jsonrpc: JsonRpcVersion,
+	Id:      123,
+	Method:  "CreateLedgerChannel",
+	Params: directfund.NewObjectiveRequest(
+		testactors.Alice.Address(),
+		345,
+		testdata.Outcomes.Create(
+			testactors.Alice.Address(),
+			testactors.Bob.Address(),
+			9,
+			7,
+			common.Address{},
+		),
+		18446744073709551615, // max uint64
+		common.Address{123},
+	),
+}
+
+var someRequestJSONString = `{"jsonrpc":"2.0","id":123,"method":"CreateLedgerChannel","params":{"CounterParty":"0xaaa6628ec44a8a742987ef3a114ddfe2d4f7adce","ChallengeDuration":345,"Outcome":[{"Asset":"0x0000000000000000000000000000000000000000","AssetMetadata":{"AssetType":0,"Metadata":null},"Allocations":[{"Destination":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce","Amount":9,"AllocationType":0,"Metadata":null},{"Destination":"0x000000000000000000000000bbb676f9cff8d242e9eac39d063848807d3d1d94","Amount":7,"AllocationType":0,"Metadata":null}]}],"AppDefinition":"0x7b00000000000000000000000000000000000000","AppData":null,"Nonce":18446744073709551615}}`
+
 func TestMarshalJSON(t *testing.T) {
 
-	req := JsonRpcRequest[directfund.ObjectiveRequest]{
-		Jsonrpc: JsonRpcVersion,
-		Id:      123,
-		Method:  "CreateLedgerChannel",
-		Params: directfund.NewObjectiveRequest(
-			testactors.Alice.Address(),
-			345,
-			testdata.Outcomes.Create(
-				testactors.Alice.Address(),
-				testactors.Bob.Address(),
-				9,
-				7,
-				common.Address{},
-			),
-			18446744073709551615, // max uint64
-			common.Address{123},
-		),
-	}
-
-	want := `{"jsonrpc":"2.0","id":123,"method":"CreateLedgerChannel","params":{"CounterParty":"0xaaa6628ec44a8a742987ef3a114ddfe2d4f7adce","ChallengeDuration":345,"Outcome":[{"Asset":"0x0000000000000000000000000000000000000000","AssetMetadata":{"AssetType":0,"Metadata":null},"Allocations":[{"Destination":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce","Amount":9,"AllocationType":0,"Metadata":null},{"Destination":"0x000000000000000000000000bbb676f9cff8d242e9eac39d063848807d3d1d94","Amount":7,"AllocationType":0,"Metadata":null}]}],"AppDefinition":"0x7b00000000000000000000000000000000000000","AppData":null,"Nonce":18446744073709551615}}`
-	enc, err := json.Marshal(req)
+	enc, err := json.Marshal(someRequest)
 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(enc) != want {
-		t.Fatalf("incorrect json marshaling, expected %v got \n%v", want, string(enc))
+	if string(enc) != someRequestJSONString {
+		t.Fatalf("incorrect json marshaling, expected %v got \n%v", someRequestJSONString, string(enc))
 	}
 
 }
 
 func TestUnmarshalJSON(t *testing.T) {
-	t.Skip()
+	got := JsonRpcRequest[directfund.ObjectiveRequest]{} // This test assumes we have a way to know the "type" (method) of the request.
+	err := json.Unmarshal([]byte(someRequestJSONString), &got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(someRequest, got, cmpopts.IgnoreUnexported(directfund.ObjectiveRequest{})); diff != "" {
+		t.Fatalf("TestCrank: side effects mismatch (-want +got):\n%s", diff)
+	}
 }

--- a/rpc/serde/serde_test.go
+++ b/rpc/serde/serde_test.go
@@ -1,0 +1,48 @@
+package serde
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/internal/testactors"
+	"github.com/statechannels/go-nitro/internal/testdata"
+	"github.com/statechannels/go-nitro/protocols/directfund"
+)
+
+func TestMarshalJSON(t *testing.T) {
+
+	req := JsonRpcRequest[directfund.ObjectiveRequest]{
+		Jsonrpc: JsonRpcVersion,
+		Id:      123,
+		Method:  "CreateLedgerChannel",
+		Params: directfund.NewObjectiveRequest(
+			testactors.Alice.Address(),
+			345,
+			testdata.Outcomes.Create(
+				testactors.Alice.Address(),
+				testactors.Bob.Address(),
+				9,
+				7,
+				common.Address{},
+			),
+			18446744073709551615, // max uint64
+			common.Address{123},
+		),
+	}
+
+	want := `{"jsonrpc":"2.0","id":123,"method":"CreateLedgerChannel","params":{"CounterParty":"0xaaa6628ec44a8a742987ef3a114ddfe2d4f7adce","ChallengeDuration":345,"Outcome":[{"Asset":"0x0000000000000000000000000000000000000000","AssetMetadata":{"AssetType":0,"Metadata":null},"Allocations":[{"Destination":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce","Amount":9,"AllocationType":0,"Metadata":null},{"Destination":"0x000000000000000000000000bbb676f9cff8d242e9eac39d063848807d3d1d94","Amount":7,"AllocationType":0,"Metadata":null}]}],"AppDefinition":"0x7b00000000000000000000000000000000000000","AppData":null,"Nonce":18446744073709551615}}`
+	enc, err := json.Marshal(req)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(enc) != want {
+		t.Fatalf("incorrect json marshaling, expected %v got \n%v", want, string(enc))
+	}
+
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	t.Skip()
+}

--- a/rpc/serde/serde_test.go
+++ b/rpc/serde/serde_test.go
@@ -53,6 +53,6 @@ func TestUnmarshalJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	if diff := cmp.Diff(someRequest, got, cmpopts.IgnoreUnexported(directfund.ObjectiveRequest{})); diff != "" {
-		t.Fatalf("TestCrank: side effects mismatch (-want +got):\n%s", diff)
+		t.Fatalf("TestUnmarshalJSON: mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
This follows the pattern we used in the `client` package. 

The only reason to not follow that pattern is concerns over serialization/deserialization. I don't see any problems with serde (please someone point them out if I have missed something) and have added tests to increase confidence that this will be ok. 

Closes #1093 