### PR TITLE
Proliferate `VirtualChannel` type

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -321,3 +321,27 @@ func (c *Channel) SignAndAddState(s state.State, sk *[]byte) (state.SignedState,
 	}
 	return ss, nil
 }
+
+type Status string
+
+// TODO: Think through statuses
+const (
+	Proposed Status = "Proposed"
+	Open     Status = "Open"
+	Closing  Status = "Closing"
+	Complete Status = "Complete"
+)
+
+func (c *Channel) Status() Status {
+	if c.FinalSignedByMe() {
+		if c.FinalCompleted() {
+			return Complete
+		}
+		return Closing
+	}
+
+	if !c.PostFundComplete() {
+		return Proposed
+	}
+	return Open
+}

--- a/channel/virtual.go
+++ b/channel/virtual.go
@@ -39,3 +39,15 @@ func (v *VirtualChannel) Clone() *VirtualChannel {
 	w := VirtualChannel{*v.Channel.Clone()}
 	return &w
 }
+
+func (v *VirtualChannel) Status() Status {
+	s := v.Channel.Status()
+
+	// ADR 0009 allows for intermediaries to exit the protocol before receiving all signed post funds
+	// So for intermediaries we return Open once they have signed their post fund state
+	amIntermediary := v.MyIndex != 0 && v.MyIndex != uint(len(v.Participants)-1)
+	if amIntermediary && v.PostFundSignedByMe() {
+		s = Open
+	}
+	return s
+}

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -372,7 +372,7 @@ func (e *Engine) handleMessage(message protocols.Message) (EngineEvent, error) {
 		if err != nil {
 			return EngineEvent{}, err
 		}
-		info, err := query.ConstructPaymentInfo(c, paid, remaining)
+		info, err := query.ConstructPaymentInfo(&channel.VirtualChannel{Channel: *c}, paid, remaining)
 		if err != nil {
 			return EngineEvent{}, err
 		}
@@ -599,27 +599,18 @@ func (e *Engine) generateNotifications(o protocols.Objective) (EngineEvent, erro
 
 	for _, rel := range o.Related() {
 		switch c := rel.(type) {
-		case *channel.Channel:
-			// If we're in direct funding/defunding then we're dealing with a leadger channel
-			_, isDF := o.(*directfund.Objective)
-			_, isDDF := o.(*directdefund.Objective)
-			if isDDF || isDF {
-				outgoing.LedgerChannelUpdates = append(outgoing.LedgerChannelUpdates, query.ConstructLedgerInfoFromChannel(c))
-			} else { // otherwise we must have a payment channel
-
-				paid, remaining, err := query.GetVoucherBalance(c.Id, e.vm)
-				if err != nil {
-					return outgoing, err
-				}
-
-				info, err := query.ConstructPaymentInfo(c, paid, remaining)
-				if err != nil {
-					return outgoing, err
-				}
-
-				outgoing.PaymentChannelUpdates = append(outgoing.PaymentChannelUpdates, info)
-
+		case *channel.VirtualChannel:
+			paid, remaining, err := query.GetVoucherBalance(c.Id, e.vm)
+			if err != nil {
+				return outgoing, err
 			}
+			info, err := query.ConstructPaymentInfo(c, paid, remaining)
+			if err != nil {
+				return outgoing, err
+			}
+			outgoing.PaymentChannelUpdates = append(outgoing.PaymentChannelUpdates, info)
+		case *channel.Channel:
+			outgoing.LedgerChannelUpdates = append(outgoing.LedgerChannelUpdates, query.ConstructLedgerInfoFromChannel(c))
 		case *consensus_channel.ConsensusChannel:
 			outgoing.LedgerChannelUpdates = append(outgoing.LedgerChannelUpdates, query.ConstructLedgerInfoFromConsensus(c))
 		default:

--- a/client/engine/store/durablestore.go
+++ b/client/engine/store/durablestore.go
@@ -517,7 +517,7 @@ func (ds *DurableStore) populateChannelData(obj protocols.Objective) error {
 		if err != nil {
 			return fmt.Errorf("error retrieving virtual channel data for objective %s: %w", id, err)
 		}
-		o.V = &v
+		o.V = &channel.VirtualChannel{Channel: v}
 
 		zeroAddress := types.Destination{}
 

--- a/client/engine/store/durablestore.go
+++ b/client/engine/store/durablestore.go
@@ -140,6 +140,11 @@ func (ds *DurableStore) SetObjective(obj protocols.Objective) error {
 	}
 	for _, rel := range obj.Related() {
 		switch ch := rel.(type) {
+		case *channel.VirtualChannel:
+			err := ds.SetChannel(&ch.Channel)
+			if err != nil {
+				return fmt.Errorf("error setting virtual channel %s from objective %s: %w", ch.Id, obj.Id(), err)
+			}
 		case *channel.Channel:
 			err := ds.SetChannel(ch)
 			if err != nil {

--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -396,7 +396,7 @@ func (ms *MemStore) populateChannelData(obj protocols.Objective) error {
 		if err != nil {
 			return fmt.Errorf("error retrieving virtual channel data for objective %s: %w", id, err)
 		}
-		o.V = &v
+		o.V = &channel.VirtualChannel{Channel: v}
 
 		zeroAddress := types.Destination{}
 

--- a/client/engine/store/memstore.go
+++ b/client/engine/store/memstore.go
@@ -91,6 +91,11 @@ func (ms *MemStore) SetObjective(obj protocols.Objective) error {
 
 	for _, rel := range obj.Related() {
 		switch ch := rel.(type) {
+		case *channel.VirtualChannel:
+			err := ms.SetChannel(&ch.Channel)
+			if err != nil {
+				return fmt.Errorf("error setting virtual channel %s from objective %s: %w", ch.Id, obj.Id(), err)
+			}
 		case *channel.Channel:
 			err := ms.SetChannel(ch)
 			if err != nil {

--- a/client/query/query.go
+++ b/client/query/query.go
@@ -209,12 +209,6 @@ func ConstructLedgerInfoFromChannel(c *channel.Channel) LedgerChannelInfo {
 
 func ConstructPaymentInfo(c *channel.VirtualChannel, paid, remaining *big.Int) (PaymentChannelInfo, error) {
 	status := c.Status()
-	// ADR 0009 allows for intermediaries to exit the protocol before receiving all signed post funds
-	// So for intermediaries we return Open once they have signed their post fund state
-	amIntermediary := c.MyIndex != 0 && c.MyIndex != uint(len(c.Participants)-1)
-	if amIntermediary && c.PostFundSignedByMe() {
-		status = channel.Open
-	}
 
 	latest, err := c.LatestSupportedState()
 	if err != nil {

--- a/client/query/query.go
+++ b/client/query/query.go
@@ -35,9 +35,9 @@ func getPaymentChannelBalance(participants []types.Address, outcome outcome.Exit
 	}
 }
 
-// getLatestSupported returns the latest supported state of the channel
+// getLatestSupportedOrPreFund returns the latest supported state of the channel
 // or the prefund state if no supported state exists
-func getLatestSupported(channel *channel.Channel) (state.State, error) {
+func getLatestSupportedOrPreFund(channel *channel.Channel) (state.State, error) {
 	if channel.HasSupportedState() {
 		return channel.LatestSupportedState()
 	}
@@ -196,7 +196,7 @@ func ConstructLedgerInfoFromConsensus(con *consensus_channel.ConsensusChannel) L
 }
 
 func ConstructLedgerInfoFromChannel(c *channel.Channel) LedgerChannelInfo {
-	latest, err := getLatestSupported(c)
+	latest, err := getLatestSupportedOrPreFund(c)
 	if err != nil {
 		panic(err)
 	}
@@ -210,7 +210,7 @@ func ConstructLedgerInfoFromChannel(c *channel.Channel) LedgerChannelInfo {
 func ConstructPaymentInfo(c *channel.VirtualChannel, paid, remaining *big.Int) (PaymentChannelInfo, error) {
 	status := c.Status()
 
-	latest, err := c.LatestSupportedState()
+	latest, err := getLatestSupportedOrPreFund(&c.Channel)
 	if err != nil {
 		return PaymentChannelInfo{}, err
 	}

--- a/client/query/types.go
+++ b/client/query/types.go
@@ -3,17 +3,8 @@ package query
 import (
 	"math/big"
 
+	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/types"
-)
-
-type ChannelStatus string
-
-// TODO: Think through statuses
-const (
-	Proposed ChannelStatus = "Proposed"
-	Open     ChannelStatus = "Open"
-	Closing  ChannelStatus = "Closing"
-	Complete ChannelStatus = "Complete"
 )
 
 // PaymentChannelBalance contains the balance of a uni-directional payment channel
@@ -28,14 +19,14 @@ type PaymentChannelBalance struct {
 // PaymentChannelInfo contains balance and status info about a payment channel
 type PaymentChannelInfo struct {
 	ID      types.Destination
-	Status  ChannelStatus
+	Status  channel.Status
 	Balance PaymentChannelBalance
 }
 
 // LedgerChannelInfo contains balance and status info about a ledger channel
 type LedgerChannelInfo struct {
 	ID      types.Destination
-	Status  ChannelStatus
+	Status  channel.Status
 	Balance LedgerChannelBalance
 }
 

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/go-cmp/cmp"
+	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine"
@@ -221,7 +222,7 @@ func setupSharedInra(tc TestCase) sharedTestInfrastructure {
 
 // checkPaymentChannel checks that the ledger channel has the expected outcome and status
 // It will fail if the channel does not exist
-func checkPaymentChannel(t *testing.T, id types.Destination, o outcome.Exit, status query.ChannelStatus, clients ...client.Client) {
+func checkPaymentChannel(t *testing.T, id types.Destination, o outcome.Exit, status channel.Status, clients ...client.Client) {
 	for _, c := range clients {
 		expected := expectedPaymentInfo(id, o, status)
 		ledger, err := c.GetPaymentChannel(id)
@@ -235,7 +236,7 @@ func checkPaymentChannel(t *testing.T, id types.Destination, o outcome.Exit, sta
 }
 
 // expectedLedgerInfo constructs a LedgerChannelInfo so we can easily compare it to the result of GetLedgerChannel
-func expectedLedgerInfo(id types.Destination, outcome outcome.Exit, status query.ChannelStatus) query.LedgerChannelInfo {
+func expectedLedgerInfo(id types.Destination, outcome outcome.Exit, status channel.Status) query.LedgerChannelInfo {
 	clientAdd, _ := outcome[0].Allocations[0].Destination.ToAddress()
 	hubAdd, _ := outcome[0].Allocations[1].Destination.ToAddress()
 
@@ -254,7 +255,7 @@ func expectedLedgerInfo(id types.Destination, outcome outcome.Exit, status query
 
 // checkLedgerChannel checks that the ledger channel has the expected outcome and status
 // It will fail if the channel does not exist
-func checkLedgerChannel(t *testing.T, ledgerId types.Destination, o outcome.Exit, status query.ChannelStatus, clients ...client.Client) {
+func checkLedgerChannel(t *testing.T, ledgerId types.Destination, o outcome.Exit, status channel.Status, clients ...client.Client) {
 	for _, c := range clients {
 		expected := expectedLedgerInfo(ledgerId, o, status)
 		ledger, err := c.GetLedgerChannel(ledgerId)
@@ -268,7 +269,7 @@ func checkLedgerChannel(t *testing.T, ledgerId types.Destination, o outcome.Exit
 }
 
 // expectedPaymentInfo constructs a LedgerChannelInfo so we can easily compare it to the result of GetPaymentChannel
-func expectedPaymentInfo(id types.Destination, outcome outcome.Exit, status query.ChannelStatus) query.PaymentChannelInfo {
+func expectedPaymentInfo(id types.Destination, outcome outcome.Exit, status channel.Status) query.PaymentChannelInfo {
 	payer, _ := outcome[0].Allocations[0].Destination.ToAddress()
 	payee, _ := outcome[0].Allocations[1].Destination.ToAddress()
 

--- a/client_test/integration_test.go
+++ b/client_test/integration_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine/messageservice"
 	p2pms "github.com/statechannels/go-nitro/client/engine/messageservice/p2p-message-service"
-	"github.com/statechannels/go-nitro/client/query"
 	"github.com/statechannels/go-nitro/internal/testactors"
 	td "github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/protocols"
@@ -111,10 +111,10 @@ func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 		for i, clientI := range intermediaries {
 			// Setup and check the ledger channel between Alice and the intermediary
 			aliceLedgers[i] = setupLedgerChannel(t, clientA, clientI, asset)
-			checkLedgerChannel(t, aliceLedgers[i], initialLedgerOutcome(*clientA.Address, *clientI.Address, asset), query.Open, clientA)
+			checkLedgerChannel(t, aliceLedgers[i], initialLedgerOutcome(*clientA.Address, *clientI.Address, asset), channel.Open, clientA)
 			// Setup and check the ledger channel between Bob and the intermediary
 			bobLedgers[i] = setupLedgerChannel(t, clientI, clientB, asset)
-			checkLedgerChannel(t, bobLedgers[i], initialLedgerOutcome(*clientI.Address, *clientB.Address, asset), query.Open, clientB)
+			checkLedgerChannel(t, bobLedgers[i], initialLedgerOutcome(*clientI.Address, *clientB.Address, asset), channel.Open, clientB)
 
 		}
 
@@ -144,7 +144,7 @@ func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 			checkPaymentChannel(t,
 				virtualIds[i],
 				initialPaymentOutcome(*clientA.Address, *clientB.Address, asset),
-				query.Open,
+				channel.Open,
 				clientA, clientB)
 		}
 
@@ -165,7 +165,7 @@ func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 			checkPaymentChannel(t,
 				virtualIds[i],
 				finalPaymentOutcome(*clientA.Address, *clientB.Address, asset, tc.NumOfPayments, 1),
-				query.Open,
+				channel.Open,
 				clientA, clientB)
 		}
 
@@ -186,16 +186,16 @@ func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 		// Close all the ledger channels we opened
 
 		closeLedgerChannel(t, clientA, intermediaries[0], aliceLedgers[0])
-		checkLedgerChannel(t, aliceLedgers[0], finalAliceLedger(*intermediaries[0].Address, asset, tc.NumOfPayments, 1, tc.NumOfChannels), query.Complete, clientA)
+		checkLedgerChannel(t, aliceLedgers[0], finalAliceLedger(*intermediaries[0].Address, asset, tc.NumOfPayments, 1, tc.NumOfChannels), channel.Complete, clientA)
 
 		// TODO: This is brittle, we should generalize this to n number of intermediaries
 		if tc.NumOfHops == 1 {
 			closeLedgerChannel(t, intermediaries[0], clientB, bobLedgers[0])
-			checkLedgerChannel(t, bobLedgers[0], finalBobLedger(*intermediaries[0].Address, asset, tc.NumOfPayments, 1, tc.NumOfChannels), query.Complete, clientB)
+			checkLedgerChannel(t, bobLedgers[0], finalBobLedger(*intermediaries[0].Address, asset, tc.NumOfPayments, 1, tc.NumOfChannels), channel.Complete, clientB)
 		}
 		if tc.NumOfHops == 2 {
 			closeLedgerChannel(t, intermediaries[1], clientB, bobLedgers[1])
-			checkLedgerChannel(t, bobLedgers[1], finalBobLedger(*intermediaries[1].Address, asset, tc.NumOfPayments, 1, tc.NumOfChannels), query.Complete, clientB)
+			checkLedgerChannel(t, bobLedgers[1], finalBobLedger(*intermediaries[1].Address, asset, tc.NumOfPayments, 1, tc.NumOfChannels), channel.Complete, clientB)
 		}
 	})
 }

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/rs/zerolog"
+	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client"
 	"github.com/statechannels/go-nitro/client/engine"
@@ -83,11 +84,11 @@ func executeRpcTest(t *testing.T, connectionType transport.TransportType) {
 	<-rpcClientI.ObjectiveCompleteChan(res.Id)
 	<-rpcClientI.ObjectiveCompleteChan(bobResponse.Id)
 
-	expectedAliceLedger := expectedLedgerInfo(res.ChannelId, aliceLedgerOutcome, query.Open)
+	expectedAliceLedger := expectedLedgerInfo(res.ChannelId, aliceLedgerOutcome, channel.Open)
 	checkQueryInfo(t, expectedAliceLedger, rpcClientA.GetLedgerChannel(res.ChannelId))
 	checkQueryInfoCollection(t, expectedAliceLedger, 1, rpcClientA.GetAllLedgerChannels())
 
-	expectedBobLedger := expectedLedgerInfo(bobResponse.ChannelId, bobLedgerOutcome, query.Open)
+	expectedBobLedger := expectedLedgerInfo(bobResponse.ChannelId, bobLedgerOutcome, channel.Open)
 	checkQueryInfo(t, expectedBobLedger, rpcClientB.GetLedgerChannel(bobResponse.ChannelId))
 	checkQueryInfoCollection(t, expectedBobLedger, 1, rpcClientB.GetAllLedgerChannels())
 
@@ -105,7 +106,7 @@ func executeRpcTest(t *testing.T, connectionType transport.TransportType) {
 	<-rpcClientB.ObjectiveCompleteChan(vRes.Id)
 	<-rpcClientI.ObjectiveCompleteChan(vRes.Id)
 
-	expectedVirtual := expectedPaymentInfo(vRes.ChannelId, initialOutcome, query.Open)
+	expectedVirtual := expectedPaymentInfo(vRes.ChannelId, initialOutcome, channel.Open)
 	aliceVirtual := rpcClientA.GetVirtualChannel(vRes.ChannelId)
 	checkQueryInfo(t, expectedVirtual, aliceVirtual)
 	checkQueryInfoCollection(t, expectedVirtual, 1, rpcClientA.GetPaymentChannelsByLedger(res.ChannelId))
@@ -147,33 +148,33 @@ func executeRpcTest(t *testing.T, connectionType transport.TransportType) {
 	}
 
 	expectedAliceLedgerNotifs := []query.LedgerChannelInfo{
-		expectedLedgerInfo(res.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Irene.Address(), 100, 100), query.Proposed),
-		expectedLedgerInfo(res.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Irene.Address(), 100, 100), query.Open),
-		expectedLedgerInfo(res.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Irene.Address(), 0, 100), query.Open),
-		expectedLedgerInfo(res.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Irene.Address(), 99, 101), query.Open),
-		expectedLedgerInfo(res.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Irene.Address(), 99, 101), query.Closing),
-		expectedLedgerInfo(res.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Irene.Address(), 99, 101), query.Complete),
+		expectedLedgerInfo(res.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Irene.Address(), 100, 100), channel.Proposed),
+		expectedLedgerInfo(res.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Irene.Address(), 100, 100), channel.Open),
+		expectedLedgerInfo(res.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Irene.Address(), 0, 100), channel.Open),
+		expectedLedgerInfo(res.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Irene.Address(), 99, 101), channel.Open),
+		expectedLedgerInfo(res.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Irene.Address(), 99, 101), channel.Closing),
+		expectedLedgerInfo(res.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Irene.Address(), 99, 101), channel.Complete),
 	}
 	checkNotifications(t, expectedAliceLedgerNotifs, []query.LedgerChannelInfo{}, aliceLedgerNotifs, defaultTimeout)
 
 	expectedBobLedgerNotifs := []query.LedgerChannelInfo{
-		expectedLedgerInfo(bobResponse.ChannelId, simpleOutcome(ta.Bob.Address(), ta.Irene.Address(), 100, 100), query.Proposed),
-		expectedLedgerInfo(bobResponse.ChannelId, simpleOutcome(ta.Bob.Address(), ta.Irene.Address(), 100, 100), query.Open),
-		expectedLedgerInfo(bobResponse.ChannelId, simpleOutcome(ta.Bob.Address(), ta.Irene.Address(), 100, 0), query.Open),
-		expectedLedgerInfo(bobResponse.ChannelId, simpleOutcome(ta.Bob.Address(), ta.Irene.Address(), 101, 99), query.Open),
-		expectedLedgerInfo(bobResponse.ChannelId, simpleOutcome(ta.Bob.Address(), ta.Irene.Address(), 101, 99), query.Closing),
-		expectedLedgerInfo(bobResponse.ChannelId, simpleOutcome(ta.Bob.Address(), ta.Irene.Address(), 101, 99), query.Complete),
+		expectedLedgerInfo(bobResponse.ChannelId, simpleOutcome(ta.Bob.Address(), ta.Irene.Address(), 100, 100), channel.Proposed),
+		expectedLedgerInfo(bobResponse.ChannelId, simpleOutcome(ta.Bob.Address(), ta.Irene.Address(), 100, 100), channel.Open),
+		expectedLedgerInfo(bobResponse.ChannelId, simpleOutcome(ta.Bob.Address(), ta.Irene.Address(), 100, 0), channel.Open),
+		expectedLedgerInfo(bobResponse.ChannelId, simpleOutcome(ta.Bob.Address(), ta.Irene.Address(), 101, 99), channel.Open),
+		expectedLedgerInfo(bobResponse.ChannelId, simpleOutcome(ta.Bob.Address(), ta.Irene.Address(), 101, 99), channel.Closing),
+		expectedLedgerInfo(bobResponse.ChannelId, simpleOutcome(ta.Bob.Address(), ta.Irene.Address(), 101, 99), channel.Complete),
 	}
 	checkNotifications(t, expectedBobLedgerNotifs, []query.LedgerChannelInfo{}, bobLedgerNotifs, defaultTimeout)
 
 	requiredVirtualNotifs := []query.PaymentChannelInfo{
-		expectedPaymentInfo(vRes.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Bob.Address(), 100, 0), query.Proposed),
-		expectedPaymentInfo(vRes.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Bob.Address(), 100, 0), query.Open),
-		expectedPaymentInfo(vRes.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Bob.Address(), 99, 1), query.Open),
-		expectedPaymentInfo(vRes.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Bob.Address(), 99, 1), query.Complete),
+		expectedPaymentInfo(vRes.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Bob.Address(), 100, 0), channel.Proposed),
+		expectedPaymentInfo(vRes.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Bob.Address(), 100, 0), channel.Open),
+		expectedPaymentInfo(vRes.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Bob.Address(), 99, 1), channel.Open),
+		expectedPaymentInfo(vRes.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Bob.Address(), 99, 1), channel.Complete),
 	}
 	optionalVirtualNotifs := []query.PaymentChannelInfo{
-		expectedPaymentInfo(vRes.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Bob.Address(), 99, 1), query.Closing),
+		expectedPaymentInfo(vRes.ChannelId, simpleOutcome(ta.Alice.Address(), ta.Bob.Address(), 99, 1), channel.Closing),
 	}
 	checkNotifications(t, requiredVirtualNotifs, optionalVirtualNotifs, aliceVirtualNotifs, defaultTimeout)
 

--- a/protocols/virtualdefund/serde.go
+++ b/protocols/virtualdefund/serde.go
@@ -79,7 +79,7 @@ func (o *Objective) UnmarshalJSON(data []byte) error {
 
 	o.MyRole = jsonVFO.MyRole
 
-	o.V = &channel.Channel{}
+	o.V = &channel.VirtualChannel{}
 	o.V.Id = jsonVFO.V
 
 	o.MinimumPaymentAmount = jsonVFO.MinimumPaymentAmount

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -262,7 +262,7 @@ func (o *Objective) GetStatus() protocols.ObjectiveStatus {
 func (o *Objective) Related() []protocols.Storable {
 	related := []protocols.Storable{}
 
-	related = append(related, &o.V.Channel)
+	related = append(related, o.V)
 
 	if o.ToMyLeft != nil {
 		related = append(related, o.ToMyLeft)

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -44,7 +44,7 @@ type Objective struct {
 	// If this is not set then virtual defunding will accept any final outcome from Alice.
 	MinimumPaymentAmount *big.Int
 
-	V *channel.Channel // This is a Virtual Channel. TODO should this be a literal channel.VirtualChannel?
+	V *channel.VirtualChannel
 
 	ToMyLeft  *consensus_channel.ConsensusChannel
 	ToMyRight *consensus_channel.ConsensusChannel
@@ -81,10 +81,12 @@ func NewObjective(request ObjectiveRequest,
 		status = protocols.Unapproved
 	}
 
-	V, found := getChannel(request.ChannelId)
+	c, found := getChannel(request.ChannelId)
+
 	if !found {
 		return Objective{}, fmt.Errorf("could not find channel %s", request.ChannelId)
 	}
+	V := &channel.VirtualChannel{Channel: *c}
 
 	alice := V.Participants[0]
 	bob := V.Participants[len(V.Participants)-1]
@@ -260,7 +262,7 @@ func (o *Objective) GetStatus() protocols.ObjectiveStatus {
 func (o *Objective) Related() []protocols.Storable {
 	related := []protocols.Storable{}
 
-	related = append(related, o.V)
+	related = append(related, &o.V.Channel)
 
 	if o.ToMyLeft != nil {
 		related = append(related, o.ToMyLeft)

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -201,7 +201,7 @@ func TestConstructObjectiveFromState(t *testing.T) {
 
 	want := Objective{
 		Status:               protocols.Approved,
-		V:                    v,
+		V:                    &channel.VirtualChannel{Channel: *v},
 		ToMyLeft:             left,
 		ToMyRight:            right,
 		MinimumPaymentAmount: big.NewInt(int64(data.paid)),

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -475,7 +475,7 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 }
 
 func (o *Objective) Related() []protocols.Storable {
-	ret := []protocols.Storable{&o.V.Channel}
+	ret := []protocols.Storable{o.V}
 
 	if o.ToMyLeft != nil {
 		ret = append(ret, o.ToMyLeft.Channel)


### PR DESCRIPTION
Closes #1280
Closes #1285 

Note: one awkward thing at present is that there is no discriminator for `Channel/VirtualChannel` in the store. This PR continues with the widespread practice of casting / wrapping / unwrapping to/from `VirtualChannel` based on the context (i.e. is a virtual protocol calling set or get). 

We could consider either:
* a distinct table in the store for virtual channels
* a discriminating enum that is serialized with the channel, and can be used by the store to know how to correctly hydrate data of the right type. 
