### PR TITLE
Fix zeroed consensus channel sneaking into data

### DIFF
--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -621,13 +621,7 @@ func (e *Engine) generateNotifications(o protocols.Objective) (EngineEvent, erro
 
 			}
 		case *consensus_channel.ConsensusChannel:
-
-			// TODO: Some of the related consensus channels are zeroed out (possibly deleted?)
-			// For now we just ignore them
-			if !c.Id.IsZero() {
-				outgoing.LedgerChannelUpdates = append(outgoing.LedgerChannelUpdates, query.ConstructLedgerInfoFromConsensus(c))
-			}
-
+			outgoing.LedgerChannelUpdates = append(outgoing.LedgerChannelUpdates, query.ConstructLedgerInfoFromConsensus(c))
 		default:
 			return outgoing, fmt.Errorf("handleNotifications: Unknown related type %T", c)
 		}

--- a/client/engine/store/durablestore.go
+++ b/client/engine/store/durablestore.go
@@ -212,6 +212,9 @@ func (ds *DurableStore) DestroyChannel(id types.Destination) {
 
 // SetConsensusChannel sets the channel in the store.
 func (ps *DurableStore) SetConsensusChannel(ch *consensus_channel.ConsensusChannel) error {
+	if ch.Id.IsZero() {
+		return fmt.Errorf("cannot store a channel with a zero id")
+	}
 	chJSON, err := ch.MarshalJSON()
 	if err != nil {
 		return err

--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -138,6 +138,9 @@ func (ms *MemStore) DestroyChannel(id types.Destination) {
 
 // SetConsensusChannel sets the channel in the store.
 func (ms *MemStore) SetConsensusChannel(ch *consensus_channel.ConsensusChannel) error {
+	if ch.Id.IsZero() {
+		return fmt.Errorf("cannot store a channel with a zero id")
+	}
 	chJSON, err := ch.MarshalJSON()
 	if err != nil {
 		return err

--- a/protocols/virtualdefund/serde.go
+++ b/protocols/virtualdefund/serde.go
@@ -64,11 +64,16 @@ func (o *Objective) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &jsonVFO); err != nil {
 		return fmt.Errorf("failed to unmarshal the VirtualDefundObjective: %w", err)
 	}
+	empty := types.Destination{}
 
-	o.ToMyLeft = &consensus_channel.ConsensusChannel{}
-	o.ToMyLeft.Id = jsonVFO.ToMyLeft
-	o.ToMyRight = &consensus_channel.ConsensusChannel{}
-	o.ToMyRight.Id = jsonVFO.ToMyRight
+	if jsonVFO.ToMyLeft != empty {
+		o.ToMyLeft = &consensus_channel.ConsensusChannel{}
+		o.ToMyLeft.Id = jsonVFO.ToMyLeft
+	}
+	if jsonVFO.ToMyRight != empty {
+		o.ToMyRight = &consensus_channel.ConsensusChannel{}
+		o.ToMyRight.Id = jsonVFO.ToMyRight
+	}
 
 	o.Status = jsonVFO.Status
 


### PR DESCRIPTION
Previously when unmarshalling a virtual defund objective we'd set `ToMyLeft/ToMyRight` to a zeroed consensus channel, and then override the channel id. However we don't check for the case when there isn't a `ToMyLeft/ToMyRight`, so if a virtual defund objective with a `nil` `ToMyLeft/ToMyRight` is serialized then deserialized it will have a zerroed consensus channel for `ToMyLeft/ToMyRight`. This ends up breaking lots of check and assumptions.

This PR:
- Updates the store to return an error if trying to call `SetConsensusChannel` with a zeroed channel id. This is a sanity check that would of caught this earlier.
- Only sets `ToMyRight/ToMyLeft` if we have a non-zero channel id when deserializing the virtual defund objective,