### PR TITLE
Remove `truncateLog()` function and ensure each logger writes to a unique file. 

### DIFF
--- a/client_test/crash_test.go
+++ b/client_test/crash_test.go
@@ -22,15 +22,10 @@ func TestCrashTolerance(t *testing.T) {
 	// Setup logging
 	logSubDir := "test_crash_tolerance"
 
-	engineLogDestinationA := newLogWriter(logSubDir, "eng-a")
-	engineLogDestinationB := newLogWriter(logSubDir, "eng-b")
-	chainLogDestinationA := newLogWriter(logSubDir, "ch-a")
-	chainLogDestinationB := newLogWriter(logSubDir, "ch-b")
-
-	truncateLog(logSubDir, "eng-a")
-	truncateLog(logSubDir, "eng-b")
-	truncateLog(logSubDir, "ch-a")
-	truncateLog(logSubDir, "ch-b")
+	engineLogDestinationA := newLogWriter(logSubDir, "a-eng.log")
+	engineLogDestinationB := newLogWriter(logSubDir, "b-eng.log")
+	chainLogDestinationA := newLogWriter(logSubDir, "a-ch.log")
+	chainLogDestinationB := newLogWriter(logSubDir, "b-ch.log")
 
 	// Setup chain service
 	sim, bindings, ethAccounts, err := chainservice.SetupSimulatedBackend(3)

--- a/client_test/crash_test.go
+++ b/client_test/crash_test.go
@@ -20,9 +20,17 @@ import (
 
 func TestCrashTolerance(t *testing.T) {
 	// Setup logging
-	logFile := "test_crash_tolerance.log"
-	truncateLog(logFile)
-	logDestination := newLogWriter(logFile)
+	logSubDir := "test_crash_tolerance"
+
+	engineLogDestinationA := newLogWriter(logSubDir, "eng-a")
+	engineLogDestinationB := newLogWriter(logSubDir, "eng-b")
+	chainLogDestinationA := newLogWriter(logSubDir, "ch-a")
+	chainLogDestinationB := newLogWriter(logSubDir, "ch-b")
+
+	truncateLog(logSubDir, "eng-a")
+	truncateLog(logSubDir, "eng-b")
+	truncateLog(logSubDir, "ch-a")
+	truncateLog(logSubDir, "ch-b")
 
 	// Setup chain service
 	sim, bindings, ethAccounts, err := chainservice.SetupSimulatedBackend(3)
@@ -31,12 +39,12 @@ func TestCrashTolerance(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	chainA, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[0], logDestination)
+	chainA, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[0], chainLogDestinationA)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	chainB, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[2], logDestination)
+	chainB, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[2], chainLogDestinationB)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,9 +58,9 @@ func TestCrashTolerance(t *testing.T) {
 	// Client setup
 	storeA := store.NewDurableStore(ta.Alice.PrivateKey, dataFolder, buntdb.Config{SyncPolicy: buntdb.Always})
 	messageserviceA := messageservice.NewTestMessageService(ta.Alice.Address(), broker, 0)
-	clientA := client.New(messageserviceA, chainA, storeA, logDestination, &engine.PermissivePolicy{}, nil)
+	clientA := client.New(messageserviceA, chainA, storeA, engineLogDestinationA, &engine.PermissivePolicy{}, nil)
 
-	clientB, _ := setupClient(ta.Bob.PrivateKey, chainB, broker, logDestination, 0)
+	clientB, _ := setupClient(ta.Bob.PrivateKey, chainB, broker, engineLogDestinationB, 0)
 	defer closeClient(t, &clientB)
 	// End Client setup
 
@@ -62,7 +70,7 @@ func TestCrashTolerance(t *testing.T) {
 
 		closeClient(t, &clientA)
 		anotherMessageserviceA := messageservice.NewTestMessageService(ta.Alice.Address(), broker, 0)
-		anotherChainA, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[0], logDestination)
+		anotherChainA, err := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[0], chainLogDestinationA)
 		anotherStoreA := store.NewDurableStore(ta.Alice.PrivateKey, dataFolder, buntdb.Config{SyncPolicy: buntdb.Always})
 		if err != nil {
 			t.Fatal(err)
@@ -70,7 +78,7 @@ func TestCrashTolerance(t *testing.T) {
 		anotherClientA := client.New(
 			anotherMessageserviceA,
 			anotherChainA,
-			anotherStoreA, logDestination, &engine.PermissivePolicy{}, nil)
+			anotherStoreA, engineLogDestinationA, &engine.PermissivePolicy{}, nil)
 		defer closeClient(t, &anotherClientA)
 
 		directlyDefundALedgerChannel(t, anotherClientA, clientB, channelId)

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -46,15 +46,7 @@ func closeClient(t *testing.T, client *client.Client) {
 	}
 }
 
