### PR TITLE
Refactor RPC Connection interface

### DIFF
--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -98,8 +98,8 @@ func executeRpcTest(t *testing.T, connectionType transport.ConnectionType) {
 	waitForObjectiveCompletion(t, rpcClientI, closeId)
 
 	closeIdB := rpcClientB.CloseLedger(bobResponse.ChannelId)
-	rpcClientB.WaitForObjectiveCompletion(closeIdB)
-	rpcClientI.WaitForObjectiveCompletion(closeIdB)
+	waitForObjectiveCompletion(t, rpcClientB, closeIdB)
+	waitForObjectiveCompletion(t, rpcClientI, closeIdB)
 }
 
 // setupNitroNodeWithRPCClient is a helper function that spins up a Nitro Node RPC Server and returns an RPC client connected to it.

--- a/rpc/network/request.go
+++ b/rpc/network/request.go
@@ -53,7 +53,7 @@ func Request[T serde.RequestPayload, U serde.ResponsePayload](connection transpo
 		Msg("sent message")
 
 	go func() {
-		responseData, err := connection.Request(requestId, data)
+		responseData, err := connection.Request(data)
 		if err != nil {
 			returnChan <- Response[U]{Error: err}
 		}

--- a/rpc/network/request.go
+++ b/rpc/network/request.go
@@ -23,7 +23,7 @@ type Response[T serde.ResponsePayload] struct {
 
 // Request uses the supplied connection and payload to send a non-blocking JSONRPC request.
 // It returns a channel that sends a response payload. If the request fails to send, an error is returned.
-func Request[T serde.RequestPayload, U serde.ResponsePayload](connection transport.Connection, request T, logger zerolog.Logger) (<-chan Response[U], error) {
+func Request[T serde.RequestPayload, U serde.ResponsePayload](connection transport.Requester, request T, logger zerolog.Logger) (<-chan Response[U], error) {
 	returnChan := make(chan Response[U], 1)
 
 	var method serde.RequestMethod
@@ -53,7 +53,7 @@ func Request[T serde.RequestPayload, U serde.ResponsePayload](connection transpo
 		Msg("sent message")
 
 	go func() {
-		responseData, err := connection.Request(method, data)
+		responseData, err := connection.Request(requestId, data)
 		if err != nil {
 			returnChan <- Response[U]{Error: err}
 		}

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -47,17 +47,21 @@ type NotificationPayload interface {
 	protocols.ObjectiveId
 }
 
-type JsonRpcRequest[T RequestPayload | NotificationPayload | any] struct {
+type JsonRpcRequest[T RequestPayload | NotificationPayload] struct {
 	Jsonrpc string `json:"jsonrpc"`
 	Id      uint64 `json:"id"`
 	Method  string `json:"method"`
 	Params  T      `json:"params"`
 }
 
+type AnyJsonRpcRequest struct {
+	Method string `json:"method"`
+}
+
 type ResponsePayload interface {
 	directfund.ObjectiveResponse | protocols.ObjectiveId | virtualfund.ObjectiveResponse | PaymentRequest
 }
-type JsonRpcResponse[T ResponsePayload | any] struct {
+type JsonRpcResponse[T ResponsePayload] struct {
 	Jsonrpc string      `json:"jsonrpc"`
 	Id      uint64      `json:"id"`
 	Result  T           `json:"result"`

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -25,6 +25,10 @@ const (
 	ObjectiveCompleted NotificationMethod = "objective_completed"
 )
 
+type NotificationOrRequest interface {
+	RequestMethod | NotificationMethod
+}
+
 const JsonRpcVersion = "2.0"
 
 type PaymentRequest struct {
@@ -43,16 +47,17 @@ type NotificationPayload interface {
 	protocols.ObjectiveId
 }
 
-type JsonRpcRequest[T RequestPayload | NotificationPayload] struct {
+type JsonRpcRequest[T RequestPayload | NotificationPayload | any] struct {
 	Jsonrpc string `json:"jsonrpc"`
 	Id      uint64 `json:"id"`
 	Method  string `json:"method"`
 	Params  T      `json:"params"`
 }
+
 type ResponsePayload interface {
 	directfund.ObjectiveResponse | protocols.ObjectiveId | virtualfund.ObjectiveResponse | PaymentRequest
 }
-type JsonRpcResponse[T ResponsePayload] struct {
+type JsonRpcResponse[T ResponsePayload | any] struct {
 	Jsonrpc string      `json:"jsonrpc"`
 	Id      uint64      `json:"id"`
 	Result  T           `json:"result"`

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -26,7 +26,6 @@ type RpcServer struct {
 
 func (rs *RpcServer) Url() string {
 	return rs.connection.Url()
-	//return "ws://127.0.0.1:" + rs.port
 }
 
 func (rs *RpcServer) Close() {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -48,7 +48,7 @@ func NewRpcServer(nitroClient *nitro.Client, logger zerolog.Logger, connection t
 func (rs *RpcServer) registerHandlers() error {
 	subscriber := func(requestData []byte) []byte {
 		rs.logger.Trace().Msgf("Rpc server received request: %+v", string(requestData))
-		requestJson := serde.JsonRpcRequest[any]{}
+		requestJson := serde.AnyJsonRpcRequest{}
 		err := json.Unmarshal(requestData, &requestJson)
 		if err != nil {
 			panic(err)

--- a/rpc/transport/connection.go
+++ b/rpc/transport/connection.go
@@ -15,7 +15,7 @@ type Requester interface {
 	// Request sends a blocking request and returns the response data or an error
 	Request([]byte) ([]byte, error)
 	// Subscribe provides a notification channel.
-	// If subscription to a notification topic fails, it returns an error.
+	// If subscription to notifications fails, it returns an error.
 	Subscribe() (<-chan []byte, error)
 }
 

--- a/rpc/transport/connection.go
+++ b/rpc/transport/connection.go
@@ -13,7 +13,7 @@ type Requester interface {
 	Close()
 
 	// Request sends data for a topic and returns the response data or an error
-	Request(uint64, []byte) ([]byte, error)
+	Request([]byte) ([]byte, error)
 	// Subscribe listens for notifications for a topic.
 	// If subscription to a notification topic fails, it returns an error.
 	Subscribe() (<-chan []byte, error)

--- a/rpc/transport/connection.go
+++ b/rpc/transport/connection.go
@@ -12,7 +12,7 @@ type Requester interface {
 	// Close closes the connection
 	Close()
 
-	// Request sends request data and returns the response data or an error
+	// Request sends a blocking request and returns the response data or an error
 	Request([]byte) ([]byte, error)
 	// Subscribe provides a notification channel.
 	// If subscription to a notification topic fails, it returns an error.
@@ -27,6 +27,8 @@ type Responder interface {
 	Url() string
 
 	// Respond listens for requests and calls the handler function when a request is received
+	// It returns an error if the listener setup fails
+	// The handler processes the incoming data and returns the response data
 	Respond(func([]byte) []byte) error
 	// Notify sends notification data without expecting a response
 	Notify([]byte) error

--- a/rpc/transport/connection.go
+++ b/rpc/transport/connection.go
@@ -12,9 +12,9 @@ type Requester interface {
 	// Close closes the connection
 	Close()
 
-	// Request sends data for a topic and returns the response data or an error
+	// Request sends request data and returns the response data or an error
 	Request([]byte) ([]byte, error)
-	// Subscribe listens for notifications for a topic.
+	// Subscribe provides a notification channel.
 	// If subscription to a notification topic fails, it returns an error.
 	Subscribe() (<-chan []byte, error)
 }
@@ -26,8 +26,8 @@ type Responder interface {
 	// Url returns the url that the responder is listening on
 	Url() string
 
-	// Respond listens for requests for a topic and calls the handler function when a request is received
+	// Respond listens for requests and calls the handler function when a request is received
 	Respond(func([]byte) []byte) error
-	// Notify sends data for a topic without expecting a response
+	// Notify sends notification data without expecting a response
 	Notify([]byte) error
 }

--- a/rpc/transport/connection.go
+++ b/rpc/transport/connection.go
@@ -1,18 +1,32 @@
 package transport
 
-import "github.com/statechannels/go-nitro/rpc/serde"
+type ConnectionType string
 
-type Connection interface {
-	// Request sends data for a topic and returns the response data or an error
-	Request(serde.RequestMethod, []byte) ([]byte, error)
-	// Respond listens for requests for a topic and calls the handler function when a request is received
-	Respond(serde.RequestMethod, func([]byte) []byte) error
+const (
+	Nats ConnectionType = "nats"
+	Ws   ConnectionType = "ws"
+)
 
-	// Notify sends data for a topic without expecting a response
-	Notify(serde.NotificationMethod, []byte) error
-	// Subscribe listens for notifications for a topic and does not respond to notifications
-	Subscribe(serde.NotificationMethod, func([]byte)) error
-
-	// Close shuts down the connection
+// Requester is a connection that can send requests and subscribe to notifications
+type Requester interface {
+	// Close closes the connection
 	Close()
+
+	// Request sends data for a topic and returns the response data or an error
+	Request(uint64, []byte) ([]byte, error)
+	// Subscribe listens for notifications for a topic and does not respond to notifications
+	Subscribe() (<-chan []byte, error)
+}
+
+// Responder is a connection that can respond to requests and send notifications
+type Responder interface {
+	// Close closes the connection
+	Close()
+	// Url returns the url that the responder is listening on
+	Url() string
+
+	// Respond listens for requests for a topic and calls the handler function when a request is received
+	Respond(func([]byte) []byte) error
+	// Notify sends data for a topic without expecting a response
+	Notify([]byte) error
 }

--- a/rpc/transport/connection.go
+++ b/rpc/transport/connection.go
@@ -14,7 +14,8 @@ type Requester interface {
 
 	// Request sends data for a topic and returns the response data or an error
 	Request(uint64, []byte) ([]byte, error)
-	// Subscribe listens for notifications for a topic and does not respond to notifications
+	// Subscribe listens for notifications for a topic.
+	// If subscription to a notification topic fails, it returns an error.
 	Subscribe() (<-chan []byte, error)
 }
 

--- a/rpc/transport/nats/nats_connection.go
+++ b/rpc/transport/nats/nats_connection.go
@@ -4,32 +4,52 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"github.com/rs/zerolog/log"
-	"github.com/statechannels/go-nitro/rpc/serde"
 )
 
 type natsConnection struct {
 	nc                *nats.Conn
 	natsSubscriptions []*nats.Subscription
+	ns                *server.Server
 }
 
-// NewNatsConnection creates an instance of a Connection interface that uses the nats transport
-func NewNatsConnection(nc *nats.Conn) *natsConnection {
-	natsConnection := &natsConnection{
+func NewNatsConnectionAsServer(rpcPort int) (*natsConnection, error) {
+	opts := &server.Options{Port: rpcPort}
+	ns, err := server.NewServer(opts)
+	if err != nil {
+		return nil, err
+	}
+	ns.Start()
+
+	con, err := NewNatsConnectionAsClient(ns.ClientURL())
+	if err != nil {
+		return nil, err
+	}
+	con.ns = ns
+	return con, nil
+}
+
+func NewNatsConnectionAsClient(url string) (*natsConnection, error) {
+	nc, err := nats.Connect(url)
+	if err != nil {
+		return nil, err
+	}
+	con := &natsConnection{
 		nc:                nc,
 		natsSubscriptions: make([]*nats.Subscription, 0),
+		ns:                nil,
 	}
-
-	return natsConnection
+	return con, nil
 }
 
 // Request sends a blocking request for a topic with the given data
 // It returns the response data and an error
-func (c *natsConnection) Request(topic serde.RequestMethod, data []byte) ([]byte, error) {
-	msg, err := c.nc.Request(methodToTopic(topic), data, 10*time.Second)
+func (c *natsConnection) Request(id uint64, data []byte) ([]byte, error) {
+	msg, err := c.nc.Request("nitro-request", data, 10*time.Second)
 	if msg == nil {
-		return nil, fmt.Errorf("received nill data for request %v with error %w", topic, err)
+		return nil, fmt.Errorf("received nill data for request %v with error %w", data, err)
 	}
 	return msg.Data, err
 }
@@ -37,8 +57,8 @@ func (c *natsConnection) Request(topic serde.RequestMethod, data []byte) ([]byte
 // Respond subscribes to a topic and calls the handler function when a message is received
 // It returns an error if the subscription fails
 // The handler processes the incoming data and returns the response data
-func (c *natsConnection) Respond(topic serde.RequestMethod, handler func([]byte) []byte) error {
-	sub, err := c.nc.Subscribe(methodToTopic(topic), func(msg *nats.Msg) {
+func (c *natsConnection) Respond(handler func([]byte) []byte) error {
+	sub, err := c.nc.Subscribe("nitro-request", func(msg *nats.Msg) {
 		responseData := handler(msg.Data)
 		err := c.nc.Publish(msg.Reply, responseData)
 		if err != nil {
@@ -50,17 +70,18 @@ func (c *natsConnection) Respond(topic serde.RequestMethod, handler func([]byte)
 	return err
 }
 
-func (c *natsConnection) Notify(topic serde.NotificationMethod, data []byte) error {
-	return c.nc.Publish(methodToTopic(topic), data)
+func (c *natsConnection) Notify(data []byte) error {
+	return c.nc.Publish("nitro-notify", data)
 }
 
-func (c *natsConnection) Subscribe(topic serde.NotificationMethod, handler func([]byte)) error {
-	sub, err := c.nc.Subscribe(methodToTopic(topic), func(msg *nats.Msg) {
-		handler(msg.Data)
+func (c *natsConnection) Subscribe() (<-chan []byte, error) {
+	notificationChan := make(chan []byte)
+	subscription, err := c.nc.Subscribe("nitro-notify", func(msg *nats.Msg) {
+		notificationChan <- msg.Data
 	})
-	c.natsSubscriptions = append(c.natsSubscriptions, sub)
+	c.natsSubscriptions = append(c.natsSubscriptions, subscription)
 
-	return err
+	return notificationChan, err
 }
 
 // Close shuts down the connection
@@ -71,6 +92,13 @@ func (c *natsConnection) Close() {
 			log.Error().Err(err).Msgf("failed to unsubscribe from a topic: %s", sub.Subject)
 		}
 	}
+	if c.ns != nil {
+		c.ns.Shutdown()
+	}
+}
+
+func (c *natsConnection) Url() string {
+	return c.ns.ClientURL()
 }
 
 func (c *natsConnection) unsubscribeFromTopic(sub *nats.Subscription, try int32) error {
@@ -79,8 +107,4 @@ func (c *natsConnection) unsubscribeFromTopic(sub *nats.Subscription, try int32)
 		return c.unsubscribeFromTopic(sub, try+1)
 	}
 	return nil
-}
-
-func methodToTopic[T serde.RequestMethod | serde.NotificationMethod](method T) string {
-	return fmt.Sprintf("nitro.%s", method)
 }

--- a/rpc/transport/nats/nats_connection.go
+++ b/rpc/transport/nats/nats_connection.go
@@ -66,7 +66,7 @@ func NewNatsConnectionAsClient(url string) (*natsConnectionClient, error) {
 
 // Request sends a blocking request for a topic with the given data
 // It returns the response data and an error
-func (c *natsConnectionClient) Request(id uint64, data []byte) ([]byte, error) {
+func (c *natsConnectionClient) Request(data []byte) ([]byte, error) {
 	msg, err := c.nc.Request("nitro-request", data, 10*time.Second)
 	if msg == nil {
 		return nil, fmt.Errorf("received nill data for request %v with error %w", data, err)

--- a/rpc/transport/nats/nats_connection.go
+++ b/rpc/transport/nats/nats_connection.go
@@ -67,8 +67,6 @@ func NewNatsConnectionAsClient(url string) (*natsConnectionClient, error) {
 	}, nil
 }
 
-// Request sends a blocking request for a topic with the given data
-// It returns the response data and an error
 func (c *natsConnectionClient) Request(data []byte) ([]byte, error) {
 	msg, err := c.nc.Request(nitroRequestTopic, data, 10*time.Second)
 	if msg == nil {
@@ -77,9 +75,6 @@ func (c *natsConnectionClient) Request(data []byte) ([]byte, error) {
 	return msg.Data, err
 }
 
-// Respond subscribes to a topic and calls the handler function when a message is received
-// It returns an error if the subscription fails
-// The handler processes the incoming data and returns the response data
 func (c *natsConnectionServer) Respond(handler func([]byte) []byte) error {
 	sub, err := c.nc.Subscribe(nitroRequestTopic, func(msg *nats.Msg) {
 		responseData := handler(msg.Data)


### PR DESCRIPTION
The Connection interface is split into Requester and Responder interfaces (thanks for the idea @geoknee). Also, request/response data specifics are removed from the connection interface.

In an ideal world, the connection should not care about the data it is sending and receiving. This goal is accomplished for the nats connection interface. This abstraction is slightly broken for websockets (see follow up PR) since the same websocket is used for responses and notification. Websocket implementation can be changed in the future to create 2 websockets (one for requests, one for notifications) for a cleaner implementation.