### PR TITLE
make testground-nightly GHA manually launchable

### DIFF
--- a/.github/workflows/testground-nightly.yml
+++ b/.github/workflows/testground-nightly.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     # Run at 05:00 UTC every day
     - cron:  '0 5 * * *'
+  workflow_dispatch:
 jobs:
   run-testground-nightly:
       runs-on: ubuntu-latest

--- a/.github/workflows/testground-nightly.yml
+++ b/.github/workflows/testground-nightly.yml
@@ -44,3 +44,12 @@ jobs:
          --metadata-branch "${{github.event.pull_request.head.ref}}" \
          --metadata-commit "${{github.event.pull_request.head.sha}}"  | tee run.out
           
+      
+      # Parse the run outcome and id from the testground run output
+      - name: Set Run Outcome
+        id: set_run_outcome
+        run: |
+          echo "::set-output name=RUN_OUTCOME::$(awk '/run finished with outcome/ {print $10}' <run.out)"
+      - name: Fail if testground run failed
+        if: ${{ steps.set_run_outcome.outputs.RUN_OUTCOME  != 'success' }}
+        run: exit 1

--- a/.github/workflows/testground.yml
+++ b/.github/workflows/testground.yml
@@ -3,7 +3,6 @@ name: Run Testground
 on:
   pull_request:
     paths: ["**/*.go", ".github/workflows/testground.yml"]
-  workflow_dispatch:
 jobs:
   run-testground:
     runs-on: ubuntu-latest


### PR DESCRIPTION
and remove from PR-based GHA
Closes #1289 

Also fails the nightly run if the testground run fails (I think it is just failing silently at the moment(. 