### PR TITLE
docs: add edit links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ theme:
     - navigation.tracking
     - navigation.tabs
     - content.tabs.link
+    - content.action.edit
 extra_css:
   - stylesheets/extra.css
 markdown_extensions:


### PR DESCRIPTION
fixes #1146.

From https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/, the template takes this added feature flag to include edit links to the configured repo.
