### PR TITLE
RPC Notifications

### DIFF
--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	p2pms "github.com/statechannels/go-nitro/client/engine/messageservice/p2p-message-service"
 	"github.com/statechannels/go-nitro/internal/testdata"
-	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/rpc"
 	"github.com/statechannels/go-nitro/types"
 	"github.com/stretchr/testify/assert"
@@ -71,7 +70,7 @@ func TestRpcClient(t *testing.T) {
 	// Quick sanity check that we're getting a valid objective id
 	assert.Regexp(t, "DirectFunding.0x.*", res.Id)
 
-	waitForObjectiveCompletion(rpcClientA, res.Id)
+	rpcClientA.WaitForObjectiveCompletion(res.Id)
 	waitTimeForCompletedObjectiveIds(t, &clientB, defaultTimeout, bobResponse.Id)
 	waitTimeForCompletedObjectiveIds(t, &clientI, defaultTimeout, res.Id, bobResponse.Id)
 
@@ -83,26 +82,19 @@ func TestRpcClient(t *testing.T) {
 
 	assert.Regexp(t, "VirtualFund.0x.*", vRes.Id)
 
-	waitForObjectiveCompletion(rpcClientA, vRes.Id)
+	rpcClientA.WaitForObjectiveCompletion(vRes.Id)
 	waitTimeForCompletedObjectiveIds(t, &clientB, defaultTimeout, vRes.Id)
 	waitTimeForCompletedObjectiveIds(t, &clientI, defaultTimeout, vRes.Id)
 	rpcClientA.Pay(vRes.ChannelId, 1)
 
 	closeVId := rpcClientA.CloseVirtual(vRes.ChannelId)
-	waitForObjectiveCompletion(rpcClientA, closeVId)
+	rpcClientA.WaitForObjectiveCompletion(closeVId)
 	waitTimeForCompletedObjectiveIds(t, &clientB, defaultTimeout, closeVId)
 	waitTimeForCompletedObjectiveIds(t, &clientI, defaultTimeout, closeVId)
 
 	closeId := rpcClientA.CloseLedger(res.ChannelId)
-	waitForObjectiveCompletion(rpcClientA, closeId)
+
+	rpcClientA.WaitForObjectiveCompletion(closeId)
 	waitTimeForCompletedObjectiveIds(t, &clientI, defaultTimeout, closeId)
 
-}
-
-func waitForObjectiveCompletion(c *rpc.RpcClient, expectedObjectiveId protocols.ObjectiveId) {
-	for receivedObjectiveId := range c.CompletedObjectives() {
-		if expectedObjectiveId == receivedObjectiveId {
-			return
-		}
-	}
 }

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -56,7 +56,11 @@ func TestRpcClient(t *testing.T) {
 	defer msgI.Close()
 
 	rpcServerA := rpc.NewRpcServer(&clientA, chainId, createLogger(logDestination, "alice", "server"))
-	rpcClientA := rpc.NewRpcClient(rpcServerA.Url(), alice.Address(), chainId, createLogger(logDestination, "alice", "client"))
+	rpcClientA, err := rpc.NewRpcClient(rpcServerA.Url(), alice.Address(), chainId, createLogger(logDestination, "alice", "client"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	defer rpcServerA.Close()
 	defer rpcClientA.Close()
 
@@ -66,7 +70,13 @@ func TestRpcClient(t *testing.T) {
 	// Quick sanity check that we're getting a valid objective id
 	assert.Regexp(t, "DirectFunding.0x.*", res.Id)
 
-	waitTimeForCompletedObjectiveIds(t, &clientA, defaultTimeout, res.Id)
+	for objectiveId := range rpcClientA.CompletedObjectives() {
+		if objectiveId == res.Id {
+			break
+		}
+	}
+
+	//waitTimeForCompletedObjectiveIds(t, &clientA, defaultTimeout, res.Id)
 	waitTimeForCompletedObjectiveIds(t, &clientB, defaultTimeout, bobResponse.Id)
 	waitTimeForCompletedObjectiveIds(t, &clientI, defaultTimeout, res.Id, bobResponse.Id)
 

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	p2pms "github.com/statechannels/go-nitro/client/engine/messageservice/p2p-message-service"
 	"github.com/statechannels/go-nitro/internal/testdata"
+	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/rpc"
 	"github.com/statechannels/go-nitro/types"
 	"github.com/stretchr/testify/assert"
@@ -70,13 +71,7 @@ func TestRpcClient(t *testing.T) {
 	// Quick sanity check that we're getting a valid objective id
 	assert.Regexp(t, "DirectFunding.0x.*", res.Id)
 
-	for objectiveId := range rpcClientA.CompletedObjectives() {
-		if objectiveId == res.Id {
-			break
-		}
-	}
-
-	//waitTimeForCompletedObjectiveIds(t, &clientA, defaultTimeout, res.Id)
+	waitForObjectiveCompletion(rpcClientA, res.Id)
 	waitTimeForCompletedObjectiveIds(t, &clientB, defaultTimeout, bobResponse.Id)
 	waitTimeForCompletedObjectiveIds(t, &clientI, defaultTimeout, res.Id, bobResponse.Id)
 
@@ -87,18 +82,27 @@ func TestRpcClient(t *testing.T) {
 		testdata.Outcomes.Create(alice.Address(), bob.Address(), 100, 100, types.Address{}))
 
 	assert.Regexp(t, "VirtualFund.0x.*", vRes.Id)
-	waitTimeForCompletedObjectiveIds(t, &clientA, defaultTimeout, vRes.Id)
+
+	waitForObjectiveCompletion(rpcClientA, vRes.Id)
 	waitTimeForCompletedObjectiveIds(t, &clientB, defaultTimeout, vRes.Id)
 	waitTimeForCompletedObjectiveIds(t, &clientI, defaultTimeout, vRes.Id)
 	rpcClientA.Pay(vRes.ChannelId, 1)
 
 	closeVId := rpcClientA.CloseVirtual(vRes.ChannelId)
-	waitTimeForCompletedObjectiveIds(t, &clientA, defaultTimeout, closeVId)
+	waitForObjectiveCompletion(rpcClientA, closeVId)
 	waitTimeForCompletedObjectiveIds(t, &clientB, defaultTimeout, closeVId)
 	waitTimeForCompletedObjectiveIds(t, &clientI, defaultTimeout, closeVId)
 
 	closeId := rpcClientA.CloseLedger(res.ChannelId)
-	waitTimeForCompletedObjectiveIds(t, &clientA, defaultTimeout, closeId)
+	waitForObjectiveCompletion(rpcClientA, closeId)
 	waitTimeForCompletedObjectiveIds(t, &clientI, defaultTimeout, closeId)
 
+}
+
+func waitForObjectiveCompletion(c *rpc.RpcClient, expectedObjectiveId protocols.ObjectiveId) {
+	for receivedObjectiveId := range c.CompletedObjectives() {
+		if expectedObjectiveId == receivedObjectiveId {
+			return
+		}
+	}
 }

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -127,3 +127,11 @@ func waitForRequest[T serde.RequestPayload, U serde.ResponsePayload](rc *RpcClie
 
 	return res.Payload
 }
+
+func (rc *RpcClient) WaitForObjectiveCompletion(expectedObjectiveId protocols.ObjectiveId) {
+	for receivedObjectiveId := range rc.CompletedObjectives() {
+		if expectedObjectiveId == receivedObjectiveId {
+			return
+		}
+	}
+}

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -32,9 +32,18 @@ type PaymentRequest struct {
 	Channel types.Destination
 }
 type RequestPayload interface {
-	directfund.ObjectiveRequest | directdefund.ObjectiveRequest | virtualfund.ObjectiveRequest | virtualdefund.ObjectiveRequest | PaymentRequest
+	directfund.ObjectiveRequest |
+		directdefund.ObjectiveRequest |
+		virtualfund.ObjectiveRequest |
+		virtualdefund.ObjectiveRequest |
+		PaymentRequest
 }
-type JsonRpcRequest[T RequestPayload] struct {
+
+type NotificationPayload interface {
+	protocols.ObjectiveId
+}
+
+type JsonRpcRequest[T RequestPayload | NotificationPayload] struct {
 	Jsonrpc string `json:"jsonrpc"`
 	Id      uint64 `json:"id"`
 	Method  string `json:"method"`
@@ -56,7 +65,7 @@ type JsonRpcError struct {
 	Data    interface{} `json:"data"`
 }
 
-func NewJsonRpcRequest[T RequestPayload](requestId uint64, method RequestMethod, objectiveRequest T) *JsonRpcRequest[T] {
+func NewJsonRpcRequest[T RequestPayload | NotificationPayload, U RequestMethod | NotificationMethod](requestId uint64, method U, objectiveRequest T) *JsonRpcRequest[T] {
 
 	return &JsonRpcRequest[T]{
 		Jsonrpc: JsonRpcVersion,

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -19,6 +19,12 @@ const (
 	PayRequestMethod           RequestMethod = "pay"
 )
 
+type NotificationMethod string
+
+const (
+	ObjectiveCompleted NotificationMethod = "objective_completed"
+)
+
 const JsonRpcVersion = "2.0"
 
 type PaymentRequest struct {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"encoding/json"
 	"math/big"
+	"math/rand"
 
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
@@ -51,6 +52,7 @@ func NewRpcServer(nitroClient *nitro.Client, chainId *big.Int, logger zerolog.Lo
 	}
 
 	rs := &RpcServer{natstrans.NewNatsConnection(nc), ns, nitroClient, chainId, logger}
+	rs.sendNotifications()
 	err = rs.registerHandlers()
 	if err != nil {
 		panic(err)
@@ -99,6 +101,22 @@ func (rs *RpcServer) registerHandlers() error {
 	})
 
 	return err
+}
+
+func (rs *RpcServer) sendNotifications() {
+	go func() {
+		for completedObjective := range rs.client.CompletedObjectives() {
+			request := serde.NewJsonRpcRequest(rand.Uint64(), serde.ObjectiveCompleted, completedObjective)
+			data, err := json.Marshal(request)
+			if err != nil {
+				panic(err)
+			}
+			err = rs.connection.Notify(serde.ObjectiveCompleted, data)
+			if err != nil {
+				panic(err)
+			}
+		}
+	}()
 }
 
 func subcribeToRequest[T serde.RequestPayload, U serde.ResponsePayload](rs *RpcServer, method serde.RequestMethod, processPayload func(T) U) error {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -102,7 +102,7 @@ func (rs *RpcServer) registerHandlers() error {
 }
 
 func subcribeToRequest[T serde.RequestPayload, U serde.ResponsePayload](rs *RpcServer, method serde.RequestMethod, processPayload func(T) U) error {
-	return rs.connection.Subscribe(method, func(data []byte) []byte {
+	return rs.connection.Respond(method, func(data []byte) []byte {
 		rs.logger.Trace().Msgf("Rpc server received request: %+v", data)
 		rpcRequest := serde.JsonRpcRequest[T]{}
 		err := json.Unmarshal(data, &rpcRequest)

--- a/rpc/transport/connection.go
+++ b/rpc/transport/connection.go
@@ -10,7 +10,7 @@ type Connection interface {
 
 	// Notify sends data for a topic without expecting a response
 	Notify(serde.NotificationMethod, []byte) error
-	// Subscribe listens for notifications for a topic and does not repond to notifications
+	// Subscribe listens for notifications for a topic and does not respond to notifications
 	Subscribe(serde.NotificationMethod, func([]byte)) error
 
 	// Close shuts down the connection

--- a/rpc/transport/connection.go
+++ b/rpc/transport/connection.go
@@ -3,8 +3,11 @@ package transport
 import "github.com/statechannels/go-nitro/rpc/serde"
 
 type Connection interface {
-	Close()
-
+	// Request sends data for a topic and returns the response data or an error
 	Request(serde.RequestMethod, []byte) ([]byte, error)
-	Subscribe(serde.RequestMethod, func([]byte) []byte) error
+	// Respond listens for requests for a topic and calls the handler function when a request is received
+	Respond(serde.RequestMethod, func([]byte) []byte) error
+
+	// Close shuts down the connection
+	Close()
 }

--- a/rpc/transport/connection.go
+++ b/rpc/transport/connection.go
@@ -8,6 +8,11 @@ type Connection interface {
 	// Respond listens for requests for a topic and calls the handler function when a request is received
 	Respond(serde.RequestMethod, func([]byte) []byte) error
 
+	// Notify sends data for a topic without expecting a response
+	Notify(serde.NotificationMethod, []byte) error
+	// Subscribe listens for notifications for a topic and does not repond to notifications
+	Subscribe(serde.NotificationMethod, func([]byte)) error
+
 	// Close shuts down the connection
 	Close()
 }

--- a/rpc/transport/nats/nats_connection.go
+++ b/rpc/transport/nats/nats_connection.go
@@ -34,10 +34,10 @@ func (c *natsConnection) Request(topic serde.RequestMethod, data []byte) ([]byte
 	return msg.Data, err
 }
 
-// Subscribe subscribes to a topic and calls the handler function when a message is received
+// Respond subscribes to a topic and calls the handler function when a message is received
 // It returns an error if the subscription fails
 // The handler processes the incoming data and returns the response data
-func (c *natsConnection) Subscribe(topic serde.RequestMethod, handler func([]byte) []byte) error {
+func (c *natsConnection) Respond(topic serde.RequestMethod, handler func([]byte) []byte) error {
 	sub, err := c.nc.Subscribe(methodToTopic(topic), func(msg *nats.Msg) {
 		responseData := handler(msg.Data)
 		err := c.nc.Publish(msg.Reply, responseData)


### PR DESCRIPTION
Fixes https://github.com/statechannels/go-nitro/issues/1108

This PR introduces the Notify/Subscribe functionality to the Connection interface (and also renames old Subscribe to Respond). The new functionality is wired up for the rpc server objective completed notifications to the client. The rpc test is converted to use the rpc notifications.

A few notes:
- `waitTimeForCompletedObjectiveIds` calls for Bob and Irene's nodes cannot be removed in the rpc test. The test never initializes rpc clients for Bob and Irene's nodes.
- https://github.com/statechannels/go-nitro/issues/1119 has been filed as a result of this work.