### PR TITLE
Add TestStartStop MWE of tcp connection refused error

### DIFF
--- a/client/engine/messageservice/p2p-message-service/service.go
+++ b/client/engine/messageservice/p2p-message-service/service.go
@@ -91,12 +91,7 @@ func NewMessageService(ip string, port int, me types.Address, pk []byte, useMdns
 	if err != nil {
 		panic(err)
 	}
-	if useMdnsPeerDiscovery {
-		mdns := mdns.NewMdnsService(host, "", ms)
-		err = mdns.Start()
-		ms.checkError(err)
-		ms.mdns = mdns
-	}
+
 	ms.p2pHost = host
 
 	ms.p2pHost.SetStreamHandler(PROTOCOL_ID, ms.msgStreamHandler)
@@ -106,6 +101,14 @@ func NewMessageService(ip string, port int, me types.Address, pk []byte, useMdns
 		stream.Close()
 	})
 
+	// Since the mdns service could trigger a call to  `HandlePeerFound` at any time once started
+	// We want to start mdns after the message service has been fully constructed
+	if useMdnsPeerDiscovery {
+		mdns := mdns.NewMdnsService(host, "", ms)
+		err = mdns.Start()
+		ms.checkError(err)
+		ms.mdns = mdns
+	}
 	return ms
 }
 

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -46,6 +46,38 @@ func createLogger(logDestination *os.File, clientName, rpcRole string) zerolog.L
 		Logger()
 }
 
