### PR TITLE
Use correct right ledger

### DIFF
--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -136,7 +136,7 @@ func NewObjective(request ObjectiveRequest,
 				if !ok {
 					return Objective{}, fmt.Errorf("could not find a ledger channel between %v and %v", leftOfMe, myAddress)
 				}
-				rightLedger, ok = getConsensusChannel(bob)
+				rightLedger, ok = getConsensusChannel(rightOfMe)
 				if !ok {
 					return Objective{}, fmt.Errorf("could not find a ledger channel between %v and %v", myAddress, rightOfMe)
 				}


### PR DESCRIPTION
Previously our virtual defunding protocol would always assume our right ledger was with `bob` instead of the `rightOfMe` we calculated.

This causes virtual defunding to fail if there are multiple intermediaries.