### PR TITLE
Prevent race condition when closing client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -118,6 +118,7 @@ func (c *Client) handleEngineEvents() {
 	// If there are blocking consumers (for or select channel statements) on any channel for which the client is a producer,
 	// those channels need to be closed.
 	close(c.completedObjectivesForRPC)
+	c.channelNotifier.Close()
 }
 
 // Begin API
@@ -273,9 +274,6 @@ func (c *Client) GetLedgerChannel(id types.Destination) (query.LedgerChannelInfo
 
 // Close stops the client from responding to any input.
 func (c *Client) Close() error {
-	if err := c.channelNotifier.Close(); err != nil {
-		return err
-	}
 	if err := c.engine.Close(); err != nil {
 		return err
 	}

--- a/client/engine/messageservice/p2p-message-service/service.go
+++ b/client/engine/messageservice/p2p-message-service/service.go
@@ -91,12 +91,7 @@ func NewMessageService(ip string, port int, me types.Address, pk []byte, useMdns
 	if err != nil {
 		panic(err)
 	}
-	if useMdnsPeerDiscovery {
-		mdns := mdns.NewMdnsService(host, "", ms)
-		err = mdns.Start()
-		ms.checkError(err)
-		ms.mdns = mdns
-	}
+
 	ms.p2pHost = host
 
 	ms.p2pHost.SetStreamHandler(PROTOCOL_ID, ms.msgStreamHandler)
@@ -106,6 +101,14 @@ func NewMessageService(ip string, port int, me types.Address, pk []byte, useMdns
 		stream.Close()
 	})
 
+	// Since the mdns service could trigger a call to  `HandlePeerFound` at any time once started
+	// We want to start mdns after the message service has been fully constructed
+	if useMdnsPeerDiscovery {
+		mdns := mdns.NewMdnsService(host, "", ms)
+		err = mdns.Start()
+		ms.checkError(err)
+		ms.mdns = mdns
+	}
 	return ms
 }
 


### PR DESCRIPTION
Fixes https://github.com/statechannels/go-nitro/issues/1330

This addresses a race condition that could occur when closing the nitro client. The nitro client starts a handleEngineEvents in a go-routine when it's constructed. This functions listens on a chan from the engine for events and dispatches them to the channelNotifier.

The problem is that handleEngineEvents would to continue to run after we close the channel notifier in Close. This means handleEngineEvents would try to call channelNotfier.Notify after it's been closed, resulting in the error we see. Since the toAPI is [a buffered chan of size 100](https://github.com/statechannels/go-nitro/blob/4c820ee15dbf04648cb91e58617c75097cc1a26f/client/engine/engine.go#L142) it's quite possible that handleEngineEvents continues to execute for awhile after Close has been called.

To address this I've moved the responsibility for closing the `channelNotifier` to the `handleEngineEvents` go routine,  so it only closes the channel notifier after it's done dispatching notifications.