### PR TITLE
[InterestBearingApp] require full consensus on supplied states

### DIFF
--- a/nitro-protocol/contracts/InterestBearingApp.sol
+++ b/nitro-protocol/contracts/InterestBearingApp.sol
@@ -47,11 +47,7 @@ contract InterestBearingApp is IForceMoveApp {
     ) external view override {
         if (proof.length == 0) {
             // unanimous consensus check
-            Consensus.requireConsensus(
-                fixedPart,
-                proof,
-                candidate
-            );
+            Consensus.requireConsensus(fixedPart, proof, candidate);
             return;
         } else if (proof.length == 1) {
             // check that proof[0] -> candidate respects the stated interest rate.
@@ -60,12 +56,8 @@ contract InterestBearingApp is IForceMoveApp {
             //  - candidate state immediately follows proof state (by turnNum)
             //  - the lender has not taken more funds than owed according
             //    to the interest rate agreement of the channel
-            RecoveredVariablePart[] memory  nullProof;
-            Consensus.requireConsensus(
-                fixedPart,
-                nullProof,
-                proof[0]
-            );
+            RecoveredVariablePart[] memory nullProof;
+            Consensus.requireConsensus(fixedPart, nullProof, proof[0]);
             require(
                 proof[0].variablePart.turnNum + 1 == candidate.variablePart.turnNum,
                 'turn(candidate) != turn(proof)+1'

--- a/nitro-protocol/test/contracts/InterestBearingApp/requireStateSupported.test.ts
+++ b/nitro-protocol/test/contracts/InterestBearingApp/requireStateSupported.test.ts
@@ -223,11 +223,11 @@ describe('requireStateSupported', () => {
 
     await expectRevert(
       () => interestBearingApp.requireStateSupported(fixedPart, [], signedByBorrower),
-      '!unanimous; |proof|=0'
+      '!unanimous'
     );
     await expectRevert(
       () => interestBearingApp.requireStateSupported(fixedPart, [], signedByLender),
-      '!unanimous; |proof|=0'
+      '!unanimous'
     );
   });
 
@@ -239,12 +239,12 @@ describe('requireStateSupported', () => {
 
     await expectRevert(
       () => interestBearingApp.requireStateSupported(fixedPart, [signedByBorrower], signedByLender),
-      '!unanimous proof state'
+      '!unanimous'
     );
 
     await expectRevert(
       () => interestBearingApp.requireStateSupported(fixedPart, [signedByLender], signedByBorrower),
-      '!unanimous proof state'
+      '!unanimous'
     );
   });
 


### PR DESCRIPTION
Per discussions, the prior implementation put unnecessary vigilance requirements on wallet implementations. Here's the attack:

- Alice, Bob agree to open an interest-bearing channel
- Alice crafts the fixedpart / opening state, which places her and Bob in the appropriate places, but also sneaks an Alice alias into the participant list
- Bob inspects the supplied channel opening state, sees that he and Alice are where they should be, and consents to open / fund the channel.

Now, Alice holds keys for two channel participants, which Bob didn't notice. Under the prior implementation, Alice could challenge with a state that included signatures from her and her alias (because it passes the 2-signers check).

This is an opportunistic attack, because it relies on some degree of negligence in Bob's wallet, which should have checked that he and Alice were the only participants.

This PR's fix moves this responsibility from implementing wallets (which could be poorly written or have bugs introduced over time) to the more durable and easily audited solidity contract.