### PR TITLE
WIP: Fix testground stalling on CI

### DIFF
--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -285,9 +285,11 @@ func (ecs *EthChainService) subscribeForLogs() {
 			ecs.logger.Print("resubscribed to filtered logs")
 
 		case <-time.After(RESUB_INTERVAL):
+
 			// Due to https://github.com/ethereum/go-ethereum/issues/23845 we can't rely on a long running subscription.
 			// We unsub here and recreate the subscription in the next iteration of the select.
 			sub.Unsubscribe()
+			ecs.logger.Print("Unsubscribed from filter logs")
 		case chainEvent := <-logs:
 			ecs.dispatchChainEvents([]ethTypes.Log{chainEvent})
 		}

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -272,7 +272,11 @@ func (ecs *EthChainService) subscribeForLogs() {
 			return
 		case err := <-sub.Err():
 			if err != nil {
-				ecs.fatalF("received error from the subscription channel: %w", err)
+				if err.Error() != "i/o timeout" {
+					ecs.fatalF("received error from the subscription channel: %w", err)
+				}
+				ecs.logger.Print("Received timeout error, attempting resubscribe")
+
 			}
 
 			// If the error is nil then the subscription was closed and we need to re-subscribe.


### PR DESCRIPTION
Address the testground test occasionally stalling out by adding logic to make multiple attempts to resubscribe for events.

This should gracefully handle the timeout error we see when trying to use a sub