### PR TITLE
Get FEVM test passing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        run: go test ./... -count=2 -shuffle=on -timeout 1m
+        run:  RUN_FEVM_TESTS=true go test ./... -count=1 -shuffle=on -timeout 15m
 
       - name: Archive logs
         if: always()

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        run:  RUN_FEVM_TESTS=true go test ./... -count=1 -shuffle=on -timeout 15m
+        run: go test ./... -count=2 -shuffle=on -timeout 1m
 
       - name: Archive logs
         if: always()

--- a/client/engine/chainservice/adjudicator/challenge_test.go
+++ b/client/engine/chainservice/adjudicator/challenge_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -95,12 +97,15 @@ func runChallengeWithTurnNum(t *testing.T, turnNum uint64, pc preparedChain) {
 		sim.Commit()
 	}
 
+	// Use random nonces so we can run this test multiple times against the same chain
+	rand.Seed(time.Now().Unix())
+	nonce := rand.Uint64()
 	var s = state.State{
 		Participants: []types.Address{
 			Actors.Alice.Address,
 			Actors.Bob.Address,
 		},
-		ChannelNonce:      37140676580,
+		ChannelNonce:      nonce,
 		AppDefinition:     consensusAppAddress,
 		ChallengeDuration: 60,
 		AppData:           []byte{},
@@ -248,7 +253,7 @@ func prepareHyperspaceBackend(t *testing.T) preparedChain {
 	}
 
 	// The 0th account is usually used for deployment and the other test could be using the 1st account so we grab the 2nd
-	a, err := wallet.Derive(hdwallet.MustParseDerivationPath(fmt.Sprintf("%s/%d", HD_PATH, 2)), false)
+	a, err := wallet.Derive(hdwallet.MustParseDerivationPath(fmt.Sprintf("%s/%d", HD_PATH, 1)), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/engine/chainservice/adjudicator/challenge_test.go
+++ b/client/engine/chainservice/adjudicator/challenge_test.go
@@ -282,8 +282,8 @@ func prepareHyperspaceBackend(t *testing.T) preparedChain {
 	// WALLABY_DEPLOYER_PK="f4d69c36885541f56f4728ddc002a6fa2fcb26c9f608910310a776c83b7fde47" npx hardhat deploy --network hyperspace --deploy-scripts ./hardhat-deploy-fvm --reset
 	// The PK corresponds to account 0xE39dce95b1A924E2472E24C20C55eA3559a09251.
 	// It should be prefunded after every hyperspace reset.
-	naAddress := common.HexToAddress("0xd354e517646872dd27d702c6f9f7a6ada3646c47")
-	caAddress := common.HexToAddress("0x91315b24Bbf0c2e640d9BD47a2ADe927e72d9173")
+	naAddress := common.HexToAddress("0xb095A67b76179dAFB5a56628378b919052f978c9")
+	caAddress := common.HexToAddress("0x64D444a7B99f07d3a1d69F82798Eaa0a98E04543")
 
 	na, err := NewNitroAdjudicator(naAddress, client)
 	if err != nil {

--- a/client/engine/chainservice/adjudicator/challenge_test.go
+++ b/client/engine/chainservice/adjudicator/challenge_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -79,7 +81,10 @@ func TestChallenge(t *testing.T) {
 	for _, turnNum := range []uint64{0, 1, 2} {
 		t.Run("HyperSpaceBackend: turnNum = "+fmt.Sprint(turnNum),
 			func(t *testing.T) {
-				t.Skip() // We run this test manually.
+				// We only run the test if the RUN_FEVM_TESTS env var is set to true
+				if key, found := os.LookupEnv("RUN_FEVM_TESTS"); !found || strings.ToLower(key) != "true" {
+					t.Skip()
+				}
 				runChallengeWithTurnNum(t, turnNum, hyperspacePreparedChain)
 			})
 	}
@@ -277,7 +282,7 @@ func prepareHyperspaceBackend(t *testing.T) preparedChain {
 		t.Fatal(err)
 	}
 
-	client, err := ethclient.Dial("https://api.hyperspace.node.glif.io/rpc/v1")
+	client, err := ethclient.Dial("wss://wss.hyperspace.node.glif.io/apigw/lotus/rpc/v0")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/engine/chainservice/adjudicator/challenge_test.go
+++ b/client/engine/chainservice/adjudicator/challenge_test.go
@@ -267,8 +267,8 @@ func prepareHyperspaceBackend(t *testing.T) preparedChain {
 		t.Fatal(err)
 	}
 
-	// The 0th account is usually used for deployment and the other test could be using the 1st account so we grab the 2nd
-	a, err := wallet.Derive(hdwallet.MustParseDerivationPath(fmt.Sprintf("%s/%d", HD_PATH, 2)), false)
+	// The 0th account is usually used for deployment and the other test could be using the first two accounts so we use the 3rd
+	a, err := wallet.Derive(hdwallet.MustParseDerivationPath(fmt.Sprintf("%s/%d", HD_PATH, 3)), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/engine/chainservice/adjudicator/challenge_test.go
+++ b/client/engine/chainservice/adjudicator/challenge_test.go
@@ -247,8 +247,8 @@ func prepareHyperspaceBackend(t *testing.T) preparedChain {
 		t.Fatal(err)
 	}
 
-	// The 0th account is usually used for deployment so we grab the 1st account
-	a, err := wallet.Derive(hdwallet.MustParseDerivationPath(fmt.Sprintf("%s/%d", HD_PATH, 1)), false)
+	// The 0th account is usually used for deployment and the other test could be using the 1st account so we grab the 2nd
+	a, err := wallet.Derive(hdwallet.MustParseDerivationPath(fmt.Sprintf("%s/%d", HD_PATH, 2)), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -235,7 +235,7 @@ func (ecs *EthChainService) dispatchChainEvents(logs []ethTypes.Log) {
 		case challengeClearedTopic:
 			ecs.logger.Info().Msg("Ignoring Challenge Cleared event")
 		default:
-			ecs.fatalF("Unknown chain event %+v", l)
+			ecs.logger.Info().Str("topic", l.Topics[0].String()).Msg("Ignoring unknown chain event topic")
 		}
 	}
 

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -25,6 +25,7 @@ import (
 var allocationUpdatedTopic = crypto.Keccak256Hash([]byte("AllocationUpdated(bytes32,uint256,uint256)"))
 var concludedTopic = crypto.Keccak256Hash([]byte("Concluded(bytes32,uint48)"))
 var depositedTopic = crypto.Keccak256Hash([]byte("Deposited(bytes32,address,uint256,uint256)"))
+var challengeRegisteredTopic = crypto.Keccak256Hash([]byte("ChallengeRegistered(bytes32 indexed channelId, uint48 turnNumRecord, uint48 finalizesAt, bool isFinal, (address[],uint64,address,uint48) fixedPart, (((address,(uint8,bytes),(bytes32,uint256,uint8,bytes)[])[],bytes,uint48,bool),(uint8,bytes32,bytes32)[])[] proof, (((address,(uint8,bytes),(bytes32,uint256,uint8,bytes)[])[],bytes,uint48,bool),(uint8,bytes32,bytes32)[]) candidate)"))
 
 type ethChain interface {
 	bind.ContractBackend
@@ -227,6 +228,9 @@ func (ecs *EthChainService) dispatchChainEvents(logs []ethTypes.Log) {
 
 			event := ConcludedEvent{commonEvent: commonEvent{channelID: ce.ChannelId, BlockNum: l.BlockNumber}}
 			ecs.out <- event
+
+		case challengeRegisteredTopic:
+			ecs.logger.Info().Msg("Ignoring Challenge registered event")
 
 		default:
 			ecs.fatalF("Unknown chain event %+v", l)

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -26,6 +26,7 @@ var allocationUpdatedTopic = crypto.Keccak256Hash([]byte("AllocationUpdated(byte
 var concludedTopic = crypto.Keccak256Hash([]byte("Concluded(bytes32,uint48)"))
 var depositedTopic = crypto.Keccak256Hash([]byte("Deposited(bytes32,address,uint256,uint256)"))
 var challengeRegisteredTopic = crypto.Keccak256Hash([]byte("ChallengeRegistered(bytes32 indexed channelId, uint48 turnNumRecord, uint48 finalizesAt, bool isFinal, (address[],uint64,address,uint48) fixedPart, (((address,(uint8,bytes),(bytes32,uint256,uint8,bytes)[])[],bytes,uint48,bool),(uint8,bytes32,bytes32)[])[] proof, (((address,(uint8,bytes),(bytes32,uint256,uint8,bytes)[])[],bytes,uint48,bool),(uint8,bytes32,bytes32)[]) candidate)"))
+var challengeClearedTopic = crypto.Keccak256Hash([]byte("ChallengeCleared(bytes32 indexed channelId, uint48 newTurnNumRecord)"))
 
 type ethChain interface {
 	bind.ContractBackend
@@ -230,8 +231,9 @@ func (ecs *EthChainService) dispatchChainEvents(logs []ethTypes.Log) {
 			ecs.out <- event
 
 		case challengeRegisteredTopic:
-			ecs.logger.Info().Msg("Ignoring Challenge registered event")
-
+			ecs.logger.Info().Msg("Ignoring Challenge Registered event")
+		case challengeClearedTopic:
+			ecs.logger.Info().Msg("Ignoring Challenge Cleared event")
 		default:
 			ecs.fatalF("Unknown chain event %+v", l)
 		}

--- a/client/engine/chainservice/eth_chainservice_FEVM_test.go
+++ b/client/engine/chainservice/eth_chainservice_FEVM_test.go
@@ -72,9 +72,9 @@ func TestEthChainServiceFEVM(t *testing.T) {
 	// WALLABY_DEPLOYER_PK="f4d69c36885541f56f4728ddc002a6fa2fcb26c9f608910310a776c83b7fde47" npx hardhat deploy --network hyperspace --deploy-scripts ./hardhat-deploy-fvm --reset
 	// The PK corresponds to account 0xE39dce95b1A924E2472E24C20C55eA3559a09251.
 	// It should be prefunded after every wallaby reset.
-	naAddress := common.HexToAddress("0x4fBeCDA4735eaF21C8ba5BD40Ab97dFa2Ed88E80")
-	caAddress := common.HexToAddress("0xC57875E317f67F2bE5D62f5c7C696D2eb7Fe79FE")
-	vpaAddress := common.HexToAddress("0xc1AcE8075ee548AA2284b61C5eD8f1a69c4cE756")
+	naAddress := common.HexToAddress("0xb095A67b76179dAFB5a56628378b919052f978c9")
+	caAddress := common.HexToAddress("0x64D444a7B99f07d3a1d69F82798Eaa0a98E04543")
+	vpaAddress := common.HexToAddress("0x76E957873156526D8BA482c4b1CE26a60dF639Ba")
 	na, err := NitroAdjudicator.NewNitroAdjudicator(naAddress, client)
 	if err != nil {
 		t.Fatal(err)

--- a/client/engine/chainservice/eth_chainservice_FEVM_test.go
+++ b/client/engine/chainservice/eth_chainservice_FEVM_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -29,8 +31,10 @@ const WALLABY_MNEMONIC = "army forest resource shop tray cluster teach cause spi
 const WALLABY_HD_PATH = "m/44'/1'/0'/0"
 
 func TestEthChainServiceFEVM(t *testing.T) {
-	// Since this is hitting a contract on a test chain we only want to run it selectively
-	t.Skip()
+	// We only run the test if the RUN_FEVM_TESTS env var is set to true
+	if key, found := os.LookupEnv("RUN_FEVM_TESTS"); !found || strings.ToLower(key) != "true" {
+		t.Skip()
+	}
 	wallet, err := hdwallet.NewFromMnemonic(WALLABY_MNEMONIC)
 	if err != nil {
 		panic(err)

--- a/client/engine/chainservice/eth_chainservice_FEVM_test.go
+++ b/client/engine/chainservice/eth_chainservice_FEVM_test.go
@@ -51,7 +51,7 @@ func TestEthChainServiceFEVM(t *testing.T) {
 		panic(err)
 	}
 
-	client, err := ethclient.Dial("https://api.hyperspace.node.glif.io/rpc/v0")
+	client, err := ethclient.Dial("https://api.hyperspace.node.glif.io/rpc/v1")
 
 	if err != nil {
 		t.Fatal(err)

--- a/client/engine/chainservice/eth_chainservice_FEVM_test.go
+++ b/client/engine/chainservice/eth_chainservice_FEVM_test.go
@@ -2,6 +2,7 @@ package chainservice
 
 import (
 	"bytes"
+	"crypto/ecdsa"
 	"fmt"
 	"log"
 	"math/big"
@@ -24,45 +25,46 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-// This is the mnemonic for the prefunded accounts on wallaby.
+// This is the mnemonic for the prefunded accounts on hyperspace.
 // The first 25 accounts will be prefunded.
-const WALLABY_MNEMONIC = "army forest resource shop tray cluster teach cause spice judge link oppose"
+const HYPERSPACE_MNEMONIC = "army forest resource shop tray cluster teach cause spice judge link oppose"
 
 // This is the HD path to use when deriving accounts from the mnemonic
-const WALLABY_HD_PATH = "m/44'/1'/0'/0"
+const HYPERSPACE_HD_PATH = "m/44'/1'/0'/0"
 
 func TestEthChainServiceFEVM(t *testing.T) {
 	// We only run the test if the RUN_FEVM_TESTS env var is set to true
 	if key, found := os.LookupEnv("RUN_FEVM_TESTS"); !found || strings.ToLower(key) != "true" {
 		t.Skip()
 	}
-	testAgainstEndpoint(t, "https://api.hyperspace.node.glif.io/rpc/v1", "test_fevm_https_endpoint.log")
-	testAgainstEndpoint(t, "wss://wss.hyperspace.node.glif.io/apigw/lotus/rpc/v0", "test_fevm_wss_endpoint.log")
+
+	testAgainstEndpoint(t, "https://api.hyperspace.node.glif.io/rpc/v1", "test_fevm_https_endpoint.log", getPK(1))
+	testAgainstEndpoint(t, "wss://wss.hyperspace.node.glif.io/apigw/lotus/rpc/v0", "test_fevm_wss_endpoint.log", getPK(2))
 
 }
 
-// testAgainstEndpoint runs a simple chain test against the provided endpoint
-func testAgainstEndpoint(t *testing.T, endpoint string, logFile string) {
-
-	wallet, err := hdwallet.NewFromMnemonic(WALLABY_MNEMONIC)
+// getPK returns the private key for the account at the given index using the hyperspace mnemonic and path
+func getPK(index uint) *ecdsa.PrivateKey {
+	wallet, err := hdwallet.NewFromMnemonic(HYPERSPACE_MNEMONIC)
 	if err != nil {
 		panic(err)
 	}
 
-	// The 0th account is usually used for deployment so we grab the 1st account
-	a, err := wallet.Derive(hdwallet.MustParseDerivationPath(fmt.Sprintf("%s/%d", WALLABY_HD_PATH, 1)), false)
+	a, err := wallet.Derive(hdwallet.MustParseDerivationPath(fmt.Sprintf("%s/%d", HYPERSPACE_HD_PATH, 2)), false)
 	if err != nil {
 		panic(err)
 	}
-
-	//PK: 0x1688820ffc6a811e09ff17eccec23d8dec4850c3098ffc03ac4aa38dd8f3a994
-	// corresponding ETH address is 0x280c53E2C574418D8d6d8d651d4c3323F4b194Be
-	// corresponding f4 address (delegated) is t410ffagfhywforay3dlnrvsr2tbtep2ldff6xuxkrjq.
 	pk, err := wallet.PrivateKey(a)
 
 	if err != nil {
 		panic(err)
 	}
+	return pk
+
+}
+
+// testAgainstEndpoint runs a simple chain test against the provided endpoint
+func testAgainstEndpoint(t *testing.T, endpoint string, logFile string, pk *ecdsa.PrivateKey) {
 
 	client, err := ethclient.Dial(endpoint)
 

--- a/client/engine/chainservice/eth_chainservice_FEVM_test.go
+++ b/client/engine/chainservice/eth_chainservice_FEVM_test.go
@@ -36,6 +36,15 @@ func TestEthChainServiceFEVM(t *testing.T) {
 	if key, found := os.LookupEnv("RUN_FEVM_TESTS"); !found || strings.ToLower(key) != "true" {
 		t.Skip()
 	}
+	testAgainstEndpoint(t, "https://api.hyperspace.node.glif.io/rpc/v1", "test_fevm_https_endpoint.log")
+	testAgainstEndpoint(t, "wss://wss.hyperspace.node.glif.io/apigw/lotus/rpc/v0", "test_fevm_wss_endpoint.log")
+
+}
+
+// testAgainstEndpoint runs a simple chain test against the provided endpoint
+func testAgainstEndpoint(t *testing.T, endpoint string, logFile string) {
+	// We only run the test if the TEST_FEVM env var is set to true
+
 	wallet, err := hdwallet.NewFromMnemonic(WALLABY_MNEMONIC)
 	if err != nil {
 		panic(err)
@@ -56,7 +65,7 @@ func TestEthChainServiceFEVM(t *testing.T) {
 		panic(err)
 	}
 
-	client, err := ethclient.Dial("https://api.hyperspace.node.glif.io/rpc/v1")
+	client, err := ethclient.Dial(endpoint)
 
 	if err != nil {
 		t.Fatal(err)
@@ -85,7 +94,6 @@ func TestEthChainServiceFEVM(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	logFile := "test_FEVM_chain_service.log"
 	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 	cs, err := NewEthChainService(client, na, naAddress, caAddress, vpaAddress, txSubmitter, logDestination)

--- a/client/engine/chainservice/eth_chainservice_FEVM_test.go
+++ b/client/engine/chainservice/eth_chainservice_FEVM_test.go
@@ -43,7 +43,6 @@ func TestEthChainServiceFEVM(t *testing.T) {
 
 // testAgainstEndpoint runs a simple chain test against the provided endpoint
 func testAgainstEndpoint(t *testing.T, endpoint string, logFile string) {
-	// We only run the test if the TEST_FEVM env var is set to true
 
 	wallet, err := hdwallet.NewFromMnemonic(WALLABY_MNEMONIC)
 	if err != nil {

--- a/client/engine/chainservice/eth_chainservice_FEVM_test.go
+++ b/client/engine/chainservice/eth_chainservice_FEVM_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"math/big"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -84,7 +85,10 @@ func TestEthChainServiceFEVM(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cs, err := NewEthChainService(client, na, naAddress, caAddress, vpaAddress, txSubmitter, NoopLogger{})
+	logFile := "test_FEVM_chain_service.log"
+	truncateLog(logFile)
+	logDestination := newLogWriter(logFile)
+	cs, err := NewEthChainService(client, na, naAddress, caAddress, vpaAddress, txSubmitter, logDestination)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -213,4 +217,28 @@ func TestEthChainServiceFEVM(t *testing.T) {
 
 	}
 
+}
+
+func newLogWriter(logFile string) *os.File {
+	err := os.MkdirAll("../artifacts", os.ModePerm)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	filename := filepath.Join("../artifacts", logFile)
+	logDestination, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return logDestination
+}
+func truncateLog(logFile string) {
+	logDestination := newLogWriter(logFile)
+
+	err := logDestination.Truncate(0)
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/nitro-protocol/hardhat.config.ts
+++ b/nitro-protocol/hardhat.config.ts
@@ -73,7 +73,7 @@ const config: HardhatUserConfig & {watcher: any} = {
       chainId: 31415,
     },
     hyperspace: {
-      url: 'https://filecoin-hyperspace.chainstacklabs.com/rpc/v0',
+      url: 'https://api.hyperspace.node.glif.io/rpc/v1',
       accounts: wallabyDeployerPk ? [wallabyDeployerPk] : [],
       chainId: 3141,
     },


### PR DESCRIPTION
Some changes to get the FEVM related tests passing.

- Updated the hyperspace RPC node url to latest `v1`
- Redeploy the contracts and update the addresses in the tests
- Updated the chain service to ignore the ChallengeRegistered event
- Updated the challenge test to use a random nonce 
- Updated the challenge test to wait longer for a receipt
- Updated the chain FEVM test to run against both a websocket and http endpoint
- Update the chain service fevm test to log out to a file

I've also added some basic logic to enable running the FEVM tests conditionally. If the `RUN_FEVM_TESTS` env var is set to true the fevm tests **will not be skipped**. Example: ` RUN_FEVM_TESTS=true go test ./... -timeout 5m`

In this [commit](https://github.com/statechannels/go-nitro/pull/1129/commits/5f70a95d4243f81542c21e3277810843a4d00b69) I've enabled the FEVM tests to run on CI. The succesfull test run can be found [here](https://github.com/statechannels/go-nitro/actions/runs/4246215515)
