### PR TITLE
Wrap ConfigureZeroLogger in a sync.Once

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -2,11 +2,18 @@ package logging
 
 import (
 	"strconv"
+	"sync"
 
 	"github.com/rs/zerolog"
 )
 
+var once sync.Once
+
 func ConfigureZeroLogger() {
+	once.Do(configureZeroLogger)
+}
+
+func configureZeroLogger() {
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnixMs
 	zerolog.CallerMarshalFunc = func(pc uintptr, file string, line int) string {
 		short := file


### PR DESCRIPTION
This seems to work, testing locally. 

The data race is caused by `ConfigureZeroLogger` (which writes some global config) running concurrently with a zerologger (which will read that global config. We can have multiple readers and multiple writers. The very first writer should run _before_ (i.e. not concurrently with) any reader, as long as the call to `ConfigureZeroLogger` is made before any loggers are instantiated. Like so:

https://github.com/statechannels/go-nitro/blob/5d024295e8430d09b5f33bc84a134d53e65be6c8/client/engine/engine.go#L144-L145


Therefore we can prevent data races by ensuring that subsequent `ConfigureZeroLogger` calls don't actually try to reset the global config. 