### PR TITLE
add "*" as acceptable origin

### DIFF
--- a/rpc/transport/ws/server.go
+++ b/rpc/transport/ws/server.go
@@ -106,7 +106,7 @@ func (wsc *serverWebSocketTransport) request(w http.ResponseWriter, r *http.Requ
 
 func (wsc *serverWebSocketTransport) subscribe(w http.ResponseWriter, r *http.Request) {
 	// Allow all localhost origins to connect via websocket
-	opts := &websocket.AcceptOptions{OriginPatterns: []string{"*localhost*"}}
+	opts := &websocket.AcceptOptions{OriginPatterns: []string{"*localhost*", "*"}}
 	c, err := websocket.Accept(w, r, opts)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Today I tried to connect to go-nitro using the TS rpc client CLI tool https://github.com/statechannels/nitro-gui/tree/main/packages/nitro-rpc-client#cli-tool . 

I got the error: 

```shell
~/s/go-nitro ❯❯❯ go run . --usenats=false                                                                                                                                                                                                     ✘ 1 remove-panic ⬆ ✭
{"level":"debug","engine":"0xAAA662","time":1683203643997,"caller":"engine.go:115","message":"Constructed Engine"}
Nitro as a Service listening on port 4005
2023/05/04 13:34:10 http: panic serving 127.0.0.1:61722: failed to accept WebSocket connection: request Origin "*" is not authorized for Host "127.0.0.1:4005"
goroutine 73 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1854 +0xb0
panic({0x101df5380, 0x14000bda240})
	/usr/local/go/src/runtime/panic.go:890 +0x258
github.com/statechannels/go-nitro/rpc/transport/ws.(*serverWebSocketTransport).subscribe(0x1400065a000, {0x1020059c0?, 0x14000204000?}, 0x140005a0100)
	/Users/georgeknee/statechannels/go-nitro/rpc/transport/ws/server.go:112 +0x468
net/http.HandlerFunc.ServeHTTP(0x14000595ad8?, {0x1020059c0?, 0x14000204000?}, 0x10?)
	/usr/local/go/src/net/http/server.go:2122 +0x38
net/http.(*ServeMux).ServeHTTP(0x0?, {0x1020059c0, 0x14000204000}, 0x140005a0100)
	/usr/local/go/src/net/http/server.go:2500 +0x140
net/http.serverHandler.ServeHTTP({0x140001de540?}, {0x1020059c0, 0x14000204000}, 0x140005a0100)
	/usr/local/go/src/net/http/server.go:2936 +0x2d8
net/http.(*conn).serve(0x1400022f8c0, {0x1020071b8, 0x140005b80c0})
	/usr/local/go/src/net/http/server.go:1995 +0x560
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:3089 +0x520
{"level":"debug","txSigner":"0xdF3e18","time":1683203794020,"caller":"eth_chainservice.go:242","message":"resubscribed to filtered logs"}
^CReceived signal interrupt, exiting..%
```

It seems that by trying to lock down connections to localhost, we have actually ended up excluding connections from our CLI tool. This change fixes the error, although I am not sure it is the correct place to do so. An alternative would be to have the CLI tool set a more meaningful `Origin:` header and have go-nitro add that to its whitelist. 

Related to #1221 and also https://github.com/statechannels/nitro-gui/issues/5

