### PR TITLE
downgrade libp2p to 0.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -151,7 +151,7 @@ require (
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
 	github.com/holiman/uint256 v1.2.0 // indirect
-	github.com/libp2p/go-libp2p v0.27.0
+	github.com/libp2p/go-libp2p v0.26.2
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/miguelmota/go-ethereum-hdwallet v0.1.1
 	github.com/olekukonko/tablewriter v0.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -467,8 +467,8 @@ github.com/libp2p/go-cidranger v1.1.0 h1:ewPN8EZ0dd1LSnrtuwd4709PXVcITVeuwbag38y
 github.com/libp2p/go-cidranger v1.1.0/go.mod h1:KWZTfSr+r9qEo9OkI9/SIEeAtw+NNoU0dXIXt15Okic=
 github.com/libp2p/go-flow-metrics v0.1.0 h1:0iPhMI8PskQwzh57jB9WxIuIOQ0r+15PChFGkx3Q3WM=
 github.com/libp2p/go-flow-metrics v0.1.0/go.mod h1:4Xi8MX8wj5aWNDAZttg6UPmc0ZrnFNsMtpsYUClFtro=
-github.com/libp2p/go-libp2p v0.27.0 h1:QbhrTuB0ln9j9op6yAOR0o+cx/qa9NyNZ5ov0Tql8ZU=
-github.com/libp2p/go-libp2p v0.27.0/go.mod h1:FAvvfQa/YOShUYdiSS03IR9OXzkcJXwcNA2FUCh9ImE=
+github.com/libp2p/go-libp2p v0.26.2 h1:eHEoW/696FP7/6DxOvcrKfTD6Bi0DExxiMSZUJxswA0=
+github.com/libp2p/go-libp2p v0.26.2/go.mod h1:x75BN32YbwuY0Awm2Uix4d4KOz+/4piInkp4Wr3yOo8=
 github.com/libp2p/go-libp2p-asn-util v0.3.0 h1:gMDcMyYiZKkocGXDQ5nsUQyquC9+H+iLEQHwOCZ7s8s=
 github.com/libp2p/go-libp2p-asn-util v0.3.0/go.mod h1:B1mcOrKUE35Xq/ASTmQ4tN3LNzVVaMNmq2NACuqyB9w=
 github.com/libp2p/go-libp2p-testing v0.12.0 h1:EPvBb4kKMWO29qP4mZGyhVzUyR25dvfUIK5WDu6iPUA=


### PR DESCRIPTION
This downgrades our version of libp2p to `0.26.2` which is the same version `boost` and `lotus` uses. Otherwise adding `go-nitro` to `boost` causes libp2p to get upgraded and breaks `boost`/`lotus`:
```
make debug
rm -f boost boostd boostx
go build  -ldflags="-X=github.com/filecoin-project/boost/build.CurrentCommit=+git.4986e2f.dirty" -tags=debug -o boost ./cmd/boost
# github.com/filecoin-project/lotus/node/impl/net
../../go/pkg/mod/github.com/filecoin-project/lotus@v1.23.0/node/impl/net/net.go:148:22: autonat.PublicAddr undefined (type autonat.AutoNAT has no field or method PublicAddr)
```

I'm not sure if we want to merge this or just keep a separate branch for `boost` work. Or try to upgrade `boost`/`lotus` code to the latest libp2p 😨 