### PR TITLE
WIP: Flush DBs in run loop

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -168,6 +168,10 @@ func (e *Engine) Run() {
 			panic(err)
 			// TODO report errors back to the consuming application
 		}
+		err = e.store.Flush()
+		if err != nil {
+			panic(err)
+		}
 
 		// Only send out an event if there are changes
 		if len(res.CompletedObjectives) > 0 || len(res.FailedObjectives) > 0 || len(res.ReceivedVouchers) > 0 {

--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -40,6 +40,10 @@ func NewMemStore(key []byte) Store {
 	return &ms
 }
 
+func (ms *MemStore) Flush() error {
+	return nil
+}
+
 func (ms *MemStore) Close() error {
 	// Since this is a memory store, there is nothing to close
 	return nil

--- a/client/engine/store/persiststore.go
+++ b/client/engine/store/persiststore.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/buntdb"
 	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/crypto"
@@ -16,7 +17,6 @@ import (
 	"github.com/statechannels/go-nitro/protocols/virtualdefund"
 	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/types"
-	"github.com/tidwall/buntdb"
 )
 
 type PersistStore struct {
@@ -75,6 +75,23 @@ func (ps *PersistStore) Close() error {
 		return err
 	}
 	return ps.channelToObjective.Close()
+}
+
+func (ps *PersistStore) Flush() error {
+	err := ps.channelToObjective.Flush()
+	if err != nil {
+		return err
+	}
+	err = ps.channels.Flush()
+	if err != nil {
+		return err
+	}
+	err = ps.consensusChannels.Flush()
+	if err != nil {
+		return err
+	}
+	return ps.objectives.Flush()
+
 }
 func (ps *PersistStore) GetAddress() *types.Address {
 	address := common.HexToAddress(ps.address)

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -34,6 +34,7 @@ type Store interface {
 
 	ConsensusChannelStore
 	io.Closer
+	Flush() error
 }
 
 type ConsensusChannelStore interface {

--- a/client_test/crash_test.go
+++ b/client_test/crash_test.go
@@ -7,13 +7,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/statechannels/buntdb"
 	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	"github.com/statechannels/go-nitro/client/engine/store"
 	"github.com/statechannels/go-nitro/types"
-	"github.com/tidwall/buntdb"
 )
 
 func TestCrashTolerance(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,10 @@ require (
 	github.com/nats-io/nats-server/v2 v2.9.10
 	github.com/nats-io/nats.go v1.21.0
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0
+	github.com/statechannels/buntdb v0.0.0-20230310210558-7916a96c8fff
 	github.com/stretchr/testify v1.8.1
 	nhooyr.io/websocket v1.8.7
 )
-
-require github.com/tidwall/buntdb v1.2.10
 
 require (
 	github.com/benbjohnson/clock v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -622,6 +622,8 @@ github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/statechannels/buntdb v0.0.0-20230310210558-7916a96c8fff h1:OQ0R3fd1MGjgficaFlqGpN/pmOVwxIMCTCd08rwKn74=
+github.com/statechannels/buntdb v0.0.0-20230310210558-7916a96c8fff/go.mod h1:5dfhq6jRO3uLH8NDwkHw9XAuT0XPd7VidahJWFI+iWU=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4 h1:Gb2Tyox57NRNuZ2d3rmvB3pcmbu7O1RS3m8WRx7ilrg=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -645,8 +647,6 @@ github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cb
 github.com/tidwall/assert v0.1.0 h1:aWcKyRBUAdLoVebxo95N7+YZVTFF/ASTr7BN4sLP6XI=
 github.com/tidwall/btree v1.6.0 h1:LDZfKfQIBHGHWSwckhXI0RPSXzlo+KYdjK7FWSqOzzg=
 github.com/tidwall/btree v1.6.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
-github.com/tidwall/buntdb v1.2.10 h1:U/ebfkmYPBnyiNZIirUiWFcxA/mgzjbKlyPynFsPtyM=
-github.com/tidwall/buntdb v1.2.10/go.mod h1:lZZrZUWzlyDJKlLQ6DKAy53LnG7m5kHyrEHvvcDmBpU=
 github.com/tidwall/gjson v1.12.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
 github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=


### PR DESCRIPTION
Uses a forked version of bundtdb that exposes a `Flush` function to flush out data to disk. In this PR we call `Flush` after the run loop runs.

- [Only flushing to disk in run loop: 154 ms TTFP](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&from=1678725624774&to=1678725787167)
- [Flushing in run loop + write to file every second sync policy: 148 ms TTFP](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&from=1678725851638&to=1678725978133&var-runId=cg7l4ignr2go0tdmcvsg&var-jobCount=3&var-testDuration=1m0s&var-hubs=1&var-payees=5&var-jitter=1&var-latency=10&var-payers=2&var-payeepayers=0&var-nitroVersion=v0.0.0-20230310211316-c6fc97572554&var-storeSyncFrequency=1)
- [Flushing in run loop + write to file every change: 265 ms TTFP](http://34.168.92.245:3000/d/5OBBeW37k/time-to-first-payment?orgId=1&from=1678725927865&to=1678726098805&var-runId=cg7l4m0nr2go0tdmcvt0&var-jobCount=3&var-testDuration=1m0s&var-hubs=1&var-payees=5&var-jitter=1&var-latency=10&var-payers=2&var-payeepayers=0&var-nitroVersion=v0.0.0-20230310211316-c6fc97572554&var-storeSyncFrequency=2)
