### PR TITLE
Add json rpc errors to the rpc server

### DIFF
--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -152,7 +152,8 @@ func setupNitroNodeWithRPCClient(
 		panic(err)
 	}
 
-	rpcServer, err := rpc.NewRpcServer(&node, createLogger(logDestination, node.Address.Hex(), "server"), serverConnection)
+	logger := createLogger(logDestination, node.Address.Hex(), "server")
+	rpcServer, err := rpc.NewRpcServer(&node, &logger, serverConnection)
 	if err != nil {
 		panic(err)
 	}

--- a/rpc/error.go
+++ b/rpc/error.go
@@ -1,0 +1,8 @@
+package rpc
+
+import "github.com/statechannels/go-nitro/rpc/serde"
+
+var parseError = serde.JsonRpcError{Code: -32700, Message: "Parse error"}
+var methodNotFoundError = serde.JsonRpcError{Code: -32601, Message: "Method not found"}
+var unexpectedRequestUnmarshalError = serde.JsonRpcError{Code: -32010, Message: "Unexpected unmarshal error"}
+var unexpectedRequestUnmarshalError2 = serde.JsonRpcError{Code: -32009, Message: "Unexpected unmarshal error"}

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -70,9 +70,10 @@ type JsonRpcResponse[T ResponsePayload] struct {
 }
 
 type JsonRpcError struct {
-	Code    uint64      `json:"code"`
+	Code    int64       `json:"code"`
 	Message string      `json:"message"`
 	Data    interface{} `json:"data"`
+	Id      uint64      `json:"id"`
 }
 
 func NewJsonRpcRequest[T RequestPayload | NotificationPayload, U RequestMethod | NotificationMethod](requestId uint64, method U, objectiveRequest T) *JsonRpcRequest[T] {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -79,7 +79,7 @@ func (rs *RpcServer) registerHandlers() error {
 			panic(fmt.Errorf("unknown method: %s", requestJson.Method))
 		}
 	}
-	return rs.transport.Respond(subscriber)
+	return rs.transport.RegisterRequestHandler(subscriber)
 }
 
 func processRequest[T serde.RequestPayload, U serde.ResponsePayload](rs *RpcServer, requestData []byte, processPayload func(T) U) []byte {

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -1,0 +1,80 @@
+package rpc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rs/zerolog"
+	nitro "github.com/statechannels/go-nitro/client"
+	"github.com/statechannels/go-nitro/rpc/serde"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockResponder struct {
+	Handler func([]byte) []byte
+}
+
+func (*mockResponder) Close() {}
+func (*mockResponder) Url() string {
+	return ""
+}
+func (m *mockResponder) RegisterRequestHandler(handler func([]byte) []byte) error {
+	m.Handler = handler
+	return nil
+}
+func (*mockResponder) Notify([]byte) error {
+	return nil
+}
+
+func sendRequestAndExpectError(t *testing.T, request []byte, expectedError serde.JsonRpcError) {
+	mockClient := &nitro.Client{}
+	mockLogger := zerolog.Logger{}
+	mockResponder := &mockResponder{}
+	_, err := NewRpcServer(mockClient, mockLogger, mockResponder)
+	if err != nil {
+		t.Error(err)
+	}
+
+	response := mockResponder.Handler(request)
+
+	jsonError := serde.JsonRpcError{}
+	err = json.Unmarshal(response, &jsonError)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, jsonError, expectedError)
+}
+
+func TestRpcParseError(t *testing.T) {
+	request := []byte{}
+	expectedError := serde.JsonRpcError{Code: -32700, Message: "Parse error"}
+	sendRequestAndExpectError(t, request, expectedError)
+}
+
+// TestRpcInvalidRequest exists to point out that the server needs request validation improvement.
+// The server receives a valid json object that does not contain any of the required feilds of a request
+// like Id or Method. The server should return an error like {-32600:	Invalid Request} or
+// {-32602:	Invalid params}.
+func TestRpcInvalidRequest(t *testing.T) {
+	type InvalidRequest struct {
+		Message string
+	}
+
+	request := InvalidRequest{Message: "hello"}
+	jsonRequest, err := json.Marshal(request)
+	if err != nil {
+		t.Error(err)
+	}
+	expectedError := serde.JsonRpcError{Code: -32601, Message: "Method not found", Id: 0}
+	sendRequestAndExpectError(t, jsonRequest, expectedError)
+}
+
+func TestRpcMethodNotFound(t *testing.T) {
+	request := serde.JsonRpcMessage{Method: "invalid", Id: 1}
+	jsonRequest, err := json.Marshal(request)
+	if err != nil {
+		t.Error(err)
+	}
+	expectedError := serde.JsonRpcError{Code: -32601, Message: "Method not found", Id: 1}
+	sendRequestAndExpectError(t, jsonRequest, expectedError)
+}

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -28,7 +28,7 @@ func (*mockResponder) Notify([]byte) error {
 
 func sendRequestAndExpectError(t *testing.T, request []byte, expectedError serde.JsonRpcError) {
 	mockClient := &nitro.Client{}
-	mockLogger := zerolog.Logger{}
+	mockLogger := &zerolog.Logger{}
 	mockResponder := &mockResponder{}
 	_, err := NewRpcServer(mockClient, mockLogger, mockResponder)
 	if err != nil {

--- a/rpc/transport/nats/nats_transport.go
+++ b/rpc/transport/nats/nats_transport.go
@@ -75,7 +75,7 @@ func (c *natsTransportClient) Request(data []byte) ([]byte, error) {
 	return msg.Data, err
 }
 
-func (c *natsTransportServer) Respond(handler func([]byte) []byte) error {
+func (c *natsTransportServer) RegisterRequestHandler(handler func([]byte) []byte) error {
 	sub, err := c.nc.Subscribe(nitroRequestTopic, func(msg *nats.Msg) {
 		responseData := handler(msg.Data)
 		err := c.nc.Publish(msg.Reply, responseData)

--- a/rpc/transport/transport.go
+++ b/rpc/transport/transport.go
@@ -26,10 +26,9 @@ type Responder interface {
 	// Url returns the url that the responder is listening on
 	Url() string
 
-	// Respond listens for requests and calls the handler function when a request is received
-	// It returns an error if the listener setup fails
-	// The handler processes the incoming data and returns the response data
-	Respond(func([]byte) []byte) error
+	// RegisterRequestHandler registers a handler that accepts a request and returns a response.
+	// It returns an error if the registration setup fails
+	RegisterRequestHandler(func([]byte) []byte) error
 	// Notify sends notification data without expecting a response
 	Notify([]byte) error
 }

--- a/rpc/transport/ws/server.go
+++ b/rpc/transport/ws/server.go
@@ -54,7 +54,7 @@ func (wsc *serverWebSocketTransport) ServeHTTP(w http.ResponseWriter, r *http.Re
 	wsc.serveMux.ServeHTTP(w, r)
 }
 
-func (wsc *serverWebSocketTransport) Respond(handler func([]byte) []byte) error {
+func (wsc *serverWebSocketTransport) RegisterRequestHandler(handler func([]byte) []byte) error {
 	wsc.requestHandler = handler
 	return nil
 }


### PR DESCRIPTION
Fixes https://github.com/statechannels/go-nitro/issues/1103.

The behavior of the rpc server is:
- If the server is not able to process a request, the server returns a json rpc error.
- If the server is not able to marshal the response, the server panics.

The general pattern is that json rpc errors are returned when request data is to blame for the error, but a panic is triggered for errors unrelated to request data. In the long term for production services, we should avoid server panics. In the short term, immediate termination of the rpc server will allow for easier debugging of unexpected issues.