### PR TITLE
Refine `client.Close()` method by having engine, services implement `Closer()`

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -186,7 +186,7 @@ func (c *Client) GetLedgerChannel(id types.Destination) (query.LedgerChannelInfo
 	return query.GetLedgerChannelInfo(id, c.store)
 }
 
-// Stop stops the client's engine run loop
-func (c *Client) Stop() {
-	c.engine.Stop()
+// Close stops the client from responding to any input.
+func (c *Client) Close() error {
+	return c.engine.Close()
 }

--- a/client/engine/chainservice/chainservice.go
+++ b/client/engine/chainservice/chainservice.go
@@ -76,4 +76,6 @@ type ChainService interface {
 	GetVirtualPaymentAppAddress() types.Address
 	// GetChainId returns the id of the chain the service is connected to
 	GetChainId() (*big.Int, error)
+	// Close closes the ChainService
+	Close() error
 }

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -76,8 +76,7 @@ func NewEthChainService(chain ethChain, na *NitroAdjudicator.NitroAdjudicator,
 
 	if ecs.subscriptionsSupported() {
 		logger.Printf("Notifications are supported by the chain. Using notifications to listen for events.")
-		context, cancel := context.WithCancel(context.Background())
-		go ecs.subscribeForLogs(context, cancel)
+		go ecs.subscribeForLogs()
 	} else {
 		logger.Printf("Notifications are NOT supported by the chain. Using polling to listen for events.")
 		go ecs.pollForLogs()
@@ -255,12 +254,13 @@ func (ecs *EthChainService) getCurrentBlockNum() *big.Int {
 
 // subscribeForLogs subscribes for logs and pushes them to the out channel.
 // It relies on notifications being supported by the chain node.
-func (ecs *EthChainService) subscribeForLogs(ctx context.Context, cancel context.CancelFunc) {
+func (ecs *EthChainService) subscribeForLogs() {
 	// Subscribe to Adjudicator events
 	query := ethereum.FilterQuery{
 		Addresses: []common.Address{ecs.naAddress},
 	}
 	logs := make(chan ethTypes.Log)
+	ctx, cancel := context.WithCancel(context.Background())
 	sub, err := ecs.chain.SubscribeFilterLogs(ctx, query, logs)
 	if err != nil {
 		ecs.fatalF("subscribeFilterLogs failed: %w", err)

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -71,13 +71,12 @@ func NewEthChainService(chain ethChain, na *NitroAdjudicator.NitroAdjudicator,
 
 	logger := zerolog.New(logDestination).With().Timestamp().Str("txSigner", txSigner.From.String()[0:8]).Caller().Logger()
 
-	context, cancel := context.WithCancel(context.Background())
-
 	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
 	ecs := EthChainService{chain, na, naAddress, caAddress, vpaAddress, txSigner, make(chan Event, 10), logger, make(chan struct{})}
 
 	if ecs.subscriptionsSupported() {
 		logger.Printf("Notifications are supported by the chain. Using notifications to listen for events.")
+		context, cancel := context.WithCancel(context.Background())
 		go ecs.subscribeForLogs(context, cancel)
 	} else {
 		logger.Printf("Notifications are NOT supported by the chain. Using polling to listen for events.")

--- a/client/engine/chainservice/mock_chain.go
+++ b/client/engine/chainservice/mock_chain.go
@@ -68,3 +68,12 @@ func (mc *MockChain) SubscribeToEvents(a types.Address) <-chan Event {
 	mc.out.Store(a.String(), c)
 	return c
 }
+
+func (mc *MockChain) Close() error {
+	f := func(key string, value chan Event) bool {
+		close(value)
+		return true
+	}
+	mc.out.Range(f)
+	return nil
+}

--- a/client/engine/chainservice/mock_chainservice.go
+++ b/client/engine/chainservice/mock_chainservice.go
@@ -56,3 +56,8 @@ func (mc *MockChainService) EventFeed() <-chan Event {
 func (mc *MockChainService) GetChainId() (*big.Int, error) {
 	return big.NewInt(TEST_CHAIN_ID), nil
 }
+
+func (mc *MockChainService) Close() error {
+	close(mc.txListener)
+	return mc.chain.Close()
+}

--- a/client/engine/chainservice/simulated_backend_chainservice.go
+++ b/client/engine/chainservice/simulated_backend_chainservice.go
@@ -68,18 +68,16 @@ func newPollingSimulatedBackendChainService(sim SimulatedChain, bindings Binding
 
 	logger := zerolog.New(logDestination).With().Timestamp().Str("txSigner", txSigner.From.String()[0:8]).Caller().Logger()
 
-	context, cancel := context.WithCancel(context.Background())
-
 	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
 	ecs := EthChainService{sim,
 		bindings.Adjudicator.Contract,
 		bindings.Adjudicator.Address,
 		bindings.ConsensusApp.Address,
 		bindings.VirtualPaymentApp.Address, txSigner,
-		make(chan Event, 10), logger, cancel,
+		make(chan Event, 10), logger, make(chan struct{}),
 	}
 
-	go ecs.pollForLogs(context)
+	go ecs.pollForLogs()
 
 	return &SimulatedBackendChainService{sim: sim, EthChainService: &ecs}, nil
 }

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -126,10 +126,10 @@ func (e *Engine) ToApi() <-chan EngineEvent {
 }
 
 func (e *Engine) Close() error {
-	e.msg.Close()
-	e.chain.Close()
 	close(e.stop)
 	close(e.toApi)
+	e.msg.Close()
+	e.chain.Close()
 	return nil
 }
 

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -125,8 +125,12 @@ func (e *Engine) ToApi() <-chan EngineEvent {
 	return e.toApi
 }
 
-func (e *Engine) Stop() {
-	e.stop <- struct{}{}
+func (e *Engine) Close() error {
+	e.msg.Close()
+	e.chain.Close()
+	close(e.stop)
+	close(e.toApi)
+	return nil
 }
 
 // Run kicks of an infinite loop that waits for communications on the supplied channels, and handles them accordingly

--- a/client/engine/messageservice/messageservice.go
+++ b/client/engine/messageservice/messageservice.go
@@ -8,4 +8,6 @@ type MessageService interface {
 	Out() <-chan protocols.Message
 	// Send is for sending messages with the message service
 	Send(protocols.Message)
+	// Close closes the message service
+	Close() error
 }

--- a/client/engine/messageservice/p2p-message-service/service.go
+++ b/client/engine/messageservice/p2p-message-service/service.go
@@ -191,7 +191,7 @@ func (s *P2PMessageService) Out() <-chan protocols.Message {
 }
 
 // Close closes the P2PMessageService
-func (s *P2PMessageService) Close() {
+func (s *P2PMessageService) Close() error {
 	close(s.quit)
-	s.p2pHost.Close()
+	return s.p2pHost.Close()
 }

--- a/client/engine/messageservice/test-messageservice.go
+++ b/client/engine/messageservice/test-messageservice.go
@@ -112,6 +112,13 @@ func (tms TestMessageService) routeFromPeers() {
 	}
 }
 
+// Close stops the TestMessagerService from sending or receiving messages.
+func (tms TestMessageService) Close() error {
+	close(tms.fromPeers)
+	close(tms.out)
+	return nil
+}
+
 // ┌──────────┐toMsg       in┌───────────┐
 // │          │  ───────────►|           │
 // │  Engine  │              │  Message  │

--- a/client_test/crash_test.go
+++ b/client_test/crash_test.go
@@ -50,7 +50,7 @@ func TestCrashTolerance(t *testing.T) {
 	{
 		channelId := directlyFundALedgerChannel(t, clientA, clientB, types.Address{})
 
-		clientA.Stop()
+		clientA.Close()
 		anotherMessageserviceA := messageservice.NewTestMessageService(alice.Address(), broker, 0)
 		anotherChainA, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[0], logDestination)
 		if err != nil {


### PR DESCRIPTION
In response to comments on #1138.

The commit messages should provide a pretty good guide to these changes.

The overall philosophy here is to try and have the tree of go routines spawned by a client tidied up / garbage collected when the `.Close()` method is called. This should happen synchronously. I verified this by watching goroutines come and go when debugging the crash tolerance test (where `.Close()` is called). 

I followed the design where a **sender** closes a channel used to communicate with a go routine (where possible). In many cases this enough (when we use `range` or `<-`). In other cases (when we use `select`) we need an additional channel to signal the go routine should finish.

In some other situations we are using a `context` to communicate with a 3rd party API such as go-ethereum -- here the context is cancelled. We therefore expect those 3rd party go routines to be cleaned up eventually (but cannot wait on that happening). 

---

Open questions:

1. Does this PR need more documentation (godoc, ADR, etc?)
2. Is there an easy way to unit-test these `Close()` methods?