### PR TITLE
Refactor LedgerChannelBalance struct, Add LedgerChannelView struct

### DIFF
--- a/internal/testdata/states.go
+++ b/internal/testdata/states.go
@@ -71,13 +71,13 @@ var testState = state.State{
 	IsFinal:           false,
 }
 
-func createLedgerState(client, hub types.Address, clientBalance, hubBalance uint) state.State {
+func createLedgerState(leader, follower types.Address, clientBalance, hubBalance uint) state.State {
 	state := testState.Clone()
 	state.Participants = []types.Address{
-		client,
-		hub,
+		leader,
+		follower,
 	}
-	state.Outcome = Outcomes.Create(client, hub, clientBalance, hubBalance, common.Address{})
+	state.Outcome = Outcomes.Create(leader, follower, clientBalance, hubBalance, common.Address{})
 	state.AppDefinition = types.Address{} // ledger channel running the consensus app
 	state.TurnNum = 0
 

--- a/internal/testdata/states.go
+++ b/internal/testdata/states.go
@@ -71,13 +71,13 @@ var testState = state.State{
 	IsFinal:           false,
 }
 
-func createLedgerState(leader, follower types.Address, clientBalance, hubBalance uint) state.State {
+func createLedgerState(leader, follower types.Address, leaderBalance, followerBalance uint) state.State {
 	state := testState.Clone()
 	state.Participants = []types.Address{
 		leader,
 		follower,
 	}
-	state.Outcome = Outcomes.Create(leader, follower, clientBalance, hubBalance, common.Address{})
+	state.Outcome = Outcomes.Create(leader, follower, leaderBalance, followerBalance, common.Address{})
 	state.AppDefinition = types.Address{} // ledger channel running the consensus app
 	state.TurnNum = 0
 

--- a/node/query/query.go
+++ b/node/query/query.go
@@ -71,11 +71,11 @@ func getLedgerBalanceFromState(latest state.State) LedgerChannelBalance {
 	hubBalance := big.NewInt(0).Set(outcome.Allocations[1].Amount)
 
 	return LedgerChannelBalance{
-		AssetAddress:  asset,
-		Leader:        client,
-		Follower:      hub,
-		HubBalance:    (*hexutil.Big)(hubBalance),
-		ClientBalance: (*hexutil.Big)(clientBalance),
+		AssetAddress:    asset,
+		Leader:          client,
+		Follower:        hub,
+		LeaderBalance:   (*hexutil.Big)(clientBalance),
+		FollowerBalance: (*hexutil.Big)(hubBalance),
 	}
 }
 

--- a/node/query/query.go
+++ b/node/query/query.go
@@ -72,8 +72,8 @@ func getLedgerBalanceFromState(latest state.State) LedgerChannelBalance {
 
 	return LedgerChannelBalance{
 		AssetAddress:  asset,
-		Hub:           hub,
-		Client:        client,
+		Leader:        client,
+		Follower:      hub,
 		HubBalance:    (*hexutil.Big)(hubBalance),
 		ClientBalance: (*hexutil.Big)(clientBalance),
 	}

--- a/node/query/query.go
+++ b/node/query/query.go
@@ -65,17 +65,17 @@ func getLedgerBalanceFromState(latest state.State) LedgerChannelBalance {
 	// TODO: We assume single asset outcomes
 	outcome := latest.Outcome[0]
 	asset := outcome.Asset
-	client := latest.Participants[0]
-	clientBalance := big.NewInt(0).Set(outcome.Allocations[0].Amount)
-	hub := latest.Participants[1]
-	hubBalance := big.NewInt(0).Set(outcome.Allocations[1].Amount)
+	leader := latest.Participants[0]
+	leaderBalance := big.NewInt(0).Set(outcome.Allocations[0].Amount)
+	follower := latest.Participants[1]
+	followerBalance := big.NewInt(0).Set(outcome.Allocations[1].Amount)
 
 	return LedgerChannelBalance{
 		AssetAddress:    asset,
-		Leader:          client,
-		Follower:        hub,
-		LeaderBalance:   (*hexutil.Big)(clientBalance),
-		FollowerBalance: (*hexutil.Big)(hubBalance),
+		Leader:          leader,
+		Follower:        follower,
+		LeaderBalance:   (*hexutil.Big)(leaderBalance),
+		FollowerBalance: (*hexutil.Big)(followerBalance),
 	}
 }
 

--- a/node/query/types.go
+++ b/node/query/types.go
@@ -40,11 +40,11 @@ type LedgerChannelInfo struct {
 
 // LedgerChannelBalance contains the balance of a ledger channel
 type LedgerChannelBalance struct {
-	AssetAddress  types.Address
-	Leader        types.Address
-	Follower      types.Address
-	HubBalance    *hexutil.Big
-	ClientBalance *hexutil.Big
+	AssetAddress    types.Address
+	Leader          types.Address
+	Follower        types.Address
+	LeaderBalance   *hexutil.Big
+	FollowerBalance *hexutil.Big
 }
 
 // Equal returns true if the other LedgerChannelBalance is equal to this one
@@ -52,8 +52,8 @@ func (lcb LedgerChannelBalance) Equal(other LedgerChannelBalance) bool {
 	return lcb.AssetAddress == other.AssetAddress &&
 		lcb.Follower == other.Follower &&
 		lcb.Leader == other.Leader &&
-		lcb.HubBalance.ToInt().Cmp(other.HubBalance.ToInt()) == 0 &&
-		lcb.ClientBalance.ToInt().Cmp(other.ClientBalance.ToInt()) == 0
+		lcb.FollowerBalance.ToInt().Cmp(other.FollowerBalance.ToInt()) == 0 &&
+		lcb.LeaderBalance.ToInt().Cmp(other.LeaderBalance.ToInt()) == 0
 }
 
 // Equal returns true if the other LedgerChannelInfo is equal to this one

--- a/node/query/types.go
+++ b/node/query/types.go
@@ -41,8 +41,8 @@ type LedgerChannelInfo struct {
 // LedgerChannelBalance contains the balance of a ledger channel
 type LedgerChannelBalance struct {
 	AssetAddress  types.Address
-	Hub           types.Address
-	Client        types.Address
+	Leader        types.Address
+	Follower      types.Address
 	HubBalance    *hexutil.Big
 	ClientBalance *hexutil.Big
 }
@@ -50,8 +50,8 @@ type LedgerChannelBalance struct {
 // Equal returns true if the other LedgerChannelBalance is equal to this one
 func (lcb LedgerChannelBalance) Equal(other LedgerChannelBalance) bool {
 	return lcb.AssetAddress == other.AssetAddress &&
-		lcb.Hub == other.Hub &&
-		lcb.Client == other.Client &&
+		lcb.Follower == other.Follower &&
+		lcb.Leader == other.Leader &&
 		lcb.HubBalance.ToInt().Cmp(other.HubBalance.ToInt()) == 0 &&
 		lcb.ClientBalance.ToInt().Cmp(other.ClientBalance.ToInt()) == 0
 }

--- a/node/query/types.go
+++ b/node/query/types.go
@@ -1,7 +1,6 @@
 package query
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -62,10 +61,9 @@ func (lcb LedgerChannelBalance) Equal(other LedgerChannelBalance) bool {
 // BalanceOf returns the balance of the given address in the channel, and an
 // error if the address is not a participant.
 func (lcb LedgerChannelBalance) BalanceOf(a types.Address) (*hexutil.Big, error) {
-	aBytes := a.Bytes()
-	if bytes.Equal(aBytes, lcb.Leader.Bytes()) {
+	if a == lcb.Leader {
 		return lcb.LeaderBalance, nil
-	} else if bytes.Equal(aBytes, lcb.Follower.Bytes()) {
+	} else if a == lcb.Follower {
 		return lcb.FollowerBalance, nil
 	} else {
 		return nil, fmt.Errorf("%s is not a participant", a)

--- a/node/query/types.go
+++ b/node/query/types.go
@@ -1,6 +1,9 @@
 package query
 
 import (
+	"bytes"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -54,6 +57,19 @@ func (lcb LedgerChannelBalance) Equal(other LedgerChannelBalance) bool {
 		lcb.Leader == other.Leader &&
 		lcb.FollowerBalance.ToInt().Cmp(other.FollowerBalance.ToInt()) == 0 &&
 		lcb.LeaderBalance.ToInt().Cmp(other.LeaderBalance.ToInt()) == 0
+}
+
+// BalanceOf returns the balance of the given address in the channel. If the address is not a
+// known participant, it returns 0.
+func (lcb LedgerChannelBalance) BalanceOf(a types.Address) *hexutil.Big {
+	aBytes := a.Bytes()
+	if bytes.Equal(aBytes, lcb.Leader.Bytes()) {
+		return lcb.LeaderBalance
+	} else if bytes.Equal(aBytes, lcb.Follower.Bytes()) {
+		return lcb.FollowerBalance
+	} else {
+		return (*hexutil.Big)(big.NewInt(0))
+	}
 }
 
 // Equal returns true if the other LedgerChannelInfo is equal to this one

--- a/node/query/types.go
+++ b/node/query/types.go
@@ -2,7 +2,7 @@ package query
 
 import (
 	"bytes"
-	"math/big"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/statechannels/go-nitro/types"
@@ -59,16 +59,16 @@ func (lcb LedgerChannelBalance) Equal(other LedgerChannelBalance) bool {
 		lcb.LeaderBalance.ToInt().Cmp(other.LeaderBalance.ToInt()) == 0
 }
 
-// BalanceOf returns the balance of the given address in the channel. If the address is not a
-// known participant, it returns 0.
-func (lcb LedgerChannelBalance) BalanceOf(a types.Address) *hexutil.Big {
+// BalanceOf returns the balance of the given address in the channel, and an
+// error if the address is not a participant.
+func (lcb LedgerChannelBalance) BalanceOf(a types.Address) (*hexutil.Big, error) {
 	aBytes := a.Bytes()
 	if bytes.Equal(aBytes, lcb.Leader.Bytes()) {
-		return lcb.LeaderBalance
+		return lcb.LeaderBalance, nil
 	} else if bytes.Equal(aBytes, lcb.Follower.Bytes()) {
-		return lcb.FollowerBalance
+		return lcb.FollowerBalance, nil
 	} else {
-		return (*hexutil.Big)(big.NewInt(0))
+		return nil, fmt.Errorf("%s is not a participant", a)
 	}
 }
 

--- a/node_test/helpers_test.go
+++ b/node_test/helpers_test.go
@@ -251,16 +251,16 @@ func checkPaymentChannel(t *testing.T, id types.Destination, o outcome.Exit, sta
 
 // createLedgerInfo constructs a LedgerChannelInfo so we can easily compare it to the result of GetLedgerChannel
 func createLedgerInfo(id types.Destination, outcome outcome.Exit, status query.ChannelStatus) query.LedgerChannelInfo {
-	clientAdd, _ := outcome[0].Allocations[0].Destination.ToAddress()
-	hubAdd, _ := outcome[0].Allocations[1].Destination.ToAddress()
+	leaderAddr, _ := outcome[0].Allocations[0].Destination.ToAddress()
+	followerAddr, _ := outcome[0].Allocations[1].Destination.ToAddress()
 
 	return query.LedgerChannelInfo{
 		ID:     id,
 		Status: status,
 		Balance: query.LedgerChannelBalance{
 			AssetAddress:    types.Address{},
-			Leader:          clientAdd,
-			Follower:        hubAdd,
+			Leader:          leaderAddr,
+			Follower:        followerAddr,
 			LeaderBalance:   (*hexutil.Big)(outcome[0].Allocations[0].Amount),
 			FollowerBalance: (*hexutil.Big)(outcome[0].Allocations[1].Amount),
 		},

--- a/node_test/helpers_test.go
+++ b/node_test/helpers_test.go
@@ -277,14 +277,14 @@ type channelStatusShorthand struct {
 // to the supplied states.
 func createLedgerStory(
 	id types.Destination,
-	clientAddr, hubAddr common.Address,
+	leaderAddr, followerAddr common.Address,
 	states []channelStatusShorthand,
 ) []query.LedgerChannelInfo {
 	story := make([]query.LedgerChannelInfo, len(states))
 	for i, state := range states {
 		story[i] = createLedgerInfo(
 			id,
-			simpleOutcome(clientAddr, hubAddr, state.clientA, state.clientB),
+			simpleOutcome(leaderAddr, followerAddr, state.clientA, state.clientB),
 			state.status,
 		)
 	}

--- a/node_test/helpers_test.go
+++ b/node_test/helpers_test.go
@@ -259,8 +259,8 @@ func createLedgerInfo(id types.Destination, outcome outcome.Exit, status query.C
 		Status: status,
 		Balance: query.LedgerChannelBalance{
 			AssetAddress:  types.Address{},
-			Hub:           hubAdd,
-			Client:        clientAdd,
+			Leader:        clientAdd,
+			Follower:      hubAdd,
 			ClientBalance: (*hexutil.Big)(outcome[0].Allocations[0].Amount),
 			HubBalance:    (*hexutil.Big)(outcome[0].Allocations[1].Amount),
 		},

--- a/node_test/helpers_test.go
+++ b/node_test/helpers_test.go
@@ -258,11 +258,11 @@ func createLedgerInfo(id types.Destination, outcome outcome.Exit, status query.C
 		ID:     id,
 		Status: status,
 		Balance: query.LedgerChannelBalance{
-			AssetAddress:  types.Address{},
-			Leader:        clientAdd,
-			Follower:      hubAdd,
-			ClientBalance: (*hexutil.Big)(outcome[0].Allocations[0].Amount),
-			HubBalance:    (*hexutil.Big)(outcome[0].Allocations[1].Amount),
+			AssetAddress:    types.Address{},
+			Leader:          clientAdd,
+			Follower:        hubAdd,
+			LeaderBalance:   (*hexutil.Big)(outcome[0].Allocations[0].Amount),
+			FollowerBalance: (*hexutil.Big)(outcome[0].Allocations[1].Amount),
 		},
 	}
 }

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -58,6 +58,32 @@ func TestRpcWithWebsockets(t *testing.T) {
 	executeNRpcTest(t, "ws", 4)
 }
 
+func TestGetAddress(t *testing.T) {
+	chain := chainservice.NewMockChain()
+	chainService := chainservice.NewMockChainService(chain, ta.Alice.Address())
+	alice, _, cleanupAlice := setupNitroNodeWithRPCClient(t, ta.Alice.PrivateKey, 3005, 4005, chainService, newLogWriter("test_init.log"), "nats")
+	defer cleanupAlice()
+
+	bob, _, cleanupBob := setupNitroNodeWithRPCClient(t, ta.Bob.PrivateKey, 3006, 4006, chainService, newLogWriter("test_init.log"), "nats")
+	defer cleanupBob()
+
+	firstCall := alice.GetAddress()
+	secondCall := alice.GetAddress()
+	if firstCall != secondCall {
+		t.Errorf("expected consistent GetAddress returns, but got [%v, %v]", firstCall, secondCall)
+	}
+
+	if alice.GetAddress() != ta.Alice.Address() {
+		t.Errorf("expected %v, got %v", ta.Alice.Address(), alice.GetAddress())
+	}
+	if bob.GetAddress() != ta.Bob.Address() {
+		t.Errorf("expected %v, got %v", ta.Bob.Address(), bob.GetAddress())
+	}
+	if alice.GetAddress() == bob.GetAddress() {
+		t.Errorf("expected different addresses, got %v", alice.GetAddress())
+	}
+}
+
 func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -349,7 +349,7 @@ func setupNitroNodeWithRPCClient(
 	if err != nil {
 		panic(err)
 	}
-	rpcClient, err := rpc.NewRpcClient(rpcServer.Url(), createLogger(logDestination, node.Address.Hex(), "client"), clientConnection)
+	rpcClient, err := rpc.NewRpcClient(createLogger(logDestination, node.Address.Hex(), "client"), clientConnection)
 	if err != nil {
 		panic(err)
 	}

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -56,6 +56,14 @@ type GetTwoPartyConsensusLedgerFunction func(counterparty types.Address) (ledger
 
 // NewObjective creates a new direct funding objective from a given request.
 func NewObjective(request ObjectiveRequest, preApprove bool, myAddress types.Address, chainId *big.Int, getChannels GetChannelsByParticipantFunction, getTwoPartyConsensusLedger GetTwoPartyConsensusLedgerFunction) (Objective, error) {
+	channelExists, err := channelsExistWithCounterparty(request.CounterParty, getChannels, getTwoPartyConsensusLedger)
+	if err != nil {
+		return Objective{}, fmt.Errorf("counterparty check failed: %w", err)
+	}
+	if channelExists {
+		return Objective{}, fmt.Errorf("a channel already exists with counterparty %s", request.CounterParty)
+	}
+
 	initialState := state.State{
 		Participants:      []types.Address{myAddress, request.CounterParty},
 		ChannelNonce:      request.Nonce,
@@ -79,13 +87,6 @@ func NewObjective(request ObjectiveRequest, preApprove bool, myAddress types.Add
 	)
 	if err != nil {
 		return Objective{}, fmt.Errorf("could not create new objective: %w", err)
-	}
-	channelExists, err := channelsExistWithCounterparty(request.CounterParty, getChannels, getTwoPartyConsensusLedger)
-	if err != nil {
-		return Objective{}, fmt.Errorf("counterparty check failed: %w", err)
-	}
-	if channelExists {
-		return Objective{}, fmt.Errorf("a channel already exists with counterparty %s", request.CounterParty)
 	}
 	return objective, nil
 }

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -101,8 +101,7 @@ func (rc *RpcClient) CreatePaymentChannel(intermediaries []types.Address, counte
 
 // ClosePaymentChannel attempts to close the payment channel with supplied id
 func (rc *RpcClient) ClosePaymentChannel(id types.Destination) protocols.ObjectiveId {
-	objReq := virtualdefund.NewObjectiveRequest(
-		id)
+	objReq := virtualdefund.NewObjectiveRequest(id)
 
 	return waitForRequest[virtualdefund.ObjectiveRequest, protocols.ObjectiveId](rc, serde.ClosePaymentChannelRequestMethod, objReq)
 }

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -116,10 +116,15 @@ func (rc *RpcClient) GetAddress() types.Address {
 	return rc.chainAddress
 }
 
-func (rc *RpcClient) GetLedgerChannel(id types.Destination) query.LedgerChannelInfo {
+func (rc *RpcClient) GetLedgerChannel(id types.Destination) LedgerChannelView {
 	req := serde.GetLedgerChannelRequest{Id: id}
 
-	return waitForRequest[serde.GetLedgerChannelRequest, query.LedgerChannelInfo](rc, serde.GetLedgerChannelRequestMethod, req)
+	lcInfo := waitForRequest[serde.GetLedgerChannelRequest, query.LedgerChannelInfo](rc, serde.GetLedgerChannelRequestMethod, req)
+	lcView, err := NewLedgerChannelView(lcInfo, rc.GetAddress())
+	if err != nil {
+		rc.logger.Error().Err(err).Msg("Error while constructing ledger channel view")
+	}
+	return lcView
 }
 
 // GetAllLedgerChannels returns all ledger channels

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -43,7 +43,7 @@ type response[T serde.ResponsePayload] struct {
 }
 
 // NewRpcClient creates a new RpcClient
-func NewRpcClient(rpcServerUrl string, logger zerolog.Logger, trans transport.Requester) (*RpcClient, error) {
+func NewRpcClient(logger zerolog.Logger, trans transport.Requester) (*RpcClient, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	c := &RpcClient{trans, logger, &safesync.Map[chan struct{}]{}, &safesync.Map[chan query.LedgerChannelInfo]{}, &safesync.Map[chan query.PaymentChannelInfo]{}, cancel, &sync.WaitGroup{}}
 

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -99,7 +99,8 @@ type ResponsePayload interface {
 		query.LedgerChannelInfo |
 		VersionResponse |
 		GetAllLedgersResponse |
-		GetPaymentChannelsByLedgerResponse
+		GetPaymentChannelsByLedgerResponse |
+		types.Address
 }
 
 type JsonRpcResponse[T ResponsePayload] struct {

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -1,0 +1,40 @@
+package rpc
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/statechannels/go-nitro/node/query"
+	"github.com/statechannels/go-nitro/types"
+)
+
+type LedgerChannelView struct {
+	ID           types.Destination
+	Counterparty types.Address
+	AssetAddress types.Address
+	MyBalance    *hexutil.Big
+	TheirBalance *hexutil.Big
+	// todo: running guarantees?
+}
+
+// NewLedgerChannelView creates a "view with perspective" into a given ledger channel.
+func NewLedgerChannelView(info query.LedgerChannelInfo, myAddress types.Address) (LedgerChannelView, error) {
+	lcv := LedgerChannelView{}
+
+	lcv.ID = info.ID
+	lcv.AssetAddress = info.Balance.AssetAddress
+
+	if info.Balance.Leader == myAddress {
+		lcv.Counterparty = info.Balance.Follower
+		lcv.MyBalance = info.Balance.LeaderBalance
+		lcv.TheirBalance = info.Balance.FollowerBalance
+	} else if info.Balance.Follower == myAddress {
+		lcv.Counterparty = info.Balance.Leader
+		lcv.MyBalance = info.Balance.FollowerBalance
+		lcv.TheirBalance = info.Balance.LeaderBalance
+	} else {
+		return lcv, fmt.Errorf("%s is not a participant in ledger channel %s", myAddress, info.ID)
+	}
+
+	return lcv, nil
+}


### PR DESCRIPTION
Closes #1362

PR replaces `Client, Hub` with `Leader, Follower`, makes follow-on changes, and adds a helper function to recover balance of a given individual in a ledger channel.

Previous implementation falsely assumed that a nitro-node in an intermediary position for a virtually funded channel was the participant at index `[1]` in the channel.

**Shortcoming**:

Leader and Follower aren't fabulous titles, but
- they feel less awkward than, eg, `firstParticipant`/`secondParticipant`, `participant0`, `participant1`...
- they carry over some implicit protocol implementation knowledge (mixed blessing).
  - leader is the person who opened the channel & is responsible for constructing & initially signing update proposals
  - this is pretty stable, but could possibly change into the future

From a consuming client / software perspective, leader and follower can be understood simply as names of ordered participants in a channel.

Notable: `hub` no longer appears in the go code base, other than 666 occurrences of `github`.

---

#### Code quality

- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [x] I have assigned myself to this PR
- [x] I have linked the appropriate github issue
- [ ] I have assigned this PR to the appropriate GitHub project
- [ ] I have assigned this PR to the appropriate GitHub Milestone
