### PR TITLE
Synchronous ethereum log subscription

### DIFF
--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -219,6 +219,8 @@ func (ecs *EthChainService) subscribeForLogs() {
 	if err != nil {
 		ecs.fatalF("subscribeFilterLogs failed: %w", err)
 	}
+
+	// Must be in a goroutine to not block chain service constructor
 	go func() {
 		for {
 			select {


### PR DESCRIPTION
Ethereum events are occasionally missed as flagged by a failing unit test: https://github.com/statechannels/go-nitro/actions/runs/4680109856/jobs/8291031994

One reason could be that Ethereum log subscription is an asynchronous operation in the chain service constructor. This change flips the subscription to be synchronous.