### PR TITLE
fix: move env-check ahead of fevm test setup

### DIFF
--- a/client/engine/chainservice/adjudicator/challenge_test.go
+++ b/client/engine/chainservice/adjudicator/challenge_test.go
@@ -76,15 +76,16 @@ func TestChallenge(t *testing.T) {
 			})
 	}
 
+	// We only run the test if the RUN_FEVM_TESTS env var is set to true
+	if key, found := os.LookupEnv("RUN_FEVM_TESTS"); !found || strings.ToLower(key) != "true" {
+		t.Skip()
+	}
+
 	hyperspacePreparedChain := prepareHyperspaceBackend(t)
 
 	for _, turnNum := range []uint64{0, 1, 2} {
 		t.Run("HyperSpaceBackend: turnNum = "+fmt.Sprint(turnNum),
 			func(t *testing.T) {
-				// We only run the test if the RUN_FEVM_TESTS env var is set to true
-				if key, found := os.LookupEnv("RUN_FEVM_TESTS"); !found || strings.ToLower(key) != "true" {
-					t.Skip()
-				}
 				runChallengeWithTurnNum(t, turnNum, hyperspacePreparedChain)
 			})
 	}


### PR DESCRIPTION
Existing tests had an environment variable check for testing against Hyperspace test net, but this test wasn't performed until *after* attempting to dial the testnet.

PR moves the environment variable check (and conditional test skip) ahead of any interaction with Hyperspace.

As far as I can tell, no such environment variables are set with the repo / GH actions, so this moved check should serve as a stop-gap fix for broken CI runs: #1320.