### PR TITLE
Properly wait for intermediaries to complete objectives

### DIFF
--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -106,6 +106,8 @@ func newLogWriter(logFile string) *os.File {
 	}
 
 	filename := filepath.Join("../artifacts", logFile)
+	// Clear the file
+	os.Remove(filename)
 	logDestination, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o666)
 	if err != nil {
 		log.Fatal(err)

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -240,7 +240,7 @@ func waitForObjectives(t *testing.T, a, b client.Client, intermediaries []client
 		<-b.ObjectiveCompleteChan(objectiveId)
 
 		for _, intermediary := range intermediaries {
-			intermediary.ObjectiveCompleteChan(objectiveId)
+			<-intermediary.ObjectiveCompleteChan(objectiveId)
 		}
 	}
 }

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -136,7 +136,7 @@ func NewObjective(request ObjectiveRequest,
 				if !ok {
 					return Objective{}, fmt.Errorf("could not find a ledger channel between %v and %v", leftOfMe, myAddress)
 				}
-				rightLedger, ok = getConsensusChannel(bob)
+				rightLedger, ok = getConsensusChannel(rightOfMe)
 				if !ok {
 					return Objective{}, fmt.Errorf("could not find a ledger channel between %v and %v", myAddress, rightOfMe)
 				}


### PR DESCRIPTION
@kerzhner spotted out that we weren't properly waiting for objectives to complete the objectives. This ended up revealing a bug in multi-hop virtual defunding (see #1218) 

I've also included a change to truncate the logfile before running a test. Before this the logs were just being appended to and growing considerably large!