### PR TITLE
`virtualdefund`: split `WaitingForCompleteLedgerDefunding` into `WaitingForDefundingOnMy{Left,Right}`

### DIFF
--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -17,10 +17,11 @@ import (
 )
 
 const (
-	WaitingForFinalStateFromAlice     protocols.WaitingFor = "WaitingForFinalStateFromAlice"
-	WaitingForSignedFinal             protocols.WaitingFor = "WaitingForSignedFinal"             // Round 1
-	WaitingForCompleteLedgerDefunding protocols.WaitingFor = "WaitingForCompleteLedgerDefunding" // Round 2
-	WaitingForNothing                 protocols.WaitingFor = "WaitingForNothing"                 // Finished
+	WaitingForFinalStateFromAlice protocols.WaitingFor = "WaitingForFinalStateFromAlice"
+	WaitingForSignedFinal         protocols.WaitingFor = "WaitingForSignedFinal"        // Round 1
+	WaitingForDefundingOnMyLeft   protocols.WaitingFor = "WaitingForDefundingOnMyLeft"  // Round 2
+	WaitingForDefundingOnMyRight  protocols.WaitingFor = "WaitingForDefundingOnMyRight" // Round 2
+	WaitingForNothing             protocols.WaitingFor = "WaitingForNothing"            // Finished
 )
 
 const (
@@ -418,8 +419,12 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 		sideEffects.Merge(ledgerSideEffects)
 	}
 
-	if fullyDefunded := updated.leftHasDefunded() && updated.rightHasDefunded(); !fullyDefunded {
-		return &updated, sideEffects, WaitingForCompleteLedgerDefunding, nil
+	if !updated.leftHasDefunded() {
+		return &updated, sideEffects, WaitingForDefundingOnMyLeft, nil
+	}
+
+	if !updated.rightHasDefunded() {
+		return &updated, sideEffects, WaitingForDefundingOnMyRight, nil
 	}
 
 	// Mark the objective as done

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -151,7 +151,12 @@ func testCrankAs(my ta.Actor) func(t *testing.T) {
 		updated = updatedObj.(*Objective)
 		testhelpers.Ok(t, err)
 
-		testhelpers.Equals(t, WaitingForCompleteLedgerDefunding, waitingFor)
+		// We wait for the ledger on our left first by default, unless we have no such channel:
+		if my.Role == 0 {
+			testhelpers.Equals(t, WaitingForDefundingOnMyRight, waitingFor)
+		} else {
+			testhelpers.Equals(t, WaitingForDefundingOnMyLeft, waitingFor)
+		}
 
 		checkForLeaderProposals(t, se, updated, data)
 


### PR DESCRIPTION
into 	WaitingForDefundingOnMy{Left,Right}.

This is for conceptual clarity and debugging ease. The ordering is not important and is simply a convention.

Related to #1216 