### PR TITLE
Rename PersisentStore to DurableStore

### DIFF
--- a/client/engine/store/durablestore.go
+++ b/client/engine/store/durablestore.go
@@ -52,6 +52,12 @@ func NewDurableStore(key []byte, folder string, config buntdb.Config) Store {
 	return &ps
 }
 
+// NewPersistStore provides backwards compatibility for testground tests built against the persist store
+// TODO: Remove this once https://github.com/statechannels/go-nitro-testground/pull/156 is merged
+func NewPersistStore(key []byte, folder string, config buntdb.Config) Store {
+	return NewDurableStore(key, folder, config)
+}
+
 func (ds *DurableStore) openDB(name string, config buntdb.Config) *buntdb.DB {
 	db, err := buntdb.Open(fmt.Sprintf("%s/%s_%s.db", ds.folder, name, ds.address[2:7]))
 	ds.checkError(err)

--- a/client_test/crash_test.go
+++ b/client_test/crash_test.go
@@ -46,7 +46,7 @@ func TestCrashTolerance(t *testing.T) {
 	defer os.RemoveAll(dataFolder)
 
 	// Client setup
-	storeA := store.NewPersistStore(alice.PrivateKey, dataFolder, buntdb.Config{SyncPolicy: buntdb.Always})
+	storeA := store.NewDurableStore(alice.PrivateKey, dataFolder, buntdb.Config{SyncPolicy: buntdb.Always})
 	messageserviceA := messageservice.NewTestMessageService(alice.Address(), broker, 0)
 	clientA := client.New(messageserviceA, chainA, storeA, logDestination, &engine.PermissivePolicy{}, nil)
 
@@ -60,7 +60,7 @@ func TestCrashTolerance(t *testing.T) {
 		clientA.Close()
 		anotherMessageserviceA := messageservice.NewTestMessageService(alice.Address(), broker, 0)
 		anotherChainA, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[0], logDestination)
-		anotherStoreA := store.NewPersistStore(alice.PrivateKey, dataFolder, buntdb.Config{SyncPolicy: buntdb.Always})
+		anotherStoreA := store.NewDurableStore(alice.PrivateKey, dataFolder, buntdb.Config{SyncPolicy: buntdb.Always})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -28,7 +28,7 @@ import (
 const TEST_CHAIN_ID = 1337
 const defaultTimeout = 10 * time.Second
 
-const PERSIST_STORE_FOLDER = "../data/client_test"
+const DURABLE_STORE_FOLDER = "../data/client_test"
 
 // waitWithTimeoutForCompletedObjectiveIds waits up to the given timeout for completed objectives and returns when the all objective ids provided have been completed.
 // If the timeout lapses and the objectives have not all completed, the parent test will be failed.
@@ -137,9 +137,9 @@ func waitTimeForReceivedVoucher(t *testing.T, client *client.Client, timeout tim
 func setupClient(pk []byte, chain chainservice.ChainService, msgBroker messageservice.Broker, logDestination io.Writer, meanMessageDelay time.Duration) (client.Client, store.Store) {
 	myAddress := crypto.GetAddressFromSecretKeyBytes(pk)
 	// TODO: Clean up test data folder?
-	dataFolder := fmt.Sprintf("%s/%s/%d", PERSIST_STORE_FOLDER, myAddress.String(), rand.Uint64())
+	dataFolder := fmt.Sprintf("%s/%s/%d", DURABLE_STORE_FOLDER, myAddress.String(), rand.Uint64())
 	messageservice := messageservice.NewTestMessageService(myAddress, msgBroker, meanMessageDelay)
-	storeA := store.NewPersistStore(pk, dataFolder, buntdb.Config{})
+	storeA := store.NewDurableStore(pk, dataFolder, buntdb.Config{})
 	return client.New(messageservice, chain, storeA, logDestination, &engine.PermissivePolicy{}, nil), storeA
 }
 


### PR DESCRIPTION
This updates the store to following the naming convention that we're using in the ADR; **Durable** Store instead of Persist Store.

Since the testground tests uses the store constructor, renaming the constructor means we need to [update the testground test](https://github.com/statechannels/go-nitro-testground/pull/156), otherwise the testground GH action will fail. To avoid blocking this PR I've added a `NewPersistStore` function that is just a wrapper around `NewDurableStore`, allowing the old testground test to work (since there is still a `store.NewPersistStore` function to call). 

Once  https://github.com/statechannels/go-nitro-testground/pull/156 is merged we can remove `NewPersistStore`