### PR TITLE
Add ability to provide bearer auth token for chainservice

### DIFF
--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -61,11 +61,11 @@ const MAX_QUERY_BLOCK_RANGE = 2000
 const RESUB_INTERVAL = 2*time.Minute + 30*time.Second
 
 // NewEthChainService is a convenient wrapper around NewEthChainService, which provides a simpler API
-func NewEthChainService(chainUrl, chainPk string, naAddress, caAddress, vpaAddress common.Address, logDestination io.Writer) (*EthChainService, error) {
+func NewEthChainService(chainUrl, chainAuthToken, chainPk string, naAddress, caAddress, vpaAddress common.Address, logDestination io.Writer) (*EthChainService, error) {
 	if vpaAddress == caAddress {
 		return nil, fmt.Errorf("virtual payment app address and consensus app address cannot be the same: %s", vpaAddress.String())
 	}
-	ethClient, txSigner, err := chainutils.ConnectToChain(context.Background(), chainUrl, common.Hex2Bytes(chainPk))
+	ethClient, txSigner, err := chainutils.ConnectToChain(context.Background(), chainUrl, chainAuthToken, common.Hex2Bytes(chainPk))
 	if err != nil {
 		panic(err)
 	}

--- a/client/engine/chainservice/eth_chainservice.go
+++ b/client/engine/chainservice/eth_chainservice.go
@@ -60,7 +60,7 @@ const MAX_QUERY_BLOCK_RANGE = 2000
 // See https://github.com/ethereum/go-ethereum/blob/e14164d516600e9ac66f9060892e078f5c076229/eth/filters/filter_system.go#L43
 const RESUB_INTERVAL = 2*time.Minute + 30*time.Second
 
-// NewEthChainService is a convenient wrapper around NewEthChainService, which provides a simpler API
+// NewEthChainService is a convenient wrapper around newEthChainService, which provides a simpler API
 func NewEthChainService(chainUrl, chainAuthToken, chainPk string, naAddress, caAddress, vpaAddress common.Address, logDestination io.Writer) (*EthChainService, error) {
 	if vpaAddress == caAddress {
 		return nil, fmt.Errorf("virtual payment app address and consensus app address cannot be the same: %s", vpaAddress.String())
@@ -78,7 +78,7 @@ func NewEthChainService(chainUrl, chainAuthToken, chainPk string, naAddress, caA
 	return newEthChainService(ethClient, na, naAddress, caAddress, vpaAddress, txSigner, logDestination)
 }
 
-// NewEthChainService constructs a chain service that submits transactions to a NitroAdjudicator
+// newEthChainService constructs a chain service that submits transactions to a NitroAdjudicator
 // and listens to events from an eventSource
 func newEthChainService(chain ethChain, na *NitroAdjudicator.NitroAdjudicator,
 	naAddress, caAddress, vpaAddress common.Address, txSigner *bind.TransactOpts, logDestination io.Writer,

--- a/client/engine/chainservice/utils/utils.go
+++ b/client/engine/chainservice/utils/utils.go
@@ -45,7 +45,7 @@ func ConnectToChain(ctx context.Context, chainUrl, chainAuthToken string, chainP
 	}
 	txSubmitter.GasLimit = uint64(30_000_000) // in units
 
-	gasPrice, err := client.SuggestGasPrice(ctx)
+	gasPrice, err := client.SuggestGasPrice(context.Background())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/client/engine/chainservice/utils/utils.go
+++ b/client/engine/chainservice/utils/utils.go
@@ -7,18 +7,33 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 // ConnectToChain connects to the chain at the given url and returns a client and a transactor.
-func ConnectToChain(ctx context.Context, chainUrl string, chainPK []byte) (*ethclient.Client, *bind.TransactOpts, error) {
-	client, err := ethclient.Dial(chainUrl)
+func ConnectToChain(ctx context.Context, chainUrl, chainAuthToken string, chainPK []byte) (*ethclient.Client, *bind.TransactOpts, error) {
+	var rpcClient *rpc.Client
+	var err error
+
+	if chainAuthToken != "" {
+		fmt.Println("Adding bearer token authorization header to chain service")
+		options := rpc.WithHeader("Authorization", "Bearer "+chainAuthToken)
+		rpcClient, err = rpc.DialOptions(ctx, chainUrl, options)
+	} else {
+		rpcClient, err = rpc.DialContext(ctx, chainUrl)
+	}
 	if err != nil {
 		return nil, nil, err
 	}
-	foundChainId, err := client.ChainID(ctx)
+
+	client := ethclient.NewClient(rpcClient)
+	fmt.Println("Connected to ethclient at url: " + chainUrl)
+
+	foundChainId, err := client.ChainID(context.Background())
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not get chain id: %w", err)
 	}
+	fmt.Printf("Found chain id: %v\n", foundChainId)
 
 	key, err := ethcrypto.ToECDSA(chainPK)
 	if err != nil {
@@ -30,7 +45,7 @@ func ConnectToChain(ctx context.Context, chainUrl string, chainPK []byte) (*ethc
 	}
 	txSubmitter.GasLimit = uint64(30_000_000) // in units
 
-	gasPrice, err := client.SuggestGasPrice(context.Background())
+	gasPrice, err := client.SuggestGasPrice(ctx)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ func main() {
 		USE_DURABLE_STORE = "usedurablestore"
 		PK                = "pk"
 		CHAIN_URL         = "chainurl"
+		CHAIN_AUTH_TOKEN  = "chainauthtoken"
 		CHAIN_PK          = "chainpk"
 		NA_ADDRESS        = "naaddress"
 		VPA_ADDRESS       = "vpaaddress"
@@ -38,7 +39,7 @@ func main() {
 		MSG_PORT          = "msgport"
 		RPC_PORT          = "rpcport"
 	)
-	var pkString, chainUrl, naAddress, vpaAddress, caAddress, chainPk string
+	var pkString, chainUrl, chainAuthToken, naAddress, vpaAddress, caAddress, chainPk string
 	var msgPort, rpcPort int
 	var useNats, useDurableStore bool
 
@@ -74,6 +75,12 @@ func main() {
 			DefaultText: "hardhat / anvil default",
 			Category:    "Connectivity:",
 			Destination: &chainUrl,
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:        CHAIN_AUTH_TOKEN,
+			Usage:       "The bearer token used for auth when making requests to the chain's RPC endpoint.",
+			Category:    "Connectivity:",
+			Destination: &chainAuthToken,
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:        CHAIN_PK,
@@ -153,6 +160,7 @@ func main() {
 			fmt.Println("Initializing chain service and connecting to " + chainUrl + "...")
 			chainService, err := chainservice.NewEthChainService(
 				chainUrl,
+				chainAuthToken,
 				chainPk,
 				common.HexToAddress(naAddress),
 				common.HexToAddress(caAddress),

--- a/scripts/start-rpc-servers.go
+++ b/scripts/start-rpc-servers.go
@@ -165,7 +165,7 @@ func newColorWriter(c color, w io.Writer) colorWriter {
 
 // deployContracts deploys the  NitroAdjudicator contract.
 func deployContracts(ctx context.Context) (na common.Address, vpa common.Address, ca common.Address, err error) {
-	client, txSubmitter, err := chainutils.ConnectToChain(context.Background(), "ws://127.0.0.1:8545", common.Hex2Bytes(FUNDED_TEST_PK))
+	client, txSubmitter, err := chainutils.ConnectToChain(context.Background(), "ws://127.0.0.1:8545", "", common.Hex2Bytes(FUNDED_TEST_PK))
 	if err != nil {
 		return types.Address{}, types.Address{}, types.Address{}, err
 	}

--- a/scripts/test-configs/alice.toml
+++ b/scripts/test-configs/alice.toml
@@ -7,3 +7,6 @@ rpcport = 4005
 
 pk = "2d999770f7b5d49b694080f987b82bbc9fc9ac2b4dcc10b0f8aba7d700f69c6d"
 chainpk = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+
+chainurl = "ws://127.0.0.1:8545"
+chainauthtoken = ""

--- a/scripts/test-configs/bob.toml
+++ b/scripts/test-configs/bob.toml
@@ -7,3 +7,6 @@ rpcport = 4007
 
 pk = "0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4"
 chainpk = "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
+
+chainurl = "ws://127.0.0.1:8545"
+chainauthtoken = ""

--- a/scripts/test-configs/irene.toml
+++ b/scripts/test-configs/irene.toml
@@ -7,3 +7,6 @@ rpcport = 4006
 
 pk = "febb3b74b0b52d0976f6571d555f4ac8b91c308dfa25c7b58d1e6a7c3f50c781"
 chainpk = "7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6"
+
+chainurl = "ws://127.0.0.1:8545"
+chainauthtoken = ""


### PR DESCRIPTION
In order for our chainservice to be able to send requests to a production Filecoin Lotus node, we need to be able to set a bearer auth token in the header of those requests. This PR allows us to pass a `--chainauthtoken` flag or set a `chainauthtoken` variable in the config file. This token will then get passed and set within the eth rpc client (wss or https) so that subsequent requests will include the auth header.

### Testing
To test that this was working I used two different Infura projects as the targeted `chainurl`. 

1. wss://mainnet.infura.io/ws/v3/<projectId_1> : no auth header required
2. wss://mainnet.infura.io/ws/v3/<projectId_2> : enabled the "JWT required" option, which says "Restrict API usage to requests that include a valid JWT. Select this to enable Bearer Auth."

To create and upload the JWT required for [2], I followed the Infura documentation [here](https://docs.infura.io/networks/ethereum/how-to/secure-a-project/use-jwts). 

If you want to test this code using my preconfigured Infura projects listed as [1] and [2] above, please reach out via Slack and I can provide those so that you don't have to run through those same prerequisite steps.