### PR TITLE
Add verbose flag to unit tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        run: go test ./... -count=2 -shuffle=on -timeout 1m
+        run: go test ./... -count=2 -shuffle=on -timeout 1m -v
 
       - name: Archive logs
         if: always()


### PR DESCRIPTION
Verbose flag logs all tests as they are run (as opposed to only package names being logged). This provides more debug information when tests fail.