### PR TITLE
only store id of consensus channels when marshalling virtualdefund objectives

### DIFF
--- a/protocols/virtualdefund/serde.go
+++ b/protocols/virtualdefund/serde.go
@@ -28,6 +28,9 @@ type jsonObjective struct {
 }
 
 // MarshalJSON returns a JSON representation of the VirtualDefundObjective
+//
+// NOTE: Marshal -> Unmarshal is a lossy process. All channel data
+// (other than Id) from the fields ToMyLeft,ToMyRight are discarded
 func (o Objective) MarshalJSON() ([]byte, error) {
 	var left types.Destination
 	var right types.Destination
@@ -56,6 +59,9 @@ func (o Objective) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON populates the calling VirtualDefundObjective with the
 // json-encoded data
+//
+// NOTE: Marshal -> Unmarshal is a lossy process. All channel data
+// (other than Id) from the fields ToMyLeft,ToMyRight are discarded
 func (o *Objective) UnmarshalJSON(data []byte) error {
 	if string(data) == "null" {
 		return nil


### PR DESCRIPTION

nil pointers represent channels that are undefined in the protocol (i.e. a channel left of Alice) These remain untouched / unpopulated throughout.

Towards #1232 

The fact that all of our tests still pass underlines that this code was totally redundant. 