### PR TITLE
WIP: Bring more harmony to `virtualfund`

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -182,7 +182,7 @@ func (c Channel) PostFundComplete() bool {
 	return c.SignedStateForTurnNum[PostFundTurnNum].HasAllSignatures()
 }
 
-// FinalSignedByMe returns true if the calling client has signed the post fund setup state, false otherwise.
+// FinalSignedByMe returns true if the calling client has signed a final state, false otherwise.
 func (c Channel) FinalSignedByMe() bool {
 	for _, ss := range c.SignedStateForTurnNum {
 		if ss.HasSignatureForParticipant(c.MyIndex) && ss.State().IsFinal {

--- a/client/engine/store/durablestore.go
+++ b/client/engine/store/durablestore.go
@@ -418,6 +418,11 @@ func (ds *DurableStore) populateChannelData(obj protocols.Objective) error {
 
 		return nil
 	case *virtualdefund.Objective:
+		v, err := ds.getChannelById(o.V.Id)
+		if err != nil {
+			return fmt.Errorf("error retrieving virtual channel data for objective %s: %w", id, err)
+		}
+		o.V = &v
 
 		zeroAddress := types.Destination{}
 

--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -314,6 +314,11 @@ func (ms *MemStore) populateChannelData(obj protocols.Objective) error {
 
 		return nil
 	case *virtualdefund.Objective:
+		v, err := ms.getChannelById(o.V.Id)
+		if err != nil {
+			return fmt.Errorf("error retrieving virtual channel data for objective %s: %w", id, err)
+		}
+		o.V = &v
 
 		zeroAddress := types.Destination{}
 

--- a/client/query/query.go
+++ b/client/query/query.go
@@ -115,7 +115,7 @@ func GetPaymentChannelInfo(id types.Destination, store store.Store, vm *payments
 		return PaymentChannelInfo{
 			ID:      id,
 			Status:  status,
-			Balance: getPaymentChannelBalance(defund.VFixed.Participants, []outcome.SingleAssetExit{defund.FinalOutcome}),
+			Balance: getPaymentChannelBalance(defund.V.Participants, []outcome.SingleAssetExit{defund.V.SignedStateForTurnNum[virtualdefund.FinalTurnNum].State().Outcome[0]}),
 		}, nil
 	}
 	// Otherwise we can just check the store

--- a/internal/testhelpers/testhelpers.go
+++ b/internal/testhelpers/testhelpers.go
@@ -74,7 +74,7 @@ func AssertStateSentTo(t *testing.T, ses protocols.SideEffects, expected state.S
 		toAddress := to.Address()
 		if bytes.Equal(msg.To[:], toAddress[:]) {
 			for _, op := range msg.ObjectivePayloads {
-				Equals(t, string(op.PayloadData), string(b))
+				Equals(t, string(b), string(op.PayloadData))
 			}
 		}
 	}

--- a/protocols/virtualdefund/helpers_test.go
+++ b/protocols/virtualdefund/helpers_test.go
@@ -17,6 +17,13 @@ import (
 
 const TEST_CHAIN_ID = 1337
 
+var (
+	alice     = ta.Alice
+	bob       = ta.Bob
+	irene     = ta.Irene
+	allActors = []ta.Actor{alice, irene, bob}
+)
+
 // generateLedgers generates the left and right ledger channels based on myRole
 // The ledger channels will include a guarantee that funds V
 func generateLedgers(myRole uint, vId types.Destination) (left, right *consensus_channel.ConsensusChannel) {
@@ -258,7 +265,6 @@ func generateTestData() testdata {
 
 	vInitial := state.StateFromFixedAndVariablePart(vFixed, state.VariablePart{IsFinal: true, Outcome: outcome.Exit{initialOutcome}, TurnNum: 1})
 	vFinal := state.StateFromFixedAndVariablePart(vFixed, state.VariablePart{IsFinal: true, Outcome: outcome.Exit{finalOutcome}, TurnNum: FinalTurnNum})
-
 	return testdata{vInitial, vFinal, paid, finalAliceAmount, finalBobAmount}
 }
 

--- a/protocols/virtualdefund/serde.go
+++ b/protocols/virtualdefund/serde.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
-	"github.com/statechannels/go-nitro/channel/state"
-	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -15,11 +14,8 @@ import (
 // jsonObjective replaces the virtualfund Objective's channel pointers
 // with the channel's respective IDs, making jsonObjective suitable for serialization
 type jsonObjective struct {
-	Status         protocols.ObjectiveStatus
-	VFixed         state.FixedPart
-	InitialOutcome outcome.SingleAssetExit
-	FinalOutcome   outcome.SingleAssetExit
-	Signatures     []state.Signature
+	Status protocols.ObjectiveStatus
+	V      types.Destination
 
 	ToMyLeft             types.Destination
 	ToMyRight            types.Destination
@@ -34,6 +30,7 @@ type jsonObjective struct {
 func (o Objective) MarshalJSON() ([]byte, error) {
 	var left types.Destination
 	var right types.Destination
+	var V types.Destination
 
 	if o.ToMyLeft != nil {
 		left = o.ToMyLeft.Id
@@ -45,10 +42,7 @@ func (o Objective) MarshalJSON() ([]byte, error) {
 
 	jsonVFO := jsonObjective{
 		Status:               o.Status,
-		VFixed:               o.VFixed,
-		Signatures:           o.Signatures,
-		FinalOutcome:         o.FinalOutcome,
-		InitialOutcome:       o.InitialOutcome,
+		V:                    V,
 		ToMyLeft:             left,
 		ToMyRight:            right,
 		MyRole:               o.MyRole,
@@ -80,10 +74,10 @@ func (o *Objective) UnmarshalJSON(data []byte) error {
 	o.Status = jsonVFO.Status
 
 	o.MyRole = jsonVFO.MyRole
-	o.Signatures = jsonVFO.Signatures
-	o.InitialOutcome = jsonVFO.InitialOutcome
-	o.VFixed = jsonVFO.VFixed
-	o.FinalOutcome = jsonVFO.FinalOutcome
+
+	o.V = &channel.Channel{}
+	o.V.Id = jsonVFO.V
+
 	o.MinimumPaymentAmount = jsonVFO.MinimumPaymentAmount
 
 	return nil

--- a/protocols/virtualdefund/serde.go
+++ b/protocols/virtualdefund/serde.go
@@ -30,7 +30,6 @@ type jsonObjective struct {
 func (o Objective) MarshalJSON() ([]byte, error) {
 	var left types.Destination
 	var right types.Destination
-	var V types.Destination
 
 	if o.ToMyLeft != nil {
 		left = o.ToMyLeft.Id
@@ -42,7 +41,7 @@ func (o Objective) MarshalJSON() ([]byte, error) {
 
 	jsonVFO := jsonObjective{
 		Status:               o.Status,
-		V:                    V,
+		V:                    o.VId(),
 		ToMyLeft:             left,
 		ToMyRight:            right,
 		MyRole:               o.MyRole,

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -39,26 +39,12 @@ const FinalTurnNum = 2
 type Objective struct {
 	Status protocols.ObjectiveStatus
 
-	// InitialOutcome is the initial outcome of the virtual channel
-	InitialOutcome outcome.SingleAssetExit
-
-	// FinalOutcome is the final outcome of the virtual channel from Alice
-	FinalOutcome outcome.SingleAssetExit
-
 	// MinimumPaymentAmount is the latest payment amount we have received from Alice before starting defunding.
 	// This is set by Bob so he can ensure he receives the latest amount from any vouchers he's received.
 	// If this is not set then virtual defunding will accept any final outcome from Alice.
 	MinimumPaymentAmount *big.Int
 
-	// VFixed is the fixed channel information for the virtual channel
-	VFixed state.FixedPart
-
-	// Signatures are the signatures for the final virtual state from each participant.
-	//
-	// Signatures are ordered by participant order: Signatures[0] is Alice's signature,
-	// Signatures[last] is Bob's signature, Signatures[1,...,n] are the intermediaries'
-	// signatures.
-	Signatures []state.Signature
+	V *channel.Channel
 
 	ToMyLeft  *consensus_channel.ConsensusChannel
 	ToMyRight *consensus_channel.ConsensusChannel
@@ -99,8 +85,6 @@ func NewObjective(request ObjectiveRequest,
 	if !found {
 		return Objective{}, fmt.Errorf("could not find channel %s", request.ChannelId)
 	}
-
-	initialOutcome := V.PostFundState().Outcome[0]
 
 	alice := V.Participants[0]
 	bob := V.Participants[len(V.Participants)-1]
@@ -155,24 +139,10 @@ func NewObjective(request ObjectiveRequest,
 		largestPaymentAmount = big.NewInt(0)
 	}
 
-	finalOutcome := outcome.SingleAssetExit{}
-	// Since Alice is responsible for issuing vouchers she always has the largest payment amount
-	// This means she can just set her FinalOutcomeFromAlice based on the largest voucher amount she has sent
-	if myAddress == alice {
-
-		finalOutcome = initialOutcome.Clone()
-		finalOutcome.Allocations[0].Amount.Sub(finalOutcome.Allocations[0].Amount, largestPaymentAmount)
-		finalOutcome.Allocations[1].Amount.Add(finalOutcome.Allocations[1].Amount, largestPaymentAmount)
-
-	}
-
 	return Objective{
 		Status:               status,
-		InitialOutcome:       initialOutcome,
-		FinalOutcome:         finalOutcome,
 		MinimumPaymentAmount: largestPaymentAmount,
-		VFixed:               V.FixedPart,
-		Signatures:           make([]state.Signature, len(V.FixedPart.Participants)),
+		V:                    V,
 		MyRole:               V.MyIndex,
 		ToMyLeft:             leftLedger,
 		ToMyRight:            rightLedger,
@@ -191,53 +161,28 @@ func ConstructObjectiveFromPayload(
 	if latestVoucherAmount == nil {
 		latestVoucherAmount = big.NewInt(0)
 	}
+	var cId types.Destination
+	var err error
 	switch p.Type {
 	case RequestFinalStatePayload:
-		cId, err := getRequestFinalStatePayload(p.PayloadData)
-		if err != nil {
-			return Objective{}, err
-		}
-		return NewObjective(
-			NewObjectiveRequest(cId),
-			preapprove,
-			myAddress,
-			latestVoucherAmount,
-			getChannel,
-			getTwoPartyConsensusLedger)
-
+		cId, err = getRequestFinalStatePayload(p.PayloadData)
 	case SignedStatePayload:
-		ss, err := getSignedStatePayload(p.PayloadData)
-		if err != nil {
-			return Objective{}, err
-		}
-
-		if !ss.State().IsFinal {
-			return Objective{}, fmt.Errorf("expected final state")
-		}
-		cId := ss.ChannelId()
-		c, found := getChannel(cId)
-		pf := c.PreFundState()
-
-		if !found {
-			return Objective{}, fmt.Errorf("could not find channel %s", cId)
-		}
-
-		err = validateFinalOutcome(pf.FixedPart(), pf.Outcome[0], ss.State().Outcome[0], myAddress, latestVoucherAmount)
-		if err != nil {
-			return Objective{}, fmt.Errorf("final outcome from alice failed validation: %w", err)
-		}
-
-		return NewObjective(
-			NewObjectiveRequest(ss.ChannelId()),
-			preapprove,
-			myAddress,
-			latestVoucherAmount,
-			getChannel,
-			getTwoPartyConsensusLedger)
-
+		var ss state.SignedState
+		ss, err = getSignedStatePayload(p.PayloadData)
+		cId = ss.ChannelId()
 	default:
 		return Objective{}, fmt.Errorf("unknown payload type %s", p.Type)
 	}
+	if err != nil {
+		return Objective{}, err
+	}
+	return NewObjective(
+		NewObjectiveRequest(cId),
+		preapprove,
+		myAddress,
+		latestVoucherAmount,
+		getChannel,
+		getTwoPartyConsensusLedger)
 }
 
 // IsVirtualDefundObjective inspects a objective id and returns true if the objective id is for a virtualdefund objective.
@@ -247,22 +192,29 @@ func IsVirtualDefundObjective(id protocols.ObjectiveId) bool {
 
 // signedFinalState returns the final state for the virtual channel
 func (o *Objective) signedFinalState() (state.SignedState, error) {
-	signed := state.NewSignedState(o.finalState())
-	for _, sig := range o.Signatures {
-		if !isZero(sig) {
-			err := signed.AddSignature(sig)
-			if err != nil {
-				return state.SignedState{}, err
-			}
-		}
+	return o.V.SignedStateForTurnNum[FinalTurnNum], nil
+}
+
+func (o *Objective) initialOutcome() outcome.SingleAssetExit {
+	return o.V.PostFundState().Outcome[0]
+}
+
+func (o *Objective) finalOutcome() outcome.SingleAssetExit {
+	finalOutcome := outcome.SingleAssetExit{}
+	// Since Alice is responsible for issuing vouchers she always has the largest payment amount
+	// This means she can just set her FinalOutcomeFromAlice based on the largest voucher amount she has sent
+	if o.isAlice() {
+		finalOutcome = o.initialOutcome().Clone()
+		finalOutcome.Allocations[0].Amount.Sub(finalOutcome.Allocations[0].Amount, o.MinimumPaymentAmount)
+		finalOutcome.Allocations[1].Amount.Add(finalOutcome.Allocations[1].Amount, o.MinimumPaymentAmount)
 	}
-	return signed, nil
+	return finalOutcome
 }
 
 // finalState returns the final state for the virtual channel
 func (o *Objective) finalState() state.State {
-	vp := state.VariablePart{Outcome: outcome.Exit{o.FinalOutcome}, TurnNum: FinalTurnNum, IsFinal: true}
-	return state.StateFromFixedAndVariablePart(o.VFixed, vp)
+	vp := state.VariablePart{Outcome: outcome.Exit{o.finalOutcome()}, TurnNum: FinalTurnNum, IsFinal: true}
+	return state.StateFromFixedAndVariablePart(o.V.FixedPart, vp)
 }
 
 // Id returns the objective id.
@@ -284,7 +236,7 @@ func (o *Objective) Reject() (protocols.Objective, protocols.SideEffects) {
 	updated := o.clone()
 	updated.Status = protocols.Rejected
 	peers := []common.Address{}
-	for i, peer := range o.VFixed.Participants {
+	for i, peer := range o.V.Participants {
 		if i != int(o.MyRole) {
 			peers = append(peers, peer)
 		}
@@ -323,16 +275,10 @@ func (o *Objective) clone() Objective {
 	clone := Objective{}
 	clone.Status = o.Status
 
-	clone.VFixed = o.VFixed.Clone()
-	clone.InitialOutcome = o.InitialOutcome.Clone()
-	clone.FinalOutcome = o.FinalOutcome.Clone()
+	clone.V = o.V.Clone()
 
 	if o.MinimumPaymentAmount != nil {
 		clone.MinimumPaymentAmount = big.NewInt(0).Set(o.MinimumPaymentAmount)
-	}
-	clone.Signatures = []state.Signature{}
-	for _, sig := range o.Signatures {
-		clone.Signatures = append(clone.Signatures, state.CloneSignature(sig))
 	}
 	clone.MyRole = o.MyRole
 
@@ -350,7 +296,7 @@ func (o *Objective) clone() Objective {
 // otherParticipants returns the participants in the channel that are not the current participant.
 func (o *Objective) otherParticipants() []types.Address {
 	others := make([]types.Address, 0)
-	for i, p := range o.VFixed.Participants {
+	for i, p := range o.V.Participants {
 		if i != int(o.MyRole) {
 			others = append(others, p)
 		}
@@ -359,7 +305,7 @@ func (o *Objective) otherParticipants() []types.Address {
 }
 
 func (o *Objective) hasFinalStateFromAlice() bool {
-	return !o.FinalOutcome.Equal(outcome.SingleAssetExit{})
+	return !o.finalOutcome().Equal(outcome.SingleAssetExit{})
 }
 
 // Crank inspects the extended state and declares a list of Effects to be executed.
@@ -374,21 +320,21 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 
 	// If we don't know the amount yet we send a message to alice to request it
 	if !updated.isAlice() && !updated.hasFinalStateFromAlice() {
-		alice := o.VFixed.Participants[0]
+		alice := o.V.Participants[0]
 		messages := protocols.CreateObjectivePayloadMessage(updated.Id(), o.VId(), RequestFinalStatePayload, alice)
 		sideEffects.MessagesToSend = append(sideEffects.MessagesToSend, messages...)
 		return &updated, sideEffects, WaitingForFinalStateFromAlice, nil
 	}
 
 	// Signing of the final state
-	if !updated.signedByMe() {
+	if updated.V.FinalSignedByMe() {
 
 		sig, err := o.finalState().Sign(*secretKey)
 		if err != nil {
 			return &updated, sideEffects, WaitingForNothing, fmt.Errorf("could not sign final state: %w", err)
 		}
 		// Update the signature stored on the objective
-		updated.Signatures[updated.MyRole] = sig
+		updated.V.AddStateWithSignature(o.finalState(), sig)
 
 		ss, err := updated.signedFinalState()
 		if err != nil {
@@ -399,7 +345,7 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 	}
 
 	// Check if all participants have signed the final state
-	if !updated.fullySigned() {
+	if !updated.V.FinalCompleted() {
 		return &updated, sideEffects, WaitingForSignedFinal, nil
 	}
 
@@ -432,20 +378,6 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 	return &updated, sideEffects, WaitingForNothing, nil
 }
 
-// fullySigned returns whether we have a signature from every partciapant.
-func (o *Objective) fullySigned() bool {
-	if len(o.Signatures) != len(o.VFixed.Participants) {
-		return false
-	}
-
-	for _, sig := range o.Signatures {
-		if isZero(sig) {
-			return false
-		}
-	}
-	return true
-}
-
 // isAlice returns true if the receiver represents participant 0 in the virtualdefund protocol.
 func (o *Objective) isAlice() bool {
 	return o.MyRole == 0
@@ -453,12 +385,12 @@ func (o *Objective) isAlice() bool {
 
 // isBob returns true if the receiver represents the last participant in the virtualdefund protocol.
 func (o *Objective) isBob() bool {
-	return int(o.MyRole) == len(o.VFixed.Participants)-1
+	return int(o.MyRole) == len(o.V.Participants)-1
 }
 
 // ledgerProposal generates a ledger proposal to remove the guarantee for V for ledger
 func (o *Objective) ledgerProposal(ledger *consensus_channel.ConsensusChannel) consensus_channel.Proposal {
-	left := o.FinalOutcome.Allocations[0].Amount
+	left := o.finalOutcome().Allocations[0].Amount
 
 	return consensus_channel.NewRemoveProposal(ledger.Id, o.VId(), left)
 }
@@ -511,17 +443,7 @@ func (o *Objective) updateLedgerToRemoveGuarantee(ledger *consensus_channel.Cons
 
 // VId returns the channel id of the virtual channel.
 func (o *Objective) VId() types.Destination {
-	return o.VFixed.ChannelId()
-}
-
-// signedBy returns whether we have a valid signature for the given participant
-func (o *Objective) signedBy(participant uint) bool {
-	return !isZero(o.Signatures[participant])
-}
-
-// signedByMe returns whether the current participant has signed the final state.
-func (o *Objective) signedByMe() bool {
-	return o.signedBy(o.MyRole)
+	return o.V.ChannelId()
 }
 
 // rightHasDefunded returns whether the ledger channel ToMyRight has removed
@@ -553,7 +475,7 @@ func (o *Objective) leftHasDefunded() bool {
 // validateSignature returns whether the given signature is valid for the given participant.
 // If a signature is invalid an error will be returned containing the reason.
 func (o *Objective) validateSignature(sig state.Signature, participantIndex uint) (bool, error) {
-	if participantIndex >= uint(len(o.VFixed.Participants)) {
+	if participantIndex >= uint(len(o.V.Participants)) {
 		return false, fmt.Errorf("participant index %d is out of bounds", participantIndex)
 	}
 
@@ -562,8 +484,8 @@ func (o *Objective) validateSignature(sig state.Signature, participantIndex uint
 	if err != nil {
 		return false, fmt.Errorf("failed to recover signer from signature: %w", err)
 	}
-	if signer != o.VFixed.Participants[participantIndex] {
-		return false, fmt.Errorf("signature is from %s, but expected signature from %s ", signer, o.VFixed.Participants[participantIndex])
+	if signer != o.V.Participants[participantIndex] {
+		return false, fmt.Errorf("signature is from %s, but expected signature from %s ", signer, o.V.Participants[participantIndex])
 	}
 	return true, nil
 }
@@ -602,44 +524,12 @@ func (o *Objective) Update(op protocols.ObjectivePayload) (protocols.Objective, 
 			return &Objective{}, err
 		}
 		updated := o.clone()
-		err = validateFinalOutcome(updated.VFixed, updated.InitialOutcome, ss.State().Outcome[0], o.VFixed.Participants[o.MyRole], updated.MinimumPaymentAmount)
+		err = validateFinalOutcome(updated.V.FixedPart, updated.initialOutcome(), ss.State().Outcome[0], o.V.Participants[o.MyRole], updated.MinimumPaymentAmount)
 		if err != nil {
 			return o, fmt.Errorf("outcome from Alice failed validation %w", err)
 		}
-
-		updated.FinalOutcome = ss.State().Outcome[0]
-		if err != nil {
-			return o, fmt.Errorf("could not get signed state payload: %w", err)
-		}
-
-		incomingSignatures := ss.Signatures()
-		for i := range o.VFixed.Participants {
-			existingSig := o.Signatures[i]
-			incomingSig := incomingSignatures[i]
-
-			// If the incoming signature is zeroed we ignore it
-			if isZero(incomingSig) {
-				continue
-			}
-			// If the existing signature is not zeroed we check that it matches the incoming signature
-			if !isZero(existingSig) {
-				if existingSig.Equal(incomingSig) {
-					continue
-				} else {
-					return o, fmt.Errorf("incoming signature %+v does not match existing %+v", incomingSig, existingSig)
-				}
-			}
-			// Otherwise we validate the incoming signature and update our signatures
-			isValid, err := updated.validateSignature(incomingSig, uint(i))
-			if isValid {
-				// Update the signature
-				updated.Signatures[i] = incomingSig
-			} else {
-				return o, fmt.Errorf("failed to validate signature: %w", err)
-			}
-		}
+		updated.V.AddSignedState(ss)
 		return &updated, nil
-
 	case RequestFinalStatePayload:
 		// Since the objective is already created we don't need to do anything else with the payload
 		return o, nil

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -44,7 +44,7 @@ type Objective struct {
 	// If this is not set then virtual defunding will accept any final outcome from Alice.
 	MinimumPaymentAmount *big.Int
 
-	V *channel.Channel
+	V *channel.Channel // This is a Virtual Channel. TODO should this be a literal channel.VirtualChannel?
 
 	ToMyLeft  *consensus_channel.ConsensusChannel
 	ToMyRight *consensus_channel.ConsensusChannel
@@ -470,24 +470,6 @@ func (o *Objective) leftHasDefunded() bool {
 
 	included := o.ToMyLeft.IncludesTarget(o.VId())
 	return !included
-}
-
-// validateSignature returns whether the given signature is valid for the given participant.
-// If a signature is invalid an error will be returned containing the reason.
-func (o *Objective) validateSignature(sig state.Signature, participantIndex uint) (bool, error) {
-	if participantIndex >= uint(len(o.V.Participants)) {
-		return false, fmt.Errorf("participant index %d is out of bounds", participantIndex)
-	}
-
-	finalState := o.finalState()
-	signer, err := finalState.RecoverSigner(sig)
-	if err != nil {
-		return false, fmt.Errorf("failed to recover signer from signature: %w", err)
-	}
-	if signer != o.V.Participants[participantIndex] {
-		return false, fmt.Errorf("signature is from %s, but expected signature from %s ", signer, o.V.Participants[participantIndex])
-	}
-	return true, nil
 }
 
 // getSignedStatePayload takes in a serialized signed state payload and returns the deserialized SignedState.

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -327,7 +327,7 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 	}
 
 	// Signing of the final state
-	if updated.V.FinalSignedByMe() {
+	if !updated.V.FinalSignedByMe() {
 
 		sig, err := o.finalState().Sign(*secretKey)
 		if err != nil {


### PR DESCRIPTION
By embedding a reference to the underlying virtual channel, rather than duplicating information directly on the objective. 

This means that things like finalization proofs can be read from the store by other tasks/objectives. I think this will be important when it comes to handling challenges. 