### PR TITLE
Use one Create2Deployer

### DIFF
--- a/client/engine/chainservice/utils/utils.go
+++ b/client/engine/chainservice/utils/utils.go
@@ -27,7 +27,9 @@ const (
 
 // DeployAdjudicator deploys the Create2Deployer and NitroAdjudicator contracts.
 // The nitro adjudicator is deployed to the address computed by the Create2Deployer contract.
-func DeployAdjudicator(ctx context.Context, client *ethclient.Client) (common.Address, error) {
+// TODO: The *bind.TransactOpts param is ignored. It's only there for compatibility with the testground test.
+// We should remove it when the testground test is updated.
+func DeployAdjudicator(ctx context.Context, client *ethclient.Client, _ *bind.TransactOpts) (common.Address, error) {
 	// We want to use the same account for deployments
 	// so we use one specific account when handling deployments.
 	chainPk, err := deriveFundedPk(deployerIndex)

--- a/client/engine/chainservice/utils/utils.go
+++ b/client/engine/chainservice/utils/utils.go
@@ -16,9 +16,29 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
+const (
+
+	// deployerIndex is the index of the HD wallet account used to deploy contracts.
+	// Using the same account for deployments ensures that the same address is generated for the Create2Deployer contract.
+	deployerIndex = 0
+	// This is the expected address of the Create2Deployer contract.
+	deployAddress = "0x5FbDB2315678afecb367f032d93F642f64180aa3"
+)
+
 // DeployAdjudicator deploys the Create2Deployer and NitroAdjudicator contracts.
 // The nitro adjudicator is deployed to the address computed by the Create2Deployer contract.
-func DeployAdjudicator(ctx context.Context, client *ethclient.Client, txSubmitter *bind.TransactOpts) (common.Address, error) {
+func DeployAdjudicator(ctx context.Context, client *ethclient.Client) (common.Address, error) {
+	// We want to use the same account for deployments
+	// so we use one specific account when handling deployments.
+	chainPk, err := deriveFundedPk(deployerIndex)
+	if err != nil {
+		return types.Address{}, err
+	}
+
+	txSubmitter, err := createTxSubmitter(context.Background(), chainPk, client)
+	if err != nil {
+		return types.Address{}, err
+	}
 	deployer, err := getCreate2Deployer(ctx, client, txSubmitter)
 	if err != nil {
 		return types.Address{}, err
@@ -50,12 +70,12 @@ func DeployAdjudicator(ctx context.Context, client *ethclient.Client, txSubmitte
 // getCreate2Deployer deploys or connects to the Create2Deployer contract at a known address
 // If the contract is not deployed, it deploys it.
 func getCreate2Deployer(ctx context.Context, client *ethclient.Client, txSubmitter *bind.TransactOpts) (*Create2Deployer.Create2Deployer, error) {
-	const deployAddress = "0xbdEd0D2bf404bdcBa897a74E6657f1f12e5C6fb6"
 	bytecode, err := client.CodeAt(ctx, common.HexToAddress(deployAddress), nil) // nil is latest block
 	if err != nil {
 		return nil, err
 	}
 	if len(bytecode) == 0 {
+
 		deployedAdd, _, deployer, err := Create2Deployer.DeployCreate2Deployer(txSubmitter, client)
 		if err != nil {
 			return nil, err
@@ -67,6 +87,31 @@ func getCreate2Deployer(ctx context.Context, client *ethclient.Client, txSubmitt
 	} else {
 		return Create2Deployer.NewCreate2Deployer(common.HexToAddress(deployAddress), client)
 	}
+}
+
+func createTxSubmitter(ctx context.Context, chainPK []byte, client *ethclient.Client) (*bind.TransactOpts, error) {
+	key, err := ethcrypto.ToECDSA(chainPK)
+	if err != nil {
+		return nil, err
+	}
+
+	chainId, err := client.ChainID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	txSubmitter, err := bind.NewKeyedTransactorWithChainID(key, chainId)
+	if err != nil {
+		return nil, err
+	}
+	txSubmitter.GasLimit = uint64(30_000_000) // in units
+
+	gasPrice, err := client.SuggestGasPrice(ctx)
+	if err != nil {
+		return nil, err
+	}
+	txSubmitter.GasPrice = gasPrice
+	return txSubmitter, nil
 }
 
 // ConnectToChain connects to the chain at the given url and returns a client and a transactor.
@@ -82,36 +127,24 @@ func ConnectToChain(ctx context.Context, chainUrl string, chainId int, chainPK [
 	if foundChainId.Cmp(big.NewInt(int64(chainId))) != 0 {
 		return nil, nil, fmt.Errorf("chain id mismatch: expected %d, got %d", chainId, foundChainId)
 	}
-	key, err := ethcrypto.ToECDSA(chainPK)
+	txSubmitter, err := createTxSubmitter(ctx, chainPK, client)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("could not construct tx submitter: %w", err)
 	}
-	txSubmitter, err := bind.NewKeyedTransactorWithChainID(key, big.NewInt(1337))
-	if err != nil {
-		return nil, nil, err
-	}
-	txSubmitter.GasLimit = uint64(30_000_000) // in units
-
-	gasPrice, err := client.SuggestGasPrice(context.Background())
-	if err != nil {
-		return nil, nil, err
-	}
-	txSubmitter.GasPrice = gasPrice
 	return client, txSubmitter, nil
 }
 
-// GetFundedTestPrivateKey selects a private key from one of 10 derived accounts using the
-//
-//	"test test test test test test test test test test test junk" mnemonic.
-//
-// Most test chains(hardhat/anvil) fund the first 10 accounts.
-func GetFundedTestPrivateKey(a types.Address) ([]byte, error) {
-	const TEST_MNEMONIC = "test test test test test test test test test test test junk"
-	const NUM_FUNDED = 10
-	const HD_PATH = "m/44'/60'/0'/0"
+const (
+	TEST_MNEMONIC = "test test test test test test test test test test test junk"
+	NUM_FUNDED    = 10
+	HD_PATH       = "m/44'/60'/0'/0"
+)
 
-	index := big.NewInt(0).Mod(a.Big(), big.NewInt(NUM_FUNDED)).Uint64()
-
+// deriveFundedPk derives a private key from the test mnemonic and the given index.
+func deriveFundedPk(index uint64) ([]byte, error) {
+	if index >= NUM_FUNDED {
+		return nil, fmt.Errorf("index %d is larger than the number of funded accounts %d", index, NUM_FUNDED)
+	}
 	wallet, err := hdwallet.NewFromMnemonic(TEST_MNEMONIC)
 	if err != nil {
 		return nil, err
@@ -128,4 +161,14 @@ func GetFundedTestPrivateKey(a types.Address) ([]byte, error) {
 		return nil, err
 	}
 	return ethcrypto.FromECDSA(pk), nil
+}
+
+// GetFundedTestPrivateKey selects a private key from one of 10 derived accounts using the
+//
+//	"test test test test test test test test test test test junk" mnemonic.
+//
+// Most test chains(hardhat/anvil) fund the first 10 accounts.
+func GetFundedTestPrivateKey(a types.Address) ([]byte, error) {
+	index := big.NewInt(0).Mod(a.Big(), big.NewInt(NUM_FUNDED)).Uint64()
+	return deriveFundedPk(index)
 }

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 	flag.BoolVar(&useDurableStore, "usedurablestore", false, "Specifies whether to use a durable store or an in-memory store.")
 	flag.StringVar(&pkString, "pk", "2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d", "Specifies the private key for the client. Default is Alice's private key.")
 	flag.StringVar(&chainUrl, "chainurl", "ws://127.0.0.1:8545", "Specifies the url of a RPC endpoint for the chain.")
-	flag.StringVar(&naAddress, "naaddress", "0x3f1E9229cd27051CF7eE76dc9579BCbF649509be", "Specifies the address of the nitro adjudicator contract. Default is the address computed by the Create2Deployer contract.")
+	flag.StringVar(&naAddress, "naaddress", "0xD5978Be8636bB9C4912617ae8389888d85108fcf", "Specifies the address of the nitro adjudicator contract. Default is the address computed by the Create2Deployer contract.")
 	flag.IntVar(&msgPort, "msgport", 3005, "Specifies the tcp port for the  message service.")
 	flag.IntVar(&rpcPort, "rpcport", 4005, "Specifies the tcp port for the rpc server.")
 	flag.IntVar(&chainId, "chainid", 1337, "Specifies the chain id of the chain.")
@@ -63,7 +63,7 @@ func main() {
 		panic(err)
 	}
 	if deployContracts {
-		deployedAddress, err := chainutils.DeployAdjudicator(context.Background(), ethClient, txSubmitter)
+		deployedAddress, err := chainutils.DeployAdjudicator(context.Background(), ethClient)
 		if err != nil {
 			panic(err)
 		}

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 		panic(err)
 	}
 	if deployContracts {
-		deployedAddress, err := chainutils.DeployAdjudicator(context.Background(), ethClient)
+		deployedAddress, err := chainutils.DeployAdjudicator(context.Background(), ethClient, nil)
 		if err != nil {
 			panic(err)
 		}

--- a/main.go
+++ b/main.go
@@ -30,12 +30,12 @@ func main() {
 	var msgPort, rpcPort, chainId int
 	var useNats, useDurableStore, deployContracts bool
 
-	flag.BoolVar(&deployContracts, "deploycontracts", false, "Specifies whether to deploy the adjudicator and create2deployer contracts.")
+	flag.BoolVar(&deployContracts, "autodeploy", false, "Specifies whether the RPC server should handle deploying/determining the address of the adjudicator contract.")
 	flag.BoolVar(&useNats, "usenats", false, "Specifies whether to use NATS or http/ws for the rpc server.")
 	flag.BoolVar(&useDurableStore, "usedurablestore", false, "Specifies whether to use a durable store or an in-memory store.")
 	flag.StringVar(&pkString, "pk", "2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d", "Specifies the private key for the client. Default is Alice's private key.")
 	flag.StringVar(&chainUrl, "chainurl", "ws://127.0.0.1:8545", "Specifies the url of a RPC endpoint for the chain.")
-	flag.StringVar(&naAddress, "naaddress", "0xC6A55E07566416274dBF020b5548eecEdB56290c", "Specifies the address of the nitro adjudicator contract. Default is the address computed by the Create2Deployer contract.")
+	flag.StringVar(&naAddress, "naaddress", "0x3f1E9229cd27051CF7eE76dc9579BCbF649509be", "Specifies the address of the nitro adjudicator contract. Default is the address computed by the Create2Deployer contract.")
 	flag.IntVar(&msgPort, "msgport", 3005, "Specifies the tcp port for the  message service.")
 	flag.IntVar(&rpcPort, "rpcport", 4005, "Specifies the tcp port for the rpc server.")
 	flag.IntVar(&chainId, "chainid", 1337, "Specifies the chain id of the chain.")
@@ -72,6 +72,8 @@ func main() {
 			naAddress = deployedAddress.String()
 		}
 	}
+
+	fmt.Printf("Using nitro adjudicator at %s\n", naAddress)
 
 	na, err := NitroAdjudicator.NewNitroAdjudicator(common.HexToAddress(naAddress), ethClient)
 	if err != nil {


### PR DESCRIPTION
Previously  if the `deploycontracts` flag was turned on we would deploy a `Create2Deployer` and then use that to deploy the nitro adjudicator.   However we would deploy a new `Create2Deployer` contract every time the RPC server is run. Each separate deployment of `Create2Deployer`  would compute a different address for the adjudicator, which means we'd just end up deploying a new adjudicator every time

This is workable but requires passing the adjudicator address to other RPC servers in a flag. You could:
1. Run one RPC server to deploy the contracts `go run . --deploycontracts`
2. Once the contracts have been deployed, pass in the adresss when starting other clients: `go run . --naaddress 0x3f1E9229cd27051CF7eE76dc9579BCbF649509be   -msgport 3007 -rpcport 4007 -pk febb3b74b0b52d0976f6571d555f4ac8b91c308dfa25c7b58d1e6a7c3f50c781`

However this is pretty painful and confusing; to avoid that this PR makes some changes to the contract deployment. Instead of deploying a `Create2Deployer` each time an RPC server is stared, we now look for it at a fixed address. If the `Create2Deployer` is not there we deploy it.  Having one fixed `Create2Deployer` means we get back the same `computedAddress` between RPC servers, so we don't have to pass that information around via flags.

I've also changed the flag name to `autodeploy. `deploycontracts` sounds like contracts will be always be deployed. However that's not always the case now; We may check the `Create2Deployer` and find an existing adjudicator address.  

To spin up multiple clients we can now just pass into the `autodeploy` flag:
1. `go run . --autodeploy`
2. `go run . --autodeploy  -msgport 3007 -rpcport 4007 -pk febb3b74b0b52d0976f6571d555f4ac8b91c308dfa25c7b58d1e6a7c3f50c781`

This results in one RPC server deploying any contracts (if needed) and any other RPC servers just connecting to the deployed contracts.