### PR TITLE
Add request-specific validation of jsonrpc request params

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -198,7 +198,7 @@ func (c *Client) ReceivedVouchers() <-chan payments.Voucher {
 
 // CreateVirtualChannel creates a virtual channel with the counterParty using ledger channels
 // with the supplied intermediaries.
-func (c *Client) CreateVirtualPaymentChannel(Intermediaries []types.Address, CounterParty types.Address, ChallengeDuration uint32, Outcome outcome.Exit) virtualfund.ObjectiveResponse {
+func (c *Client) CreateVirtualPaymentChannel(Intermediaries []types.Address, CounterParty types.Address, ChallengeDuration uint32, Outcome outcome.Exit) (virtualfund.ObjectiveResponse, error) {
 	objectiveRequest := virtualfund.NewObjectiveRequest(
 		Intermediaries,
 		CounterParty,
@@ -212,22 +212,22 @@ func (c *Client) CreateVirtualPaymentChannel(Intermediaries []types.Address, Cou
 	c.engine.ObjectiveRequestsFromAPI <- objectiveRequest
 
 	objectiveRequest.WaitForObjectiveToStart()
-	return objectiveRequest.Response(*c.Address)
+	return objectiveRequest.Response(*c.Address), nil
 }
 
 // CloseVirtualChannel attempts to close and defund the given virtually funded channel.
-func (c *Client) CloseVirtualChannel(channelId types.Destination) protocols.ObjectiveId {
+func (c *Client) CloseVirtualChannel(channelId types.Destination) (protocols.ObjectiveId, error) {
 	objectiveRequest := virtualdefund.NewObjectiveRequest(channelId)
 
 	// Send the event to the engine
 	c.engine.ObjectiveRequestsFromAPI <- objectiveRequest
 	objectiveRequest.WaitForObjectiveToStart()
-	return objectiveRequest.Id(*c.Address, c.chainId)
+	return objectiveRequest.Id(*c.Address, c.chainId), nil
 }
 
 // CreateLedgerChannel creates a directly funded ledger channel with the given counterparty.
 // The channel will run under full consensus rules (it is not possible to provide a custom AppDefinition or AppData).
-func (c *Client) CreateLedgerChannel(Counterparty types.Address, ChallengeDuration uint32, outcome outcome.Exit) directfund.ObjectiveResponse {
+func (c *Client) CreateLedgerChannel(Counterparty types.Address, ChallengeDuration uint32, outcome outcome.Exit) (directfund.ObjectiveResponse, error) {
 	objectiveRequest := directfund.NewObjectiveRequest(
 		Counterparty,
 		ChallengeDuration,
@@ -240,17 +240,17 @@ func (c *Client) CreateLedgerChannel(Counterparty types.Address, ChallengeDurati
 	// Send the event to the engine
 	c.engine.ObjectiveRequestsFromAPI <- objectiveRequest
 	objectiveRequest.WaitForObjectiveToStart()
-	return objectiveRequest.Response(*c.Address, c.chainId)
+	return objectiveRequest.Response(*c.Address, c.chainId), nil
 }
 
 // CloseLedgerChannel attempts to close and defund the given directly funded channel.
-func (c *Client) CloseLedgerChannel(channelId types.Destination) protocols.ObjectiveId {
+func (c *Client) CloseLedgerChannel(channelId types.Destination) (protocols.ObjectiveId, error) {
 	objectiveRequest := directdefund.NewObjectiveRequest(channelId)
 
 	// Send the event to the engine
 	c.engine.ObjectiveRequestsFromAPI <- objectiveRequest
 	objectiveRequest.WaitForObjectiveToStart()
-	return objectiveRequest.Id(*c.Address, c.chainId)
+	return objectiveRequest.Id(*c.Address, c.chainId), nil
 }
 
 // Pay will send a signed voucher to the payee that they can redeem for the given amount.

--- a/client_test/crash_test.go
+++ b/client_test/crash_test.go
@@ -84,7 +84,10 @@ func TestCrashTolerance(t *testing.T) {
 }
 
 func directlyDefundALedgerChannel(t *testing.T, alpha client.Client, beta client.Client, channelId types.Destination) {
-	id, _ := alpha.CloseLedgerChannel(channelId)
+	id, err := alpha.CloseLedgerChannel(channelId)
+	if err != nil {
+		t.Fatal(err)
+	}
 	<-alpha.ObjectiveCompleteChan(id)
 	<-beta.ObjectiveCompleteChan(id)
 }
@@ -93,7 +96,10 @@ func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.C
 	// Set up an outcome that requires both participants to deposit
 	outcome := testdata.Outcomes.Create(*alpha.Address, *beta.Address, ledgerChannelDeposit, ledgerChannelDeposit, asset)
 
-	response, _ := alpha.CreateLedgerChannel(*beta.Address, 0, outcome)
+	response, err := alpha.CreateLedgerChannel(*beta.Address, 0, outcome)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	<-alpha.ObjectiveCompleteChan(response.Id)
 	<-beta.ObjectiveCompleteChan(response.Id)

--- a/client_test/crash_test.go
+++ b/client_test/crash_test.go
@@ -84,7 +84,7 @@ func TestCrashTolerance(t *testing.T) {
 }
 
 func directlyDefundALedgerChannel(t *testing.T, alpha client.Client, beta client.Client, channelId types.Destination) {
-	id := alpha.CloseLedgerChannel(channelId)
+	id, _ := alpha.CloseLedgerChannel(channelId)
 	<-alpha.ObjectiveCompleteChan(id)
 	<-beta.ObjectiveCompleteChan(id)
 }
@@ -93,7 +93,7 @@ func directlyFundALedgerChannel(t *testing.T, alpha client.Client, beta client.C
 	// Set up an outcome that requires both participants to deposit
 	outcome := testdata.Outcomes.Create(*alpha.Address, *beta.Address, ledgerChannelDeposit, ledgerChannelDeposit, asset)
 
-	response := alpha.CreateLedgerChannel(*beta.Address, 0, outcome)
+	response, _ := alpha.CreateLedgerChannel(*beta.Address, 0, outcome)
 
 	<-alpha.ObjectiveCompleteChan(response.Id)
 	<-beta.ObjectiveCompleteChan(response.Id)

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -176,7 +176,7 @@ func setupLedgerChannel(t *testing.T, alpha client.Client, beta client.Client, a
 	// Set up an outcome that requires both participants to deposit
 	outcome := initialLedgerOutcome(*alpha.Address, *beta.Address, asset)
 
-	response := alpha.CreateLedgerChannel(*beta.Address, 0, outcome)
+	response, _ := alpha.CreateLedgerChannel(*beta.Address, 0, outcome)
 
 	<-alpha.ObjectiveCompleteChan(response.Id)
 	<-beta.ObjectiveCompleteChan(response.Id)
@@ -185,7 +185,7 @@ func setupLedgerChannel(t *testing.T, alpha client.Client, beta client.Client, a
 }
 
 func closeLedgerChannel(t *testing.T, alpha client.Client, beta client.Client, channelId types.Destination) {
-	response := alpha.CloseLedgerChannel(channelId)
+	response, _ := alpha.CloseLedgerChannel(channelId)
 
 	<-alpha.ObjectiveCompleteChan(response)
 	<-beta.ObjectiveCompleteChan(response)

--- a/client_test/helpers_test.go
+++ b/client_test/helpers_test.go
@@ -176,7 +176,10 @@ func setupLedgerChannel(t *testing.T, alpha client.Client, beta client.Client, a
 	// Set up an outcome that requires both participants to deposit
 	outcome := initialLedgerOutcome(*alpha.Address, *beta.Address, asset)
 
-	response, _ := alpha.CreateLedgerChannel(*beta.Address, 0, outcome)
+	response, err := alpha.CreateLedgerChannel(*beta.Address, 0, outcome)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	<-alpha.ObjectiveCompleteChan(response.Id)
 	<-beta.ObjectiveCompleteChan(response.Id)
@@ -185,7 +188,10 @@ func setupLedgerChannel(t *testing.T, alpha client.Client, beta client.Client, a
 }
 
 func closeLedgerChannel(t *testing.T, alpha client.Client, beta client.Client, channelId types.Destination) {
-	response, _ := alpha.CloseLedgerChannel(channelId)
+	response, err := alpha.CloseLedgerChannel(channelId)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	<-alpha.ObjectiveCompleteChan(response)
 	<-beta.ObjectiveCompleteChan(response)

--- a/client_test/integration_test.go
+++ b/client_test/integration_test.go
@@ -126,12 +126,15 @@ func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 		virtualIds := make([]types.Destination, tc.NumOfChannels)
 		for i := 0; i < int(tc.NumOfChannels); i++ {
 			outcome := td.Outcomes.Create(testactors.Alice.Address(), testactors.Bob.Address(), virtualChannelDeposit, 0, types.Address{})
-			response, _ := clientA.CreateVirtualPaymentChannel(
+			response, err := clientA.CreateVirtualPaymentChannel(
 				clientAddresses(intermediaries),
 				testactors.Bob.Address(),
 				0,
 				outcome,
 			)
+			if err != nil {
+				t.Fatal(err)
+			}
 			objectiveIds[i] = response.Id
 			virtualIds[i] = response.ChannelId
 
@@ -175,9 +178,15 @@ func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 			// alternative who is responsible for closing the channel
 			switch i % 2 {
 			case 0:
-				closeVirtualIds[i], _ = clientA.CloseVirtualChannel(virtualIds[i])
+				closeVirtualIds[i], err = clientA.CloseVirtualChannel(virtualIds[i])
+				if err != nil {
+					t.Fatal(err)
+				}
 			case 1:
-				closeVirtualIds[i], _ = clientB.CloseVirtualChannel(virtualIds[i])
+				closeVirtualIds[i], err = clientB.CloseVirtualChannel(virtualIds[i])
+				if err != nil {
+					t.Fatal(err)
+				}
 			}
 		}
 

--- a/client_test/integration_test.go
+++ b/client_test/integration_test.go
@@ -126,7 +126,7 @@ func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 		virtualIds := make([]types.Destination, tc.NumOfChannels)
 		for i := 0; i < int(tc.NumOfChannels); i++ {
 			outcome := td.Outcomes.Create(testactors.Alice.Address(), testactors.Bob.Address(), virtualChannelDeposit, 0, types.Address{})
-			response := clientA.CreateVirtualPaymentChannel(
+			response, _ := clientA.CreateVirtualPaymentChannel(
 				clientAddresses(intermediaries),
 				testactors.Bob.Address(),
 				0,
@@ -175,9 +175,9 @@ func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 			// alternative who is responsible for closing the channel
 			switch i % 2 {
 			case 0:
-				closeVirtualIds[i] = clientA.CloseVirtualChannel(virtualIds[i])
+				closeVirtualIds[i], _ = clientA.CloseVirtualChannel(virtualIds[i])
 			case 1:
-				closeVirtualIds[i] = clientB.CloseVirtualChannel(virtualIds[i])
+				closeVirtualIds[i], _ = clientB.CloseVirtualChannel(virtualIds[i])
 			}
 		}
 

--- a/rpc/serde/validation.go
+++ b/rpc/serde/validation.go
@@ -1,0 +1,29 @@
+package serde
+
+import (
+	"github.com/statechannels/go-nitro/types"
+)
+
+func ValidatePaymentRequest(req PaymentRequest) error {
+	if req.Amount == 0 {
+		return types.InvalidParamsError
+	}
+	if (req.Channel == types.Destination{}) {
+		return types.InvalidParamsError
+	}
+	return nil
+}
+
+func ValidateGetPaymentChannelRequest(req GetPaymentChannelRequest) error {
+	if (req.Id == types.Destination{}) {
+		return types.InvalidParamsError
+	}
+	return nil
+}
+
+func ValidateGetPaymentChannelsByLedgerRequest(req GetPaymentChannelsByLedgerRequest) error {
+	if (req.LedgerId == types.Destination{}) {
+		return types.InvalidParamsError
+	}
+	return nil
+}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -76,75 +76,69 @@ func (rs *RpcServer) registerHandlers() (err error) {
 			return marshalResponse(types.ParseError, rs.logger)
 		}
 
-		validationResult := validateRequest(requestData, rs.logger)
-		if validationResult.Error != nil {
-			return validationResult.Error
+		jsonrpcReq := validateJsonrpcRequest(requestData, rs.logger)
+		if jsonrpcReq.Error != nil {
+			return jsonrpcReq.Error
 		}
 
-		switch serde.RequestMethod(validationResult.Method) {
+		switch serde.RequestMethod(jsonrpcReq.Method) {
 		case serde.GetAddressMethod:
-			return processRequest(rs, requestData, func(T serde.NoPayloadRequest) (string, error) {
+			return processRequest(rs, requestData, func(req serde.NoPayloadRequest) (string, error) {
 				return rs.client.Address.Hex(), nil
 			})
 		case serde.VersionMethod:
-			return processRequest(rs, requestData, func(T serde.NoPayloadRequest) (string, error) {
+			return processRequest(rs, requestData, func(req serde.NoPayloadRequest) (string, error) {
 				return rs.client.Version(), nil
 			})
 		case serde.DirectFundRequestMethod:
-			return processRequest(rs, requestData, func(obj directfund.ObjectiveRequest) (directfund.ObjectiveResponse, error) {
-				return rs.client.CreateLedgerChannel(obj.CounterParty, obj.ChallengeDuration, obj.Outcome), nil
+			return processRequest(rs, requestData, func(req directfund.ObjectiveRequest) (directfund.ObjectiveResponse, error) {
+				return rs.client.CreateLedgerChannel(req.CounterParty, req.ChallengeDuration, req.Outcome)
 			})
 		case serde.DirectDefundRequestMethod:
-			return processRequest(rs, requestData, func(obj directdefund.ObjectiveRequest) (protocols.ObjectiveId, error) {
-				return rs.client.CloseLedgerChannel(obj.ChannelId), nil
+			return processRequest(rs, requestData, func(req directdefund.ObjectiveRequest) (protocols.ObjectiveId, error) {
+				return rs.client.CloseLedgerChannel(req.ChannelId)
 			})
 		case serde.VirtualFundRequestMethod:
-			return processRequest(rs, requestData, func(obj virtualfund.ObjectiveRequest) (virtualfund.ObjectiveResponse, error) {
-				return rs.client.CreateVirtualPaymentChannel(obj.Intermediaries, obj.CounterParty, obj.ChallengeDuration, obj.Outcome), nil
+			return processRequest(rs, requestData, func(req virtualfund.ObjectiveRequest) (virtualfund.ObjectiveResponse, error) {
+				return rs.client.CreateVirtualPaymentChannel(req.Intermediaries, req.CounterParty, req.ChallengeDuration, req.Outcome)
 			})
 		case serde.VirtualDefundRequestMethod:
-			return processRequest(rs, requestData, func(obj virtualdefund.ObjectiveRequest) (protocols.ObjectiveId, error) {
-				return rs.client.CloseVirtualChannel(obj.ChannelId), nil
+			return processRequest(rs, requestData, func(req virtualdefund.ObjectiveRequest) (protocols.ObjectiveId, error) {
+				return rs.client.CloseVirtualChannel(req.ChannelId)
 			})
 		case serde.PayRequestMethod:
-			return processRequest(rs, requestData, func(obj serde.PaymentRequest) (serde.PaymentRequest, error) {
-				if obj.Amount == 0 {
-					return serde.PaymentRequest{}, types.InvalidParamsError
+			return processRequest(rs, requestData, func(req serde.PaymentRequest) (serde.PaymentRequest, error) {
+				if err := serde.ValidatePaymentRequest(req); err != nil {
+					return serde.PaymentRequest{}, err
 				}
-				if (obj.Channel == types.Destination{}) {
-					return serde.PaymentRequest{}, types.InvalidParamsError
-				}
-				rs.client.Pay(obj.Channel, big.NewInt(int64(obj.Amount)))
-				return obj, nil
+				rs.client.Pay(req.Channel, big.NewInt(int64(req.Amount)))
+				return req, nil
 			})
 		case serde.GetPaymentChannelRequestMethod:
-			return processRequest(rs, requestData, func(r serde.GetPaymentChannelRequest) (query.PaymentChannelInfo, error) {
-				if (r.Id == types.Destination{}) {
-					return query.PaymentChannelInfo{}, types.InvalidParamsError
+			return processRequest(rs, requestData, func(req serde.GetPaymentChannelRequest) (query.PaymentChannelInfo, error) {
+				if err := serde.ValidateGetPaymentChannelRequest(req); err != nil {
+					return query.PaymentChannelInfo{}, err
 				}
-				return rs.client.GetPaymentChannel(r.Id)
+				return rs.client.GetPaymentChannel(req.Id)
 			})
 		case serde.GetLedgerChannelRequestMethod:
-			return processRequest(rs, requestData, func(r serde.GetLedgerChannelRequest) (query.LedgerChannelInfo, error) {
-				if (r.Id == types.Destination{}) {
-					return query.LedgerChannelInfo{}, types.InvalidParamsError
-				}
-				return rs.client.GetLedgerChannel(r.Id)
+			return processRequest(rs, requestData, func(req serde.GetLedgerChannelRequest) (query.LedgerChannelInfo, error) {
+				return rs.client.GetLedgerChannel(req.Id)
 			})
 		case serde.GetAllLedgerChannelsMethod:
-			return processRequest(rs, requestData, func(r serde.NoPayloadRequest) ([]query.LedgerChannelInfo, error) {
+			return processRequest(rs, requestData, func(req serde.NoPayloadRequest) ([]query.LedgerChannelInfo, error) {
 				return rs.client.GetAllLedgerChannels()
 			})
 		case serde.GetPaymentChannelsByLedgerMethod:
-			return processRequest(rs, requestData, func(r serde.GetPaymentChannelsByLedgerRequest) ([]query.PaymentChannelInfo, error) {
-				if r.LedgerId == (types.Destination{}) {
-					return []query.PaymentChannelInfo{}, types.InvalidParamsError
+			return processRequest(rs, requestData, func(req serde.GetPaymentChannelsByLedgerRequest) ([]query.PaymentChannelInfo, error) {
+				if err := serde.ValidateGetPaymentChannelsByLedgerRequest(req); err != nil {
+					return []query.PaymentChannelInfo{}, err
 				}
-				return rs.client.GetPaymentChannelsByLedger(r.LedgerId)
+				return rs.client.GetPaymentChannelsByLedger(req.LedgerId)
 			})
 		default:
 			responseErr := types.MethodNotFoundError
-			responseErr.Id = validationResult.Id
+			responseErr.Id = jsonrpcReq.Id
 			return marshalResponse(responseErr, rs.logger)
 		}
 	}
@@ -162,8 +156,8 @@ func processRequest[T serde.RequestPayload, U serde.ResponsePayload](rs *RpcServ
 		return marshalResponse(types.UnexpectedRequestUnmarshalError2, rs.logger)
 	}
 
-	obj := rpcRequest.Params
-	objResponse, err := processPayload(obj)
+	payload := rpcRequest.Params
+	processedResponse, err := processPayload(payload)
 	if err != nil {
 		responseErr := types.JsonRpcError{
 			Code:    types.InternalServerError.Code, // default error code
@@ -178,7 +172,7 @@ func processRequest[T serde.RequestPayload, U serde.ResponsePayload](rs *RpcServ
 		return marshalResponse(responseErr, rs.logger)
 	}
 
-	response := serde.NewJsonRpcResponse(rpcRequest.Id, objResponse)
+	response := serde.NewJsonRpcResponse(rpcRequest.Id, processedResponse)
 	return marshalResponse(response, rs.logger)
 }
 
@@ -191,15 +185,15 @@ func marshalResponse(response any, log *zerolog.Logger) []byte {
 	return responseData
 }
 
-type validationResult struct {
+type jsonrpcReq struct {
 	Error  []byte
 	Method string
 	Id     uint64
 }
 
-func validateRequest(requestData []byte, logger *zerolog.Logger) validationResult {
+func validateJsonrpcRequest(requestData []byte, logger *zerolog.Logger) jsonrpcReq {
 	var request map[string]interface{}
-	vr := validationResult{}
+	vr := jsonrpcReq{}
 	err := json.Unmarshal(requestData, &request)
 	if err != nil {
 		vr.Error = marshalResponse(types.UnexpectedRequestUnmarshalError, logger)

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -121,3 +121,36 @@ func TestRpcMethodNotFound(t *testing.T) {
 	expectedError.Id = 2
 	sendRequestAndExpectError(t, jsonRequest, expectedError)
 }
+
+func TestRpcGetPaymentChannelMissingParam(t *testing.T) {
+	request := serde.JsonRpcRequest[serde.GetPaymentChannelRequest]{Jsonrpc: "2.0", Id: 2, Method: "get_payment_channel"}
+	jsonRequest, err := json.Marshal(request)
+	if err != nil {
+		t.Error(err)
+	}
+	expectedError := types.InvalidParamsError
+	expectedError.Id = 2
+	sendRequestAndExpectError(t, jsonRequest, expectedError)
+}
+
+func TestRpcPayInvalidParam(t *testing.T) {
+	paymentRequest := serde.PaymentRequest{
+		Amount:  100,
+		Channel: types.Destination{},
+	}
+
+	request := serde.JsonRpcRequest[serde.PaymentRequest]{
+		Jsonrpc: "2.0",
+		Id:      2,
+		Method:  "pay",
+		Params:  paymentRequest,
+	}
+
+	jsonRequest, err := json.Marshal(request)
+	if err != nil {
+		t.Error(err)
+	}
+	expectedError := types.InvalidParamsError
+	expectedError.Id = 2
+	sendRequestAndExpectError(t, jsonRequest, expectedError)
+}


### PR DESCRIPTION
We already had some validation to ensure the jsonrpc request is properly formatted according to jsonrpc spec 2.0. This PR adds validation for the "params" field within the jsonrpc request, which is different for each jsonrpc method.