### PR TITLE
Add request validation to jsonrpc server

### DIFF
--- a/rpc/error.go
+++ b/rpc/error.go
@@ -3,6 +3,7 @@ package rpc
 import "github.com/statechannels/go-nitro/rpc/serde"
 
 var parseError = serde.JsonRpcError{Code: -32700, Message: "Parse error"}
+var invalidRequestError = serde.JsonRpcError{Code: -32600, Message: "Invalid Request"}
 var methodNotFoundError = serde.JsonRpcError{Code: -32601, Message: "Method not found"}
 var unexpectedRequestUnmarshalError = serde.JsonRpcError{Code: -32010, Message: "Unexpected unmarshal error"}
 var unexpectedRequestUnmarshalError2 = serde.JsonRpcError{Code: -32009, Message: "Unexpected unmarshal error"}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -126,7 +126,7 @@ func validateRequest(requestData []byte, logger *zerolog.Logger) validationResul
 	}
 
 	// jsonrpc spec says id can be a string, number.
-	// We only support numbers.
+	// We only support numbers: https://github.com/statechannels/go-nitro/issues/1160
 	// When golang unmarshals JSON into an interface value, float64 is used for numbers.
 	requestId := request["id"]
 	if !assertType[float64](request["id"]) {


### PR DESCRIPTION
This PR adds sanity checks to jsonrpc requests. The checks are:
- Is the jsonrpc version 2.0?
- Is the method a string?
- Is the id an integer?

Note that [jsonrpc spec](https://www.jsonrpc.org/specification) allows for string ids. Our jsonrpcs interface is more restrictive for clarity of code. We can implement string ids if want to adhere fully to the jsonrpc spec. https://github.com/statechannels/go-nitro/issues/1160 tracks this work.