### PR TITLE
RPC server refactor

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -103,11 +103,6 @@ func (c *Client) ReceivedVouchers() <-chan payments.Voucher {
 	return c.receivedVouchers
 }
 
-// IncomingObjectiveRequests is a chan that accepts objective requests from an RPC server.
-func (c *Client) IncomingObjectiveRequests() chan<- protocols.ObjectiveRequest {
-	return c.engine.ObjectiveRequestsFromAPI
-}
-
 // CreateVirtualChannel creates a virtual channel with the counterParty using ledger channels
 // with the supplied intermediaries.
 func (c *Client) CreateVirtualPaymentChannel(Intermediaries []types.Address, CounterParty types.Address, ChallengeDuration uint32, Outcome outcome.Exit) virtualfund.ObjectiveResponse {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -33,7 +33,9 @@ type RpcClient struct {
 // NewRpcClient creates a new RpcClient
 func NewRpcClient(rpcServerUrl string, myAddress types.Address, chainId *big.Int, logger zerolog.Logger) *RpcClient {
 	nc, err := nats.Connect(rpcServerUrl)
-	handleError(err)
+	if err != nil {
+		panic(err)
+	}
 	con := natstrans.NewNatsConnection(nc)
 	c := &RpcClient{con, myAddress, chainId, logger}
 	return c

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -107,7 +107,7 @@ func subcribeToRequest[T serde.RequestPayload, U serde.ResponsePayload](rs *RpcS
 		rpcRequest := serde.JsonRpcRequest[T]{}
 		err := json.Unmarshal(data, &rpcRequest)
 		if err != nil {
-			panic("could not unmarshal direct fund objective request")
+			panic("could not unmarshal objective request")
 		}
 		obj := rpcRequest.Params
 		objResponse := processPayload(obj)
@@ -115,7 +115,7 @@ func subcribeToRequest[T serde.RequestPayload, U serde.ResponsePayload](rs *RpcS
 		msg := serde.NewJsonRpcResponse(rpcRequest.Id, objResponse)
 		messageData, err := json.Marshal(msg)
 		if err != nil {
-			panic("Could not marshal direct fund response message")
+			panic("Could not marshal response message")
 		}
 
 		return messageData


### PR DESCRIPTION
Fixes https://github.com/statechannels/go-nitro/issues/1096, fixes https://github.com/statechannels/go-nitro/issues/1094.

This PR:
- Factors out copy/pasted code between server request handlers.
- Removes IncomingObjectiveRequest from the client library. Now, when a server receives a jsonrpc request, the server maps that request to a client library api.