### PR TITLE
lower default num of funded accounts to use

### DIFF
--- a/client/engine/chainservice/utils/utils.go
+++ b/client/engine/chainservice/utils/utils.go
@@ -85,7 +85,7 @@ func GetHardhatFundedPrivateKey(a types.Address) ([]byte, error) {
 	// This is the default mnemonic used by hardhat
 	const HARDHAT_MNEMONIC = "test test test test test test test test test test test junk"
 	// This is the number of accounts hardhat funds by default
-	const NUM_FUNDED = 20
+	const NUM_FUNDED = 10
 	// This is the default hd wallet path used by hardhat
 	const HD_PATH = "m/44'/60'/0'/0"
 

--- a/client/engine/chainservice/utils/utils.go
+++ b/client/engine/chainservice/utils/utils.go
@@ -78,20 +78,19 @@ func ConnectToChain(ctx context.Context, chainUrl string, chainId int, chainPK [
 	return client, txSubmitter, nil
 }
 
-// GetHardhatFundedPrivateKey selects a private key from one of the 1000 funded accounts in hardhat.
-// It modulates the address by 1000 to select a funded account.
-func GetHardhatFundedPrivateKey(a types.Address) ([]byte, error) {
-	// See https://hardhat.org/hardhat-network/docs/reference#accounts for defaults
-	// This is the default mnemonic used by hardhat
-	const HARDHAT_MNEMONIC = "test test test test test test test test test test test junk"
-	// This is the number of accounts hardhat funds by default
+// GetFundedTestPrivateKey selects a private key from one of 10 derived accounts using the
+//
+//	"test test test test test test test test test test test junk" mnemonic.
+//
+// Most test chains(hardhat/anvil) fund the first 10 accounts.
+func GetFundedTestPrivateKey(a types.Address) ([]byte, error) {
+	const TEST_MNEMONIC = "test test test test test test test test test test test junk"
 	const NUM_FUNDED = 10
-	// This is the default hd wallet path used by hardhat
 	const HD_PATH = "m/44'/60'/0'/0"
 
 	index := big.NewInt(0).Mod(a.Big(), big.NewInt(NUM_FUNDED)).Uint64()
 
-	wallet, err := hdwallet.NewFromMnemonic(HARDHAT_MNEMONIC)
+	wallet, err := hdwallet.NewFromMnemonic(TEST_MNEMONIC)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func main() {
 		ourStore = store.NewMemStore(pk)
 	}
 
-	chainPk, err := chainutils.GetHardhatFundedPrivateKey(*ourStore.GetAddress())
+	chainPk, err := chainutils.GetFundedTestPrivateKey(*ourStore.GetAddress())
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
[Anvil currently defaults to 10 funded accounts](https://book.getfoundry.sh/reference/anvil/), not 20. This updates the chain service utils use the first 10 derived PKs, not 20. This resolves an issue where a go-nitro RPC server could fail if it happened to grab an unfunded PK.