### PR TITLE
Add race flag to CI unit tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        run: go test ./... -count=2 -shuffle=on -timeout 1m -v -failfast
+        run: go test ./... -count=2 -shuffle=on -timeout 1m -v -failfast -race
 
       - name: Archive logs
         if: always()


### PR DESCRIPTION
The flag will fail the CI unit tests if a race condition is detected. The only downside of adding this flag is the increased runtime overhead. According to https://go.dev/doc/articles/race_detector: "The cost of race detection varies by program, but for a typical program, memory usage may increase by 5-10x and execution time by 2-20x".

Unit tests currently take around 14 seconds to execute on CI without the flag.