### PR TITLE
Websocket race condition fix

### DIFF
--- a/rand/rand.go
+++ b/rand/rand.go
@@ -8,16 +8,10 @@ import (
 	"time"
 )
 
-var r *rand.Rand
-
 // getRandGenerator seeds a random number generator based on current time
 func getRandGenerator() *rand.Rand {
-	if r != nil {
-		return r
-	}
 	source := rand.NewSource(time.Now().UnixNano())
-	r = rand.New(source)
-	return r
+	return rand.New(source)
 }
 
 func Uint64() uint64 {

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -66,11 +66,6 @@ type JsonRpcRequest[T RequestPayload | NotificationPayload] struct {
 	Params  T      `json:"params"`
 }
 
-type JsonRpcMessage struct {
-	Method string `json:"method"`
-	Id     uint64 `json:"id"`
-}
-
 type ResponsePayload interface {
 	directfund.ObjectiveResponse |
 		protocols.ObjectiveId |

--- a/rpc/transport/ws/client.go
+++ b/rpc/transport/ws/client.go
@@ -23,7 +23,7 @@ func NewWebSocketTransportAsClient(url string) (*clientWebSocketTransport, error
 	wsc.notificationChan = make(chan []byte)
 	wsc.url = url
 
-	conn, _, err := websocket.Dial(context.Background(), url+"/subscribe", &websocket.DialOptions{})
+	conn, _, err := websocket.Dial(context.Background(), "ws://"+url+"/subscribe", &websocket.DialOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +33,7 @@ func NewWebSocketTransportAsClient(url string) (*clientWebSocketTransport, error
 }
 
 func (wsc *clientWebSocketTransport) Request(data []byte) ([]byte, error) {
-	resp, err := http.Post("http"+wsc.url[2:], "application/json", bytes.NewBuffer(data))
+	resp, err := http.Post("http://"+wsc.url, "application/json", bytes.NewBuffer(data))
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/transport/ws/client.go
+++ b/rpc/transport/ws/client.go
@@ -50,7 +50,7 @@ func (wsc *clientWebSocketTransport) Subscribe() (<-chan []byte, error) {
 }
 
 func (wsc *clientWebSocketTransport) Close() {
-	// Clients initiate and close websockets{
+	// Clients initiate and close websockets
 	wsc.clientWebsocket.Close(websocket.StatusNormalClosure, "client initiated close")
 	close(wsc.notificationChan)
 }

--- a/rpc/transport/ws/server.go
+++ b/rpc/transport/ws/server.go
@@ -105,6 +105,8 @@ func (wsc *serverWebSocketTransport) subscribe(w http.ResponseWriter, r *http.Re
 	defer wsc.notificationListeners.Delete(key)
 
 	// A client closes a connection by sending a message over the websocket
+	// This code converts the socket `Read` call to a channel.
+	// Ideally, all signals would be managed in the select statement below. But there is no channel API for the websocket read.
 	closeChan := make(chan error)
 	go func() {
 		_, _, err := c.Read(r.Context())

--- a/rpc/transport/ws/server.go
+++ b/rpc/transport/ws/server.go
@@ -72,7 +72,7 @@ func (wsc *serverWebSocketTransport) Close() {
 }
 
 func (wsc *serverWebSocketTransport) Url() string {
-	return "ws://" + webscocketServerAddress + wsc.port
+	return webscocketServerAddress + wsc.port
 }
 
 func (wsc *serverWebSocketTransport) request(w http.ResponseWriter, r *http.Request) {

--- a/rpc/transport/ws/server.go
+++ b/rpc/transport/ws/server.go
@@ -34,7 +34,7 @@ func NewWebSocketTransportAsServer(port string) (*serverWebSocketTransport, erro
 	}
 
 	wsc.httpServer = &http.Server{
-		Handler:      wsc,
+		Handler:      &wsc.serveMux,
 		ReadTimeout:  time.Second * 10,
 		WriteTimeout: time.Second * 10,
 	}
@@ -47,11 +47,6 @@ func NewWebSocketTransportAsServer(port string) (*serverWebSocketTransport, erro
 	}()
 
 	return wsc, nil
-}
-
-// ServeHTTP is a required method for the http.Handler interface
-func (wsc *serverWebSocketTransport) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	wsc.serveMux.ServeHTTP(w, r)
 }
 
 func (wsc *serverWebSocketTransport) RegisterRequestHandler(handler func([]byte) []byte) error {

--- a/rpc/transport/ws/server.go
+++ b/rpc/transport/ws/server.go
@@ -14,7 +14,10 @@ import (
 	"nhooyr.io/websocket"
 )
 
-const webscocketServerAddress = "127.0.0.1:"
+const (
+	webscocketServerAddress = "127.0.0.1:"
+	maxRequestSize          = 8192
+)
 
 type serverWebSocketTransport struct {
 	httpServer            *http.Server
@@ -80,7 +83,7 @@ func (wsc *serverWebSocketTransport) request(w http.ResponseWriter, r *http.Requ
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 		return
 	}
-	body := http.MaxBytesReader(w, r.Body, 8192)
+	body := http.MaxBytesReader(w, r.Body, maxRequestSize)
 	msg, err := io.ReadAll(body)
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)

--- a/rpc/transport/ws/server.go
+++ b/rpc/transport/ws/server.go
@@ -16,7 +16,6 @@ const webscocketServerAddress = "127.0.0.1:"
 type serverWebSocketTransport struct {
 	httpServer       *http.Server
 	requestHandler   func([]byte) []byte
-	serverWebsocket  *websocket.Conn
 	port             string
 	notificationChan chan []byte
 }
@@ -94,7 +93,6 @@ func (wsc *serverWebSocketTransport) subscribe(w http.ResponseWriter, r *http.Re
 	if err != nil {
 		panic(err)
 	}
-	wsc.serverWebsocket = c
 	defer c.Close(websocket.StatusInternalError, "server initiated websocket close")
 
 	done := false
@@ -104,7 +102,7 @@ func (wsc *serverWebSocketTransport) subscribe(w http.ResponseWriter, r *http.Re
 			err = r.Context().Err()
 			done = true
 		case notificationData := <-wsc.notificationChan:
-			err := wsc.serverWebsocket.Write(r.Context(), websocket.MessageText, notificationData)
+			err := c.Write(r.Context(), websocket.MessageText, notificationData)
 			if err != nil {
 				done = true
 			}

--- a/rpc/transport/ws/server.go
+++ b/rpc/transport/ws/server.go
@@ -111,18 +111,18 @@ func (wsc *serverWebSocketTransport) subscribe(w http.ResponseWriter, r *http.Re
 		closeChan <- err
 	}()
 
-	done := false
-	for !done {
+EventLoop:
+	for {
 		select {
 		case err = <-closeChan:
-			done = true
+			break EventLoop
 		case <-r.Context().Done():
 			err = r.Context().Err()
-			done = true
+			break EventLoop
 		case notificationData := <-notificationChan:
 			err := c.Write(r.Context(), websocket.MessageText, notificationData)
 			if err != nil {
-				done = true
+				break EventLoop
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/statechannels/go-nitro/issues/1208.

This PR originated from running unit tests with [`-race`](https://go.dev/doc/articles/race_detector) flag. This PR includes a minor fix for a race condition in the `rand` package and a major change to the websocket rpc implementation.

The websocket rpc client (which should be renamed to http client) now makes requests to the rpc server using http post. The client listens to notifications over a websocket. Previously, the client used a single websocket connection for requests and notifications. While this solution was seemingly simple, the implementation had race conditions as well as complexity around managing of the websocket connection.