### PR TITLE
Add more query functions to the API

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -214,7 +214,7 @@ func (c *ConsensusChannel) Follower() common.Address {
 
 // FundingTargets returns a list of channels funded by the ConsensusChannel
 func (c *ConsensusChannel) FundingTargets() []types.Destination {
-	return c.current.Outcome.fundingTargets()
+	return c.current.Outcome.FundingTargets()
 }
 
 func (c *ConsensusChannel) Accept(p SignedProposal) error {
@@ -496,8 +496,8 @@ func (o *LedgerOutcome) AsOutcome() outcome.Exit {
 	}
 }
 
-// fundingTargets returns a list of channels funded by the LedgerOutcome
-func (o *LedgerOutcome) fundingTargets() []types.Destination {
+// FundingTargets returns a list of channels funded by the LedgerOutcome
+func (o LedgerOutcome) FundingTargets() []types.Destination {
 	targets := []types.Destination{}
 
 	for dest := range o.guarantees {

--- a/client/client.go
+++ b/client/client.go
@@ -255,6 +255,14 @@ func (c *Client) GetPaymentChannel(id types.Destination) (query.PaymentChannelIn
 	return query.GetPaymentChannelInfo(id, c.store, c.vm)
 }
 
+func (c *Client) GetPaymentChannelsByLedger(ledgerId types.Destination) ([]query.PaymentChannelInfo, error) {
+	return query.GetPaymentChannelsByLedger(ledgerId, c.store, c.vm)
+}
+
+func (c *Client) GetAllLedgerChannels() ([]query.LedgerChannelInfo, error) {
+	return query.GetAllLedgerChannels(c.store, c.engine.GetConsensusAppAddress())
+}
+
 // GetLedgerChannel returns the ledger channel with the given id.
 // If no ledger channel exists with the given id an error is returned.
 func (c *Client) GetLedgerChannel(id types.Destination) (query.LedgerChannelInfo, error) {

--- a/client/client.go
+++ b/client/client.go
@@ -255,10 +255,12 @@ func (c *Client) GetPaymentChannel(id types.Destination) (query.PaymentChannelIn
 	return query.GetPaymentChannelInfo(id, c.store, c.vm)
 }
 
+// GetPaymentChannelsByLedger returns all active payment channels that are funded by the given ledger channel.
 func (c *Client) GetPaymentChannelsByLedger(ledgerId types.Destination) ([]query.PaymentChannelInfo, error) {
 	return query.GetPaymentChannelsByLedger(ledgerId, c.store, c.vm)
 }
 
+// GetAllLedgerChannels returns all ledger channels.
 func (c *Client) GetAllLedgerChannels() ([]query.LedgerChannelInfo, error) {
 	return query.GetAllLedgerChannels(c.store, c.engine.GetConsensusAppAddress())
 }

--- a/client/engine/store/durablestore.go
+++ b/client/engine/store/durablestore.go
@@ -305,35 +305,6 @@ func (ds *DurableStore) GetChannelsByIds(ids []types.Destination) ([]*channel.Ch
 	return toReturn, nil
 }
 
-// GetObjectiveByChannelIds returns a collection of objectives for the given channel ids
-func (ds *DurableStore) GetObjectiveByChannelIds(ids []types.Destination) (map[types.Destination]protocols.Objective, error) {
-	toReturn := map[types.Destination]protocols.Objective{}
-	var err error
-
-	txError := ds.objectives.View(func(tx *buntdb.Tx) error {
-		return tx.Ascend("", func(key, objJSON string) bool {
-			var o protocols.Objective
-			o, err = decodeObjective(protocols.ObjectiveId(key), []byte(objJSON))
-			if err != nil {
-				return false
-			}
-			if !contains(ids, o.OwnsChannel()) {
-				toReturn[o.OwnsChannel()] = o
-			}
-
-			// Keep iterating through if we haven't found all the channels yet
-			return len(toReturn) < len(ids)
-		})
-	})
-	if txError != nil {
-		return map[types.Destination]protocols.Objective{}, txError
-	}
-	if err != nil {
-		return map[types.Destination]protocols.Objective{}, err
-	}
-	return toReturn, nil
-}
-
 // GetChannelsByAppDefinition returns any channels that include the given app definition
 func (ds *DurableStore) GetChannelsByAppDefinition(appDef types.Address) []*channel.Channel {
 	toReturn := []*channel.Channel{}

--- a/client/engine/store/durablestore.go
+++ b/client/engine/store/durablestore.go
@@ -310,7 +310,7 @@ func (ds *DurableStore) GetObjectiveByChannelIds(ids []types.Destination) (map[t
 	toReturn := map[types.Destination]protocols.Objective{}
 	var err error
 
-	txError := ds.channels.View(func(tx *buntdb.Tx) error {
+	txError := ds.objectives.View(func(tx *buntdb.Tx) error {
 		return tx.Ascend("", func(key, chJSON string) bool {
 			var o protocols.Objective
 			err = json.Unmarshal([]byte(chJSON), &o)

--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -210,7 +210,7 @@ func (ms *MemStore) GetChannelsByIds(ids []types.Destination) ([]*channel.Channe
 	return toReturn, nil
 }
 
-// GetChannelsByAppDefinition returns any channels that include the given participant
+// GetChannelsByAppDefinition returns any channels that include the given app definition
 func (ms *MemStore) GetChannelsByAppDefinition(appDef types.Address) []*channel.Channel {
 	toReturn := []*channel.Channel{}
 	ms.channels.Range(func(key string, chJSON []byte) bool {

--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -179,30 +179,6 @@ func (ms *MemStore) getChannelById(id types.Destination) (channel.Channel, error
 	return ch, nil
 }
 
-// GetObjectiveByChannelIds returns a collection of objectives for the given channel ids
-func (ms *MemStore) GetObjectiveByChannelIds(ids []types.Destination) (map[types.Destination]protocols.Objective, error) {
-	toReturn := map[types.Destination]protocols.Objective{}
-	var err error
-
-	ms.objectives.Range(func(key string, oJSON []byte) bool {
-		var o protocols.Objective
-		o, err = decodeObjective(protocols.ObjectiveId(key), []byte(oJSON))
-		if err != nil {
-			return false
-		}
-		if !contains(ids, o.OwnsChannel()) {
-			toReturn[o.OwnsChannel()] = o
-		}
-
-		// Keep iterating through if we haven't found all the channels yet
-		return len(toReturn) < len(ids)
-	})
-	if err != nil {
-		return map[types.Destination]protocols.Objective{}, err
-	}
-	return toReturn, nil
-}
-
 // GetChannelsByIds returns a collection of channels with the given ids
 func (ms *MemStore) GetChannelsByIds(ids []types.Destination) ([]*channel.Channel, error) {
 	toReturn := []*channel.Channel{}

--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -179,6 +179,37 @@ func (ms *MemStore) getChannelById(id types.Destination) (channel.Channel, error
 	return ch, nil
 }
 
+// GetChannelsByIds returns a collection of channels with the given ids
+func (ms *MemStore) GetChannelsByIds(ids []types.Destination) ([]*channel.Channel, error) {
+	toReturn := []*channel.Channel{}
+
+	var err error
+
+	ms.channels.Range(func(key string, chJSON []byte) bool {
+		var ch channel.Channel
+		err = json.Unmarshal(chJSON, &ch)
+		if err != nil {
+			return false
+		}
+
+		// If the channel is one of the ones we're looking for, add it to the list
+		if contains(ids, ch.Id) {
+			toReturn = append(toReturn, &ch)
+		}
+
+		// If we've found all the channels we need, stop looking
+		if len(toReturn) == len(ids) {
+			return false
+		}
+
+		return true // otherwise, continue looking
+	})
+	if err != nil {
+		return []*channel.Channel{}, err
+	}
+	return toReturn, nil
+}
+
 // GetChannelsByAppDefinition returns any channels that include the given participant
 func (ms *MemStore) GetChannelsByAppDefinition(appDef types.Address) []*channel.Channel {
 	toReturn := []*channel.Channel{}
@@ -442,4 +473,14 @@ func (ms *MemStore) GetVoucherInfo(channelId types.Destination) (v *payments.Vou
 func (ms *MemStore) RemoveVoucherInfo(channelId types.Destination) error {
 	ms.vouchers.Delete(channelId.String())
 	return nil
+}
+
+// contains is a helper function which returns true if the given item is included in col
+func contains[T types.Destination](col []T, item T) bool {
+	for _, i := range col {
+		if i == item {
+			return true
+		}
+	}
+	return false
 }

--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -211,13 +211,14 @@ func (ms *MemStore) GetChannelsByIds(ids []types.Destination) ([]*channel.Channe
 }
 
 // GetChannelsByAppDefinition returns any channels that include the given app definition
-func (ms *MemStore) GetChannelsByAppDefinition(appDef types.Address) []*channel.Channel {
+func (ms *MemStore) GetChannelsByAppDefinition(appDef types.Address) ([]*channel.Channel, error) {
 	toReturn := []*channel.Channel{}
+	var err error
 	ms.channels.Range(func(key string, chJSON []byte) bool {
 		var ch channel.Channel
-		err := json.Unmarshal(chJSON, &ch)
+		err = json.Unmarshal(chJSON, &ch)
 		if err != nil {
-			return true // channel not found, continue looking
+			return false
 		}
 		if ch.AppDefinition == appDef {
 			toReturn = append(toReturn, &ch)
@@ -226,7 +227,11 @@ func (ms *MemStore) GetChannelsByAppDefinition(appDef types.Address) []*channel.
 		return true // channel not found: continue looking
 	})
 
-	return toReturn
+	if err != nil {
+		return []*channel.Channel{}, err
+	}
+
+	return toReturn, nil
 }
 
 // GetChannelsByParticipant returns any channels that include the given participant

--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -179,6 +179,25 @@ func (ms *MemStore) getChannelById(id types.Destination) (channel.Channel, error
 	return ch, nil
 }
 
+// GetChannelsByAppDefinition returns any channels that include the given participant
+func (ms *MemStore) GetChannelsByAppDefinition(appDef types.Address) []*channel.Channel {
+	toReturn := []*channel.Channel{}
+	ms.channels.Range(func(key string, chJSON []byte) bool {
+		var ch channel.Channel
+		err := json.Unmarshal(chJSON, &ch)
+		if err != nil {
+			return true // channel not found, continue looking
+		}
+		if ch.AppDefinition == appDef {
+			toReturn = append(toReturn, &ch)
+		}
+
+		return true // channel not found: continue looking
+	})
+
+	return toReturn
+}
+
 // GetChannelsByParticipant returns any channels that include the given participant
 func (ms *MemStore) GetChannelsByParticipant(participant types.Address) []*channel.Channel {
 	toReturn := []*channel.Channel{}
@@ -243,6 +262,26 @@ func (ms *MemStore) GetConsensusChannel(counterparty types.Address) (channel *co
 	})
 
 	return
+}
+
+func (ms *MemStore) GetAllConsensusChannels() ([]*consensus_channel.ConsensusChannel, error) {
+	toReturn := []*consensus_channel.ConsensusChannel{}
+	var err error
+	ms.consensusChannels.Range(func(key string, chJSON []byte) bool {
+		var ch consensus_channel.ConsensusChannel
+
+		err = json.Unmarshal(chJSON, &ch)
+		if err != nil {
+			return false
+		}
+
+		toReturn = append(toReturn, &ch)
+		return true // channel not found: continue looking
+	})
+	if err != nil {
+		return nil, err
+	}
+	return toReturn, nil
 }
 
 func (ms *MemStore) GetObjectiveByChannelId(channelId types.Destination) (protocols.Objective, bool) {

--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -186,11 +186,13 @@ func (ms *MemStore) GetObjectiveByChannelIds(ids []types.Destination) (map[types
 
 	ms.objectives.Range(func(key string, oJSON []byte) bool {
 		var o protocols.Objective
-		err = json.Unmarshal(oJSON, &o)
+		o, err = decodeObjective(protocols.ObjectiveId(key), []byte(oJSON))
 		if err != nil {
 			return false
 		}
-		toReturn[o.OwnsChannel()] = o
+		if !contains(ids, o.OwnsChannel()) {
+			toReturn[o.OwnsChannel()] = o
+		}
 
 		// Keep iterating through if we haven't found all the channels yet
 		return len(toReturn) < len(ids)

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -29,8 +29,8 @@ type Store interface {
 	GetChannelsByParticipant(participant types.Address) []*channel.Channel // Returns any channels that includes the given participant
 	SetChannel(*channel.Channel) error
 	DestroyChannel(id types.Destination)
-	GetChannelsByAppDefinition(appDef types.Address) []*channel.Channel // Returns any channels that includes the given app definition
-	ReleaseChannelFromOwnership(types.Destination)                      // Release channel from being owned by any objective
+	GetChannelsByAppDefinition(appDef types.Address) ([]*channel.Channel, error) // Returns any channels that includes the given app definition
+	ReleaseChannelFromOwnership(types.Destination)                               // Release channel from being owned by any objective
 
 	ConsensusChannelStore
 	payments.VoucherStore

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -24,12 +24,12 @@ type Store interface {
 	GetObjectiveById(protocols.ObjectiveId) (protocols.Objective, error)          // Read an existing objective
 	GetObjectiveByChannelId(types.Destination) (obj protocols.Objective, ok bool) // Get the objective that currently owns the channel with the supplied ChannelId
 	SetObjective(protocols.Objective) error                                       // Write an objective
-	GetChannelsByIds(ids []types.Destination) ([]*channel.Channel, error)
+	GetChannelsByIds(ids []types.Destination) ([]*channel.Channel, error)         // Returns a collection of channels with the given ids
 	GetChannelById(id types.Destination) (c *channel.Channel, ok bool)
 	GetChannelsByParticipant(participant types.Address) []*channel.Channel // Returns any channels that includes the given participant
 	SetChannel(*channel.Channel) error
 	DestroyChannel(id types.Destination)
-	GetChannelsByAppDefinition(appDef types.Address) []*channel.Channel // Returns any channels that includes the given participant
+	GetChannelsByAppDefinition(appDef types.Address) []*channel.Channel // Returns any channels that includes the given app definition
 	ReleaseChannelFromOwnership(types.Destination)                      // Release channel from being owned by any objective
 
 	ConsensusChannelStore

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -19,9 +19,8 @@ var (
 
 // Store is responsible for persisting objectives, objective metadata, states, signatures, private keys and blockchain data
 type Store interface {
-	GetChannelSecretKey() *[]byte // Get a pointer to a secret key for signing channel updates
-	GetAddress() *types.Address   // Get the (Ethereum) address associated with the ChannelSecretKey
-	GetObjectiveByChannelIds(ids []types.Destination) (map[types.Destination]protocols.Objective, error)
+	GetChannelSecretKey() *[]byte                                                 // Get a pointer to a secret key for signing channel updates
+	GetAddress() *types.Address                                                   // Get the (Ethereum) address associated with the ChannelSecretKey
 	GetObjectiveById(protocols.ObjectiveId) (protocols.Objective, error)          // Read an existing objective
 	GetObjectiveByChannelId(types.Destination) (obj protocols.Objective, ok bool) // Get the objective that currently owns the channel with the supplied ChannelId
 	SetObjective(protocols.Objective) error                                       // Write an objective

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -21,7 +21,7 @@ var (
 type Store interface {
 	GetChannelSecretKey() *[]byte // Get a pointer to a secret key for signing channel updates
 	GetAddress() *types.Address   // Get the (Ethereum) address associated with the ChannelSecretKey
-
+	GetObjectiveByChannelIds(ids []types.Destination) (map[types.Destination]protocols.Objective, error)
 	GetObjectiveById(protocols.ObjectiveId) (protocols.Objective, error)          // Read an existing objective
 	GetObjectiveByChannelId(types.Destination) (obj protocols.Objective, ok bool) // Get the objective that currently owns the channel with the supplied ChannelId
 	SetObjective(protocols.Objective) error                                       // Write an objective

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -25,7 +25,7 @@ type Store interface {
 	GetObjectiveById(protocols.ObjectiveId) (protocols.Objective, error)          // Read an existing objective
 	GetObjectiveByChannelId(types.Destination) (obj protocols.Objective, ok bool) // Get the objective that currently owns the channel with the supplied ChannelId
 	SetObjective(protocols.Objective) error                                       // Write an objective
-
+	GetChannelsByIds(ids []types.Destination) ([]*channel.Channel, error)
 	GetChannelById(id types.Destination) (c *channel.Channel, ok bool)
 	GetChannelsByParticipant(participant types.Address) []*channel.Channel // Returns any channels that includes the given participant
 	SetChannel(*channel.Channel) error

--- a/client/engine/store/store.go
+++ b/client/engine/store/store.go
@@ -30,8 +30,8 @@ type Store interface {
 	GetChannelsByParticipant(participant types.Address) []*channel.Channel // Returns any channels that includes the given participant
 	SetChannel(*channel.Channel) error
 	DestroyChannel(id types.Destination)
-
-	ReleaseChannelFromOwnership(types.Destination) // Release channel from being owned by any objective
+	GetChannelsByAppDefinition(appDef types.Address) []*channel.Channel // Returns any channels that includes the given participant
+	ReleaseChannelFromOwnership(types.Destination)                      // Release channel from being owned by any objective
 
 	ConsensusChannelStore
 	payments.VoucherStore
@@ -39,6 +39,7 @@ type Store interface {
 }
 
 type ConsensusChannelStore interface {
+	GetAllConsensusChannels() ([]*consensus_channel.ConsensusChannel, error)
 	GetConsensusChannel(counterparty types.Address) (channel *consensus_channel.ConsensusChannel, ok bool)
 	GetConsensusChannelById(id types.Destination) (channel *consensus_channel.ConsensusChannel, err error)
 	SetConsensusChannel(*consensus_channel.ConsensusChannel) error

--- a/client/query/query.go
+++ b/client/query/query.go
@@ -159,7 +159,7 @@ func GetPaymentChannelsByLedger(ledgerId types.Destination, store store.Store, v
 	}
 	objectives, err := store.GetObjectiveByChannelIds(toQuery)
 	if err != nil {
-		return []PaymentChannelInfo{}, fmt.Errorf("could not query the store about ids %v: %w", toQuery, err)
+		return []PaymentChannelInfo{}, fmt.Errorf("could not query the store about objectives for ids %v: %w", toQuery, err)
 	}
 
 	toReturn := []PaymentChannelInfo{}

--- a/client/query/query.go
+++ b/client/query/query.go
@@ -139,7 +139,10 @@ func GetAllLedgerChannels(store store.Store, consensusAppDefinition types.Addres
 	for _, con := range allConsensus {
 		toReturn = append(toReturn, ConstructLedgerInfoFromConsensus(con))
 	}
-	allChannels := store.GetChannelsByAppDefinition(consensusAppDefinition)
+	allChannels, err := store.GetChannelsByAppDefinition(consensusAppDefinition)
+	if err != nil {
+		return []LedgerChannelInfo{}, err
+	}
 	for _, c := range allChannels {
 		toReturn = append(toReturn, ConstructLedgerInfoFromChannel(c))
 	}

--- a/client/query/query.go
+++ b/client/query/query.go
@@ -128,6 +128,7 @@ func GetPaymentChannelInfo(id types.Destination, store store.Store, vm *payments
 	return PaymentChannelInfo{}, fmt.Errorf("could not find channel with id %v", id)
 }
 
+// GetAllLedgerChannels returns a `LedgerChannelInfo` for each ledger channel in the store.
 func GetAllLedgerChannels(store store.Store, consensusAppDefinition types.Address) ([]LedgerChannelInfo, error) {
 	toReturn := []LedgerChannelInfo{}
 
@@ -145,6 +146,7 @@ func GetAllLedgerChannels(store store.Store, consensusAppDefinition types.Addres
 	return toReturn, nil
 }
 
+// GetPaymentChannelsByLedger returns a `PaymentChannelInfo` for each active payment channel funded by the given ledger channel.
 func GetPaymentChannelsByLedger(ledgerId types.Destination, s store.Store, vm *payments.VoucherManager) ([]PaymentChannelInfo, error) {
 	// If a ledger channel is actively funding payment channels it must be in the form of a consensus channel
 	con, err := s.GetConsensusChannelById(ledgerId)

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -132,6 +132,19 @@ func executeRpcTest(t *testing.T, connectionType transport.TransportType) {
 	<-rpcClientB.ObjectiveCompleteChan(closeIdB)
 	<-rpcClientI.ObjectiveCompleteChan(closeIdB)
 
+	if len(rpcClientA.GetPaymentChannelsByLedger(res.ChannelId)) != 0 {
+		t.Error("Alice should not have any payment channels open")
+	}
+	if len(rpcClientB.GetPaymentChannelsByLedger(bobResponse.ChannelId)) != 0 {
+		t.Error("Bob should not have any payment channels open")
+	}
+	if len(rpcClientI.GetPaymentChannelsByLedger(res.ChannelId)) != 0 {
+		t.Error("Irene should not have any payment channels open")
+	}
+	if len(rpcClientI.GetPaymentChannelsByLedger(bobResponse.ChannelId)) != 0 {
+		t.Error("Irene should not have any payment channels open")
+	}
+
 	expectedAliceLedgerNotifs := []query.LedgerChannelInfo{
 		expectedLedgerInfo(res.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Irene.Address(), 100, 100), query.Proposed),
 		expectedLedgerInfo(res.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Irene.Address(), 100, 100), query.Ready),

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -81,6 +81,14 @@ func (rc *RpcClient) GetLedgerChannel(id types.Destination) query.LedgerChannelI
 	return waitForRequest[serde.GetLedgerChannelRequest, query.LedgerChannelInfo](rc, serde.GetLedgerChannelRequestMethod, req)
 }
 
+func (rc *RpcClient) GetAllLedgerChannels() []query.LedgerChannelInfo {
+	return waitForRequest[serde.NoPayloadRequest, []query.LedgerChannelInfo](rc, serde.GetAllLedgerChannelsMethod, struct{}{})
+}
+
+func (rc *RpcClient) GetPaymentChannelsByLedger(ledgerId types.Destination) []query.PaymentChannelInfo {
+	return waitForRequest[serde.GetPaymentChannelsByLedgerRequest, []query.PaymentChannelInfo](rc, serde.GetPaymentChannelsByLedgerMethod, serde.GetPaymentChannelsByLedgerRequest{LedgerId: ledgerId})
+}
+
 // CreateLedger creates a new ledger channel
 func (rc *RpcClient) CreateLedger(counterparty types.Address, ChallengeDuration uint32, outcome outcome.Exit) directfund.ObjectiveResponse {
 	objReq := directfund.NewObjectiveRequest(

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -81,10 +81,12 @@ func (rc *RpcClient) GetLedgerChannel(id types.Destination) query.LedgerChannelI
 	return waitForRequest[serde.GetLedgerChannelRequest, query.LedgerChannelInfo](rc, serde.GetLedgerChannelRequestMethod, req)
 }
 
+// GetAllLedgerChannels returns all ledger channels
 func (rc *RpcClient) GetAllLedgerChannels() []query.LedgerChannelInfo {
 	return waitForRequest[serde.NoPayloadRequest, []query.LedgerChannelInfo](rc, serde.GetAllLedgerChannelsMethod, struct{}{})
 }
 
+// GetPaymentChannelsByLedger returns all active payment channels for a given ledger channel
 func (rc *RpcClient) GetPaymentChannelsByLedger(ledgerId types.Destination) []query.PaymentChannelInfo {
 	return waitForRequest[serde.GetPaymentChannelsByLedgerRequest, []query.PaymentChannelInfo](rc, serde.GetPaymentChannelsByLedgerMethod, serde.GetPaymentChannelsByLedgerRequest{LedgerId: ledgerId})
 }

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -51,7 +51,7 @@ func NewRpcClient(rpcServerUrl string, myAddress types.Address, logger zerolog.L
 func (rc *RpcClient) GetVirtualChannel(id types.Destination) query.PaymentChannelInfo {
 	req := serde.GetPaymentChannelRequest{Id: id}
 
-	return waitForRequest[serde.GetPaymentChannelRequest, query.PaymentChannelInfo](rc, req)
+	return waitForRequest[serde.GetPaymentChannelRequest, query.PaymentChannelInfo](rc, serde.GetPaymentChannelRequestMethod, req)
 }
 
 // CreateLedger creates a new ledger channel
@@ -64,7 +64,7 @@ func (rc *RpcClient) CreateVirtual(intermediaries []types.Address, counterparty 
 		rand.Uint64(),
 		common.Address{})
 
-	return waitForRequest[virtualfund.ObjectiveRequest, virtualfund.ObjectiveResponse](rc, objReq)
+	return waitForRequest[virtualfund.ObjectiveRequest, virtualfund.ObjectiveResponse](rc, serde.VirtualFundRequestMethod, objReq)
 }
 
 // CloseVirtual closes a virtual channel
@@ -72,13 +72,13 @@ func (rc *RpcClient) CloseVirtual(id types.Destination) protocols.ObjectiveId {
 	objReq := virtualdefund.NewObjectiveRequest(
 		id)
 
-	return waitForRequest[virtualdefund.ObjectiveRequest, protocols.ObjectiveId](rc, objReq)
+	return waitForRequest[virtualdefund.ObjectiveRequest, protocols.ObjectiveId](rc, serde.VirtualDefundRequestMethod, objReq)
 }
 
 func (rc *RpcClient) GetLedgerChannel(id types.Destination) query.LedgerChannelInfo {
 	req := serde.GetLedgerChannelRequest{Id: id}
 
-	return waitForRequest[serde.GetLedgerChannelRequest, query.LedgerChannelInfo](rc, req)
+	return waitForRequest[serde.GetLedgerChannelRequest, query.LedgerChannelInfo](rc, serde.GetLedgerChannelRequestMethod, req)
 }
 
 // CreateLedger creates a new ledger channel
@@ -90,21 +90,21 @@ func (rc *RpcClient) CreateLedger(counterparty types.Address, ChallengeDuration 
 		rand.Uint64(),
 		common.Address{})
 
-	return waitForRequest[directfund.ObjectiveRequest, directfund.ObjectiveResponse](rc, objReq)
+	return waitForRequest[directfund.ObjectiveRequest, directfund.ObjectiveResponse](rc, serde.DirectFundRequestMethod, objReq)
 }
 
 // CloseLedger closes a ledger channel
 func (rc *RpcClient) CloseLedger(id types.Destination) protocols.ObjectiveId {
 	objReq := directdefund.NewObjectiveRequest(id)
 
-	return waitForRequest[directdefund.ObjectiveRequest, protocols.ObjectiveId](rc, objReq)
+	return waitForRequest[directdefund.ObjectiveRequest, protocols.ObjectiveId](rc, serde.DirectDefundRequestMethod, objReq)
 }
 
 // Pay uses the specified channel to pay the specified amount
 func (rc *RpcClient) Pay(id types.Destination, amount uint64) {
 	pReq := serde.PaymentRequest{Amount: amount, Channel: id}
 
-	waitForRequest[serde.PaymentRequest, serde.PaymentRequest](rc, pReq)
+	waitForRequest[serde.PaymentRequest, serde.PaymentRequest](rc, serde.PayRequestMethod, pReq)
 }
 
 func (rc *RpcClient) Close() {
@@ -154,8 +154,8 @@ func (rc *RpcClient) subscribeToNotifications() error {
 	return err
 }
 
-func waitForRequest[T serde.RequestPayload, U serde.ResponsePayload](rc *RpcClient, requestData T) U {
-	resChan, err := request[T, U](rc.transport, requestData, rc.logger)
+func waitForRequest[T serde.RequestPayload, U serde.ResponsePayload](rc *RpcClient, method serde.RequestMethod, requestData T) U {
+	resChan, err := request[T, U](rc.transport, method, requestData, rc.logger)
 	if err != nil {
 		panic(err)
 	}
@@ -188,28 +188,13 @@ func (rc *RpcClient) PaymentChannelUpdatesChan(paymentChannelId types.Destinatio
 
 // request uses the supplied transport and payload to send a non-blocking JSONRPC request.
 // It returns a channel that sends a response payload. If the request fails to send, an error is returned.
-func request[T serde.RequestPayload, U serde.ResponsePayload](trans transport.Requester, request T, logger zerolog.Logger) (<-chan response[U], error) {
+func request[T serde.RequestPayload, U serde.ResponsePayload](trans transport.Requester, method serde.RequestMethod, reqPayload T, logger zerolog.Logger) (<-chan response[U], error) {
+	return sendRPCRequest[T, U](method, reqPayload, trans, logger)
+}
+
+func sendRPCRequest[T serde.RequestPayload, U serde.ResponsePayload](method serde.RequestMethod, request T, trans transport.Requester, logger zerolog.Logger) (<-chan response[U], error) {
 	returnChan := make(chan response[U], 1)
 
-	var method serde.RequestMethod
-	switch any(request).(type) {
-	case directfund.ObjectiveRequest:
-		method = serde.DirectFundRequestMethod
-	case directdefund.ObjectiveRequest:
-		method = serde.DirectDefundRequestMethod
-	case virtualfund.ObjectiveRequest:
-		method = serde.VirtualFundRequestMethod
-	case virtualdefund.ObjectiveRequest:
-		method = serde.VirtualDefundRequestMethod
-	case serde.PaymentRequest:
-		method = serde.PayRequestMethod
-	case serde.GetLedgerChannelRequest:
-		method = serde.GetLedgerChannelRequestMethod
-	case serde.GetPaymentChannelRequest:
-		method = serde.GetPaymentChannelRequestMethod
-	default:
-		return nil, fmt.Errorf("unknown request type %v", request)
-	}
 	requestId := rand.Uint64()
 	message := serde.NewJsonRpcRequest(requestId, method, request)
 	data, err := json.Marshal(message)
@@ -237,7 +222,6 @@ func request[T serde.RequestPayload, U serde.ResponsePayload](trans transport.Re
 
 		returnChan <- response[U]{jsonResponse.Result, nil}
 	}()
-
 	return returnChan, nil
 }
 

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -13,15 +13,17 @@ import (
 type RequestMethod string
 
 const (
-	GetAddressMethod               RequestMethod = "get_address"
-	VersionMethod                  RequestMethod = "version"
-	DirectFundRequestMethod        RequestMethod = "direct_fund"
-	DirectDefundRequestMethod      RequestMethod = "direct_defund"
-	VirtualFundRequestMethod       RequestMethod = "virtual_fund"
-	VirtualDefundRequestMethod     RequestMethod = "virtual_defund"
-	PayRequestMethod               RequestMethod = "pay"
-	GetPaymentChannelRequestMethod RequestMethod = "get_payment_channel"
-	GetLedgerChannelRequestMethod  RequestMethod = "get_ledger_channel"
+	GetAddressMethod                 RequestMethod = "get_address"
+	VersionMethod                    RequestMethod = "version"
+	DirectFundRequestMethod          RequestMethod = "direct_fund"
+	DirectDefundRequestMethod        RequestMethod = "direct_defund"
+	VirtualFundRequestMethod         RequestMethod = "virtual_fund"
+	VirtualDefundRequestMethod       RequestMethod = "virtual_defund"
+	PayRequestMethod                 RequestMethod = "pay"
+	GetPaymentChannelRequestMethod   RequestMethod = "get_payment_channel"
+	GetLedgerChannelRequestMethod    RequestMethod = "get_ledger_channel"
+	GetPaymentChannelsByLedgerMethod RequestMethod = "get_payment_channels_by_ledger"
+	GetAllLedgerChannelsMethod       RequestMethod = "get_all_ledger_channels"
 )
 
 type NotificationMethod string
@@ -48,6 +50,9 @@ type GetPaymentChannelRequest struct {
 type GetLedgerChannelRequest struct {
 	Id types.Destination
 }
+type GetPaymentChannelsByLedgerRequest struct {
+	LedgerId types.Destination
+}
 
 type (
 	NoPayloadRequest = struct{}
@@ -61,6 +66,7 @@ type RequestPayload interface {
 		PaymentRequest |
 		GetLedgerChannelRequest |
 		GetPaymentChannelRequest |
+		GetPaymentChannelsByLedgerRequest |
 		NoPayloadRequest
 }
 
@@ -77,18 +83,24 @@ type JsonRpcRequest[T RequestPayload | NotificationPayload] struct {
 	Params  T      `json:"params"`
 }
 
+type VersionResponse = string
+
 type (
-	VersionResponse = string
-	ResponsePayload interface {
-		directfund.ObjectiveResponse |
-			protocols.ObjectiveId |
-			virtualfund.ObjectiveResponse |
-			PaymentRequest |
-			query.PaymentChannelInfo |
-			query.LedgerChannelInfo |
-			VersionResponse
-	}
+	GetAllLedgersResponse              = []query.LedgerChannelInfo
+	GetPaymentChannelsByLedgerResponse = []query.PaymentChannelInfo
 )
+
+type ResponsePayload interface {
+	directfund.ObjectiveResponse |
+		protocols.ObjectiveId |
+		virtualfund.ObjectiveResponse |
+		PaymentRequest |
+		query.PaymentChannelInfo |
+		query.LedgerChannelInfo |
+		VersionResponse |
+		GetAllLedgersResponse |
+		GetPaymentChannelsByLedgerResponse
+}
 
 type JsonRpcResponse[T ResponsePayload] struct {
 	Jsonrpc string      `json:"jsonrpc"`

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -118,6 +118,24 @@ func (rs *RpcServer) registerHandlers() (err error) {
 				}
 				return l
 			})
+		case serde.GetAllLedgerChannelsMethod:
+			return processRequest(rs, requestData, func(r serde.NoPayloadRequest) []query.LedgerChannelInfo {
+				ledgers, err := rs.client.GetAllLedgerChannels()
+				if err != nil {
+					// TODO: What's the best way to handle this error?
+					panic(err)
+				}
+				return ledgers
+			})
+		case serde.GetPaymentChannelsByLedgerMethod:
+			return processRequest(rs, requestData, func(r serde.GetPaymentChannelsByLedgerRequest) []query.PaymentChannelInfo {
+				payChs, err := rs.client.GetPaymentChannelsByLedger(r.LedgerId)
+				if err != nil {
+					// TODO: What's the best way to handle this error?
+					panic(err)
+				}
+				return payChs
+			})
 		default:
 			responseErr := methodNotFoundError
 			responseErr.Id = validationResult.Id


### PR DESCRIPTION
Adds two new query functions to the API and RPC API:
- `GetAllLedgerChannels` : Returns a `query.LedgerChannelInfo` for each ledger channel in the store. We check both the store's `consensuschannels`s as well as the store's `channels`.
- `GetPaymentChannelsByLedger` Returns all payment channels that are being actively funded by the ledger channel. We iterate through a ledger channel's `FundingTargets` and return a `query.PaymentChannelInfo` for each one.

The rpc test has been updated with some basic checks of these new query functions.

To support these new query functions a few functions have been added to the store interface. Allowing us to fetch channels in bulk.