### PR TITLE
Clean up chain service construction

### DIFF
--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rs/zerolog"
 	NitroAdjudicator "github.com/statechannels/go-nitro/client/engine/chainservice/adjudicator"
 	Token "github.com/statechannels/go-nitro/client/engine/chainservice/erc20"
+	chainutils "github.com/statechannels/go-nitro/client/engine/chainservice/utils"
 	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
@@ -58,6 +59,21 @@ const MAX_QUERY_BLOCK_RANGE = 2000
 // We use 2.5 minutes as the default filter timeout is 5 minutes.
 // See https://github.com/ethereum/go-ethereum/blob/e14164d516600e9ac66f9060892e078f5c076229/eth/filters/filter_system.go#L43
 const RESUB_INTERVAL = 2*time.Minute + 30*time.Second
+
+// NewEthChainService2 is a convenient wrapper around NewEthChainService, which provides a simpler API
+func NewEthChainService2(chainUrl, chainPk string, chainId int, naAddress, caAddress, vpaAddress common.Address, logDestination io.Writer) (*EthChainService, error) {
+	ethClient, txSigner, err := chainutils.ConnectToChain(context.Background(), chainUrl, chainId, common.Hex2Bytes(chainPk))
+	if err != nil {
+		panic(err)
+	}
+
+	na, err := NitroAdjudicator.NewNitroAdjudicator(naAddress, ethClient)
+	if err != nil {
+		panic(err)
+	}
+
+	return NewEthChainService(ethClient, na, naAddress, caAddress, vpaAddress, txSigner, logDestination)
+}
 
 // NewEthChainService constructs a chain service that submits transactions to a NitroAdjudicator
 // and listens to events from an eventSource

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -60,8 +60,8 @@ const MAX_QUERY_BLOCK_RANGE = 2000
 // See https://github.com/ethereum/go-ethereum/blob/e14164d516600e9ac66f9060892e078f5c076229/eth/filters/filter_system.go#L43
 const RESUB_INTERVAL = 2*time.Minute + 30*time.Second
 
