### PR TITLE
Stop generating ecdsa.PrivKey in P2P Message Service

### DIFF
--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -1,6 +1,7 @@
 package client_test
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"log"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	p2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine"
@@ -228,4 +230,23 @@ func closeSimulatedChain(t *testing.T, chain chainservice.SimulatedChain) {
 	if err := chain.Close(); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// generateMessageKey generates a ECDSA private key deterministically using the given pk bytes.
+func generateMessageKey(pk []byte) p2pcrypto.PrivKey {
+
+	// We use he given
+	totalSize := 256
+	large := make([]byte, totalSize)
+	copy(large, pk)
+
+	messageKey, _, err := p2pcrypto.GenerateECDSAKeyPair(bytes.NewReader(large))
+	if err != nil {
+		panic(err)
+	}
+
+	if err != nil {
+		panic(err)
+	}
+	return messageKey
 }

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -233,7 +233,7 @@ func closeSimulatedChain(t *testing.T, chain chainservice.SimulatedChain) {
 }
 
 // generateMessageKey generates a ECDSA private key using the given pk bytes, and is idempotent.
-func generateMessageKey(pk []byte) p2pcrypto.PrivKey {
+func generateMessageKey(t *testing.T, pk []byte) p2pcrypto.PrivKey {
 
 	// GenerateECDSAKeyPair expects a source to read random bytes from.
 	// We don't know exactly how many random bytes it will read, but we know it's under 256.
@@ -245,7 +245,7 @@ func generateMessageKey(pk []byte) p2pcrypto.PrivKey {
 
 	messageKey, _, err := p2pcrypto.GenerateECDSAKeyPair(bytes.NewReader(large))
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	return messageKey

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -232,10 +232,13 @@ func closeSimulatedChain(t *testing.T, chain chainservice.SimulatedChain) {
 	}
 }
 
-// generateMessageKey generates a ECDSA private key deterministically using the given pk bytes.
+// generateMessageKey generates a ECDSA private key using the given pk bytes, and is idempotent.
 func generateMessageKey(pk []byte) p2pcrypto.PrivKey {
 
-	// We use he given
+	// GenerateECDSAKeyPair expects a source to read random bytes from.
+	// We don't know exactly how many random bytes it will read, but we know it's under 256.
+	// We generate a 256 byte slice and copy the pk into it, leaving the rest empty.
+	// This lets us generate the exact same message key for the given pk.
 	totalSize := 256
 	large := make([]byte, totalSize)
 	copy(large, pk)
@@ -245,8 +248,5 @@ func generateMessageKey(pk []byte) p2pcrypto.PrivKey {
 		panic(err)
 	}
 
-	if err != nil {
-		panic(err)
-	}
 	return messageKey
 }

--- a/client_test/payment_with_p2p_ms_test.go
+++ b/client_test/payment_with_p2p_ms_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	p2pms "github.com/statechannels/go-nitro/client/engine/messageservice/p2p-message-service"
 	"github.com/statechannels/go-nitro/client/engine/store"
+	"github.com/statechannels/go-nitro/crypto"
 	td "github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
@@ -18,7 +19,11 @@ import (
 // setupClientWithP2PMessageService is a helper function that contructs a client and returns the new client and its store.
 func setupClientWithP2PMessageService(pk []byte, port int, chain *chainservice.MockChainService, logDestination io.Writer) (client.Client, *p2pms.P2PMessageService) {
 
-	messageservice := p2pms.NewMessageService("127.0.0.1", port, pk)
+	messageservice := p2pms.NewMessageService(
+		"127.0.0.1",
+		port,
+		crypto.GetAddressFromSecretKeyBytes(pk),
+		generateMessageKey(pk))
 	storeA := store.NewMemStore(pk)
 	return client.New(messageservice, chain, storeA, logDestination, &engine.PermissivePolicy{}, nil), messageservice
 }

--- a/client_test/payment_with_p2p_ms_test.go
+++ b/client_test/payment_with_p2p_ms_test.go
@@ -17,13 +17,13 @@ import (
 )
 
 // setupClientWithP2PMessageService is a helper function that contructs a client and returns the new client and its store.
-func setupClientWithP2PMessageService(pk []byte, port int, chain *chainservice.MockChainService, logDestination io.Writer) (client.Client, *p2pms.P2PMessageService) {
+func setupClientWithP2PMessageService(t *testing.T, pk []byte, port int, chain *chainservice.MockChainService, logDestination io.Writer) (client.Client, *p2pms.P2PMessageService) {
 
 	messageservice := p2pms.NewMessageService(
 		"127.0.0.1",
 		port,
 		crypto.GetAddressFromSecretKeyBytes(pk),
-		generateMessageKey(pk))
+		generateMessageKey(t, pk))
 	storeA := store.NewMemStore(pk)
 	return client.New(messageservice, chain, storeA, logDestination, &engine.PermissivePolicy{}, nil), messageservice
 }
@@ -40,11 +40,11 @@ func TestPayments(t *testing.T) {
 	chainServiceB := chainservice.NewMockChainService(chain, bob.Address())
 	chainServiceI := chainservice.NewMockChainService(chain, irene.Address())
 
-	clientA, msgA := setupClientWithP2PMessageService(alice.PrivateKey, 3005, chainServiceA, logDestination)
+	clientA, msgA := setupClientWithP2PMessageService(t, alice.PrivateKey, 3005, chainServiceA, logDestination)
 	defer closeClient(t, &clientA)
-	clientB, msgB := setupClientWithP2PMessageService(bob.PrivateKey, 3006, chainServiceB, logDestination)
+	clientB, msgB := setupClientWithP2PMessageService(t, bob.PrivateKey, 3006, chainServiceB, logDestination)
 	defer closeClient(t, &clientB)
-	clientI, msgI := setupClientWithP2PMessageService(irene.PrivateKey, 3007, chainServiceI, logDestination)
+	clientI, msgI := setupClientWithP2PMessageService(t, irene.PrivateKey, 3007, chainServiceI, logDestination)
 	defer closeClient(t, &clientI)
 	peers := []p2pms.PeerInfo{
 		{Id: msgA.Id(), IpAddress: "127.0.0.1", Port: 3005, Address: alice.Address()},

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
 	p2pms "github.com/statechannels/go-nitro/client/engine/messageservice/p2p-message-service"
 	"github.com/statechannels/go-nitro/client/engine/store"
+	"github.com/statechannels/go-nitro/crypto"
 	"github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/rpc"
 	"github.com/statechannels/go-nitro/rpc/transport"
@@ -115,7 +116,10 @@ func setupNitroNodeWithRPCClient(
 	logDestination *os.File,
 	connectionType transport.TransportType,
 ) (*rpc.RpcClient, *p2pms.P2PMessageService, func()) {
-	messageservice := p2pms.NewMessageService("127.0.0.1", msgPort, pk)
+	messageservice := p2pms.NewMessageService("127.0.0.1",
+		msgPort,
+		crypto.GetAddressFromSecretKeyBytes(pk),
+		generateMessageKey(pk))
 	storeA := store.NewMemStore(pk)
 	node := client.New(
 		messageservice,

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -50,9 +50,9 @@ func executeRpcTest(t *testing.T, connectionType transport.TransportType) {
 	chainServiceB := chainservice.NewMockChainService(chain, bob.Address())
 	chainServiceI := chainservice.NewMockChainService(chain, irene.Address())
 
-	rpcClientA, msgA, cleanupFnA := setupNitroNodeWithRPCClient(alice.PrivateKey, 3005, 4005, chainServiceA, logDestination, connectionType)
-	rpcClientB, msgB, cleanupFnB := setupNitroNodeWithRPCClient(bob.PrivateKey, 3006, 4006, chainServiceB, logDestination, connectionType)
-	rpcClientI, msgI, cleanupFnC := setupNitroNodeWithRPCClient(irene.PrivateKey, 3007, 4007, chainServiceI, logDestination, connectionType)
+	rpcClientA, msgA, cleanupFnA := setupNitroNodeWithRPCClient(t, alice.PrivateKey, 3005, 4005, chainServiceA, logDestination, connectionType)
+	rpcClientB, msgB, cleanupFnB := setupNitroNodeWithRPCClient(t, bob.PrivateKey, 3006, 4006, chainServiceB, logDestination, connectionType)
+	rpcClientI, msgI, cleanupFnC := setupNitroNodeWithRPCClient(t, irene.PrivateKey, 3007, 4007, chainServiceI, logDestination, connectionType)
 
 	peers := []p2pms.PeerInfo{
 		{Id: msgA.Id(), IpAddress: "127.0.0.1", Port: 3005, Address: alice.Address()},
@@ -109,6 +109,7 @@ func executeRpcTest(t *testing.T, connectionType transport.TransportType) {
 
 // setupNitroNodeWithRPCClient is a helper function that spins up a Nitro Node RPC Server and returns an RPC client connected to it.
 func setupNitroNodeWithRPCClient(
+	t *testing.T,
 	pk []byte,
 	msgPort int,
 	rpcPort int,
@@ -119,7 +120,7 @@ func setupNitroNodeWithRPCClient(
 	messageservice := p2pms.NewMessageService("127.0.0.1",
 		msgPort,
 		crypto.GetAddressFromSecretKeyBytes(pk),
-		generateMessageKey(pk))
+		generateMessageKey(t, pk))
 	storeA := store.NewMemStore(pk)
 	node := client.New(
 		messageservice,


### PR DESCRIPTION
Previously we were generating a ECDSA private key for the p2p message service by hashing our private key and then using it a seed for a random source when calling `GenerateECDSAKeyPair`. This private key used to derive the Id of the message service. This was awkward and  made it difficult to precompute the IDs of message services,  since each call will use a different random number to generate the key.

To address this I've removed the key generation code from the P2P message service, it now just accepts an `*p2pcrypto.PrivKey` allowing us to generate the private key however we want **outside** of the message service. I've also added an `generateMessageKey` function that can be used to deterministically generate a message key for a given `pk`, that we can use in testing.  This is helpful if for some reason we want to know the ID of a message service in advance of the constructor (which would be very helpful in https://github.com/statechannels/go-nitro/pull/1193)

**Note**: Since this changes the message service constructor the testground test needs to be [updated](https://github.com/statechannels/go-nitro-testground/pull/157).  Once both PRs are approved I can merge them in together, until them the testground GH action will fail on this PR.