### PR TITLE
WIP debugging gas benchmark timeouts.

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: "npm"
+          cache-dependency-path: ./nitro-protocol/package-lock.json
       - name: Install dependencies
         run: npm install --legacy-peer-deps
       - name: check git tree is clean

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    paths: ["nitro-protocol/**"]
+    paths: ["nitro-protocol/**", ".github/workflows/node.yml"]
 
 jobs:
   build:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
       - name: Install dependencies
-        run: npm --legacy-peer-deps
+        run: npm install --legacy-peer-deps
       - name: check git tree is clean
         # This will fail the job if any previous step (re)generated a file
         # that doesn't match what you checked in (or forgot to check in)

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -28,10 +28,14 @@ jobs:
         run: npx hardhat compile
       - name: Run eslint (including prettier)
         run: npm run lint:check
-      - name: DEBUG fire up hardhat
-        run: npx hardhat node --no-deploy --port 9546
       - name: Run gas benchmarks
         run: npm run benchmark:diff
         timeout-minutes: 1
+      - name: Archive logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: ./**/*.log
       - name: Run tests
         run: npm test

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -30,5 +30,6 @@ jobs:
         run: npm run lint:check
       - name: Run gas benchmarks
         run: npm run benchmark:diff
+        timeout-minutes: 1
       - name: Run tests
         run: npm test

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -28,6 +28,8 @@ jobs:
         run: npx hardhat compile
       - name: Run eslint (including prettier)
         run: npm run lint:check
+      - name: DEBUG fire up hardhat
+        run: npx hardhat node --no-deploy --port 9546
       - name: Run gas benchmarks
         run: npm run benchmark:diff
         timeout-minutes: 1

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -16,7 +16,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm --legacy-peer-deps
+      - name: check git tree is clean
+        # This will fail the job if any previous step (re)generated a file
+        # that doesn't match what you checked in (or forgot to check in)
+        run: git diff --exit-code
       - name: Compile contracts
         run: npx hardhat compile
       - name: Run eslint (including prettier)

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -39,3 +39,12 @@ jobs:
           path: ./**/*.log
       - name: Run tests
         run: npm test
+      - name: Notify slack fail
+        if: ${{ failure() && github.ref == 'refs/heads/main'}}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: C03G4AUGA7M
+          status: FAILED
+          color: danger

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        with:
+          cache: "npm"
       - name: Install dependencies
         run: npm install --legacy-peer-deps
       - name: check git tree is clean

--- a/nitro-protocol/gas-benchmarks/jestSetup.ts
+++ b/nitro-protocol/gas-benchmarks/jestSetup.ts
@@ -32,7 +32,7 @@ const hardhatProcessClosed = new Promise(resolve => hardhatProcess.on('close', r
 let snapshot: SnapshotRestorer;
 
 beforeAll(async () => {
-  await waitOn({resources: [hardHatNetworkEndpoint]});
+  await waitOn({resources: [hardHatNetworkEndpoint], log: true, verbose: true});
 
   await deployContracts();
 

--- a/nitro-protocol/gas-benchmarks/jestSetup.ts
+++ b/nitro-protocol/gas-benchmarks/jestSetup.ts
@@ -21,7 +21,7 @@ declare global {
 const logFile = './hardhat-network-output.log';
 const hardHatNetworkEndpoint = 'http://localhost:9546'; // the port should be unique
 
-jest.setTimeout(15_000); // give hardhat network a chance to get going
+jest.setTimeout(30_000); // give hardhat network a chance to get going
 if (existsSync(logFile)) truncateSync(logFile);
 const hardhatProcess = exec('npx hardhat node --no-deploy --port 9546', (error, stdout) => {
   promises.appendFile(logFile, stdout);

--- a/nitro-protocol/hardhat.config.ts
+++ b/nitro-protocol/hardhat.config.ts
@@ -61,6 +61,7 @@ const config: HardhatUserConfig & {watcher: any} = {
   networks: {
     hardhat: {
       chainId: 31337,
+      loggingEnabled: true,
     },
     goerli: {
       url: infuraToken ? 'https://goerli.infura.io/v3/' + infuraToken : '',


### PR DESCRIPTION
 Enforce lockfile checked in: In my understanding, this is a better method than `npm ci` for ensuring that developer's local install matches that on CI. 