### PR TITLE
Closing go-routines ADR

### DIFF
--- a/.adr/0016-closing-go-routines.md
+++ b/.adr/0016-closing-go-routines.md
@@ -113,10 +113,6 @@ wg := sync.WaitGroup{}
 
 Once a struct has waited for all go-routines to finish executing, it can dispose of any resources like network connections or child structs. We do this by calling `Close` on any child structs that implement [io.Closer interface](https://pkg.go.dev/io#Closer). **In general, if a child struct implements the `Closer` interface, we should consider calling it in our struct's `Close`**
 
-### Step 4: Return any errors
-
-If any error has
-
 ## Prior Art
 
 A example of this pattern can be found in the libp2p codebase, such as the [mdns service Close function](https://github.com/libp2p/go-libp2p/blob/c9de1665054229bdfd40884cd0b893744ec8ef7e/p2p/discovery/mdns/mdns.go#L75).

--- a/.adr/0016-closing-go-routines.md
+++ b/.adr/0016-closing-go-routines.md
@@ -12,7 +12,6 @@ Here's a list of structs that spin up long-running go-routines:
 
 - [The RPC client](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/rpc/client.go#L14)
 - [The RPC server](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/rpc/server.go#L223)
-- [RPC Websocket Transport](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/rpc/transport/ws/server.go#L49)
 - [Eth Chain service](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/client/engine/chainservice/eth_chainservice.go#L244)
 - [The API client](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/client/client.go#L87)
 

--- a/.adr/0016-closing-go-routines.md
+++ b/.adr/0016-closing-go-routines.md
@@ -10,7 +10,7 @@ In our codebase we have a few structs that use long-running go-routines to handl
 
 Here's a list of structs that spin up long-running go-routines.
 
-- [The RPC client](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/rpc/client.go#L14)
+- [The RPC client](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/rpc/client.go#L142)
 - [The RPC server](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/rpc/server.go#L223)
 - [Eth Chain service](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/client/engine/chainservice/eth_chainservice.go#L244)
 - [The API client](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/client/client.go#L87)

--- a/.adr/0016-closing-go-routines.md
+++ b/.adr/0016-closing-go-routines.md
@@ -32,6 +32,8 @@ To enforce these constraints we should follow this pattern in a struct's `Close`
 2. Wait until all go-routines have completed execution.
 3. Close any resources it owns.
 
+We want to adhere to the [io.Closer interface](https://pkg.go.dev/io#Closer) so the `Close` function should return an `error`.
+
 ### Step 1: Signal go-routines to exit
 
 Long-running `go-routines` need some kind of trigger to stop executing. A common and simple pattern we often use is simply closing the chan the go-routine is consuming from.
@@ -110,6 +112,10 @@ wg := sync.WaitGroup{}
 ### Step 3: Close Resources
 
 Once a struct has waited for all go-routines to finish executing, it can dispose of any resources like network connections or child structs. We do this by calling `Close` on any child structs that implement [io.Closer interface](https://pkg.go.dev/io#Closer). **In general, if a child struct implements the `Closer` interface, we should consider calling it in our struct's `Close`**
+
+### Step 4: Return any errors
+
+If any error has
 
 ## Prior Art
 

--- a/.adr/0016-closing-go-routines.md
+++ b/.adr/0016-closing-go-routines.md
@@ -1,0 +1,143 @@
+# 0016 Closing Go-routines
+
+## Status
+
+Review
+
+## Context
+
+We have multiple structs that use long-running go-routines to handle tasks asynchronously (often things like sending out messages/notifications). However we don't always consider how to stop and clean up after these go-routines, and when we do we the implementation can vary between structs. In some scenarios these long-running go-routines can continue running after `Close` has been called on the struct resulting in go-routines accessing resources that are already closed.
+
+Here's a list of structs that spin up long-running go-routines:
+
+- [The RPC client](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/rpc/client.go#L14)
+- [The RPC server](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/rpc/server.go#L223)
+- [RPC Websocket Transport](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/rpc/transport/ws/server.go#L49)
+- [Eth Chain service](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/client/engine/chainservice/eth_chainservice.go#L244)
+- [The engine](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/client/engine/engine.go#L544)
+- [The API client](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/client/client.go#L87)
+
+## Decision
+
+**Note:** I use the term struct as a shorthand for a struct with a long-running go-routine, like the examples above.
+
+When a struct's `Close` function is called, it should block and not return until:
+
+- all go-routines a struct owns have stopped executing.
+- any closeable resources are closed.
+
+By enforcing these constraints a running go-routine can be guaranteed that it's parent struct is in a "running" state. This rules out a large amount of confusing situations or possible footguns when implementing the go-routine, as we don't have to worry about the possibility that resources have been closed.
+
+#### What if we don't want to block on `Close`?
+
+Maybe there's some scenarios where we don't care about waiting until all a struct's go-routines fully exit, we just want to trigger `Close` and move on. Due to the flexibility of golang, it's very easy to accomplish this by wrapping the blocking `Close` in a go-routine.
+
+```golang
+c:= SomeClient{}
+	go func() {
+		c.Close()
+	}()
+```
+
+## Close Pattern
+
+To enforce these constraints we should implement the following pattern in a struct's `Close`. It should:
+
+1. Signal to any go-routines to exit.
+2. Block until all go-routine finish executing.
+3. Close any resources it owns.
+
+### Step 1: Signal go-routines to exit
+
+Long-running `go-routines` need some kind of trigger to stop executing. A common and simple pattern we often use is simply closing the chan the go-routine is consuming from.
+
+```golang
+	toRoutine := make(chan int)
+
+	go func() {
+		for v := range toRoutine {
+			doSomething(v)
+		}
+		// This logic runs once the channel is closed
+		doCleanup()
+	}()
+
+	// This closes the channel and signals the go routine to exit
+	close(toRoutine)
+
+```
+
+This works, however a [cancelable context](https://cs.opensource.google/go/go/+/go1.20.5:src/context/context.go;l=238) provides some benefits over this:
+
+- A buffered chan will only get closed once it's buffer is read. This means a go-routine will read all the buffered entries before it finishes executing. By using a context we can halt the execution almost immediately.
+- It makes go-routine cleanup logic explicit and easy to see. It's now just a case statement for `ctx.Done`.
+- Minor but it would allow us to use other context features (such as timeouts) in the future.
+
+Due to these benefits, and the limited use of go-routines, we should update our structs to use a cancelable context where reasonable.
+
+```golang
+	toRoutine := make(chan int)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		for {
+			select {
+			case v := <-toRoutine:
+				doSomething(v)
+			case <-ctx.Done():
+				doCleanup()
+			}
+		}
+	}()
+
+	// This triggers the goroutine to exit
+	cancel()
+```
+
+### 2: Block until all go-routine finishes executing
+
+After we have signalled our go-routines to exit we should wait for them to complete. The easiest way to accomplish this is with a `sync.WaitGroup`
+
+```golang
+wg := sync.WaitGroup{}
+	toRoutine := make(chan int)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	wg.Add(1)
+	go func() {
+		for {
+			select {
+			case v := <-toRoutine:
+				doSomething(v)
+			case <-ctx.Done():
+				doCleanup()
+				wg.Done()
+			}
+		}
+	}()
+
+	// This triggers the goroutine to exit
+	cancel()
+
+	// This blocks until the goroutine has exited
+	wg.Wait()
+```
+
+### Step 3: Close Resources
+
+Once a struct has waited for all go-routines to finish executing, it can dispose of any resources like network connections or child structs. We do this by calling `Close` on any child structs that implement [io.Closer interface](https://pkg.go.dev/io#Closer). **In general, if a child struct implements the `Closer` interface, we should probably call it in our `Close`**
+
+## Prior Art
+
+A example of this pattern can be found in the libp2p codebase, such as the [mdns service Close function](https://github.com/libp2p/go-libp2p/blob/c9de1665054229bdfd40884cd0b893744ec8ef7e/p2p/discovery/mdns/mdns.go#L75).
+
+```golang
+
+func (s *mdnsService) Close() error {
+	s.ctxCancel()
+	if s.server != nil {
+		s.server.Shutdown()
+	}
+	s.resolverWG.Wait()
+	return nil
+}
+```

--- a/.adr/0016-closing-go-routines.md
+++ b/.adr/0016-closing-go-routines.md
@@ -82,7 +82,7 @@ Due to these benefits, and the limited use of go-routines, we should update our 
 
 ### 2: Wait until all go-routines have completed execution.
 
-After we have signalled our "long-running" go-routines to exit we should wait for **all** go-routines to exit(both long and short lived). The easiest way to accomplish this is with a `sync.WaitGroup`
+After we have signalled our "long-running" go-routines to exit we should wait for **all** go-routines to exit (both long and short lived). The easiest way to accomplish this is with a `sync.WaitGroup`
 
 ```golang
 wg := sync.WaitGroup{}

--- a/.adr/0016-closing-go-routines.md
+++ b/.adr/0016-closing-go-routines.md
@@ -14,7 +14,6 @@ Here's a list of structs that spin up long-running go-routines:
 - [The RPC server](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/rpc/server.go#L223)
 - [RPC Websocket Transport](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/rpc/transport/ws/server.go#L49)
 - [Eth Chain service](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/client/engine/chainservice/eth_chainservice.go#L244)
-- [The engine](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/client/engine/engine.go#L544)
 - [The API client](https://github.com/statechannels/go-nitro/blob/0b5fa37613363720c91c115c3de252a39b1b1f0a/client/client.go#L87)
 
 ## Decision

--- a/client/client.go
+++ b/client/client.go
@@ -75,12 +75,11 @@ func New(messageService messageservice.MessageService, chainservice chainservice
 	c.channelNotifier = notifier.NewChannelNotifier(store, c.vm)
 
 	// Start the engine in a go routine
-
-	go c.engine.Run()
+	ctx, cancel := context.WithCancel(context.Background())
 
 	c.wg = &sync.WaitGroup{}
 	c.wg.Add(1)
-	ctx, cancel := context.WithCancel(context.Background())
+
 	c.cancelEventHandler = cancel
 	// Start the event handler in a go routine
 	// It will listen for events from the engine and dispatch events to client channels

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -47,7 +47,7 @@ type EthChainService struct {
 	logger                   zerolog.Logger
 	ctx                      context.Context
 	cancel                   context.CancelFunc
-	wg                       sync.WaitGroup
+	wg                       *sync.WaitGroup
 }
 
 // MAX_QUERY_BLOCK_RANGE is the maximum range of blocks we query for events at once.
@@ -91,7 +91,7 @@ func newEthChainService(chain ethChain, na *NitroAdjudicator.NitroAdjudicator,
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
-	ecs := EthChainService{chain, na, naAddress, caAddress, vpaAddress, txSigner, make(chan Event, 10), logger, ctx, cancelCtx, sync.WaitGroup{}}
+	ecs := EthChainService{chain, na, naAddress, caAddress, vpaAddress, txSigner, make(chan Event, 10), logger, ctx, cancelCtx, &sync.WaitGroup{}}
 	errChan, err := ecs.subscribeForLogs()
 	if err != nil {
 		return nil, err

--- a/client/engine/engine.go
+++ b/client/engine/engine.go
@@ -550,12 +550,14 @@ func (e *Engine) sendMessages(msgs []protocols.Message) {
 		e.recordMessageMetrics(message)
 		e.msg.Send(message)
 	}
+	e.wg.Done()
 }
 
 // executeSideEffects executes the SideEffects declared by cranking an Objective or handling a payment request.
 func (e *Engine) executeSideEffects(sideEffects protocols.SideEffects) error {
 	defer e.metrics.RecordFunctionDuration()()
 
+	e.wg.Add(1)
 	// Send messages in a go routine so that we don't block on message delivery
 	go e.sendMessages(sideEffects.MessagesToSend)
 

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -235,14 +235,9 @@ func (rc *RpcClient) PaymentChannelUpdatesChan(paymentChannelId types.Destinatio
 // request uses the supplied transport and payload to send a non-blocking JSONRPC request.
 // It returns a channel that sends a response payload. If the request fails to send, an error is returned.
 func request[T serde.RequestPayload, U serde.ResponsePayload](trans transport.Requester, method serde.RequestMethod, reqPayload T, logger zerolog.Logger, wg *sync.WaitGroup) (<-chan response[U], error) {
-	return sendRPCRequest[T, U](method, reqPayload, trans, logger, wg)
-}
-
-func sendRPCRequest[T serde.RequestPayload, U serde.ResponsePayload](method serde.RequestMethod, request T, trans transport.Requester, logger zerolog.Logger, wg *sync.WaitGroup) (<-chan response[U], error) {
 	returnChan := make(chan response[U], 1)
-
 	requestId := rand.Uint64()
-	message := serde.NewJsonRpcRequest(requestId, method, request)
+	message := serde.NewJsonRpcRequest(requestId, method, reqPayload)
 	data, err := json.Marshal(message)
 	if err != nil {
 		return nil, err
@@ -253,24 +248,26 @@ func sendRPCRequest[T serde.RequestPayload, U serde.ResponsePayload](method serd
 		Msg("sent message")
 
 	wg.Add(1)
-	go func() {
-		responseData, err := trans.Request(data)
-		if err != nil {
-			returnChan <- response[U]{Error: err}
-		}
-
-		logger.Trace().Msgf("Rpc client received response: %+v", string(responseData))
-
-		jsonResponse := serde.JsonRpcResponse[U]{}
-		err = json.Unmarshal(responseData, &jsonResponse)
-		if err != nil {
-			returnChan <- response[U]{Error: err}
-		}
-
-		returnChan <- response[U]{jsonResponse.Result, nil}
-		wg.Done()
-	}()
+	go sendRPCRequest[T, U](data, trans, returnChan, logger, wg)
 	return returnChan, nil
+}
+
+func sendRPCRequest[T serde.RequestPayload, U serde.ResponsePayload](data []byte, trans transport.Requester, returnChan chan response[U], logger zerolog.Logger, wg *sync.WaitGroup) {
+	responseData, err := trans.Request(data)
+	if err != nil {
+		returnChan <- response[U]{Error: err}
+	}
+
+	logger.Trace().Msgf("Rpc client received response: %+v", string(responseData))
+
+	jsonResponse := serde.JsonRpcResponse[U]{}
+	err = json.Unmarshal(responseData, &jsonResponse)
+	if err != nil {
+		returnChan <- response[U]{Error: err}
+	}
+
+	returnChan <- response[U]{jsonResponse.Result, nil}
+	wg.Done()
 }
 
 // getNotificationMethod parses the raw notification and returns the notification method

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -25,7 +25,7 @@ type RpcServer struct {
 	client    *nitro.Client
 	logger    *zerolog.Logger
 	cancel    context.CancelFunc
-	wg        sync.WaitGroup
+	wg        *sync.WaitGroup
 }
 
 func (rs *RpcServer) Url() string {
@@ -46,7 +46,7 @@ func (rs *RpcServer) Close() error {
 
 // newRpcServerWithoutNotifications creates a new rpc server without notifications enabled
 func newRpcServerWithoutNotifications(nitroClient *nitro.Client, logger *zerolog.Logger, trans transport.Responder) (*RpcServer, error) {
-	rs := &RpcServer{trans, nitroClient, logger, func() {}, sync.WaitGroup{}}
+	rs := &RpcServer{trans, nitroClient, logger, func() {}, &sync.WaitGroup{}}
 
 	err := rs.registerHandlers()
 	if err != nil {
@@ -58,7 +58,7 @@ func newRpcServerWithoutNotifications(nitroClient *nitro.Client, logger *zerolog
 
 func NewRpcServer(nitroClient *nitro.Client, logger *zerolog.Logger, trans transport.Responder) (*RpcServer, error) {
 	ctx, cancel := context.WithCancel(context.Background())
-	rs := &RpcServer{trans, nitroClient, logger, cancel, sync.WaitGroup{}}
+	rs := &RpcServer{trans, nitroClient, logger, cancel, &sync.WaitGroup{}}
 
 	rs.wg.Add(1)
 	go rs.sendNotifications(ctx)

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -35,10 +35,6 @@ func (rs *RpcServer) Url() string {
 func (rs *RpcServer) Close() error {
 	rs.cancel()
 	rs.wg.Wait()
-	err := rs.client.Close()
-	if err != nil {
-		return err
-	}
 
 	rs.transport.Close()
 	return rs.client.Close()


### PR DESCRIPTION
This PR:
- Adds an ADR for the pattern we should use when closing long running go-routines in a struct.
- Applies this pattern throughout our codebase, where appropriate. 