### PR TITLE
Set Different App Definitions

### DIFF
--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -62,6 +62,9 @@ const RESUB_INTERVAL = 2*time.Minute + 30*time.Second
 
 // NewEthChainService is a convenient wrapper around NewEthChainService, which provides a simpler API
 func NewEthChainService(chainUrl, chainPk string, naAddress, caAddress, vpaAddress common.Address, logDestination io.Writer) (*EthChainService, error) {
+	if vpaAddress == caAddress {
+		return nil, fmt.Errorf("virtual payment app address and consensus app address cannot be the same: %s", vpaAddress.String())
+	}
 	ethClient, txSigner, err := chainutils.ConnectToChain(context.Background(), chainUrl, common.Hex2Bytes(chainPk))
 	if err != nil {
 		panic(err)

--- a/main.go
+++ b/main.go
@@ -33,10 +33,12 @@ func main() {
 		CHAIN_URL         = "chainurl"
 		CHAIN_PK          = "chainpk"
 		NA_ADDRESS        = "naaddress"
+		VPA_ADDRESS       = "vpaaddress"
+		CA_ADDRESS        = "caaddress"
 		MSG_PORT          = "msgport"
 		RPC_PORT          = "rpcport"
 	)
-	var pkString, chainUrl, naAddress, chainPk string
+	var pkString, chainUrl, naAddress, vpaAddress, caAddress, chainPk string
 	var msgPort, rpcPort int
 	var useNats, useDurableStore bool
 
@@ -86,6 +88,20 @@ func main() {
 			Destination: &naAddress,
 			Required:    true,
 		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:        VPA_ADDRESS,
+			Usage:       "Specifies the address of the virtual payment app.",
+			Category:    "Connectivity:",
+			Destination: &vpaAddress,
+			Required:    true,
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:        CA_ADDRESS,
+			Usage:       "Specifies the address of the consensus app.",
+			Category:    "Connectivity:",
+			Destination: &caAddress,
+			Required:    true,
+		}),
 		altsrc.NewIntFlag(&cli.IntFlag{
 			Name:        MSG_PORT,
 			Usage:       "Specifies the tcp port for the message service.",
@@ -130,7 +146,13 @@ func main() {
 			}
 
 			fmt.Println("Initializing chain service and connecting to " + chainUrl + "...")
-			chainService, err := chainservice.NewEthChainService(chainUrl, chainPk, common.HexToAddress(naAddress), common.Address{1}, common.Address{2}, os.Stdout)
+			chainService, err := chainservice.NewEthChainService(
+				chainUrl,
+				chainPk,
+				common.HexToAddress(naAddress),
+				common.HexToAddress(caAddress),
+				common.HexToAddress(vpaAddress),
+				os.Stdout)
 			if err != nil {
 				panic(err)
 			}

--- a/main.go
+++ b/main.go
@@ -130,7 +130,7 @@ func main() {
 			}
 
 			fmt.Println("Initializing chain service and connecting to " + chainUrl + "...")
-			chainService, err := chainservice.NewEthChainService(chainUrl, chainPk, common.HexToAddress(naAddress), common.Address{}, common.Address{}, os.Stdout)
+			chainService, err := chainservice.NewEthChainService(chainUrl, chainPk, common.HexToAddress(naAddress), common.Address{1}, common.Address{2}, os.Stdout)
 			if err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
This PR updates the eth chain service to require two different addresses for the virtual payment app and consensus app. Since we rely on the appDef address in our `query` package to differentiate between virtual and ledger channels we want to enforce those addresses are different. 

This PR also updates `main.go` to pass into two different (dummy) addresses.