### PR TITLE
Remove chain service polling

### DIFF
--- a/client/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/client/engine/chainservice/simulated_backend_chainservice_test.go
@@ -88,13 +88,6 @@ func TestDepositSimulatedBackendChainService(t *testing.T) {
 
 }
 func TestConcludeSimulatedBackendChainService(t *testing.T) {
-	runDepositAndConcludeTest(t, false)
-}
-func TestConcludeSimulatedBackendChainServiceWithPolling(t *testing.T) {
-	runDepositAndConcludeTest(t, true)
-}
-
-func runDepositAndConcludeTest(t *testing.T, usePolling bool) {
 	sim, bindings, ethAccounts, err := SetupSimulatedBackend(1)
 	defer closeSimulatedChain(t, sim)
 

--- a/client/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/client/engine/chainservice/simulated_backend_chainservice_test.go
@@ -102,16 +102,10 @@ func runDepositAndConcludeTest(t *testing.T, usePolling bool) {
 		t.Fatal(err)
 	}
 	var cs ChainService
-	if usePolling {
-		cs, err = newPollingSimulatedBackendChainService(sim, bindings, ethAccounts[0], NoopLogger{})
-		if err != nil {
-			t.Fatal(err)
-		}
-	} else {
-		cs, err = NewSimulatedBackendChainService(sim, bindings, ethAccounts[0], NoopLogger{})
-		if err != nil {
-			t.Fatal(err)
-		}
+
+	cs, err = NewSimulatedBackendChainService(sim, bindings, ethAccounts[0], NoopLogger{})
+	if err != nil {
+		t.Fatal(err)
 	}
 	defer cs.Close()
 


### PR DESCRIPTION
The polling feature is currently unused. Our unit test is occasionally flagging an issue with either the polling feature or the polling unit test.

```
=== RUN   TestConcludeSimulatedBackendChainServiceWithPolling
    simulated_backend_chainservice_test.go:169: Received event did not match expectation; (-want +got):
          any(
        - 	chainservice.ConcludedEvent{
        - 		commonEvent: chainservice.commonEvent{
        - 			channelID: s"0x40c6f219558ae4d6dbe29b49096cb283a03be8e23191e8e40560708cecf17416",
        - 			BlockNum:  3,
        - 		},
        - 	},
        + 	chainservice.DepositedEvent{
        + 		commonEvent: chainservice.commonEvent{
        + 			channelID: s"0x40c6f219558ae4d6dbe29b49096cb283a03be8e23191e8e40560708cecf17416",
        + 			BlockNum:  2,
        + 		},
        + 		assetAndAmount: chainservice.assetAndAmount{AssetAmount: s"3"},
        + 		NowHeld:        s"3",
        + 	},
          )
--- FAIL: TestConcludeSimulatedBackendChainServiceWithPolling (0.09s)
```