### PR TITLE
Have nitro process exit gracefully

### DIFF
--- a/main.go
+++ b/main.go
@@ -193,7 +193,8 @@ func main() {
 				Str("rpc", "server").
 				Str("scope", "").
 				Logger()
-			_, err = rpc.NewRpcServer(&node, &logger, transport)
+
+			rpcServer, err := rpc.NewRpcServer(&node, &logger, transport)
 			if err != nil {
 				return err
 			}
@@ -204,7 +205,7 @@ func main() {
 			signal.Notify(stopChan, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 			<-stopChan // wait for interrupt or terminate signal
 
-			return nil
+			return rpcServer.Close()
 		},
 	}
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -28,9 +28,9 @@ func (rs *RpcServer) Url() string {
 	return rs.transport.Url()
 }
 
-func (rs *RpcServer) Close() {
-	rs.client.Close()
+func (rs *RpcServer) Close() error {
 	rs.transport.Close()
+	return rs.client.Close()
 }
 
 // newRpcServerWithoutNotifications creates a new rpc server without notifications enabled


### PR DESCRIPTION
Testing manually, this causes mdns records to be cleaned up properly.

