### PR TITLE
Handle StatusGoingAway

### DIFF
--- a/rpc/transport/ws/server.go
+++ b/rpc/transport/ws/server.go
@@ -144,7 +144,8 @@ EventLoop:
 	if errors.Is(err, context.Canceled) {
 		return
 	}
-	if websocket.CloseStatus(err) == websocket.StatusNormalClosure {
+	if websocket.CloseStatus(err) == websocket.StatusNormalClosure ||
+		websocket.CloseStatus(err) == websocket.StatusGoingAway {
 		return
 	}
 	if err != nil {


### PR DESCRIPTION
Fixes #1291 

Handles the close status of `StatusGoingAway`, so we don't get an ugly error message. We get this status from the browser on a page refresh/close, so we should handle it.