### PR TITLE
Fix rpc test race condition

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,8 +31,7 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        timeout-minutes: 1
-        run: go test ./... -count=2 -shuffle=on
+        run: go test ./... -count=2 -shuffle=on -timeout 1m
 
       - name: Archive logs
         if: always()

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -63,8 +63,7 @@ func TestRpc(t *testing.T) {
 
 	rpcClientA.WaitForObjectiveCompletion(res.Id)
 	rpcClientB.WaitForObjectiveCompletion(bobResponse.Id)
-	rpcClientI.WaitForObjectiveCompletion(res.Id)
-	rpcClientI.WaitForObjectiveCompletion(bobResponse.Id)
+	rpcClientI.WaitForObjectiveCompletion(res.Id, bobResponse.Id)
 
 	vRes := rpcClientA.CreateVirtual(
 		[]types.Address{irene.Address()},

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -111,6 +111,7 @@ func (rc *RpcClient) subscribeToNotifications() error {
 		}
 		rc.completedObjectives <- rpcRequest.Params
 	})
+	rc.logger.Trace().Msg("Subscribed to notifications")
 	return err
 }
 

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -141,7 +141,7 @@ func (rc *RpcClient) WaitForObjectiveCompletion(expectedObjectiveId ...protocols
 			}
 		}
 		if !isObjectiveExpected {
-			err := fmt.Errorf("Received unexpected objective completion notification for objective %v", receivedObjectiveId)
+			err := fmt.Errorf("received unexpected objective completion notification for objective %v", receivedObjectiveId)
 			panic(err)
 		}
 

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -130,7 +130,7 @@ func waitForRequest[T serde.RequestPayload, U serde.ResponsePayload](rc *RpcClie
 	return res.Payload
 }
 
-func (rc *RpcClient) WaitForObjectiveCompletion(expectedObjectiveId ...protocols.ObjectiveId) {
+func (rc *RpcClient) WaitForObjectiveCompletion(expectedObjectiveId ...protocols.ObjectiveId) error {
 	completed := make(map[protocols.ObjectiveId]bool)
 
 	for receivedObjectiveId := range rc.CompletedObjectives() {
@@ -141,8 +141,7 @@ func (rc *RpcClient) WaitForObjectiveCompletion(expectedObjectiveId ...protocols
 			}
 		}
 		if !isObjectiveExpected {
-			err := fmt.Errorf("received unexpected objective completion notification for objective %v", receivedObjectiveId)
-			panic(err)
+			return fmt.Errorf("received unexpected objective completion notification for objective %v", receivedObjectiveId)
 		}
 
 		completed[receivedObjectiveId] = true
@@ -153,7 +152,8 @@ func (rc *RpcClient) WaitForObjectiveCompletion(expectedObjectiveId ...protocols
 			}
 		}
 		if done {
-			return
+			return nil
 		}
 	}
+	return nil
 }

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -106,6 +106,7 @@ func (rs *RpcServer) registerHandlers() error {
 func (rs *RpcServer) sendNotifications() {
 	go func() {
 		for completedObjective := range rs.client.CompletedObjectives() {
+			rs.logger.Trace().Msgf("Sending notification: %+v", completedObjective)
 			request := serde.NewJsonRpcRequest(rand.Uint64(), serde.ObjectiveCompleted, completedObjective)
 			data, err := json.Marshal(request)
 			if err != nil {
@@ -121,7 +122,7 @@ func (rs *RpcServer) sendNotifications() {
 
 func subcribeToRequest[T serde.RequestPayload, U serde.ResponsePayload](rs *RpcServer, method serde.RequestMethod, processPayload func(T) U) error {
 	return rs.connection.Respond(method, func(data []byte) []byte {
-		rs.logger.Trace().Msgf("Rpc server received request: %+v", data)
+		rs.logger.Trace().Msgf("Rpc server received request: %+v", string(data))
 		rpcRequest := serde.JsonRpcRequest[T]{}
 		err := json.Unmarshal(data, &rpcRequest)
 		if err != nil {


### PR DESCRIPTION
We are seeing timeouts in github ci such as https://github.com/statechannels/go-nitro/actions/runs/4146194983/jobs/7171543355 As is, it's hard to tell which test is causing the timeout. The hope is that using the go test timeout flag will give more debug information.

Follow up: the timeouts are caused by an rpc test race condition. The race condition has been fixed in [6a1b0e0](https://github.com/statechannels/go-nitro/pull/1125/commits/6a1b0e09b948d56a4bfccd068afe23bdadbbe4bb)