### PR TITLE
Add non fatal errors to the engine

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -36,10 +36,10 @@ const (
 type ConsensusChannel struct {
 	// constants
 
-	MyIndex        ledgerIndex
-	fp             state.FixedPart
 	Id             types.Destination
+	MyIndex        ledgerIndex
 	OnChainFunding types.Funds
+	fp             state.FixedPart
 
 	// variables
 
@@ -894,7 +894,10 @@ func (c *ConsensusChannel) Clone() *ConsensusChannel {
 	for i, p := range c.proposalQueue {
 		clonedProposalQueue[i] = p.Clone()
 	}
-	d := ConsensusChannel{c.MyIndex, c.fp.Clone(), c.Id, c.OnChainFunding.Clone(), c.current.clone(), clonedProposalQueue}
+	d := ConsensusChannel{
+		MyIndex: c.MyIndex, fp: c.fp.Clone(),
+		Id: c.Id, OnChainFunding: c.OnChainFunding.Clone(), current: c.current.clone(), proposalQueue: clonedProposalQueue,
+	}
 	return &d
 }
 

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -740,9 +740,10 @@ func (e *Engine) checkError(err error) {
 		}
 
 		<-time.After(1000 * time.Millisecond) // We wait for a bit so the previous log line has time to complete
-		// TODO do not panic if in production.
+
+		// TODO instead of a panic, errors should be sent to the manager of the engine via a channel. At the moment,
+		// the engine manager is the nitro client.
 		panic(err)
-		// TODO report errors back to the consuming application
 
 	}
 }


### PR DESCRIPTION
When initially developing `go-nitro`, we adopted the methodology of panicking the engine when an error is encountered. This is approach works well during the development phase as we avoid introducing any errors during normal nitro node operation.

In production, a nitro node should panic infrequently. The panic scenario is when the node reaches an irrecoverable state. This PR moves in that direction by introducing a class of errors for which the node logs an error but does not panic. We then use the new non-fatal errors to fix https://github.com/statechannels/go-nitro/issues/1216.

That issue involves a duplicate, delayed message causing the store to look up a deleted consensus channel. While many different approaches exist to solving this particular issue (such as not deleting consensus channels or merging consensus channels and vanilla channels), this PR choses to classify the failure to fetch an objective as a non fatal error.  