-// NewEthChainService2 is a convenient wrapper around NewEthChainService, which provides a simpler API
-func NewEthChainService2(chainUrl, chainPk string, naAddress, caAddress, vpaAddress common.Address, logDestination io.Writer) (*EthChainService, error) {
+// NewEthChainService is a convenient wrapper around NewEthChainService, which provides a simpler API
+func NewEthChainService(chainUrl, chainPk string, naAddress, caAddress, vpaAddress common.Address, logDestination io.Writer) (*EthChainService, error) {
 	ethClient, txSigner, err := chainutils.ConnectToChain(context.Background(), chainUrl, common.Hex2Bytes(chainPk))
 	if err != nil {
 		panic(err)
@@ -72,12 +72,12 @@ func NewEthChainService2(chainUrl, chainPk string, naAddress, caAddress, vpaAddr
 		panic(err)
 	}
 
-	return NewEthChainService(ethClient, na, naAddress, caAddress, vpaAddress, txSigner, logDestination)
+	return newEthChainService(ethClient, na, naAddress, caAddress, vpaAddress, txSigner, logDestination)
 }
 
 // NewEthChainService constructs a chain service that submits transactions to a NitroAdjudicator
 // and listens to events from an eventSource
-func NewEthChainService(chain ethChain, na *NitroAdjudicator.NitroAdjudicator,
+func newEthChainService(chain ethChain, na *NitroAdjudicator.NitroAdjudicator,
 	naAddress, caAddress, vpaAddress common.Address, txSigner *bind.TransactOpts, logDestination io.Writer,
 ) (*EthChainService, error) {
 	logging.ConfigureZeroLogger()

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -61,8 +61,8 @@ const MAX_QUERY_BLOCK_RANGE = 2000
 const RESUB_INTERVAL = 2*time.Minute + 30*time.Second
 
 // NewEthChainService2 is a convenient wrapper around NewEthChainService, which provides a simpler API
-func NewEthChainService2(chainUrl, chainPk string, chainId int, naAddress, caAddress, vpaAddress common.Address, logDestination io.Writer) (*EthChainService, error) {
-	ethClient, txSigner, err := chainutils.ConnectToChain(context.Background(), chainUrl, chainId, common.Hex2Bytes(chainPk))
+func NewEthChainService2(chainUrl, chainPk string, naAddress, caAddress, vpaAddress common.Address, logDestination io.Writer) (*EthChainService, error) {
+	ethClient, txSigner, err := chainutils.ConnectToChain(context.Background(), chainUrl, common.Hex2Bytes(chainPk))
 	if err != nil {
 		panic(err)
 	}

--- a/client/engine/chainservice/eth_chainservice_FEVM_test.go
+++ b/client/engine/chainservice/eth_chainservice_FEVM_test.go
@@ -91,7 +91,7 @@ func testAgainstEndpoint(t *testing.T, endpoint string, logFile string, pk *ecds
 	}
 
 	logDestination := newLogWriter(logFile)
-	cs, err := NewEthChainService(client, na, naAddress, caAddress, vpaAddress, txSubmitter, logDestination)
+	cs, err := newEthChainService(client, na, naAddress, caAddress, vpaAddress, txSubmitter, logDestination)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/engine/chainservice/simulated_backend_chainservice.go
+++ b/client/engine/chainservice/simulated_backend_chainservice.go
@@ -62,7 +62,7 @@ type SimulatedBackendChainService struct {
 func NewSimulatedBackendChainService(sim SimulatedChain, bindings Bindings,
 	txSigner *bind.TransactOpts, logDestination io.Writer,
 ) (ChainService, error) {
-	ethChainService, err := NewEthChainService(sim,
+	ethChainService, err := newEthChainService(sim,
 		bindings.Adjudicator.Contract,
 		bindings.Adjudicator.Address,
 		bindings.ConsensusApp.Address,

--- a/client/engine/chainservice/utils/utils.go
+++ b/client/engine/chainservice/utils/utils.go
@@ -3,7 +3,6 @@ package chainutils
 import (
 	"context"
 	"fmt"
-	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
@@ -11,7 +10,7 @@ import (
 )
 
 // ConnectToChain connects to the chain at the given url and returns a client and a transactor.
-func ConnectToChain(ctx context.Context, chainUrl string, chainId int, chainPK []byte) (*ethclient.Client, *bind.TransactOpts, error) {
+func ConnectToChain(ctx context.Context, chainUrl string, chainPK []byte) (*ethclient.Client, *bind.TransactOpts, error) {
 	client, err := ethclient.Dial(chainUrl)
 	if err != nil {
 		return nil, nil, err
@@ -20,14 +19,12 @@ func ConnectToChain(ctx context.Context, chainUrl string, chainId int, chainPK [
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not get chain id: %w", err)
 	}
-	if foundChainId.Cmp(big.NewInt(int64(chainId))) != 0 {
-		return nil, nil, fmt.Errorf("chain id mismatch: expected %d, got %d", chainId, foundChainId)
-	}
+
 	key, err := ethcrypto.ToECDSA(chainPK)
 	if err != nil {
 		return nil, nil, err
 	}
-	txSubmitter, err := bind.NewKeyedTransactorWithChainID(key, big.NewInt(int64(chainId)))
+	txSubmitter, err := bind.NewKeyedTransactorWithChainID(key, foundChainId)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -35,10 +35,9 @@ func main() {
 		NA_ADDRESS        = "naaddress"
 		MSG_PORT          = "msgport"
 		RPC_PORT          = "rpcport"
-		CHAIN_ID          = "chainid"
 	)
 	var pkString, chainUrl, naAddress, chainPk string
-	var msgPort, rpcPort, chainId int
+	var msgPort, rpcPort int
 	var useNats, useDurableStore bool
 
 	flags := []cli.Flag{
@@ -101,14 +100,6 @@ func main() {
 			Category:    "Connectivity:",
 			Destination: &rpcPort,
 		}),
-		altsrc.NewIntFlag(&cli.IntFlag{
-			Name:        CHAIN_ID,
-			Usage:       "Specifies the chain id of the chain.",
-			Value:       1337,
-			DefaultText: "hardhat default",
-			Category:    "Connectivity:",
-			Destination: &chainId,
-		}),
 	}
 	app := &cli.App{
 		Name:   "go-nitro",
@@ -138,8 +129,8 @@ func main() {
 				ourStore = store.NewMemStore(pk)
 			}
 
-			fmt.Println("Initializing chain service and connecting to " + chainUrl + " with chain id " + fmt.Sprint(chainId) + "...")
-			chainService, err := chainservice.NewEthChainService2(chainUrl, chainPk, chainId, common.HexToAddress(naAddress), common.Address{}, common.Address{}, os.Stdout)
+			fmt.Println("Initializing chain service and connecting to " + chainUrl + "...")
+			chainService, err := chainservice.NewEthChainService2(chainUrl, chainPk, common.HexToAddress(naAddress), common.Address{}, common.Address{}, os.Stdout)
 			if err != nil {
 				panic(err)
 			}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"os"
@@ -13,8 +12,6 @@ import (
 	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine"
 	"github.com/statechannels/go-nitro/client/engine/chainservice"
-	NitroAdjudicator "github.com/statechannels/go-nitro/client/engine/chainservice/adjudicator"
-	chainutils "github.com/statechannels/go-nitro/client/engine/chainservice/utils"
 	p2pms "github.com/statechannels/go-nitro/client/engine/messageservice/p2p-message-service"
 	"github.com/statechannels/go-nitro/client/engine/store"
 	"github.com/statechannels/go-nitro/crypto"
@@ -141,18 +138,8 @@ func main() {
 				ourStore = store.NewMemStore(pk)
 			}
 
-			fmt.Println("Connecting to chain " + chainUrl + " with chain id " + fmt.Sprint(chainId) + "...")
-			ethClient, txSubmitter, err := chainutils.ConnectToChain(context.Background(), chainUrl, chainId, common.Hex2Bytes(chainPk))
-			if err != nil {
-				panic(err)
-			}
-
-			na, err := NitroAdjudicator.NewNitroAdjudicator(common.HexToAddress(naAddress), ethClient)
-			if err != nil {
-				panic(err)
-			}
-
-			chainService, err := chainservice.NewEthChainService(ethClient, na, common.HexToAddress(naAddress), common.Address{}, common.Address{}, txSubmitter, os.Stdout)
+			fmt.Println("Initializing chain service and connecting to " + chainUrl + " with chain id " + fmt.Sprint(chainId) + "...")
+			chainService, err := chainservice.NewEthChainService2(chainUrl, chainPk, chainId, common.HexToAddress(naAddress), common.Address{}, common.Address{}, os.Stdout)
 			if err != nil {
 				panic(err)
 			}

--- a/main.go
+++ b/main.go
@@ -130,7 +130,7 @@ func main() {
 			}
 
 			fmt.Println("Initializing chain service and connecting to " + chainUrl + "...")
-			chainService, err := chainservice.NewEthChainService2(chainUrl, chainPk, common.HexToAddress(naAddress), common.Address{}, common.Address{}, os.Stdout)
+			chainService, err := chainservice.NewEthChainService(chainUrl, chainPk, common.HexToAddress(naAddress), common.Address{}, common.Address{}, os.Stdout)
 			if err != nil {
 				panic(err)
 			}

--- a/scripts/start-rpc-servers.go
+++ b/scripts/start-rpc-servers.go
@@ -163,7 +163,7 @@ func newColorWriter(c color, w io.Writer) colorWriter {
 
 // deployAdjudicator deploys the  NitroAdjudicator contract.
 func deployAdjudicator(ctx context.Context) (common.Address, error) {
-	client, txSubmitter, err := chainutils.ConnectToChain(context.Background(), "ws://127.0.0.1:8545", 1337, common.Hex2Bytes(FUNDED_TEST_PK))
+	client, txSubmitter, err := chainutils.ConnectToChain(context.Background(), "ws://127.0.0.1:8545", common.Hex2Bytes(FUNDED_TEST_PK))
 	if err != nil {
 		return types.Address{}, err
 	}


### PR DESCRIPTION
Closes #1270

This removes `chainId` entirely from the "production constructor".

NOTE: needs some changes in testground repo to get CI passing


