### PR TITLE
remove truncateLog()

### DIFF
--- a/client/engine/chainservice/eth_chainservice_FEVM_test.go
+++ b/client/engine/chainservice/eth_chainservice_FEVM_test.go
@@ -90,7 +90,6 @@ func testAgainstEndpoint(t *testing.T, endpoint string, logFile string, pk *ecds
 		t.Fatal(err)
 	}
 
-	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 	cs, err := NewEthChainService(client, na, naAddress, caAddress, vpaAddress, txSubmitter, logDestination)
 	if err != nil {
@@ -235,13 +234,4 @@ func newLogWriter(logFile string) *os.File {
 	}
 
 	return logDestination
-}
-
-func truncateLog(logFile string) {
-	logDestination := newLogWriter(logFile)
-
-	err := logDestination.Truncate(0)
-	if err != nil {
-		log.Fatal(err)
-	}
 }

--- a/client_test/crash_test.go
+++ b/client_test/crash_test.go
@@ -21,7 +21,6 @@ import (
 func TestCrashTolerance(t *testing.T) {
 	// Setup logging
 	logFile := "test_crash_tolerance.log"
-	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
 	// Setup chain service

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -46,15 +46,6 @@ func closeClient(t *testing.T, client *client.Client) {
 	}
 }
 
-func truncateLog(logFile string) {
-	logDestination := newLogWriter(logFile)
-
-	err := logDestination.Truncate(0)
-	if err != nil {
-		log.Fatal(err)
-	}
-}
-
 func newLogWriter(logFile string) *os.File {
 	err := os.MkdirAll("../artifacts", os.ModePerm)
 	if err != nil {

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -46,7 +46,6 @@ func TestRpcWithWebsockets(t *testing.T) {
 
 func executeRpcTest(t *testing.T, connectionType transport.TransportType) {
 	logFile := "test_rpc_client.log"
-	truncateLog(logFile)
 	logDestination := newLogWriter(logFile)
 
 	chain := chainservice.NewMockChain()


### PR DESCRIPTION
 not sure why, but it seems to result in empty logfiles even if called before the test starts. We weren't calling it at all in the main integration test, and it is actually redundant (when we create a log file, we remove any existing file).


Fixes #1237 