### PR TITLE
Avoid starting MDNS before message service is ready

### DIFF
--- a/client/engine/messageservice/p2p-message-service/service.go
+++ b/client/engine/messageservice/p2p-message-service/service.go
@@ -91,12 +91,7 @@ func NewMessageService(ip string, port int, me types.Address, pk []byte, useMdns
 	if err != nil {
 		panic(err)
 	}
-	if useMdnsPeerDiscovery {
-		mdns := mdns.NewMdnsService(host, "", ms)
-		err = mdns.Start()
-		ms.checkError(err)
-		ms.mdns = mdns
-	}
+
 	ms.p2pHost = host
 
 	ms.p2pHost.SetStreamHandler(PROTOCOL_ID, ms.msgStreamHandler)
@@ -106,6 +101,14 @@ func NewMessageService(ip string, port int, me types.Address, pk []byte, useMdns
 		stream.Close()
 	})
 
+	// Since the mdns service could trigger a call to  `HandlePeerFound` at any time once started
+	// We want to start mdns after the message service has been fully constructed
+	if useMdnsPeerDiscovery {
+		mdns := mdns.NewMdnsService(host, "", ms)
+		err = mdns.Start()
+		ms.checkError(err)
+		ms.mdns = mdns
+	}
 	return ms
 }
 

--- a/client/engine/messageservice/p2p-message-service/service.go
+++ b/client/engine/messageservice/p2p-message-service/service.go
@@ -231,7 +231,10 @@ func (s *P2PMessageService) Out() <-chan protocols.Message {
 func (s *P2PMessageService) Close() error {
 	// The mdns service is optional so we only close it if it exists
 	if s.mdns != nil {
-		s.mdns.Close()
+		err := s.mdns.Close()
+		if err != nil {
+			return err
+		}
 	}
 	s.p2pHost.RemoveStreamHandler(PROTOCOL_ID)
 	return s.p2pHost.Close()

--- a/client/engine/messageservice/p2p-message-service/service.go
+++ b/client/engine/messageservice/p2p-message-service/service.go
@@ -105,9 +105,11 @@ func NewMessageService(ip string, port int, me types.Address, pk []byte, useMdns
 	// We want to start mdns after the message service has been fully constructed
 	if useMdnsPeerDiscovery {
 		mdns := mdns.NewMdnsService(host, "", ms)
+
+		ms.mdns = mdns
+
 		err = mdns.Start()
 		ms.checkError(err)
-		ms.mdns = mdns
 	}
 	return ms
 }


### PR DESCRIPTION
Previously we would start up the `mdns` service before we had finished constructing the message service. This meant that if we're unlikely with timing `mdns` could call `HandlePeerFound` on the message service before the constructor had completed. We now start`mdns` at the end of constructor after everything has been initialized. 

I've also noticed that if we use the `-race` flag we get a race condition complaining about our use of our logger. I've created a new issue for that : #1329 