### PR TITLE
Nitro rpc server

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -107,7 +107,7 @@ func (c *Client) Version() string {
 
 	version := info.Main.Version
 	// Depending on how the binary was built we may get back no version info.
-	// If there's no version we'll default to "(devel)", which seems to be the default.
+	// In this case we default to "(devel)".
 	// See https://github.com/golang/go/issues/51831#issuecomment-1074188363 for more details.
 	if version == "" {
 		version = "(devel)"

--- a/client/client.go
+++ b/client/client.go
@@ -4,6 +4,7 @@ package client // import "github.com/statechannels/go-nitro/client"
 import (
 	"io"
 	"math/big"
+	"runtime/debug"
 
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client/engine"
@@ -99,6 +100,29 @@ func (c *Client) handleEngineEvents() {
 }
 
 // Begin API
+
+// Version returns the go-nitro version
+func (c *Client) Version() string {
+	info, _ := debug.ReadBuildInfo()
+
+	version := info.Main.Version
+	// Depending on how the binary was built we may get back no version info.
+	// If there's no version we'll default to "(devel)", which seems to be the default.
+	// See https://github.com/golang/go/issues/51831#issuecomment-1074188363 for more details.
+	if version == "" {
+		version = "(devel)"
+	}
+
+	// If the binary was built with the -buildvcs flag we can get the git commit hash and use that as the version.
+	for _, s := range info.Settings {
+		if s.Key == "vcs.revision" {
+			version = s.Value
+			break
+		}
+	}
+
+	return version
+}
 
 // CompletedObjectives returns a chan that receives a objective id whenever that objective is completed. Not suitable fo multiple subscribers.
 func (c *Client) CompletedObjectives() <-chan protocols.ObjectiveId {

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 
 	chainService, err := newChainService(context.Background(), *ourStore.GetAddress(), hardhatUrl)
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("connection to chain not established: %w", err))
 	}
 
 	messageservice := p2pms.NewMessageService("127.0.0.1", msgPort, *ourStore.GetAddress(), pk, logDestination)
@@ -99,7 +99,7 @@ func main() {
 		panic(err)
 	}
 
-	fmt.Println("Nitro as a Service listening on localhost:", rpcPort)
+	fmt.Println("Nitro as a Service listening on port", rpcPort)
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	sig := <-sigs

--- a/main.go
+++ b/main.go
@@ -35,13 +35,14 @@ import (
 )
 
 func main() {
-	var pkString string
+	var pkString, hardhatUrl string
 	var msgPort, rpcPort int
 	var useWs, useDurableStore bool
 
 	flag.BoolVar(&useWs, "useWS", false, "Specifies whether to use websockets or NATS for the rpc server.")
 	flag.BoolVar(&useDurableStore, "useDurableStore", false, "Specifies whether to use a durable store or an in-memory store.")
 	flag.StringVar(&pkString, "pk", "2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d", "Specifies the private key for the client. Default is Alice's private key.")
+	flag.StringVar(&hardhatUrl, "hardhatUrl", "ws://127.0.0.1:8545", "Specifies the url for the hardhat node.")
 	flag.IntVar(&msgPort, "msgPort", 3005, "Specifies the tcp port for the  message service.")
 	flag.IntVar(&rpcPort, "rpcPort", 4005, "Specifies the tcp port for the rpc server.")
 	flag.Parse()
@@ -56,7 +57,7 @@ func main() {
 	} else {
 		ourStore = store.NewMemStore(pk)
 	}
-	chainService := NewChainService(context.Background(), *ourStore.GetAddress())
+	chainService := NewChainService(context.Background(), *ourStore.GetAddress(), hardhatUrl)
 	messageservice := p2pms.NewMessageService("127.0.0.1", msgPort, *ourStore.GetAddress(), pk)
 
 	node := client.New(
@@ -98,9 +99,8 @@ func main() {
 	fmt.Printf("Received signal %s, exiting..", sig)
 }
 
-func NewChainService(ctx context.Context, address types.Address) chainservice.ChainService {
-	// TODO: Don't use hardcoded values
-	client, err := ethclient.Dial("ws://127.0.0.1:8545/")
+func NewChainService(ctx context.Context, address types.Address, hardhatUrl string) chainservice.ChainService {
+	client, err := ethclient.Dial(hardhatUrl)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -36,9 +36,9 @@ import (
 func main() {
 	var pkString, hardhatUrl string
 	var msgPort, rpcPort int
-	var useWs, useDurableStore bool
+	var useNats, useDurableStore bool
 
-	flag.BoolVar(&useWs, "useWS", false, "Specifies whether to use websockets or NATS for the rpc server.")
+	flag.BoolVar(&useNats, "useNats", true, "Specifies whether to use NATS or http/ws for the rpc server.")
 	flag.BoolVar(&useDurableStore, "useDurableStore", false, "Specifies whether to use a durable store or an in-memory store.")
 	flag.StringVar(&pkString, "pk", "2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d", "Specifies the private key for the client. Default is Alice's private key.")
 	flag.StringVar(&hardhatUrl, "hardhatUrl", "ws://127.0.0.1:8545", "Specifies the url for the hardhat node.")
@@ -77,10 +77,10 @@ func main() {
 
 	var transport transport.Responder
 
-	if useWs {
-		transport, err = ws.NewWebSocketTransportAsServer(fmt.Sprint(rpcPort))
-	} else {
+	if useNats {
 		transport, err = nats.NewNatsTransportAsServer(rpcPort)
+	} else {
+		transport, err = ws.NewWebSocketTransportAsServer(fmt.Sprint(rpcPort))
 	}
 	if err != nil {
 		panic(err)

--- a/main.go
+++ b/main.go
@@ -38,12 +38,12 @@ func main() {
 	var msgPort, rpcPort int
 	var useNats, useDurableStore bool
 
-	flag.BoolVar(&useNats, "useNats", true, "Specifies whether to use NATS or http/ws for the rpc server.")
-	flag.BoolVar(&useDurableStore, "useDurableStore", false, "Specifies whether to use a durable store or an in-memory store.")
+	flag.BoolVar(&useNats, "usenats", true, "Specifies whether to use NATS or http/ws for the rpc server.")
+	flag.BoolVar(&useDurableStore, "usedurablestore", false, "Specifies whether to use a durable store or an in-memory store.")
 	flag.StringVar(&pkString, "pk", "2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d", "Specifies the private key for the client. Default is Alice's private key.")
-	flag.StringVar(&hardhatUrl, "hardhatUrl", "ws://127.0.0.1:8545", "Specifies the url for the hardhat node.")
-	flag.IntVar(&msgPort, "msgPort", 3005, "Specifies the tcp port for the  message service.")
-	flag.IntVar(&rpcPort, "rpcPort", 4005, "Specifies the tcp port for the rpc server.")
+	flag.StringVar(&hardhatUrl, "hardhaturl", "ws://127.0.0.1:8545", "Specifies the url for the hardhat node.")
+	flag.IntVar(&msgPort, "msgport", 3005, "Specifies the tcp port for the  message service.")
+	flag.IntVar(&rpcPort, "rpcport", 4005, "Specifies the tcp port for the rpc server.")
 
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"log"
+	"math/big"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	hdwallet "github.com/miguelmota/go-ethereum-hdwallet"
+	"github.com/rs/zerolog"
+	"github.com/statechannels/go-nitro/client"
+	"github.com/statechannels/go-nitro/client/engine"
+	"github.com/statechannels/go-nitro/client/engine/chainservice"
+	NitroAdjudicator "github.com/statechannels/go-nitro/client/engine/chainservice/adjudicator"
+	Create2Deployer "github.com/statechannels/go-nitro/client/engine/chainservice/create2deployer"
+	p2pms "github.com/statechannels/go-nitro/client/engine/messageservice/p2p-message-service"
+	"github.com/statechannels/go-nitro/client/engine/store"
+	"github.com/statechannels/go-nitro/crypto"
+	"github.com/statechannels/go-nitro/rpc"
+	"github.com/statechannels/go-nitro/rpc/transport"
+	"github.com/statechannels/go-nitro/rpc/transport/nats"
+	"github.com/statechannels/go-nitro/rpc/transport/ws"
+	"github.com/statechannels/go-nitro/types"
+	"github.com/tidwall/buntdb"
+)
+
+func main() {
+	var pkString string
+	var msgPort, rpcPort int
+	var useWs, useDurableStore bool
+
+	flag.BoolVar(&useWs, "useWS", false, "Specifies whether to use websockets or NATS for the rpc server.")
+	flag.BoolVar(&useDurableStore, "useDurableStore", false, "Specifies whether to use a durable store or an in-memory store.")
+	flag.StringVar(&pkString, "pk", "2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d", "Specifies the private key for the client. Default is Alice's private key.")
+	flag.IntVar(&msgPort, "msgPort", 3005, "Specifies the tcp port for the  message service.")
+	flag.IntVar(&rpcPort, "rpcPort", 4005, "Specifies the tcp port for the rpc server.")
+	flag.Parse()
+	pk := common.Hex2Bytes(pkString)
+	me := crypto.GetAddressFromSecretKeyBytes(pk)
+	logDestination := os.Stdout
+
+	var ourStore store.Store
+	if useDurableStore {
+		dataFolder := fmt.Sprintf("./data/nitro-service/%s", me.String())
+		ourStore = store.NewDurableStore(pk, dataFolder, buntdb.Config{})
+	} else {
+		ourStore = store.NewMemStore(pk)
+	}
+	chainService := NewChainService(context.Background(), *ourStore.GetAddress())
+	messageservice := p2pms.NewMessageService("127.0.0.1", msgPort, *ourStore.GetAddress(), pk)
+
+	node := client.New(
+		messageservice,
+		chainService,
+		ourStore,
+		logDestination,
+		&engine.PermissivePolicy{},
+		nil)
+
+	var transport transport.Responder
+	var err error
+	if useWs {
+		transport, err = ws.NewWebSocketTransportAsServer(fmt.Sprint(rpcPort))
+	} else {
+		transport, err = nats.NewNatsTransportAsServer(rpcPort)
+	}
+	if err != nil {
+		panic(err)
+	}
+
+	logger := zerolog.New(logDestination).
+		Level(zerolog.TraceLevel).
+		With().
+		Timestamp().
+		Str("client", ourStore.GetAddress().String()).
+		Str("rpc", "server").
+		Str("scope", "").
+		Logger()
+	_, err = rpc.NewRpcServer(&node, &logger, transport)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Nitro as a Service listening on localhost:", rpcPort)
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	sig := <-sigs
+	fmt.Printf("Received signal %s, exiting..", sig)
+}
+
+func NewChainService(ctx context.Context, address types.Address) chainservice.ChainService {
+	// TODO: Don't use hardcoded values
+	client, err := ethclient.Dial("ws://127.0.0.1:8545/")
+	if err != nil {
+		log.Fatal(err)
+	}
+	key := GetHardhatFundedPrivateKey(address)
+	fmt.Printf("Using private key %s", common.Bytes2Hex(ethcrypto.FromECDSA(key)))
+	txSubmitter, err := bind.NewKeyedTransactorWithChainID(key, big.NewInt(1337))
+	if err != nil {
+		log.Fatal(err)
+	}
+	txSubmitter.GasLimit = uint64(30_000_000) // in units
+
+	gasPrice, err := client.SuggestGasPrice(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+	txSubmitter.GasPrice = gasPrice
+
+	deployer, err := Create2Deployer.NewCreate2Deployer(common.HexToAddress("0x5fbdb2315678afecb367f032d93f642f64180aa3"), client)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	hexBytecode, err := hex.DecodeString(NitroAdjudicator.NitroAdjudicatorMetaData.Bin[2:])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	naAddress, err := deployer.ComputeAddress(&bind.CallOpts{}, [32]byte{}, ethcrypto.Keccak256Hash(hexBytecode))
+	if err != nil {
+		log.Fatal(err)
+	}
+	bytecode, err := client.CodeAt(ctx, naAddress, nil) // nil is latest block
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Has NitroAdjudicator been deployed? If not, deploy it.
+	if len(bytecode) == 0 {
+		_, err = deployer.Deploy(txSubmitter, big.NewInt(0), [32]byte{}, hexBytecode)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	na, err := NitroAdjudicator.NewNitroAdjudicator(naAddress, client)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cs, err := chainservice.NewEthChainService(client, na, naAddress, common.Address{}, common.Address{}, txSubmitter, os.Stdout)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return cs
+}
+
+func GetHardhatFundedPrivateKey(a types.Address) *ecdsa.PrivateKey {
+	// See https://hardhat.org/hardhat-network/docs/reference#accounts for defaults
+	// This is the default mnemonic used by hardhat
+	const HARDHAT_MNEMONIC = "test test test test test test test test test test test junk"
+	// We manually set the amount of funded accounts in our hardhat config
+	// If that value changes, this value must change as well
+	const NUM_FUNDED = 1000
+	// This is the default hd wallet path used by hardhat
+	const HD_PATH = "m/44'/60'/0'/0"
+
+	index := big.NewInt(0).Mod(a.Big(), big.NewInt(NUM_FUNDED)).Uint64()
+
+	return derivePrivateKey(uint(index), HARDHAT_MNEMONIC, HD_PATH, NUM_FUNDED)
+}
+
+func derivePrivateKey(index uint, mnemonic string, path string, numFunded uint) *ecdsa.PrivateKey {
+	if numFunded < index {
+		panic(fmt.Errorf("only the first %d accounts are funded", numFunded))
+	}
+
+	wallet, err := hdwallet.NewFromMnemonic(mnemonic)
+
+	ourPath := fmt.Sprintf("%s/%d", path, index)
+	if err != nil {
+		panic(err)
+	}
+
+	a, err := wallet.Derive(hdwallet.MustParseDerivationPath(ourPath), false)
+	if err != nil {
+		panic(err)
+	}
+	pk, err := wallet.PrivateKey(a)
+	if err != nil {
+		panic(err)
+	}
+	return pk
+}

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func main() {
 		panic(err)
 	}
 
-	messageservice := p2pms.NewMessageService("127.0.0.1", msgPort, *ourStore.GetAddress(), pk)
+	messageservice := p2pms.NewMessageService("127.0.0.1", msgPort, *ourStore.GetAddress(), pk, logDestination)
 
 	node := client.New(
 		messageservice,

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -73,11 +73,6 @@ type JsonRpcRequest[T RequestPayload | NotificationPayload] struct {
 	Params  T      `json:"params"`
 }
 
-type JsonRpcMessage struct {
-	Method string `json:"method"`
-	Id     uint64 `json:"id"`
-}
-
 type (
 	VersionResponse = string
 	ResponsePayload interface {

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -13,6 +13,8 @@ import (
 type RequestMethod string
 
 const (
+	GetAddressMethod               RequestMethod = "get_address"
+	VersionMethod                  RequestMethod = "version"
 	DirectFundRequestMethod        RequestMethod = "direct_fund"
 	DirectDefundRequestMethod      RequestMethod = "direct_defund"
 	VirtualFundRequestMethod       RequestMethod = "virtual_fund"
@@ -45,6 +47,10 @@ type GetLedgerChannelRequest struct {
 	Id types.Destination
 }
 
+type (
+	NoPayloadRequest = struct{}
+)
+
 type RequestPayload interface {
 	directfund.ObjectiveRequest |
 		directdefund.ObjectiveRequest |
@@ -52,7 +58,8 @@ type RequestPayload interface {
 		virtualdefund.ObjectiveRequest |
 		PaymentRequest |
 		GetLedgerChannelRequest |
-		GetPaymentChannelRequest
+		GetPaymentChannelRequest |
+		NoPayloadRequest
 }
 
 type NotificationPayload interface {
@@ -66,14 +73,23 @@ type JsonRpcRequest[T RequestPayload | NotificationPayload] struct {
 	Params  T      `json:"params"`
 }
 
-type ResponsePayload interface {
-	directfund.ObjectiveResponse |
-		protocols.ObjectiveId |
-		virtualfund.ObjectiveResponse |
-		PaymentRequest |
-		query.PaymentChannelInfo |
-		query.LedgerChannelInfo
+type JsonRpcMessage struct {
+	Method string `json:"method"`
+	Id     uint64 `json:"id"`
 }
+
+type (
+	VersionResponse = string
+	ResponsePayload interface {
+		directfund.ObjectiveResponse |
+			protocols.ObjectiveId |
+			virtualfund.ObjectiveResponse |
+			PaymentRequest |
+			query.PaymentChannelInfo |
+			query.LedgerChannelInfo |
+			VersionResponse
+	}
+)
 
 type JsonRpcResponse[T ResponsePayload] struct {
 	Jsonrpc string      `json:"jsonrpc"`

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -59,6 +59,14 @@ func (rs *RpcServer) registerHandlers() (err error) {
 		}
 
 		switch serde.RequestMethod(validationResult.Method) {
+		case serde.GetAddressMethod:
+			return processRequest(rs, requestData, func(T serde.NoPayloadRequest) string {
+				return rs.client.Address.Hex()
+			})
+		case serde.VersionMethod:
+			return processRequest(rs, requestData, func(T serde.NoPayloadRequest) string {
+				return rs.client.Version()
+			})
 		case serde.DirectFundRequestMethod:
 			return processRequest(rs, requestData, func(obj directfund.ObjectiveRequest) directfund.ObjectiveResponse {
 				return rs.client.CreateLedgerChannel(obj.CounterParty, obj.ChallengeDuration, obj.Outcome)


### PR DESCRIPTION
This PR allows go-nitro to run as an RPC server executable.

## Running the RPC Server

The RPC server can be started by running `go run .` in the `go-nitro` directory.

```shell
go run .
```
You can also build a binary and execute that. (This will embed the git commit info for the version API call).

```shell
go build  -o nitro-rpc-server
```
## RPC Server Options

There a a couple of CLI flags that control things like ports to listen on or the SC key to use. **Note:** All flags have a default value (seen below).
```
❯ ./nitro-rpc-server --help
Usage of ./nitro-rpc-server:
 ./nitro-rpc-server --help
Usage of ./nitro-rpc-server:
  -hardhatUrl string
    	Specifies the url for the hardhat node. (default "ws://127.0.0.1:8545")
  -msgPort int
    	Specifies the tcp port for the  message service. (default 3005)
  -pk string
    	Specifies the private key for the client. Default is Alice's private key. (default "2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d")
  -rpcPort int
    	Specifies the tcp port for the rpc server. (default 4005)
  -useDurableStore
    	Specifies whether to use a durable store or an in-memory store.
  -useNats
    	Specifies whether to use NATS or http/ws for the rpc server. (default true)
```

## Interacting with the RPC Server
Right now the easiest way of interacting with the RPC server is by using the [typescript RPC client](https://github.com/statechannels/nitro-rpc-client).

