### PR TITLE
Close client producer channels in handleEngineEvent

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -92,6 +92,11 @@ func (c *Client) handleEngineEvents() {
 		}
 
 	}
+
+	// At this point, the engine ToApi channel has been closed.
+	// If there are blocking consumers (for or select channel statements) on any channel for which the client is a producer,
+	// those channels need to be closed.
+	close(c.completedObjectivesForRPC)
 }
 
 // Begin API
@@ -205,6 +210,5 @@ func (c *Client) Close() error {
 	if err := c.engine.Close(); err != nil {
 		return err
 	}
-	close(c.completedObjectivesForRPC)
 	return c.store.Close()
 }


### PR DESCRIPTION
Otherwise we see a race condition:
```
=== RUN   TestWhenObjectiveIsRejected
panic: send on closed channel

goroutine 221 [running]:
github.com/statechannels/go-nitro/client.(*Client).handleEngineEvents(0xc0005df400)
        /Users/misha/dev/statechannels/go-nitro/client/client.go:80 +0x232
created by github.com/statechannels/go-nitro/client.New
        /Users/misha/dev/statechannels/go-nitro/client/client.go:64 +0x53f
exit status 2
FAIL    github.com/statechannels/go-nitro/client_test   1.453s
```
