### PR TITLE
remove `respond` from channel lifecycle diagram

### DIFF
--- a/docs/protocol-tutorial/0040-lifecycle-of-a-channel.md
+++ b/docs/protocol-tutorial/0040-lifecycle-of-a-channel.md
@@ -117,7 +117,6 @@ Open -->Challenge: challenge
 Open --> Open: checkpoint
 Open--> Finalized: conclude
 Challenge--> Challenge: challenge
-Challenge--> Open: respond
 Challenge--> Open: checkpoint
 Challenge--> Finalized: conclude
 Challenge--> Finalized': timeout


### PR DESCRIPTION
Closes #1141
