### PR TITLE
Fail CI unit tests after first failure

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        run: go test ./... -count=2 -shuffle=on -timeout 1m -v
+        run: go test ./... -count=2 -shuffle=on -timeout 1m -v -failfast
 
       - name: Archive logs
         if: always()


### PR DESCRIPTION
When a test for a package fails, no more tests are run for the package. But tests for other packages will continue. See
https://github.com/golang/go/issues/33038.

For now, this is good enough. The main issue we are seeing is flickering of `client_test` unit tests. As soon as a `client_test` test fails, no more tests for the `client_test` package will run. So logs with the failing test will not be overwritten.