### PR TITLE
Fix RPC Server exitting immediately 

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/rs/zerolog"
@@ -192,6 +194,10 @@ func main() {
 			}
 
 			fmt.Println("Nitro as a Service listening on port", rpcPort)
+
+			stopChan := make(chan os.Signal, 2)
+			signal.Notify(stopChan, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
+			<-stopChan // wait for interrupt or terminate signal
 
 			return nil
 		},


### PR DESCRIPTION
With the change to the `urFave` CLI library we removed the wait for an interrupt/terminate signal. This means that the RPC server program exits immediately after it's done setting everything up. **It does not continue to run and listen for RPC requests.**
```shell
❯ go run . -naaddress 0x8464135c8F25Da09e49BC8782676a84730C318bC -config ./scripts/test-configs/alice.toml
Initialising durable store...
Connecting to chain ws://127.0.0.1:8545 with chain id 1337...
Initializing message service on port 3005...
{"level":"debug","engine":"0xAAA662","time":1683919244668,"caller":"engine.go:151","message":"Constructed Engine"}
Initializing websocketNATS RPC transport...
Nitro as a Service listening on port 4005
  ~/code/go-nitro on   main *42 ······
```

This PR adds back waiting for an interrupt/terminate signal. This means the RPC server will continue to run until it's terminated with `ctrl+C`, which is the behaviour we want.