### PR TITLE
Add input validation to query.GetVirtualChannel

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -196,9 +196,9 @@ func (c *Client) ReceivedVouchers() <-chan payments.Voucher {
 	return c.receivedVouchers
 }
 
-// CreateVirtualChannel creates a virtual channel with the counterParty using ledger channels
+// CreatePaymentChannel creates a virtual channel with the counterParty using ledger channels
 // with the supplied intermediaries.
-func (c *Client) CreateVirtualPaymentChannel(Intermediaries []types.Address, CounterParty types.Address, ChallengeDuration uint32, Outcome outcome.Exit) (virtualfund.ObjectiveResponse, error) {
+func (c *Client) CreatePaymentChannel(Intermediaries []types.Address, CounterParty types.Address, ChallengeDuration uint32, Outcome outcome.Exit) (virtualfund.ObjectiveResponse, error) {
 	objectiveRequest := virtualfund.NewObjectiveRequest(
 		Intermediaries,
 		CounterParty,
@@ -215,8 +215,8 @@ func (c *Client) CreateVirtualPaymentChannel(Intermediaries []types.Address, Cou
 	return objectiveRequest.Response(*c.Address), nil
 }
 
-// CloseVirtualChannel attempts to close and defund the given virtually funded channel.
-func (c *Client) CloseVirtualChannel(channelId types.Destination) (protocols.ObjectiveId, error) {
+// ClosePaymentChannel attempts to close and defund the given virtually funded channel.
+func (c *Client) ClosePaymentChannel(channelId types.Destination) (protocols.ObjectiveId, error) {
 	objectiveRequest := virtualdefund.NewObjectiveRequest(channelId)
 
 	// Send the event to the engine

--- a/client/query/query.go
+++ b/client/query/query.go
@@ -115,6 +115,11 @@ func GetVoucherBalance(id types.Destination, vm *payments.VoucherManager) (paid,
 // GetPaymentChannelInfo returns the PaymentChannelInfo for the given channel
 // It does this by querying the provided store and voucher manager
 func GetPaymentChannelInfo(id types.Destination, store store.Store, vm *payments.VoucherManager) (PaymentChannelInfo, error) {
+	if (id == types.Destination{}) {
+		err := types.InvalidParamsError
+		err.Message = "a valid channel id must be provided"
+		return PaymentChannelInfo{}, err
+	}
 	// Otherwise we can just check the store
 	c, channelFound := store.GetChannelById(id)
 

--- a/client_test/integration_test.go
+++ b/client_test/integration_test.go
@@ -126,7 +126,7 @@ func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 		virtualIds := make([]types.Destination, tc.NumOfChannels)
 		for i := 0; i < int(tc.NumOfChannels); i++ {
 			outcome := td.Outcomes.Create(testactors.Alice.Address(), testactors.Bob.Address(), virtualChannelDeposit, 0, types.Address{})
-			response, err := clientA.CreateVirtualPaymentChannel(
+			response, err := clientA.CreatePaymentChannel(
 				clientAddresses(intermediaries),
 				testactors.Bob.Address(),
 				0,
@@ -178,12 +178,12 @@ func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 			// alternative who is responsible for closing the channel
 			switch i % 2 {
 			case 0:
-				closeVirtualIds[i], err = clientA.CloseVirtualChannel(virtualIds[i])
+				closeVirtualIds[i], err = clientA.ClosePaymentChannel(virtualIds[i])
 				if err != nil {
 					t.Fatal(err)
 				}
 			case 1:
-				closeVirtualIds[i], err = clientB.CloseVirtualChannel(virtualIds[i])
+				closeVirtualIds[i], err = clientB.ClosePaymentChannel(virtualIds[i])
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -116,7 +116,7 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 	ledgerChannels := make([]directfund.ObjectiveResponse, n-1)
 	for i := 0; i < n-1; i++ {
 		outcome := simpleOutcome(actors[i].Address(), actors[i+1].Address(), 100, 100)
-		ledgerChannels[i] = clients[i].CreateLedger(actors[i+1].Address(), 100, outcome)
+		ledgerChannels[i] = clients[i].CreateLedgerChannel(actors[i+1].Address(), 100, outcome)
 
 		if !directfund.IsDirectFundObjective(ledgerChannels[i].Id) {
 			t.Errorf("expected direct fund objective, got %s", ledgerChannels[i].Id)
@@ -165,7 +165,7 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 
 	initialOutcome := simpleOutcome(actors[0].Address(), actors[n-1].Address(), 100, 0)
 
-	vabCreateResponse := aliceClient.CreateVirtual(
+	vabCreateResponse := aliceClient.CreatePaymentChannel(
 		intermediaries,
 		bob.Address(),
 		100,
@@ -199,16 +199,16 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 
 	aliceClient.Pay(vabCreateResponse.ChannelId, 1)
 
-	vabClosure := aliceClient.CloseVirtual(vabCreateResponse.ChannelId)
+	vabClosure := aliceClient.ClosePaymentChannel(vabCreateResponse.ChannelId)
 	for _, client := range clients {
 		<-client.ObjectiveCompleteChan(vabClosure)
 	}
 
-	laiClosure := aliceClient.CloseLedger(aliceLedger.ChannelId)
+	laiClosure := aliceClient.CloseLedgerChannel(aliceLedger.ChannelId)
 	<-aliceClient.ObjectiveCompleteChan(laiClosure)
 
 	if n != 2 { // for n=2, alice and bob share a ledger, which should only be closed once.
-		libClosure := bobClient.CloseLedger(bobLedger.ChannelId)
+		libClosure := bobClient.CloseLedgerChannel(bobLedger.ChannelId)
 		<-bobClient.ObjectiveCompleteChan(libClosure)
 	}
 

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -181,7 +181,8 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 	// assert correct reporting from query api
 	for i, client := range clients {
 		<-client.ObjectiveCompleteChan(vabCreateResponse.Id)
-		checkQueryInfo(t, expectedVirtualChannel, client.GetVirtualChannel(vabCreateResponse.ChannelId))
+		channelInfo, _, _ := client.GetVirtualChannel(vabCreateResponse.ChannelId)
+		checkQueryInfo(t, expectedVirtualChannel, channelInfo)
 		if i != 0 {
 			checkQueryInfoCollection(t, expectedVirtualChannel, 1,
 				client.GetPaymentChannelsByLedger(ledgerChannels[i-1].ChannelId))

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -177,6 +177,8 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 		query.Open,
 	)
 
+	aliceClient.GetPaymentChannel(types.Destination{0x000}) // Confirms server won't crash if invalid chId is provided
+
 	// wait for the virtual channel to be ready, and
 	// assert correct reporting from query api
 	for i, client := range clients {

--- a/client_test/rpc_test.go
+++ b/client_test/rpc_test.go
@@ -181,7 +181,7 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 	// assert correct reporting from query api
 	for i, client := range clients {
 		<-client.ObjectiveCompleteChan(vabCreateResponse.Id)
-		channelInfo, _, _ := client.GetVirtualChannel(vabCreateResponse.ChannelId)
+		channelInfo := client.GetPaymentChannel(vabCreateResponse.ChannelId)
 		checkQueryInfo(t, expectedVirtualChannel, channelInfo)
 		if i != 0 {
 			checkQueryInfoCollection(t, expectedVirtualChannel, 1,

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -85,8 +85,8 @@ func (rc *RpcClient) GetPaymentChannel(chId types.Destination) query.PaymentChan
 	return waitForRequest[serde.GetPaymentChannelRequest, query.PaymentChannelInfo](rc, serde.GetPaymentChannelRequestMethod, req)
 }
 
-// CreateVirtual creates a new virtual channel
-func (rc *RpcClient) CreateVirtual(intermediaries []types.Address, counterparty types.Address, ChallengeDuration uint32, outcome outcome.Exit) virtualfund.ObjectiveResponse {
+// CreatePaymentChannel creates a new virtual channel
+func (rc *RpcClient) CreatePaymentChannel(intermediaries []types.Address, counterparty types.Address, ChallengeDuration uint32, outcome outcome.Exit) virtualfund.ObjectiveResponse {
 	objReq := virtualfund.NewObjectiveRequest(
 		intermediaries,
 		counterparty,
@@ -98,8 +98,8 @@ func (rc *RpcClient) CreateVirtual(intermediaries []types.Address, counterparty 
 	return waitForRequest[virtualfund.ObjectiveRequest, virtualfund.ObjectiveResponse](rc, serde.CreatePaymentChannelRequestMethod, objReq)
 }
 
-// CloseVirtual closes a virtual channel
-func (rc *RpcClient) CloseVirtual(id types.Destination) protocols.ObjectiveId {
+// ClosePaymentChannel closes a virtual channel
+func (rc *RpcClient) ClosePaymentChannel(id types.Destination) protocols.ObjectiveId {
 	objReq := virtualdefund.NewObjectiveRequest(
 		id)
 
@@ -123,7 +123,7 @@ func (rc *RpcClient) GetPaymentChannelsByLedger(ledgerId types.Destination) []qu
 }
 
 // CreateLedger creates a new ledger channel
-func (rc *RpcClient) CreateLedger(counterparty types.Address, ChallengeDuration uint32, outcome outcome.Exit) directfund.ObjectiveResponse {
+func (rc *RpcClient) CreateLedgerChannel(counterparty types.Address, ChallengeDuration uint32, outcome outcome.Exit) directfund.ObjectiveResponse {
 	objReq := directfund.NewObjectiveRequest(
 		counterparty,
 		100,
@@ -135,7 +135,7 @@ func (rc *RpcClient) CreateLedger(counterparty types.Address, ChallengeDuration 
 }
 
 // CloseLedger closes a ledger channel
-func (rc *RpcClient) CloseLedger(id types.Destination) protocols.ObjectiveId {
+func (rc *RpcClient) CloseLedgerChannel(id types.Destination) protocols.ObjectiveId {
 	objReq := directdefund.NewObjectiveRequest(id)
 
 	return waitForRequest[directdefund.ObjectiveRequest, protocols.ObjectiveId](rc, serde.CloseLedgerChannelRequestMethod, objReq)

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -85,7 +85,7 @@ func (rc *RpcClient) GetPaymentChannel(chId types.Destination) query.PaymentChan
 	return waitForRequest[serde.GetPaymentChannelRequest, query.PaymentChannelInfo](rc, serde.GetPaymentChannelRequestMethod, req)
 }
 
-// CreatePaymentChannel creates a new virtual channel
+// CreatePaymentChannel creates a new virtual payment channel
 func (rc *RpcClient) CreatePaymentChannel(intermediaries []types.Address, counterparty types.Address, ChallengeDuration uint32, outcome outcome.Exit) virtualfund.ObjectiveResponse {
 	objReq := virtualfund.NewObjectiveRequest(
 		intermediaries,
@@ -98,7 +98,7 @@ func (rc *RpcClient) CreatePaymentChannel(intermediaries []types.Address, counte
 	return waitForRequest[virtualfund.ObjectiveRequest, virtualfund.ObjectiveResponse](rc, serde.CreatePaymentChannelRequestMethod, objReq)
 }
 
-// ClosePaymentChannel closes a virtual channel
+// ClosePaymentChannel attempts to close the payment channel with supplied id
 func (rc *RpcClient) ClosePaymentChannel(id types.Destination) protocols.ObjectiveId {
 	objReq := virtualdefund.NewObjectiveRequest(
 		id)
@@ -142,10 +142,10 @@ func (rc *RpcClient) CloseLedgerChannel(id types.Destination) protocols.Objectiv
 }
 
 // Pay uses the specified channel to pay the specified amount
-func (rc *RpcClient) Pay(id types.Destination, amount uint64) serde.PaymentRequest {
+func (rc *RpcClient) Pay(id types.Destination, amount uint64) {
 	pReq := serde.PaymentRequest{Amount: amount, Channel: id}
 
-	return waitForRequest[serde.PaymentRequest, serde.PaymentRequest](rc, serde.PayRequestMethod, pReq)
+	waitForRequest[serde.PaymentRequest, serde.PaymentRequest](rc, serde.PayRequestMethod, pReq)
 }
 
 func (rc *RpcClient) Close() error {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -3,14 +3,14 @@ package rpc
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/rs/zerolog"
+
+	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/client/query"
 	"github.com/statechannels/go-nitro/internal/safesync"
 	"github.com/statechannels/go-nitro/protocols"
@@ -18,14 +18,11 @@ import (
 	"github.com/statechannels/go-nitro/protocols/directfund"
 	"github.com/statechannels/go-nitro/protocols/virtualdefund"
 	"github.com/statechannels/go-nitro/protocols/virtualfund"
+	"github.com/statechannels/go-nitro/rand"
 	"github.com/statechannels/go-nitro/rpc/serde"
 	"github.com/statechannels/go-nitro/rpc/transport"
 	"github.com/statechannels/go-nitro/rpc/transport/ws"
-
 	"github.com/statechannels/go-nitro/types"
-
-	"github.com/statechannels/go-nitro/channel/state/outcome"
-	"github.com/statechannels/go-nitro/rand"
 )
 
 // RpcClient is a client for making nitro rpc calls
@@ -82,13 +79,10 @@ func NewHttpRpcClient(rpcServerUrl string) (*RpcClient, error) {
 	return c, nil
 }
 
-func (rc *RpcClient) GetVirtualChannel(chId types.Destination) (query.PaymentChannelInfo, int, error) {
-	if (chId == types.Destination{}) {
-		return query.PaymentChannelInfo{}, http.StatusBadRequest, errors.New("a valid channel id must be provided")
-	}
+func (rc *RpcClient) GetPaymentChannel(chId types.Destination) query.PaymentChannelInfo {
 	req := serde.GetPaymentChannelRequest{Id: chId}
 
-	return waitForRequest[serde.GetPaymentChannelRequest, query.PaymentChannelInfo](rc, serde.GetPaymentChannelRequestMethod, req), http.StatusOK, nil
+	return waitForRequest[serde.GetPaymentChannelRequest, query.PaymentChannelInfo](rc, serde.GetPaymentChannelRequestMethod, req)
 }
 
 // CreateVirtual creates a new virtual channel

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -84,7 +84,7 @@ func NewHttpRpcClient(rpcServerUrl string) (*RpcClient, error) {
 
 func (rc *RpcClient) GetVirtualChannel(chId types.Destination) (query.PaymentChannelInfo, int, error) {
 	if (chId == types.Destination{}) {
-		return query.PaymentChannelInfo{}, http.StatusBadRequest, errors.New("Valid channel id must be provided")
+		return query.PaymentChannelInfo{}, http.StatusBadRequest, errors.New("a valid channel id must be provided")
 	}
 	req := serde.GetPaymentChannelRequest{Id: chId}
 

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -95,7 +95,7 @@ func (rc *RpcClient) CreateVirtual(intermediaries []types.Address, counterparty 
 		rand.Uint64(),
 		common.Address{})
 
-	return waitForRequest[virtualfund.ObjectiveRequest, virtualfund.ObjectiveResponse](rc, serde.VirtualFundRequestMethod, objReq)
+	return waitForRequest[virtualfund.ObjectiveRequest, virtualfund.ObjectiveResponse](rc, serde.CreatePaymentChannelRequestMethod, objReq)
 }
 
 // CloseVirtual closes a virtual channel
@@ -103,7 +103,7 @@ func (rc *RpcClient) CloseVirtual(id types.Destination) protocols.ObjectiveId {
 	objReq := virtualdefund.NewObjectiveRequest(
 		id)
 
-	return waitForRequest[virtualdefund.ObjectiveRequest, protocols.ObjectiveId](rc, serde.VirtualDefundRequestMethod, objReq)
+	return waitForRequest[virtualdefund.ObjectiveRequest, protocols.ObjectiveId](rc, serde.ClosePaymentChannelRequestMethod, objReq)
 }
 
 func (rc *RpcClient) GetLedgerChannel(id types.Destination) query.LedgerChannelInfo {
@@ -131,14 +131,14 @@ func (rc *RpcClient) CreateLedger(counterparty types.Address, ChallengeDuration 
 		rand.Uint64(),
 		common.Address{})
 
-	return waitForRequest[directfund.ObjectiveRequest, directfund.ObjectiveResponse](rc, serde.DirectFundRequestMethod, objReq)
+	return waitForRequest[directfund.ObjectiveRequest, directfund.ObjectiveResponse](rc, serde.CreateLedgerChannelRequestMethod, objReq)
 }
 
 // CloseLedger closes a ledger channel
 func (rc *RpcClient) CloseLedger(id types.Destination) protocols.ObjectiveId {
 	objReq := directdefund.NewObjectiveRequest(id)
 
-	return waitForRequest[directdefund.ObjectiveRequest, protocols.ObjectiveId](rc, serde.DirectDefundRequestMethod, objReq)
+	return waitForRequest[directdefund.ObjectiveRequest, protocols.ObjectiveId](rc, serde.CloseLedgerChannelRequestMethod, objReq)
 }
 
 // Pay uses the specified channel to pay the specified amount

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -13,17 +13,17 @@ import (
 type RequestMethod string
 
 const (
-	GetAddressMethod                 RequestMethod = "get_address"
-	VersionMethod                    RequestMethod = "version"
-	DirectFundRequestMethod          RequestMethod = "direct_fund"
-	DirectDefundRequestMethod        RequestMethod = "direct_defund"
-	VirtualFundRequestMethod         RequestMethod = "virtual_fund"
-	VirtualDefundRequestMethod       RequestMethod = "virtual_defund"
-	PayRequestMethod                 RequestMethod = "pay"
-	GetPaymentChannelRequestMethod   RequestMethod = "get_payment_channel"
-	GetLedgerChannelRequestMethod    RequestMethod = "get_ledger_channel"
-	GetPaymentChannelsByLedgerMethod RequestMethod = "get_payment_channels_by_ledger"
-	GetAllLedgerChannelsMethod       RequestMethod = "get_all_ledger_channels"
+	GetAddressMethod                  RequestMethod = "get_address"
+	VersionMethod                     RequestMethod = "version"
+	CreateLedgerChannelRequestMethod  RequestMethod = "create_ledger_channel"
+	CloseLedgerChannelRequestMethod   RequestMethod = "close_ledger_channel"
+	CreatePaymentChannelRequestMethod RequestMethod = "create_payment_channel"
+	ClosePaymentChannelRequestMethod  RequestMethod = "close_payment_channel"
+	PayRequestMethod                  RequestMethod = "pay"
+	GetPaymentChannelRequestMethod    RequestMethod = "get_payment_channel"
+	GetLedgerChannelRequestMethod     RequestMethod = "get_ledger_channel"
+	GetPaymentChannelsByLedgerMethod  RequestMethod = "get_payment_channels_by_ledger"
+	GetAllLedgerChannelsMethod        RequestMethod = "get_all_ledger_channels"
 )
 
 type NotificationMethod string

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -100,11 +100,11 @@ func (rs *RpcServer) registerHandlers() (err error) {
 			})
 		case serde.CreatePaymentChannelRequestMethod:
 			return processRequest(rs, requestData, func(req virtualfund.ObjectiveRequest) (virtualfund.ObjectiveResponse, error) {
-				return rs.client.CreateVirtualPaymentChannel(req.Intermediaries, req.CounterParty, req.ChallengeDuration, req.Outcome)
+				return rs.client.CreatePaymentChannel(req.Intermediaries, req.CounterParty, req.ChallengeDuration, req.Outcome)
 			})
 		case serde.ClosePaymentChannelRequestMethod:
 			return processRequest(rs, requestData, func(req virtualdefund.ObjectiveRequest) (protocols.ObjectiveId, error) {
-				return rs.client.CloseVirtualChannel(req.ChannelId)
+				return rs.client.ClosePaymentChannel(req.ChannelId)
 			})
 		case serde.PayRequestMethod:
 			return processRequest(rs, requestData, func(req serde.PaymentRequest) (serde.PaymentRequest, error) {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -90,19 +90,19 @@ func (rs *RpcServer) registerHandlers() (err error) {
 			return processRequest(rs, requestData, func(T serde.NoPayloadRequest) (string, error) {
 				return rs.client.Version(), nil
 			})
-		case serde.DirectFundRequestMethod:
+		case serde.CreateLedgerChannelRequestMethod:
 			return processRequest(rs, requestData, func(obj directfund.ObjectiveRequest) (directfund.ObjectiveResponse, error) {
 				return rs.client.CreateLedgerChannel(obj.CounterParty, obj.ChallengeDuration, obj.Outcome), nil
 			})
-		case serde.DirectDefundRequestMethod:
+		case serde.CloseLedgerChannelRequestMethod:
 			return processRequest(rs, requestData, func(obj directdefund.ObjectiveRequest) (protocols.ObjectiveId, error) {
 				return rs.client.CloseLedgerChannel(obj.ChannelId), nil
 			})
-		case serde.VirtualFundRequestMethod:
+		case serde.CreatePaymentChannelRequestMethod:
 			return processRequest(rs, requestData, func(obj virtualfund.ObjectiveRequest) (virtualfund.ObjectiveResponse, error) {
 				return rs.client.CreateVirtualPaymentChannel(obj.Intermediaries, obj.CounterParty, obj.ChallengeDuration, obj.Outcome), nil
 			})
-		case serde.VirtualDefundRequestMethod:
+		case serde.ClosePaymentChannelRequestMethod:
 			return processRequest(rs, requestData, func(obj virtualdefund.ObjectiveRequest) (protocols.ObjectiveId, error) {
 				return rs.client.CloseVirtualChannel(obj.ChannelId), nil
 			})


### PR DESCRIPTION
In order to reduce friction of go-nitro integration into boost, this PR adds some input validation to the rpcClient.GetVirtualChannel method. This means the validation occurs inside go-nitro code instead of the burden being placed on boost or another consumer

Resolves https://github.com/statechannels/boost/issues/8