### PR TITLE
Unit tests clean up goroutines

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -205,5 +205,6 @@ func (c *Client) Close() error {
 	if err := c.engine.Close(); err != nil {
 		return err
 	}
+	close(c.completedObjectives)
 	return c.store.Close()
 }

--- a/client/client.go
+++ b/client/client.go
@@ -202,9 +202,8 @@ func (c *Client) GetLedgerChannel(id types.Destination) (query.LedgerChannelInfo
 
 // Close stops the client from responding to any input.
 func (c *Client) Close() error {
-	err := c.store.Close()
-	if err != nil {
+	if err := c.engine.Close(); err != nil {
 		return err
 	}
-	return c.engine.Close()
+	return c.store.Close()
 }

--- a/client/client.go
+++ b/client/client.go
@@ -205,6 +205,6 @@ func (c *Client) Close() error {
 	if err := c.engine.Close(); err != nil {
 		return err
 	}
-	close(c.completedObjectives)
+	close(c.completedObjectivesForRPC)
 	return c.store.Close()
 }

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -408,6 +408,5 @@ func (ecs *EthChainService) GetChainId() (*big.Int, error) {
 
 func (ecs *EthChainService) Close() error {
 	ecs.cancel()
-	close(ecs.out)
 	return nil
 }

--- a/client/engine/chainservice/mock_chainservice.go
+++ b/client/engine/chainservice/mock_chainservice.go
@@ -58,6 +58,8 @@ func (mc *MockChainService) GetChainId() (*big.Int, error) {
 }
 
 func (mc *MockChainService) Close() error {
-	close(mc.txListener)
-	return mc.chain.Close()
+	if mc.txListener != nil {
+		close(mc.txListener)
+	}
+	return nil
 }

--- a/client/engine/chainservice/mock_chainservice.go
+++ b/client/engine/chainservice/mock_chainservice.go
@@ -10,9 +10,8 @@ import (
 
 // MockChainService adheres to the ChainService interface. The constructor accepts a MockChain, which allows multiple clients to share the same, in-memory chain.
 type MockChainService struct {
-	chain      *MockChain
-	txListener chan protocols.ChainTransaction // this is used to broadcast transactions that have been received
-	eventFeed  <-chan Event
+	chain     *MockChain
+	eventFeed <-chan Event
 }
 
 // NewMockChainService returns a new MockChainService.
@@ -22,20 +21,8 @@ func NewMockChainService(chain *MockChain, address common.Address) *MockChainSer
 	return &mc
 }
 
-// NewMockChainWithTransactionListener returns a new MockChainService that will send transactions to the supplied chan.
-// This lets us easily rebroadcast transactions to other MockChainServices.
-func NewMockChainWithTransactionListener(chain *MockChain, address common.Address, txListener chan protocols.ChainTransaction) *MockChainService {
-	mc := NewMockChainService(chain, address)
-	mc.txListener = txListener
-	return mc
-}
-
 // SendTransaction responds to the given tx.
 func (mc *MockChainService) SendTransaction(tx protocols.ChainTransaction) error {
-	if mc.txListener != nil {
-		mc.txListener <- tx
-	}
-
 	return mc.chain.SubmitTransaction(tx)
 }
 
@@ -58,8 +45,5 @@ func (mc *MockChainService) GetChainId() (*big.Int, error) {
 }
 
 func (mc *MockChainService) Close() error {
-	if mc.txListener != nil {
-		close(mc.txListener)
-	}
 	return nil
 }

--- a/client/engine/chainservice/simulated_backend_chainservice.go
+++ b/client/engine/chainservice/simulated_backend_chainservice.go
@@ -67,6 +67,7 @@ func newPollingSimulatedBackendChainService(sim SimulatedChain, bindings Binding
 	logging.ConfigureZeroLogger()
 
 	logger := zerolog.New(logDestination).With().Timestamp().Str("txSigner", txSigner.From.String()[0:8]).Caller().Logger()
+	ctx, ctxCancel := context.WithCancel(context.Background())
 
 	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
 	ecs := EthChainService{sim,
@@ -74,7 +75,7 @@ func newPollingSimulatedBackendChainService(sim SimulatedChain, bindings Binding
 		bindings.Adjudicator.Address,
 		bindings.ConsensusApp.Address,
 		bindings.VirtualPaymentApp.Address, txSigner,
-		make(chan Event, 10), logger, make(chan struct{}),
+		make(chan Event, 10), logger, ctx, ctxCancel,
 	}
 
 	go ecs.pollForLogs()

--- a/client/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/client/engine/chainservice/simulated_backend_chainservice_test.go
@@ -45,13 +45,13 @@ func (l NoopLogger) Write(p []byte) (n int, err error) {
 func TestDepositSimulatedBackendChainService(t *testing.T) {
 	one := big.NewInt(1)
 	sim, bindings, ethAccounts, err := SetupSimulatedBackend(1)
-	defer sim.Close()
+	defer closeSimulatedChain(t, sim)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	cs, err := NewSimulatedBackendChainService(sim, bindings, ethAccounts[0], NoopLogger{})
-	defer cs.Close()
+	defer closeChainService(t, cs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestConcludeSimulatedBackendChainServiceWithPolling(t *testing.T) {
 
 func runDepositAndConcludeTest(t *testing.T, usePolling bool) {
 	sim, bindings, ethAccounts, err := SetupSimulatedBackend(1)
-	defer sim.Close()
+	defer closeSimulatedChain(t, sim)
 
 	if err != nil {
 		t.Fatal(err)
@@ -187,5 +187,17 @@ func runDepositAndConcludeTest(t *testing.T, usePolling bool) {
 	// Make assertion
 	if !bytes.Equal(statusOnChain[:], emptyBytes[:]) {
 		t.Fatalf("Adjudicator not updated as expected, got %v wanted %v", common.Bytes2Hex(statusOnChain[:]), common.Bytes2Hex(emptyBytes[:]))
+	}
+}
+
+func closeChainService(t *testing.T, cs ChainService) {
+	if err := cs.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func closeSimulatedChain(t *testing.T, chain SimulatedChain) {
+	if err := chain.Close(); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/client/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/client/engine/chainservice/simulated_backend_chainservice_test.go
@@ -45,11 +45,13 @@ func (l NoopLogger) Write(p []byte) (n int, err error) {
 func TestDepositSimulatedBackendChainService(t *testing.T) {
 	one := big.NewInt(1)
 	sim, bindings, ethAccounts, err := SetupSimulatedBackend(1)
+	defer sim.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	cs, err := NewSimulatedBackendChainService(sim, bindings, ethAccounts[0], NoopLogger{})
+	defer cs.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +86,6 @@ func TestDepositSimulatedBackendChainService(t *testing.T) {
 		t.Fatalf("Mismatch between the deposit transaction and the received events")
 	}
 
-	sim.Close()
 }
 func TestConcludeSimulatedBackendChainService(t *testing.T) {
 	runDepositAndConcludeTest(t, false)
@@ -95,6 +96,8 @@ func TestConcludeSimulatedBackendChainServiceWithPolling(t *testing.T) {
 
 func runDepositAndConcludeTest(t *testing.T, usePolling bool) {
 	sim, bindings, ethAccounts, err := SetupSimulatedBackend(1)
+	defer sim.Close()
+
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,6 +113,7 @@ func runDepositAndConcludeTest(t *testing.T, usePolling bool) {
 			t.Fatal(err)
 		}
 	}
+	defer cs.Close()
 
 	out := cs.EventFeed()
 
@@ -184,7 +188,4 @@ func runDepositAndConcludeTest(t *testing.T, usePolling bool) {
 	if !bytes.Equal(statusOnChain[:], emptyBytes[:]) {
 		t.Fatalf("Adjudicator not updated as expected, got %v wanted %v", common.Bytes2Hex(statusOnChain[:]), common.Bytes2Hex(emptyBytes[:]))
 	}
-
-	// Not sure if this is necessary
-	sim.Close()
 }

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -125,12 +125,11 @@ func (e *Engine) ToApi() <-chan EngineEvent {
 }
 
 func (e *Engine) Close() error {
-	close(e.stop)
-	close(e.toApi)
-	err := e.msg.Close()
-	if err != nil {
+	if err := e.msg.Close(); err != nil {
 		return err
 	}
+	close(e.stop)
+	close(e.toApi)
 	return e.chain.Close()
 }
 

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -128,7 +128,7 @@ func (e *Engine) Close() error {
 	if err := e.msg.Close(); err != nil {
 		return err
 	}
-	close(e.stop)
+	e.stop <- struct{}{}
 	close(e.toApi)
 	return e.chain.Close()
 }

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -127,9 +127,11 @@ func (e *Engine) ToApi() <-chan EngineEvent {
 func (e *Engine) Close() error {
 	close(e.stop)
 	close(e.toApi)
-	e.msg.Close()
-	e.chain.Close()
-	return nil
+	err := e.msg.Close()
+	if err != nil {
+		return err
+	}
+	return e.chain.Close()
 }
 
 // Run kicks of an infinite loop that waits for communications on the supplied channels, and handles them accordingly

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -134,6 +134,7 @@ func (e *Engine) Close() error {
 }
 
 // Run kicks of an infinite loop that waits for communications on the supplied channels, and handles them accordingly
+// The loop exits when a struct is received on the stop channel. Engine.Close() sends that signal.
 func (e *Engine) Run() {
 	for {
 		var res EngineEvent

--- a/client/engine/messageservice/p2p-message-service/service.go
+++ b/client/engine/messageservice/p2p-message-service/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/statechannels/go-nitro/crypto"
 	"github.com/statechannels/go-nitro/internal/safesync"
@@ -84,7 +85,7 @@ func NewMessageService(ip string, port int, pk []byte) *P2PMessageService {
 	}
 	options := []libp2p.Option{libp2p.Identity(messageKey),
 		libp2p.ListenAddrStrings(fmt.Sprintf("/ip4/%s/tcp/%d", ip, port)),
-		libp2p.DefaultTransports,
+		libp2p.Transport(tcp.NewTCPTransport),
 		libp2p.NoSecurity,
 		libp2p.DefaultMuxers,
 	}

--- a/client/engine/messageservice/test-messageservice.go
+++ b/client/engine/messageservice/test-messageservice.go
@@ -115,7 +115,6 @@ func (tms TestMessageService) routeFromPeers() {
 // Close stops the TestMessagerService from sending or receiving messages.
 func (tms TestMessageService) Close() error {
 	close(tms.fromPeers)
-	close(tms.out)
 	return nil
 }
 

--- a/client/engine/messageservice/test-messageservice.go
+++ b/client/engine/messageservice/test-messageservice.go
@@ -121,7 +121,7 @@ func (tms TestMessageService) Close() error {
 //                                │
 //                                │
 //                                │
-//                                v fromPeers
+//                                v HandleMessage
 // ┌──────────┐toMsg       in┌───────────┐
 // │          │  ───────────►|           │
 // │  Engine  │              │  Message  │

--- a/client/engine/store/durablestore.go
+++ b/client/engine/store/durablestore.go
@@ -79,7 +79,11 @@ func (ds *DurableStore) Close() error {
 	if err != nil {
 		return err
 	}
-	return ds.channelToObjective.Close()
+	err = ds.channelToObjective.Close()
+	if err != nil {
+		return err
+	}
+	return ds.vouchers.Close()
 }
 func (ds *DurableStore) GetAddress() *types.Address {
 	address := common.HexToAddress(ds.address)

--- a/client_test/crash_test.go
+++ b/client_test/crash_test.go
@@ -25,6 +25,7 @@ func TestCrashTolerance(t *testing.T) {
 
 	// Setup chain service
 	sim, bindings, ethAccounts, err := chainservice.SetupSimulatedBackend(3)
+	defer sim.Close()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client_test/directdefund_test.go
+++ b/client_test/directdefund_test.go
@@ -27,7 +27,7 @@ func TestDirectDefund(t *testing.T) {
 
 	// Setup chain service
 	sim, bindings, ethAccounts, err := chainservice.SetupSimulatedBackend(3)
-	defer sim.Close()
+	defer closeSimulatedChain(t, sim)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,8 +47,10 @@ func TestDirectDefund(t *testing.T) {
 
 	// Client setup
 	clientA, storeA := setupClient(alice.PrivateKey, chainA, broker, logDestination, 0)
+	defer closeClient(t, &clientA)
 
 	clientB, storeB := setupClient(bob.PrivateKey, chainB, broker, logDestination, 0)
+	defer closeClient(t, &clientB)
 	// End Client setup
 
 	// test successful condition for setup / teadown of unused ledger channel

--- a/client_test/directdefund_test.go
+++ b/client_test/directdefund_test.go
@@ -27,6 +27,7 @@ func TestDirectDefund(t *testing.T) {
 
 	// Setup chain service
 	sim, bindings, ethAccounts, err := chainservice.SetupSimulatedBackend(3)
+	defer sim.Close()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client_test/directfund_test.go
+++ b/client_test/directfund_test.go
@@ -145,6 +145,7 @@ func TestDirectFund(t *testing.T) {
 
 	// Setup long-running chain
 	sim, bindings, ethAccounts, err := chainservice.SetupSimulatedBackend(2)
+	defer sim.Close()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -29,8 +29,7 @@ import (
 
 const TEST_CHAIN_ID = 1337
 
-// TODO: change me back
-const defaultTimeout = 1000 * time.Second
+const defaultTimeout = 10 * time.Second
 
 const DURABLE_STORE_FOLDER = "../data/client_test"
 

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -28,7 +28,9 @@ import (
 )
 
 const TEST_CHAIN_ID = 1337
-const defaultTimeout = 10 * time.Second
+
+// TODO: change me back
+const defaultTimeout = 1000 * time.Second
 
 const DURABLE_STORE_FOLDER = "../data/client_test"
 
@@ -142,6 +144,13 @@ func setupClient(pk []byte, chain chainservice.ChainService, msgBroker messagese
 	return client.New(messageservice, chain, storeA, logDestination, &engine.PermissivePolicy{}, nil), storeA
 }
 
+func closeClient(t *testing.T, client *client.Client) {
+	err := client.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func truncateLog(logFile string) {
 	logDestination := newLogWriter(logFile)
 
@@ -213,5 +222,11 @@ func checkLedgerChannel(t *testing.T, ledgerId types.Destination, o outcome.Exit
 		if diff := cmp.Diff(expected, ledger, cmp.AllowUnexported(big.Int{})); diff != "" {
 			t.Fatalf("Ledger diff mismatch (-want +got):\n%s", diff)
 		}
+	}
+}
+
+func closeSimulatedChain(t *testing.T, chain chainservice.SimulatedChain) {
+	if err := chain.Close(); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/client_test/payment_with_p2p_ms_test.go
+++ b/client_test/payment_with_p2p_ms_test.go
@@ -36,8 +36,11 @@ func TestPayments(t *testing.T) {
 	chainServiceI := chainservice.NewMockChainService(chain, irene.Address())
 
 	clientA, msgA := setupClientWithP2PMessageService(alice.PrivateKey, 3005, chainServiceA, logDestination)
+	defer closeClient(t, &clientA)
 	clientB, msgB := setupClientWithP2PMessageService(bob.PrivateKey, 3006, chainServiceB, logDestination)
+	defer closeClient(t, &clientB)
 	clientI, msgI := setupClientWithP2PMessageService(irene.PrivateKey, 3007, chainServiceI, logDestination)
+	defer closeClient(t, &clientI)
 	peers := []p2pms.PeerInfo{
 		{Id: msgA.Id(), IpAddress: "127.0.0.1", Port: 3005, Address: alice.Address()},
 		{Id: msgB.Id(), IpAddress: "127.0.0.1", Port: 3006, Address: bob.Address()},
@@ -47,10 +50,6 @@ func TestPayments(t *testing.T) {
 	msgA.AddPeers(peers)
 	msgB.AddPeers(peers)
 	msgI.AddPeers(peers)
-
-	defer msgA.Close()
-	defer msgB.Close()
-	defer msgI.Close()
 
 	directlyFundALedgerChannel(t, clientA, clientI, types.Address{})
 	directlyFundALedgerChannel(t, clientI, clientB, types.Address{})

--- a/client_test/query_test.go
+++ b/client_test/query_test.go
@@ -25,7 +25,9 @@ func TestQueryLedgerChannel(t *testing.T) {
 	broker := messageservice.NewBroker()
 
 	aliceClient, _ := setupClient(alice.PrivateKey, chainServiceA, broker, logDestination, 0)
+	defer closeClient(t, &aliceClient)
 	ireneClient, _ := setupClient(irene.PrivateKey, chainServiceI, broker, logDestination, 0)
+	defer closeClient(t, &ireneClient)
 
 	// Set up an outcome that requires both participants to deposit
 	outcome := testdata.Outcomes.Create(alice.Address(), irene.Address(), 7, 3, types.Address{})
@@ -81,8 +83,11 @@ func TestQueryPaymentChannel(t *testing.T) {
 	broker := messageservice.NewBroker()
 
 	aliceClient, _ := setupClient(alice.PrivateKey, chainServiceA, broker, logDestination, 0)
+	defer closeClient(t, &aliceClient)
 	ireneClient, _ := setupClient(irene.PrivateKey, chainServiceI, broker, logDestination, 0)
+	defer closeClient(t, &ireneClient)
 	bobClient, _ := setupClient(bob.PrivateKey, chainServiceB, broker, logDestination, 0)
+	defer closeClient(t, &bobClient)
 
 	directlyFundALedgerChannel(t, aliceClient, ireneClient, types.Address{})
 	directlyFundALedgerChannel(t, bobClient, ireneClient, types.Address{})

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -162,7 +162,6 @@ func setupNitroNodeWithRPCClient(
 		panic(err)
 	}
 	cleanupFn := func() {
-		messageservice.Close()
 		rpcClient.Close()
 		rpcServer.Close()
 	}

--- a/client_test/virtualdefund_test.go
+++ b/client_test/virtualdefund_test.go
@@ -60,8 +60,11 @@ func runVirtualDefundIntegrationTestAs(t *testing.T, closer types.Address, messa
 	broker := messageservice.NewBroker()
 
 	clientA, storeA := setupClient(alice.PrivateKey, chainServiceA, broker, logDestination, messageDelay)
+	defer closeClient(t, &clientA)
 	clientB, storeB := setupClient(bob.PrivateKey, chainServiceB, broker, logDestination, messageDelay)
+	defer closeClient(t, &clientB)
 	clientI, storeI := setupClient(irene.PrivateKey, chainServiceI, broker, logDestination, messageDelay)
+	defer closeClient(t, &clientI)
 
 	numOfVirtualChannels := uint(5)
 	paidToBob := uint(1)
@@ -161,6 +164,7 @@ func TestWhenVirtualDefundObjectiveIsRejected(t *testing.T) {
 
 	meanMessageDelay := time.Duration(0)
 	clientA, storeA := setupClient(alice.PrivateKey, chainServiceA, broker, logDestination, meanMessageDelay)
+	defer closeClient(t, &clientA)
 	var (
 		clientB client.Client
 		storeB  store.Store
@@ -171,6 +175,7 @@ func TestWhenVirtualDefundObjectiveIsRejected(t *testing.T) {
 		clientB = client.New(messageservice, chainServiceB, storeB, logDestination, &RejectingPolicyMaker{}, nil)
 	}
 	clientI, storeI := setupClient(irene.PrivateKey, chainServiceI, broker, logDestination, meanMessageDelay)
+	defer closeClient(t, &clientI)
 
 	directlyFundALedgerChannel(t, clientA, clientI, types.Address{})
 	directlyFundALedgerChannel(t, clientB, clientI, types.Address{})

--- a/client_test/virtualdefund_test.go
+++ b/client_test/virtualdefund_test.go
@@ -174,6 +174,7 @@ func TestWhenVirtualDefundObjectiveIsRejected(t *testing.T) {
 		storeB = store.NewMemStore(bob.PrivateKey)
 		clientB = client.New(messageservice, chainServiceB, storeB, logDestination, &RejectingPolicyMaker{}, nil)
 	}
+	defer closeClient(t, &clientB)
 	clientI, storeI := setupClient(irene.PrivateKey, chainServiceI, broker, logDestination, meanMessageDelay)
 	defer closeClient(t, &clientI)
 

--- a/client_test/virtualfund_multi_party_test.go
+++ b/client_test/virtualfund_multi_party_test.go
@@ -24,9 +24,13 @@ func TestVirtualFundMultiParty(t *testing.T) {
 	broker := messageservice.NewBroker()
 
 	clientAlice, _ := setupClient(alice.PrivateKey, chainServiceA, broker, logDestination, 0)
+	defer closeClient(t, &clientAlice)
 	clientBob, _ := setupClient(bob.PrivateKey, chainServiceBo, broker, logDestination, 0)
+	defer closeClient(t, &clientBob)
 	clientBrian, _ := setupClient(brian.PrivateKey, chainServiceBr, broker, logDestination, 0)
+	defer closeClient(t, &clientBrian)
 	clientIrene, _ := setupClient(irene.PrivateKey, chainServiceI, broker, logDestination, 0)
+	defer closeClient(t, &clientIrene)
 
 	directlyFundALedgerChannel(t, clientAlice, clientIrene, types.Address{})
 	directlyFundALedgerChannel(t, clientIrene, clientBob, types.Address{})

--- a/client_test/virtualfund_test.go
+++ b/client_test/virtualfund_test.go
@@ -51,9 +51,13 @@ func TestVirtualFundIntegration(t *testing.T) {
 	broker := messageservice.NewBroker()
 
 	clientA, _ := setupClient(alice.PrivateKey, chainServiceA, broker, logDestination, 0)
+	defer closeClient(t, &clientA)
 	irene, _ := setupClient(irene.PrivateKey, chainServiceI, broker, logDestination, 0)
+	defer closeClient(t, &irene)
 	ivan, _ := setupClient(brian.PrivateKey, chainServiceBr, broker, logDestination, 0)
+	defer closeClient(t, &ivan)
 	clientB, _ := setupClient(bob.PrivateKey, chainServiceB, broker, logDestination, 0)
+	defer closeClient(t, &clientB)
 
 	openN_HopVirtualChannels(t, []client.Client{clientA, irene, ivan, clientB}, 1)
 }

--- a/client_test/virtualfund_with_message_delays_test.go
+++ b/client_test/virtualfund_with_message_delays_test.go
@@ -31,8 +31,11 @@ func TestVirtualFundWithMessageDelays(t *testing.T) {
 	broker := messageservice.NewBroker()
 
 	clientA, _ := setupClient(alice.PrivateKey, chainServiceA, broker, logDestination, MAX_MESSAGE_DELAY)
+	defer closeClient(t, &clientA)
 	clientB, _ := setupClient(bob.PrivateKey, chainServiceB, broker, logDestination, MAX_MESSAGE_DELAY)
+	defer closeClient(t, &clientB)
 	clientI, _ := setupClient(irene.PrivateKey, chainServiceI, broker, logDestination, MAX_MESSAGE_DELAY)
+	defer closeClient(t, &clientI)
 
 	directlyFundALedgerChannel(t, clientA, clientI, types.Address{})
 	directlyFundALedgerChannel(t, clientI, clientB, types.Address{})

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -28,6 +28,7 @@ func (rs *RpcServer) Url() string {
 }
 
 func (rs *RpcServer) Close() {
+	rs.client.Close()
 	rs.transport.Close()
 }
 

--- a/rpc/transport/nats/nats_transport.go
+++ b/rpc/transport/nats/nats_transport.go
@@ -127,6 +127,7 @@ func (c *natsTransport) Close() {
 			log.Error().Err(err).Msgf("failed to unsubscribe from a topic: %s", sub.Subject)
 		}
 	}
+	c.nc.Close()
 }
 
 func (c *natsTransport) unsubscribeFromTopic(sub *nats.Subscription, try int32) error {

--- a/rpc/transport/ws/client.go
+++ b/rpc/transport/ws/client.go
@@ -55,6 +55,7 @@ func (wsc *clientWebSocketTransport) Subscribe() (<-chan []byte, error) {
 func (wsc *clientWebSocketTransport) Close() {
 	// Clients initiate and close websockets{
 	wsc.clientWebsocket.Close(websocket.StatusNormalClosure, "client initiated close")
+	close(wsc.notificationChan)
 }
 
 func (wsc *clientWebSocketTransport) readMessages(ctx context.Context) {


### PR DESCRIPTION
The goal of this PR is for every unit test to not leave any orphaned goroutines. An orphaned goroutine is defined as a goroutine that is waiting on a signal that will never come. Note that this PR does **not** attempt to block a unit test until all goroutines started by the unit test exit. Some goroutines spun up by a unit test persist past the unit test but are expected to exit in a finite (and hopefully small) amount of time. Not ideal, but it is not clear there is an elegant way to block a unit test on all goroutine exits.

This PR follows these rules:
- A channel is only closed when necessary. It is necessary to close a channel when there is a goroutine that is waiting for the channel output. Only channel writers should close a channel.
- goroutines are only used when asynchronicity is necessary. Otherwise, functions are used.
- "if variable == condition then work else exit" pattern must be avoided when condition can be written by another goroutine. This pattern creates a race condition that can be solved by a mutex. But mutexes are not the preferred golang way. 