### PR TITLE
Use api path for jsonrpc instead of root path

### DIFF
--- a/rpc/transport/ws/client.go
+++ b/rpc/transport/ws/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	urlUtil "net/url"
 
 	"github.com/rs/zerolog"
 	"nhooyr.io/websocket"
@@ -17,13 +18,19 @@ type clientWebSocketTransport struct {
 	url              string
 }
 
+const rpcPath = "api"
+
 // NewWebSocketTransportAsClient creates a websocket connection that can be used to send requests and listen for notifications
 func NewWebSocketTransportAsClient(url string) (*clientWebSocketTransport, error) {
 	wsc := &clientWebSocketTransport{}
 	wsc.notificationChan = make(chan []byte)
 	wsc.url = url
 
-	conn, _, err := websocket.Dial(context.Background(), "ws://"+url+"/subscribe", &websocket.DialOptions{})
+	subscribeUrl, err := urlUtil.JoinPath("ws://", url, rpcPath, "subscribe")
+	if err != nil {
+		return nil, err
+	}
+	conn, _, err := websocket.Dial(context.Background(), subscribeUrl, &websocket.DialOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +40,11 @@ func NewWebSocketTransportAsClient(url string) (*clientWebSocketTransport, error
 }
 
 func (wsc *clientWebSocketTransport) Request(data []byte) ([]byte, error) {
-	resp, err := http.Post("http://"+wsc.url, "application/json", bytes.NewBuffer(data))
+	requestUrl, err := urlUtil.JoinPath("http://", wsc.url, rpcPath)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.Post(requestUrl, "application/json", bytes.NewBuffer(data))
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/transport/ws/server.go
+++ b/rpc/transport/ws/server.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"path"
 	"strconv"
 	"time"
 
@@ -37,8 +38,8 @@ func NewWebSocketTransportAsServer(port string) (*serverWebSocketTransport, erro
 
 	var serveMux http.ServeMux
 
-	serveMux.HandleFunc("/", wsc.request)
-	serveMux.HandleFunc("/subscribe", wsc.subscribe)
+	serveMux.HandleFunc(path.Join("/", rpcPath), wsc.request)
+	serveMux.HandleFunc(path.Join("/", rpcPath, "subscribe"), wsc.subscribe)
 	wsc.httpServer = &http.Server{
 		Handler:      &serveMux,
 		ReadTimeout:  time.Second * 10,


### PR DESCRIPTION
This will make nitro node routing more robust as we add other endpoints like node health, serve dashboard, etc.