+func TestStartStop(t *testing.T) {
+	chain := chainservice.NewMockChain()
+	_, msg1, cleanup1 := setupNitroNodeWithRPCClient(
+		t,
+		common.Hex2Bytes(`febb3b74b0b52d0976f6571d555f4ac8b91c308dfa25c7b58d1e6a7c3f50c781`),
+		3005,
+		4005,
+		chainservice.NewMockChainService(chain, types.Address{0}),
+		os.Stdout,
+		"ws")
+	_, msg2, cleanup2 := setupNitroNodeWithRPCClient(
+		t,
+		common.Hex2Bytes(`febb3b74b0b52d0976f6571d555f4ac8b91c308dfa25c7b58d1e6a7c3f50c782`),
+		3006,
+		4006,
+		chainservice.NewMockChainService(chain, types.Address{1}),
+		os.Stdout,
+		"ws")
+	_, msg3, cleanup3 := setupNitroNodeWithRPCClient(
+		t,
+		common.Hex2Bytes(`febb3b74b0b52d0976f6571d555f4ac8b91c308dfa25c7b58d1e6a7c3f50c783`),
+		3007,
+		4007,
+		chainservice.NewMockChainService(chain, types.Address{1}),
+		os.Stdout,
+		"ws")
+	waitForPeerInfoExchange(msg1, msg2, msg3)
+	cleanup1()
+	cleanup2()
+	cleanup3()
+}
+
 func TestRpcWithNats(t *testing.T) {
 	executeNRpcTest(t, "nats", 2)
 	executeNRpcTest(t, "nats", 3)

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -47,6 +47,7 @@ func createLogger(logDestination *os.File, clientName, rpcRole string) zerolog.L
 }
 
 func TestStartStop(t *testing.T) {
+	logDest := newLogWriter("test_rpc_start_stop.log")
 	chain := chainservice.NewMockChain()
 	_, msg1, cleanup1 := setupNitroNodeWithRPCClient(
 		t,
@@ -54,7 +55,7 @@ func TestStartStop(t *testing.T) {
 		3005,
 		4005,
 		chainservice.NewMockChainService(chain, types.Address{0}),
-		os.Stdout,
+		logDest,
 		"ws")
 	_, msg2, cleanup2 := setupNitroNodeWithRPCClient(
 		t,
@@ -62,7 +63,7 @@ func TestStartStop(t *testing.T) {
 		3006,
 		4006,
 		chainservice.NewMockChainService(chain, types.Address{1}),
-		os.Stdout,
+		logDest,
 		"ws")
 	_, msg3, cleanup3 := setupNitroNodeWithRPCClient(
 		t,
@@ -70,7 +71,7 @@ func TestStartStop(t *testing.T) {
 		3007,
 		4007,
 		chainservice.NewMockChainService(chain, types.Address{1}),
-		os.Stdout,
+		logDest,
 		"ws")
 	waitForPeerInfoExchange(msg1, msg2, msg3)
 	cleanup1()


### PR DESCRIPTION
I have a suspicion that we aren't cleaning up nitro nodes properly / possibly have a race condition around the message service shutdown.. 

I think related to #1323 

This new test seems to pass every time (on my machine) when I run it with `-count=1`. But if I run it with a higher count, I often get a failure. 

`go test ./client_test -run TestStartStop -v -count=10`

So I am wondering if there is something lingering on from the previous test which interferes with the next one. 

Error message:

```
{"level":"debug","engine":"0x111A00","time":1686154669417,"caller":"engine.go:151","message":"Constructed Engine"}
{"level":"trace","client":"0x111A00868581f73AB42FEEF67D235Ca09ca1E8db","rpc":"client","scope":"","time":1686154669417,"message":"Subscribed to notifications"}
{"level":"debug","engine":"0x3bc760","time":1686154669420,"caller":"engine.go:151","message":"Constructed Engine"}
{"level":"trace","client":"0x3bc7608cB3D5ea0572717C276386b8a12Fd8289B","rpc":"client","scope":"","time":1686154669420,"message":"Subscribed to notifications"}
{"level":"debug","engine":"0x9d31D3","time":1686154669421,"caller":"engine.go:151","message":"Constructed Engine"}
{"level":"trace","client":"0x9d31D3448D20B777C252EbBA830c1BbA8532BE43","rpc":"client","scope":"","time":1686154669422,"message":"Subscribed to notifications"}
{"level":"debug","message-service":"0x111A00","peerInfo":{"Id":"16Uiu2HAmDWx6b4aRap2nxiW3QwyyPSQCrYSU2wX84HWa3jWGENQW","Address":"0x3bc7608cb3d5ea0572717c276386b8a12fd8289b"},"time":1686154669424,"caller":"service.go:172","message":"New peer found"}
{"level":"debug","message-service":"0x3bc760","peerInfo":{"Id":"16Uiu2HAmHntR3SGeS7iF2tdeNBefSahXBhmTrqVozVLHydxzkaZn","Address":"0x111a00868581f73ab42feef67d235ca09ca1e8db"},"time":1686154669424,"caller":"service.go:172","message":"New peer found"}
{"level":"debug","message-service":"0x3bc760","peerInfo":{"Id":"16Uiu2HAmEKETsG9XtxdXpyYNxKfkuBdWEDq656zrWZZd5FvVvtZ1","Address":"0x9d31d3448d20b777c252ebba830c1bba8532be43"},"time":1686154669425,"caller":"service.go:172","message":"New peer found"}
{"level":"debug","message-service":"0x9d31D3","peerInfo":{"Id":"16Uiu2HAmDWx6b4aRap2nxiW3QwyyPSQCrYSU2wX84HWa3jWGENQW","Address":"0x3bc7608cb3d5ea0572717c276386b8a12fd8289b"},"time":1686154669425,"caller":"service.go:172","message":"New peer found"}
{"level":"debug","message-service":"0x111A00","peerInfo":{"Id":"16Uiu2HAmEKETsG9XtxdXpyYNxKfkuBdWEDq656zrWZZd5FvVvtZ1","Address":"0x9d31d3448d20b777c252ebba830c1bba8532be43"},"time":1686154669425,"caller":"service.go:172","message":"New peer found"}
{"level":"debug","message-service":"0x9d31D3","peerInfo":{"Id":"16Uiu2HAmHntR3SGeS7iF2tdeNBefSahXBhmTrqVozVLHydxzkaZn","Address":"0x111a00868581f73ab42feef67d235ca09ca1e8db"},"time":1686154669425,"caller":"service.go:172","message":"New peer found"}
{"level":"warn","client":"0x111A00868581f73AB42FEEF67D235Ca09ca1E8db","rpc":"server","scope":"","time":1686154669425,"message":"LedgerUpdates channel closed, exiting sendNotifications"}
{"level":"warn","client":"0x3bc7608cB3D5ea0572717C276386b8a12Fd8289B","rpc":"server","scope":"","time":1686154669426,"message":"LedgerUpdates channel closed, exiting sendNotifications"}
{"level":"warn","client":"0x9d31D3448D20B777C252EbBA830c1BbA8532BE43","rpc":"server","scope":"","time":1686154669427,"message":"LedgerUpdates channel closed, exiting sendNotifications"}
{"level":"debug","engine":"0x111A00","time":1686154669429,"caller":"engine.go:151","message":"Constructed Engine"}
{"level":"trace","client":"0x111A00868581f73AB42FEEF67D235Ca09ca1E8db","rpc":"client","scope":"","time":1686154669429,"message":"Subscribed to notifications"}
panic: failed to dial 16Uiu2HAmDWx6b4aRap2nxiW3QwyyPSQCrYSU2wX84HWa3jWGENQW:
  * [/ip4/127.0.0.1/tcp/3006] dial tcp4 127.0.0.1:3006: connect: connection refused

goroutine 5729 [running]:
github.com/statechannels/go-nitro/client/engine/messageservice/p2p-message-service.(*P2PMessageService).checkError(...)
	/Users/georgeknee/statechannels/go-nitro/client/engine/messageservice/p2p-message-service/service.go:217
github.com/statechannels/go-nitro/client/engine/messageservice/p2p-message-service.(*P2PMessageService).HandlePeerFound(0x140005da180, {{0x1400064e0f0, 0x27}, {0x14000d08e30, 0x1, 0x1}})
	/Users/georgeknee/statechannels/go-nitro/client/engine/messageservice/p2p-message-service/service.go:116 +0x138
created by github.com/libp2p/go-libp2p/p2p/discovery/mdns.(*mdnsService).startResolver.func1
	/Users/georgeknee/go/pkg/mod/github.com/libp2p/go-libp2p@v0.27.0/p2p/discovery/mdns/mdns.go:183 +0x490
FAIL	github.com/statechannels/go-nitro/client_test	0.525s
FAIL
```