### PR TITLE
Modify notifications check test to improve error reporting

### DIFF
--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -429,12 +429,14 @@ func checkNotifications[T channelInfo](t *testing.T, client string, required []T
 			t.Logf("%s received %v+", client, info)
 
 			// Check that the notification is a required or optional one.
-			_, found := acceptableNotifications[notifJSON]
-			if !found {
+			_, isExpected := acceptableNotifications[notifJSON]
+
+			if isExpected {
+				// To signal we received a notification we delete it from the map
+				delete(acceptableNotifications, notifJSON)
+			} else {
 				unexpectedNotifications[notifJSON] = true
 			}
-			// To signal we received a notification we delete it from the map
-			delete(acceptableNotifications, notifJSON)
 
 		case <-time.After(timeout):
 			logUnexpected()


### PR DESCRIPTION
Toward #1323 

PR improves debug information from failed runs by failing more slowly. Instead of immediate fail on receipt of an unexpected notification, test now waits the test timeout until all required notifications have been seen.

After the timeout, it reports on all abnormalities (missing & required, present & unexpected).