### PR TITLE
Specify node version for node related CI

### DIFF
--- a/.github/workflows/bindings-check.yml
+++ b/.github/workflows/bindings-check.yml
@@ -2,9 +2,10 @@ name: Check Bindings and Lockfile
 
 on:
   push:
-    branches: [main]
+    branches: ["*"]
   pull_request:
-    paths: ["nitro-protocol/contracts/**", generate-adjudicator-bindings.sh]
+    paths:
+      ["nitro-protocol/contracts/**", generate-adjudicator-bindings.sh, "*"]
 
 jobs:
   build:

--- a/.github/workflows/bindings-check.yml
+++ b/.github/workflows/bindings-check.yml
@@ -2,10 +2,9 @@ name: Check Bindings and Lockfile
 
 on:
   push:
-    branches: ["*"]
+    branches: [main]
   pull_request:
-    paths:
-      ["nitro-protocol/contracts/**", generate-adjudicator-bindings.sh, "*"]
+    paths: ["nitro-protocol/contracts/**", generate-adjudicator-bindings.sh]
 
 jobs:
   build:

--- a/.github/workflows/bindings-check.yml
+++ b/.github/workflows/bindings-check.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        with:
+          node-version: "18.16.0"
       - name: Install dependencies
         run: |
           cd ./nitro-protocol

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -2,9 +2,10 @@ name: Node
 
 on:
   push:
-    branches: [main]
+    branches: ["*"]
   pull_request:
-    paths: ["nitro-protocol/**", ".github/workflows/node.yml"]
+    paths:
+      ["nitro-protocol/contracts/**", generate-adjudicator-bindings.sh, "*"]
 
 jobs:
   build:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        with:
+          node-version: "18.16.0"
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
       - name: Compile contracts

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -2,10 +2,9 @@ name: Node
 
 on:
   push:
-    branches: ["*"]
+    branches: [main]
   pull_request:
-    paths:
-      ["nitro-protocol/contracts/**", generate-adjudicator-bindings.sh, "*"]
+    paths: ["nitro-protocol/**", ".github/workflows/node.yml"]
 
 jobs:
   build:


### PR DESCRIPTION
Specify a version of node (the LTS version of node) for the node-related CI workflows. This seems to resolve the [error](https://github.com/statechannels/go-nitro/actions/runs/4802488125/jobs/8565167719) we were seeing on main?
