### PR TITLE
Implement a store for vouchers

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -47,7 +47,7 @@ func New(messageService messageservice.MessageService, chainservice chainservice
 	}
 	c.chainId = chainId
 	c.store = store
-	c.vm = payments.NewVoucherManager(*store.GetAddress())
+	c.vm = payments.NewVoucherManager(*store.GetAddress(), store)
 	c.engine = engine.New(c.vm, messageService, chainservice, store, logDestination, policymaker, metricsApi)
 	c.completedObjectives = make(chan protocols.ObjectiveId, 100)
 	c.failedObjectives = make(chan protocols.ObjectiveId, 100)

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -406,7 +406,7 @@ func (e *Engine) handleObjectiveRequest(or protocols.ObjectiveRequest) (EngineEv
 	case virtualdefund.ObjectiveRequest:
 		minAmount := big.NewInt(0)
 		if e.vm.ChannelRegistered(request.ChannelId) {
-			_, paid, _, err := e.vm.Balance(request.ChannelId)
+			paid, err := e.vm.Paid(request.ChannelId)
 			if err != nil {
 				return EngineEvent{}, fmt.Errorf("handleAPIEvent: Could not create objective for %+v: %w", request, err)
 			}
@@ -631,7 +631,7 @@ func (e *Engine) constructObjectiveFromMessage(id protocols.ObjectiveId, p proto
 		}
 		minAmount := big.NewInt(0)
 		if e.vm.ChannelRegistered(vId) {
-			_, paid, _, err := e.vm.Balance(vId)
+			paid, err := e.vm.Paid(vId)
 			if err != nil {
 				return &virtualdefund.Objective{}, fmt.Errorf("could not determine virtual channel id from objective %s: %w", id, err)
 			}

--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -388,8 +388,8 @@ func (ms *MemStore) ReleaseChannelFromOwnership(channelId types.Destination) {
 	ms.channelToObjective.Delete(channelId.String())
 }
 
-func (ms *MemStore) SetVoucherInfo(channelId types.Destination, vs payments.VoucherInfo) error {
-	jsonData, err := json.Marshal(vs)
+func (ms *MemStore) SetVoucherInfo(channelId types.Destination, v payments.VoucherInfo) error {
+	jsonData, err := json.Marshal(v)
 	if err != nil {
 		return err
 	}

--- a/client/engine/store/persiststore.go
+++ b/client/engine/store/persiststore.go
@@ -472,13 +472,13 @@ func (ps *PersistStore) checkError(err error) {
 	}
 }
 
-func (ps *PersistStore) SetVoucherInfo(channelId types.Destination, vs payments.VoucherInfo) error {
+func (ps *PersistStore) SetVoucherInfo(channelId types.Destination, v payments.VoucherInfo) error {
 	return ps.vouchers.Update(func(tx *buntdb.Tx) error {
-		vsJSON, err := json.Marshal(vs)
+		vJSON, err := json.Marshal(v)
 		if err != nil {
 			return err
 		}
-		_, _, err = tx.Set(channelId.String(), string(vsJSON), nil)
+		_, _, err = tx.Set(channelId.String(), string(vJSON), nil)
 
 		return err
 	})

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
+	"github.com/statechannels/go-nitro/payments"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -33,6 +34,7 @@ type Store interface {
 	ReleaseChannelFromOwnership(types.Destination) // Release channel from being owned by any objective
 
 	ConsensusChannelStore
+	payments.VoucherStore
 	io.Closer
 }
 

--- a/client/query/query.go
+++ b/client/query/query.go
@@ -117,12 +117,12 @@ func GetPaymentChannelInfo(id types.Destination, store store.Store, vm *payments
 
 		// If we have received vouchers we want to update the channel balance to reflect the vouchers
 		if hasVouchers := vm.ChannelRegistered(id); status == Ready && hasVouchers {
-			voucherBal, err := vm.Balance(id)
+			_, paid, remaining, err := vm.Balance(id)
 			if err != nil {
 				return PaymentChannelInfo{}, err
 			}
-			balance.PaidSoFar.Set(voucherBal.Paid)
-			balance.RemainingFunds.Set(voucherBal.Remaining)
+			balance.PaidSoFar.Set(paid)
+			balance.RemainingFunds.Set(remaining)
 		}
 
 		return PaymentChannelInfo{

--- a/client/query/query.go
+++ b/client/query/query.go
@@ -117,11 +117,17 @@ func GetPaymentChannelInfo(id types.Destination, store store.Store, vm *payments
 
 		// If we have received vouchers we want to update the channel balance to reflect the vouchers
 		if hasVouchers := vm.ChannelRegistered(id); status == Ready && hasVouchers {
-			_, paid, remaining, err := vm.Balance(id)
+
+			paid, err := vm.Paid(id)
 			if err != nil {
 				return PaymentChannelInfo{}, err
 			}
 			balance.PaidSoFar.Set(paid)
+
+			remaining, err := vm.Remaining(id)
+			if err != nil {
+				return PaymentChannelInfo{}, err
+			}
 			balance.RemainingFunds.Set(remaining)
 		}
 

--- a/payments/payments_test.go
+++ b/payments/payments_test.go
@@ -33,8 +33,8 @@ type simpleVoucherStore struct {
 	vouchers safesync.Map[*VoucherInfo]
 }
 
-func (svs *simpleVoucherStore) SetVoucherInfo(channelId types.Destination, vs VoucherInfo) error {
-	svs.vouchers.Store(channelId.String(), &vs)
+func (svs *simpleVoucherStore) SetVoucherInfo(channelId types.Destination, v VoucherInfo) error {
+	svs.vouchers.Store(channelId.String(), &v)
 	return nil
 }
 func (svs *simpleVoucherStore) GetVoucherInfo(channelId types.Destination) (v *VoucherInfo, ok bool) {

--- a/payments/payments_test.go
+++ b/payments/payments_test.go
@@ -14,9 +14,13 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
+type balance struct {
+	remaining, paid *big.Int
+}
+
 // manager lets us implement a getBalancer helper to make test assertions a little neater
 type manager interface {
-	Balance(chanId types.Destination) (Balance, error)
+	Balance(chanId types.Destination) (initial, paid, remaining *big.Int, err error)
 }
 
 // Since the store package already imports the payments package if we tried to use the mem or persist store
@@ -61,14 +65,14 @@ func TestPaymentManager(t *testing.T) {
 		triplePayment = big.NewInt(60)
 		overPayment   = big.NewInt(2000)
 
-		startingBalance = Balance{big.NewInt(1000), big.NewInt(0)}
-		onePaymentMade  = Balance{big.NewInt(980), big.NewInt(20)}
-		twoPaymentsMade = Balance{big.NewInt(960), big.NewInt(40)}
+		startingBalance = balance{big.NewInt(1000), big.NewInt(0)}
+		onePaymentMade  = balance{big.NewInt(980), big.NewInt(20)}
+		twoPaymentsMade = balance{big.NewInt(960), big.NewInt(40)}
 	)
 
-	getBalance := func(m manager) Balance {
-		bal, _ := m.Balance(channelId)
-		return bal
+	getBalance := func(m manager) balance {
+		_, paid, remaining, _ := m.Balance(channelId)
+		return balance{remaining, paid}
 	}
 
 	// Happy path: Payment manager can register channels and make payments

--- a/payments/payments_test.go
+++ b/payments/payments_test.go
@@ -20,7 +20,8 @@ type balance struct {
 
 // manager lets us implement a getBalancer helper to make test assertions a little neater
 type manager interface {
-	Balance(chanId types.Destination) (initial, paid, remaining *big.Int, err error)
+	Paid(chanId types.Destination) (*big.Int, error)
+	Remaining(chanId types.Destination) (*big.Int, error)
 }
 
 // Since the store package already imports the payments package if we tried to use the mem or persist store
@@ -71,7 +72,8 @@ func TestPaymentManager(t *testing.T) {
 	)
 
 	getBalance := func(m manager) balance {
-		_, paid, remaining, _ := m.Balance(channelId)
+		paid, _ := m.Paid(channelId)
+		remaining, _ := m.Remaining(channelId)
 		return balance{remaining, paid}
 	}
 

--- a/payments/voucher_manager.go
+++ b/payments/voucher_manager.go
@@ -11,7 +11,7 @@ import (
 // VoucherStore is an interface for storing voucher information that the voucher manager expects.
 // To avoid import cycles, this interface is defined in the payments package, but implemented in the store package.
 type VoucherStore interface {
-	SetVoucherInfo(channelId types.Destination, vs VoucherInfo) error
+	SetVoucherInfo(channelId types.Destination, v VoucherInfo) error
 	GetVoucherInfo(channelId types.Destination) (v *VoucherInfo, ok bool)
 	RemoveVoucherInfo(channelId types.Destination) error
 }

--- a/payments/voucher_manager.go
+++ b/payments/voucher_manager.go
@@ -5,29 +5,28 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/statechannels/go-nitro/internal/safesync"
 	"github.com/statechannels/go-nitro/types"
 )
 
-// paymentStatus stores the status of payments for a given payment channel.
-type paymentStatus struct {
-	channelPayer    common.Address
-	channelPayee    common.Address
-	startingBalance *big.Int
-	largestVoucher  Voucher
-	currentBalance  Balance
+// VoucherStore is an interface for storing voucher information that the voucher manager expects.
+// To avoid import cycles, this interface is defined in the payments package, but implemented in the store package.
+type VoucherStore interface {
+	SetVoucherInfo(channelId types.Destination, vs VoucherInfo) error
+	GetVoucherInfo(channelId types.Destination) (v *VoucherInfo, ok bool)
+	RemoveVoucherInfo(channelId types.Destination) error
 }
 
+// VoucherInfo stores the status of payments for a given payment channel.
 // VoucherManager receives and generates vouchers. It is responsible for storing vouchers.
 type VoucherManager struct {
-	channels *safesync.Map[*paymentStatus]
-	me       common.Address
+	store VoucherStore
+	me    common.Address
 }
 
 // NewVoucherManager creates a new voucher manager
-func NewVoucherManager(me types.Address) *VoucherManager {
-	channels := safesync.Map[*paymentStatus]{}
-	return &VoucherManager{&channels, me}
+func NewVoucherManager(me types.Address, store VoucherStore) *VoucherManager {
+
+	return &VoucherManager{store, me}
 }
 
 // Register registers a channel for use, given the payer, payee and starting balance of the channel
@@ -35,71 +34,78 @@ func (vm *VoucherManager) Register(channelId types.Destination, payer common.Add
 
 	balance := Balance{big.NewInt(0).Set(startingBalance), &big.Int{}}
 	voucher := Voucher{ChannelId: channelId, Amount: big.NewInt(0)}
-	data := &paymentStatus{payer, payee, big.NewInt(0).Set(startingBalance), voucher, balance}
-	if _, ok := vm.channels.Load(channelId.String()); ok {
+	data := VoucherInfo{payer, payee, big.NewInt(0).Set(startingBalance), voucher, balance}
+
+	if v, _ := vm.store.GetVoucherInfo(channelId); v != nil {
 		return fmt.Errorf("channel already registered")
 	}
+	return vm.store.SetVoucherInfo(channelId, data)
 
-	vm.channels.Store(channelId.String(), data)
-
-	return nil
 }
 
 // Remove deletes the channel's status
 func (vm *VoucherManager) Remove(channelId types.Destination) {
-	vm.channels.Delete(channelId.String())
+	err := vm.store.RemoveVoucherInfo(channelId)
+	// TODO: Return error instead of panicking
+	if err != nil {
+		panic(err)
+	}
 }
 
 // Pay will deduct amount from balance and add it to paid, returning a signed voucher for the
 // total amount paid.
 func (vm *VoucherManager) Pay(channelId types.Destination, amount *big.Int, pk []byte) (Voucher, error) {
-	pStatus, ok := vm.channels.Load(channelId.String())
+	pStatus, ok := vm.store.GetVoucherInfo(channelId)
 
 	voucher := Voucher{Amount: &big.Int{}}
 	if !ok {
 		return Voucher{}, fmt.Errorf("channel not found")
 	}
 
-	if types.Gt(amount, pStatus.currentBalance.Remaining) {
+	if types.Gt(amount, pStatus.CurrentBalance.Remaining) {
 		return Voucher{}, fmt.Errorf("unable to pay amount: insufficient funds")
 	}
 
-	if pStatus.channelPayer != vm.me {
+	if pStatus.ChannelPayer != vm.me {
 		return Voucher{}, fmt.Errorf("can only sign vouchers if we're the payer")
 	}
 
-	pStatus.currentBalance.Remaining.Sub(pStatus.currentBalance.Remaining, amount)
-	pStatus.currentBalance.Paid.Add(pStatus.currentBalance.Paid, amount)
-	pStatus.largestVoucher = voucher
+	pStatus.CurrentBalance.Remaining.Sub(pStatus.CurrentBalance.Remaining, amount)
+	pStatus.CurrentBalance.Paid.Add(pStatus.CurrentBalance.Paid, amount)
+	pStatus.LargestVoucher = voucher
 
-	voucher.Amount.Set(pStatus.currentBalance.Paid)
+	voucher.Amount.Set(pStatus.CurrentBalance.Paid)
 	voucher.ChannelId = channelId
 
 	if err := voucher.Sign(pk); err != nil {
 		return voucher, err
 	}
 
+	err := vm.store.SetVoucherInfo(channelId, *pStatus)
+	if err != nil {
+		return Voucher{}, err
+	}
 	return voucher, nil
 }
 
 // Receive validates the incoming voucher, and returns the total amount received so far
 func (vm *VoucherManager) Receive(voucher Voucher) (*big.Int, error) {
-	status, ok := vm.channels.Load(voucher.ChannelId.String())
+	status, ok := vm.store.GetVoucherInfo(voucher.ChannelId)
 	if !ok {
 		return &big.Int{}, fmt.Errorf("channel not registered")
 	}
 
 	// We only care about vouchers when we are the recipient of the payment
-	if status.channelPayee != vm.me {
+	if status.ChannelPayee != vm.me {
 		return &big.Int{}, nil
 	}
 	received := &big.Int{}
 	received.Set(voucher.Amount)
-	if types.Gt(received, status.startingBalance) {
+	if types.Gt(received, status.StartingBalance) {
 		return &big.Int{}, fmt.Errorf("channel has insufficient funds")
 	}
 
-	receivedSoFar := status.largestVoucher.Amount
+	receivedSoFar := status.LargestVoucher.Amount
 	if !types.Gt(received, receivedSoFar) {
 		return receivedSoFar, nil
 	}
@@ -108,31 +114,36 @@ func (vm *VoucherManager) Receive(voucher Voucher) (*big.Int, error) {
 	if err != nil {
 		return &big.Int{}, err
 	}
-	if signer != status.channelPayer {
-		return &big.Int{}, fmt.Errorf("wrong signer: %+v, %+v", signer, status.channelPayer)
+	if signer != status.ChannelPayer {
+		return &big.Int{}, fmt.Errorf("wrong signer: %+v, %+v", signer, status.ChannelPayer)
 	}
-	status.currentBalance.Paid.Set(received)
-	remaining := big.NewInt(0).Sub(status.startingBalance, received)
-	status.currentBalance.Remaining.Set(remaining)
+	status.CurrentBalance.Paid.Set(received)
+	remaining := big.NewInt(0).Sub(status.StartingBalance, received)
+	status.CurrentBalance.Remaining.Set(remaining)
 
-	status.largestVoucher = voucher
+	status.LargestVoucher = voucher
+
+	err = vm.store.SetVoucherInfo(voucher.ChannelId, *status)
+	if err != nil {
+		return nil, err
+	}
 	return received, nil
 }
 
 // ChannelRegistered returns  whether a channel has been registered with the voucher manager or not
 func (vm *VoucherManager) ChannelRegistered(channelId types.Destination) bool {
-	_, ok := vm.channels.Load(channelId.String())
+	_, ok := vm.store.GetVoucherInfo(channelId)
 	return ok
 
 }
 
 // Balance returns the balance of the channel
 func (vm *VoucherManager) Balance(channelId types.Destination) (Balance, error) {
-	data, ok := vm.channels.Load(channelId.String())
+	data, ok := vm.store.GetVoucherInfo(channelId)
 	if !ok {
 		return Balance{}, fmt.Errorf("channel not found")
 	}
 
-	return data.currentBalance, nil
+	return data.CurrentBalance, nil
 
 }

--- a/payments/vouchers.go
+++ b/payments/vouchers.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	nitroAbi "github.com/statechannels/go-nitro/abi"
 	"github.com/statechannels/go-nitro/channel/state"
@@ -25,6 +26,16 @@ type Voucher struct {
 	ChannelId types.Destination
 	Amount    *big.Int
 	Signature state.Signature
+}
+
+// VoucherInfo contains the largest voucher we've received on a channel.
+// As well as details about the balance and who the payee/payer is.
+type VoucherInfo struct {
+	ChannelPayer    common.Address
+	ChannelPayee    common.Address
+	StartingBalance *big.Int
+	LargestVoucher  Voucher
+	CurrentBalance  Balance
 }
 
 // Balance stores the remaining and paid funds in a channel.

--- a/payments/vouchers.go
+++ b/payments/vouchers.go
@@ -35,8 +35,6 @@ type VoucherInfo struct {
 	ChannelPayee    common.Address
 	StartingBalance *big.Int
 	LargestVoucher  Voucher
-	Remaining       *big.Int
-	Paid            *big.Int
 }
 
 func (v *Voucher) Hash() (types.Bytes32, error) {
@@ -79,4 +77,14 @@ func (v *Voucher) RecoverSigner() (types.Address, error) {
 // Equal returns true if the two vouchers have the same channel id, amount and signatures
 func (v *Voucher) Equal(other *Voucher) bool {
 	return v.ChannelId == other.ChannelId && v.Amount.Cmp(other.Amount) == 0 && v.Signature.Equal(other.Signature)
+}
+
+// Paid is the amount of funds that already have been used as payments
+func (v *VoucherInfo) Paid() *big.Int {
+	return v.LargestVoucher.Amount
+}
+
+// Remaining returns the amount of funds left to be used as payments
+func (v *VoucherInfo) Remaining() *big.Int {
+	return big.NewInt(0).Sub(v.StartingBalance, v.Paid())
 }

--- a/payments/vouchers.go
+++ b/payments/vouchers.go
@@ -35,13 +35,8 @@ type VoucherInfo struct {
 	ChannelPayee    common.Address
 	StartingBalance *big.Int
 	LargestVoucher  Voucher
-	CurrentBalance  Balance
-}
-
-// Balance stores the remaining and paid funds in a channel.
-type Balance struct {
-	Remaining *big.Int
-	Paid      *big.Int
+	Remaining       *big.Int
+	Paid            *big.Int
 }
 
 func (v *Voucher) Hash() (types.Bytes32, error) {


### PR DESCRIPTION
Fix #822.

This PR introduce a new interface `payments.VoucherStore`. The `VoucherManager` now uses the `VoucherStore` to store and fetch vouchers, instead of using a `safesync.Map`. I've defined `VoucherStore` in payments to avoid an import cycle if I were to declare it in the `store` package.

Both the `MemStore` and `PersistStore` have been updated to implement `payments.VoucherStore`. The `VoucherManager` now expects a `VoucherStore` when constructed and it uses that to fetch and store voucher related information.

TODO:
- [x] ~Expand crash test to test losing vouchers.~ Created https://github.com/statechannels/go-nitro/issues/1167 
