### PR TITLE
test config does not use durable store

### DIFF
--- a/scripts/test-configs/alice.toml
+++ b/scripts/test-configs/alice.toml
@@ -1,6 +1,6 @@
 # Alice's test Config
 
-usedurablestore = true
+usedurablestore = false
 
 msgport = 3005
 rpcport = 4005

--- a/scripts/test-configs/bob.toml
+++ b/scripts/test-configs/bob.toml
@@ -1,6 +1,6 @@
 # Bob's test Config
 
-usedurablestore = true
+usedurablestore = false
 
 msgport = 3007
 rpcport = 4007

--- a/scripts/test-configs/irene.toml
+++ b/scripts/test-configs/irene.toml
@@ -1,6 +1,6 @@
 # Irene's test Config
 
-usedurablestore = true
+usedurablestore = false
 
 msgport = 3006
 rpcport = 4006


### PR DESCRIPTION
At the moment the `start-rpc-servers` script is mostly being used to derive UI development in conjunction with the `client-runner` script from the nitro-gui repo. 

GIven 
1. that script will fail out if there are already things in the store
2. wiping / deleting the stores is a manual process

it seems easiest to not use a durable store for now in this context. 