### PR TITLE
Do not generate Create2Deployer bindings

### DIFF
--- a/generate-adjudicator-bindings.sh
+++ b/generate-adjudicator-bindings.sh
@@ -18,7 +18,6 @@ runAbigen "NitroAdjudicator" "adjudicator"
 runAbigen "ConsensusApp" "consensusapp"
 runAbigen "Token" "erc20"
 runAbigen "VirtualPaymentApp" "virtualpaymentapp"
-runAbigen "Create2Deployer" "create2deployer"
 
 rm -rf $(pwd)/tmp-build
 echo "Deleted tmp-build directory."


### PR DESCRIPTION
Now that we've removed the `Create2Deployer` artifacts from go-nitro, we no longer want to generate them as well. 

Since there is no  `Create2Deployer` folder is `go-nitro` anymore this actually causes the `generate-adjudicator-bindings.sh` script to fail.  This caused the [failure on main](https://github.com/statechannels/go-nitro)