### PR TITLE
remove 0-hop and 2-hop tests...

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -166,7 +166,7 @@ func (c *ConsensusChannel) IncludesTarget(target types.Destination) bool {
 	return c.current.Outcome.IncludesTarget(target)
 }
 
-// HasRemovalBeenProposed returns whether or not a proposal exists to remove the guaranatee for the target.
+// HasRemovalBeenProposed returns whether or not a proposal exists to remove the guarantee for the target.
 func (c *ConsensusChannel) HasRemovalBeenProposed(target types.Destination) bool {
 	for _, p := range c.proposalQueue {
 		if p.Proposal.Type() == RemoveProposal {
@@ -270,8 +270,8 @@ func (c *ConsensusChannel) latestProposedVars() (Vars, error) {
 
 // validateProposalID checks that the given proposal's ID matches
 // the channel's ID.
-func (c *ConsensusChannel) validateProposalID(propsal Proposal) error {
-	if propsal.LedgerID != c.Id {
+func (c *ConsensusChannel) validateProposalID(proposal Proposal) error {
+	if proposal.LedgerID != c.Id {
 		return ErrIncorrectChannelID
 	}
 
@@ -365,7 +365,7 @@ func (g Guarantee) AsAllocation() outcome.Allocation {
 // participant.
 //
 // This struct does not store items in sorted order. The conventional ordering of allocation items is:
-// [leader, follower, ...guaranteesSortedbyTargetDestination]
+// [leader, follower, ...guaranteesSortedByTargetDestination]
 type LedgerOutcome struct {
 	assetAddress types.Address // Address of the asset type
 	leader       Balance       // Balance of participants[0]
@@ -433,8 +433,8 @@ func (o *LedgerOutcome) includes(g Guarantee) bool {
 // FromExit creates a new LedgerOutcome from the given SingleAssetExit.
 //
 // It makes the following assumptions about the exit:
-//   - The first alloction entry is for the ledger leader
-//   - The second alloction entry is for the ledger follower
+//   - The first allocation entry is for the ledger leader
+//   - The second allocation entry is for the ledger follower
 //   - All other allocations are guarantees
 func FromExit(sae outcome.SingleAssetExit) (LedgerOutcome, error) {
 	var (
@@ -678,7 +678,7 @@ func NewAdd(g Guarantee, leftDeposit *big.Int) Add {
 	}
 }
 
-// NewAddProposal constucts a proposal with a valid Add proposal and empty remove proposal.
+// NewAddProposal constructs a proposal with a valid Add proposal and empty remove proposal.
 func NewAddProposal(ledgerID types.Destination, g Guarantee, leftDeposit *big.Int) Proposal {
 	return Proposal{ToAdd: NewAdd(g, leftDeposit), LedgerID: ledgerID}
 }
@@ -688,7 +688,7 @@ func NewRemove(target types.Destination, leftAmount *big.Int) Remove {
 	return Remove{Target: target, LeftAmount: leftAmount}
 }
 
-// NewRemoveProposal constucts a proposal with a valid Remove proposal and empty Add proposal.
+// NewRemoveProposal constructs a proposal with a valid Remove proposal and empty Add proposal.
 func NewRemoveProposal(ledgerID types.Destination, target types.Destination, leftAmount *big.Int) Proposal {
 	return Proposal{ToRemove: NewRemove(target, leftAmount), LedgerID: ledgerID}
 }

--- a/channel/consensus_channel/leader_channel.go
+++ b/channel/consensus_channel/leader_channel.go
@@ -119,7 +119,7 @@ func (c *ConsensusChannel) leaderReceive(countersigned SignedProposal) error {
 }
 
 // appendToProposalQueue safely appends the given SignedProposal to the proposal queue of the receiver.
-// It will return an error if the turn number of the signedproposal is not consecutive with the existing queue.
+// It will return an error if the turn number of the SignedProposal is not consecutive with the existing queue.
 func (c *ConsensusChannel) appendToProposalQueue(signed SignedProposal) error {
 	if len(c.proposalQueue) > 0 && c.proposalQueue[len(c.proposalQueue)-1].TurnNum+1 != signed.TurnNum {
 		return fmt.Errorf("appending to ConsensusChannel.proposalQueue: not a consecutive TurnNum")

--- a/channel/consensus_channel/leader_channel_test.go
+++ b/channel/consensus_channel/leader_channel_test.go
@@ -411,10 +411,10 @@ func TestLeaderChannel(t *testing.T) {
 		}
 	}
 
-	for i, signedbyAlice := range populatedQueue() {
+	for i, signedByAlice := range populatedQueue() {
 		msg := fmt.Sprintf("ok: receiving a valid counter proposal in position %v", i)
 
-		counterP := bobSignedProposal(signedbyAlice.Vars, signedbyAlice.Proposal, signedbyAlice.SignedProposal.TurnNum)
+		counterP := bobSignedProposal(signedByAlice.Vars, signedByAlice.Proposal, signedByAlice.SignedProposal.TurnNum)
 		t.Run(msg, testUpdateConsensusOk(counterP))
 	}
 

--- a/client/engine/chainservice/adjudicator/challenge_test.go
+++ b/client/engine/chainservice/adjudicator/challenge_test.go
@@ -76,15 +76,16 @@ func TestChallenge(t *testing.T) {
 			})
 	}
 
+	// We only run the test if the RUN_FEVM_TESTS env var is set to true
+	if key, found := os.LookupEnv("RUN_FEVM_TESTS"); !found || strings.ToLower(key) != "true" {
+		t.Skip()
+	}
+
 	hyperspacePreparedChain := prepareHyperspaceBackend(t)
 
 	for _, turnNum := range []uint64{0, 1, 2} {
 		t.Run("HyperSpaceBackend: turnNum = "+fmt.Sprint(turnNum),
 			func(t *testing.T) {
-				// We only run the test if the RUN_FEVM_TESTS env var is set to true
-				if key, found := os.LookupEnv("RUN_FEVM_TESTS"); !found || strings.ToLower(key) != "true" {
-					t.Skip()
-				}
 				runChallengeWithTurnNum(t, turnNum, hyperspacePreparedChain)
 			})
 	}

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -100,8 +100,8 @@ func setupChainService(tc TestCase, tp TestParticipant, si sharedTestInfrastruct
 	case SimulatedChain:
 		logDestination := newLogWriter(tc.LogName)
 
-		ethAcountIndex := tp.Port - testactors.START_PORT
-		cs, err := chainservice.NewSimulatedBackendChainService(si.simulatedChain, *si.bindings, si.ethAccounts[ethAcountIndex], logDestination)
+		ethAccountIndex := tp.Port - testactors.START_PORT
+		cs, err := chainservice.NewSimulatedBackendChainService(si.simulatedChain, *si.bindings, si.ethAccounts[ethAccountIndex], logDestination)
 		if err != nil {
 			panic(err)
 		}
@@ -203,7 +203,7 @@ func waitForObjectives(t *testing.T, a, b client.Client, intermediaries []client
 	}
 }
 
-func setupSharedInra(tc TestCase) sharedTestInfrastructure {
+func setupSharedInfra(tc TestCase) sharedTestInfrastructure {
 	infra := sharedTestInfrastructure{}
 	switch tc.Chain {
 	case MockChain:

--- a/client_test/integration_test.go
+++ b/client_test/integration_test.go
@@ -66,7 +66,7 @@ func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		infra := setupSharedInra(tc)
+		infra := setupSharedInfra(tc)
 		defer infra.Close(t)
 
 		msgServices := make([]messageservice.MessageService, 0)

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -110,7 +110,7 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 	t.Logf("%d Clients created", n)
 
 	waitForPeerInfoExchange(msgServices...)
-	t.Logf("Peerexchange complete")
+	t.Logf("Peer exchange complete")
 
 	// create n-1 ledger channels
 	ledgerChannels := make([]directfund.ObjectiveResponse, n-1)
@@ -315,7 +315,7 @@ func setupNitroNodeWithRPCClient(
 		nil)
 
 	var serverConnection transport.Responder
-	var clienConnection transport.Requester
+	var clientConnection transport.Requester
 	var err error
 	switch connectionType {
 	case "nats":
@@ -323,7 +323,7 @@ func setupNitroNodeWithRPCClient(
 		if err != nil {
 			panic(err)
 		}
-		clienConnection, err = natstrans.NewNatsTransportAsClient(serverConnection.Url())
+		clientConnection, err = natstrans.NewNatsTransportAsClient(serverConnection.Url())
 		if err != nil {
 			panic(err)
 		}
@@ -332,7 +332,7 @@ func setupNitroNodeWithRPCClient(
 		if err != nil {
 			panic(err)
 		}
-		clienConnection, err = ws.NewWebSocketTransportAsClient(serverConnection.Url())
+		clientConnection, err = ws.NewWebSocketTransportAsClient(serverConnection.Url())
 		if err != nil {
 			panic(err)
 		}
@@ -346,7 +346,7 @@ func setupNitroNodeWithRPCClient(
 	if err != nil {
 		panic(err)
 	}
-	rpcClient, err := rpc.NewRpcClient(rpcServer.Url(), createLogger(logDestination, node.Address.Hex(), "client"), clienConnection)
+	rpcClient, err := rpc.NewRpcClient(rpcServer.Url(), createLogger(logDestination, node.Address.Hex(), "client"), clientConnection)
 	if err != nil {
 		panic(err)
 	}

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -47,15 +47,15 @@ func createLogger(logDestination *os.File, clientName, rpcRole string) zerolog.L
 }
 
 func TestRpcWithNats(t *testing.T) {
-	executeNRpcTest(t, "nats", 2)
+	// executeNRpcTest(t, "nats", 2)
 	executeNRpcTest(t, "nats", 3)
-	executeNRpcTest(t, "nats", 4)
+	// executeNRpcTest(t, "nats", 4)
 }
 
 func TestRpcWithWebsockets(t *testing.T) {
-	executeNRpcTest(t, "ws", 2)
+	// executeNRpcTest(t, "ws", 2)
 	executeNRpcTest(t, "ws", 3)
-	executeNRpcTest(t, "ws", 4)
+	// executeNRpcTest(t, "ws", 4)
 }
 
 func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int) {


### PR DESCRIPTION
github CI was frequently failing with larger test loads.

PR is up for testing purpose - wanting to re-run the `go build` action to see whether the lighter load is more reliable.