### PR TITLE
Allow requests from any Origin

### DIFF
--- a/rpc/transport/ws/server.go
+++ b/rpc/transport/ws/server.go
@@ -105,8 +105,8 @@ func (wsc *serverWebSocketTransport) request(w http.ResponseWriter, r *http.Requ
 }
 
 func (wsc *serverWebSocketTransport) subscribe(w http.ResponseWriter, r *http.Request) {
-	// Allow all localhost origins to connect via websocket
-	opts := &websocket.AcceptOptions{OriginPatterns: []string{"*localhost*"}}
+	// TODO: We currently allow requests from any origins. We should probably use a whitelist.
+	opts := &websocket.AcceptOptions{InsecureSkipVerify: true}
 	c, err := websocket.Accept(w, r, opts)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This PR allows the RPC server to accept requests from any hosts, not just those coming from `localhost`. This will avoid issues with requests coming from a `netlify` domain being rejected. Note that the documentation says to use `InsecureSkipVerify` instead of `OriginPatterns: *`
```
	// Do not use * as a pattern to allow any origin, prefer to use InsecureSkipVerify instead
	// to bring attention to the danger of such a setting.
```

Longer term we may want to accept the allowable origins in as a config, so an RPC server can be started up with a specific list of allowable origins.