-func truncateLog(logSubDir string, logFile string) {
-	logDestination := newLogWriter(logSubDir, logFile)
-
-	err := logDestination.Truncate(0)
-	if err != nil {
-		log.Fatal(err)
-	}
-}
-
+// newLogWriter will create the given subDir under ../artifacts, remove any file of name logFile in that dir, and open a new one, returning a pointer.
 func newLogWriter(logSubDir string, logFile string) *os.File {
 	err := os.MkdirAll(filepath.Join("../artifacts", logSubDir), os.ModePerm)
 	if err != nil {

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -46,8 +46,8 @@ func closeClient(t *testing.T, client *client.Client) {
 	}
 }
 
-func truncateLog(logFile string) {
-	logDestination := newLogWriter(logFile)
+func truncateLog(logSubDir string, logFile string) {
+	logDestination := newLogWriter(logSubDir, logFile)
 
 	err := logDestination.Truncate(0)
 	if err != nil {
@@ -55,13 +55,13 @@ func truncateLog(logFile string) {
 	}
 }
 
-func newLogWriter(logFile string) *os.File {
-	err := os.MkdirAll("../artifacts", os.ModePerm)
+func newLogWriter(logSubDir string, logFile string) *os.File {
+	err := os.MkdirAll(filepath.Join("../artifacts", logSubDir), os.ModePerm)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	filename := filepath.Join("../artifacts", logFile)
+	filename := filepath.Join("../artifacts", logSubDir, logFile)
 	// Clear the file
 	os.Remove(filename)
 	logDestination, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o666)
@@ -102,7 +102,7 @@ func setupChainService(tc TestCase, tp TestParticipant, si sharedTestInfrastruct
 	case MockChain:
 		return chainservice.NewMockChainService(si.mockChain, tp.Address())
 	case SimulatedChain:
-		logDestination := newLogWriter(tc.LogName)
+		logDestination := newLogWriter(tc.LogSubDir, string(tp.Name)+"-ch.log")
 
 		ethAcountIndex := tp.Port - testactors.START_PORT
 		cs, err := chainservice.NewSimulatedBackendChainService(si.simulatedChain, *si.bindings, si.ethAccounts[ethAcountIndex], logDestination)
@@ -128,10 +128,10 @@ func setupStore(tc TestCase, tp TestParticipant, si sharedTestInfrastructure) st
 }
 
 func setupIntegrationClient(tc TestCase, tp TestParticipant, si sharedTestInfrastructure) (client.Client, messageservice.MessageService) {
-	messageService := setupMessageService(tc, tp, si, newLogWriter(tc.LogName))
+	messageService := setupMessageService(tc, tp, si, newLogWriter(tc.LogSubDir, string(tp.Name)+"-msg.log"))
 	cs := setupChainService(tc, tp, si)
 	store := setupStore(tc, tp, si)
-	c := client.New(messageService, cs, store, newLogWriter(tc.LogName), &engine.PermissivePolicy{}, nil)
+	c := client.New(messageService, cs, store, newLogWriter(tc.LogSubDir, string(tp.Name)+"-eng.log"), &engine.PermissivePolicy{}, nil)
 	return c, messageService
 }
 

--- a/client_test/integration_test.go
+++ b/client_test/integration_test.go
@@ -23,7 +23,7 @@ func TestSimpleIntegrationScenario(t *testing.T) {
 		MessageService: TestMessageService,
 		NumOfChannels:  1,
 		MessageDelay:   0,
-		LogName:        "simple_integration_run.log",
+		LogSubDir:      "simple_integration_run",
 		NumOfHops:      1,
 		NumOfPayments:  1,
 		Participants: []TestParticipant{
@@ -43,7 +43,7 @@ func TestComplexIntegrationScenario(t *testing.T) {
 		MessageService: P2PMessageService,
 		NumOfChannels:  5,
 		MessageDelay:   0,
-		LogName:        "complex_integration_run.log",
+		LogSubDir:      "complex_integration_run",
 		NumOfHops:      2,
 		NumOfPayments:  5,
 		Participants: []TestParticipant{

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -45,18 +45,25 @@ func TestRpcWithWebsockets(t *testing.T) {
 }
 
 func executeRpcTest(t *testing.T, connectionType transport.TransportType) {
-	logFile := "test_rpc_client.log"
-	truncateLog(logFile)
-	logDestination := newLogWriter(logFile)
+	logSubDir := "test_rpc_client"
+
+	engineLogDestinationA := newLogWriter(logSubDir, "eng-a")
+	engineLogDestinationB := newLogWriter(logSubDir, "eng-b")
+	engineLogDestinationI := newLogWriter(logSubDir, "eng-i")
+
+	truncateLog(logSubDir, "eng-a")
+	truncateLog(logSubDir, "eng-b")
+	truncateLog(logSubDir, "ch-a")
+	truncateLog(logSubDir, "ch-b")
 
 	chain := chainservice.NewMockChain()
 	chainServiceA := chainservice.NewMockChainService(chain, ta.Alice.Address())
 	chainServiceB := chainservice.NewMockChainService(chain, ta.Bob.Address())
 	chainServiceI := chainservice.NewMockChainService(chain, ta.Irene.Address())
 
-	rpcClientA, msgA, cleanupFnA := setupNitroNodeWithRPCClient(t, ta.Alice.PrivateKey, 3005, 4005, chainServiceA, logDestination, connectionType)
-	rpcClientB, msgB, cleanupFnB := setupNitroNodeWithRPCClient(t, ta.Bob.PrivateKey, 3006, 4006, chainServiceB, logDestination, connectionType)
-	rpcClientI, msgI, cleanupFnC := setupNitroNodeWithRPCClient(t, ta.Irene.PrivateKey, 3007, 4007, chainServiceI, logDestination, connectionType)
+	rpcClientA, msgA, cleanupFnA := setupNitroNodeWithRPCClient(t, ta.Alice.PrivateKey, 3005, 4005, chainServiceA, engineLogDestinationA, connectionType)
+	rpcClientB, msgB, cleanupFnB := setupNitroNodeWithRPCClient(t, ta.Bob.PrivateKey, 3006, 4006, chainServiceB, engineLogDestinationB, connectionType)
+	rpcClientI, msgI, cleanupFnC := setupNitroNodeWithRPCClient(t, ta.Irene.PrivateKey, 3007, 4007, chainServiceI, engineLogDestinationI, connectionType)
 	waitForPeerInfoExchange(2, msgA, msgB, msgI)
 	defer cleanupFnA()
 	defer cleanupFnB()

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -47,14 +47,9 @@ func TestRpcWithWebsockets(t *testing.T) {
 func executeRpcTest(t *testing.T, connectionType transport.TransportType) {
 	logSubDir := "test_rpc_client"
 
-	engineLogDestinationA := newLogWriter(logSubDir, "eng-a")
-	engineLogDestinationB := newLogWriter(logSubDir, "eng-b")
-	engineLogDestinationI := newLogWriter(logSubDir, "eng-i")
-
-	truncateLog(logSubDir, "eng-a")
-	truncateLog(logSubDir, "eng-b")
-	truncateLog(logSubDir, "ch-a")
-	truncateLog(logSubDir, "ch-b")
+	engineLogDestinationA := newLogWriter(logSubDir, "a-eng")
+	engineLogDestinationB := newLogWriter(logSubDir, "b-eng")
+	engineLogDestinationI := newLogWriter(logSubDir, "i-eng")
 
 	chain := chainservice.NewMockChain()
 	chainServiceA := chainservice.NewMockChainService(chain, ta.Alice.Address())

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -47,9 +47,9 @@ func TestRpcWithWebsockets(t *testing.T) {
 func executeRpcTest(t *testing.T, connectionType transport.TransportType) {
 	logSubDir := "test_rpc_client"
 
-	engineLogDestinationA := newLogWriter(logSubDir, "a-eng")
-	engineLogDestinationB := newLogWriter(logSubDir, "b-eng")
-	engineLogDestinationI := newLogWriter(logSubDir, "i-eng")
+	engineLogDestinationA := newLogWriter(logSubDir, "a-eng.log")
+	engineLogDestinationB := newLogWriter(logSubDir, "b-eng.log")
+	engineLogDestinationI := newLogWriter(logSubDir, "i-eng.log")
 
 	chain := chainservice.NewMockChain()
 	chainServiceA := chainservice.NewMockChainService(chain, ta.Alice.Address())

--- a/client_test/types_test.go
+++ b/client_test/types_test.go
@@ -54,7 +54,7 @@ type TestCase struct {
 	NumOfChannels  uint
 	NumOfPayments  uint
 	MessageDelay   time.Duration
-	LogName        string
+	LogSubDir      string
 	NumOfHops      uint
 	Participants   []TestParticipant
 }

--- a/combinelogs.sh
+++ b/combinelogs.sh
@@ -1,0 +1,5 @@
+cd artifacts
+for d in */ ; do
+    echo "$d"
+    cat $d/*.log | pino-pretty -S -o "{engine} {To} < {From}" > $d/combined.tmp
+done


### PR DESCRIPTION
Closes #1237 

Also ensures every logger writes to a unique file. I think it is important for us to not run into any problems with sharing resources across clients / even across loggers within the same client. 

We can combine the logs into one file at debug-time if we wish. 

After running all tests, the `artifacts` directory has gone from this:
```shell
artifacts
├── complex_integration_run.log
├── simple_integration_run.log
├── test_crash_tolerance.log
└── test_rpc_client.log
```

 to this:

```shell
artifacts
├── complex_integration_run
│   ├── alice-ch.log
│   ├── alice-eng.log
│   ├── alice-msg.log
│   ├── bob-ch.log
│   ├── bob-eng.log
│   ├── bob-msg.log
│   ├── brian-ch.log
│   ├── brian-eng.log
│   ├── brian-msg.log
│   ├── irene-ch.log
│   ├── irene-eng.log
│   └── irene-msg.log
├── simple_integration_run
│   ├── alice-eng.log
│   ├── alice-msg.log
│   ├── bob-eng.log
│   ├── bob-msg.log
│   ├── irene-eng.log
│   └── irene-msg.log
├── test_crash_tolerance
│   ├── a-ch.log
│   ├── a-eng.log
│   ├── b-ch.log
│   └── b-eng.log
└── test_rpc_client
    ├── a-eng.log
    ├── b-eng.log
    └── i-eng.log
```


⚠️ when we make changes to the artifacts "schema", it will leave behind old files (since the new cleanup operations only cleanup the new schema. Therefore it is recommended to occasionally blow away your `artifacts` folder (particularly after schema changes such as this). 

