### PR TITLE
Use a secp256k1 key in p2p message service

### DIFF
--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -1,7 +1,6 @@
 package client_test
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"log"
@@ -13,7 +12,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	p2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine"
@@ -224,22 +222,4 @@ func closeSimulatedChain(t *testing.T, chain chainservice.SimulatedChain) {
 	if err := chain.Close(); err != nil {
 		t.Fatal(err)
 	}
-}
-
-// generateMessageKey generates a ECDSA private key using the given pk bytes, and is idempotent.
-func generateMessageKey(t *testing.T, pk []byte) p2pcrypto.PrivKey {
-	// GenerateECDSAKeyPair expects a source to read random bytes from.
-	// We don't know exactly how many random bytes it will read, but we know it's under 256.
-	// We generate a 256 byte slice and copy the pk into it, leaving the rest empty.
-	// This lets us generate the exact same message key for the given pk.
-	totalSize := 256
-	large := make([]byte, totalSize)
-	copy(large, pk)
-
-	messageKey, _, err := p2pcrypto.GenerateECDSAKeyPair(bytes.NewReader(large))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return messageKey
 }

--- a/client_test/payment_with_p2p_ms_test.go
+++ b/client_test/payment_with_p2p_ms_test.go
@@ -22,7 +22,7 @@ func setupClientWithP2PMessageService(t *testing.T, pk []byte, port int, chain *
 		"127.0.0.1",
 		port,
 		crypto.GetAddressFromSecretKeyBytes(pk),
-		generateMessageKey(t, pk))
+		pk)
 	storeA := store.NewMemStore(pk)
 	return client.New(messageservice, chain, storeA, logDestination, &engine.PermissivePolicy{}, nil), messageservice
 }

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -120,7 +120,7 @@ func setupNitroNodeWithRPCClient(
 	messageservice := p2pms.NewMessageService("127.0.0.1",
 		msgPort,
 		crypto.GetAddressFromSecretKeyBytes(pk),
-		generateMessageKey(t, pk))
+		pk)
 	storeA := store.NewMemStore(pk)
 	node := client.New(
 		messageservice,


### PR DESCRIPTION
It turns out we can use a `secp256k1` key with `libp2p` by calling `UnmarshalSecp256k1PrivateKey`. This means we can use the existing private keys as a message key.

**Note:** The testground action will fail until this [PR](https://github.com/statechannels/go-nitro-testground/pull/159) is merged.