### PR TITLE
Make mdns optional for the message service

### DIFF
--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -79,6 +79,7 @@ func setupMessageService(tc TestCase, tp TestParticipant, si sharedTestInfrastru
 			int(tp.Port),
 			tp.Address(),
 			tp.PrivateKey,
+			true,
 			logWriter,
 		)
 

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -194,6 +194,7 @@ func setupNitroNodeWithRPCClient(
 		msgPort,
 		crypto.GetAddressFromSecretKeyBytes(pk),
 		pk,
+		true,
 		logDestination)
 	storeA := store.NewMemStore(pk)
 	node := client.New(

--- a/main.go
+++ b/main.go
@@ -136,7 +136,7 @@ func main() {
 			}
 
 			fmt.Println("Initializing message service on port " + fmt.Sprint(msgPort) + "...")
-			messageservice := p2pms.NewMessageService("127.0.0.1", msgPort, *ourStore.GetAddress(), pk, logDestination)
+			messageservice := p2pms.NewMessageService("127.0.0.1", msgPort, *ourStore.GetAddress(), pk, true, logDestination)
 			node := client.New(
 				messageservice,
 				chainService,


### PR DESCRIPTION
This makes `mdns` optional for the p2p message service. In some complicated network environments `mdns` might not be that helpful. In the case of testground the `mdns` peer discovery was using the docker container ip address instead of the correct data network address.  