### PR TITLE
Gracefully handle errors within node engine (instead of panic)

### DIFF
--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -864,6 +864,6 @@ func (e *Engine) checkError(err error) {
 			}
 		}
 
-		panic(err)
+		e.logger.Panic().Msg(err.Error())
 	}
 }

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -47,9 +47,6 @@ func (e *ErrGetObjective) Error() string {
 	return fmt.Sprintf("unexpected error getting/creating objective %s: %v", e.objectiveId, e.wrappedError)
 }
 
-// nonFatalErrors is a list of errors for which the engine should not panic
-var nonFatalErrors = []error{&ErrGetObjective{}}
-
 // Engine is the imperative part of the core business logic of a go-nitro Node
 type Engine struct {
 	// inbound go channels
@@ -443,10 +440,11 @@ func (e *Engine) handleObjectiveRequest(or protocols.ObjectiveRequest) (EngineEv
 
 	chainId, err := e.chain.GetChainId()
 	if err != nil {
-		return EngineEvent{}, fmt.Errorf("could get chain id from chain service: %w", err)
+		return EngineEvent{}, fmt.Errorf("could not get chain id from chain service: %w", err)
 	}
 
 	objectiveId := or.Id(myAddress, chainId)
+	failedEngineEvent := EngineEvent{FailedObjectives: []protocols.ObjectiveId{objectiveId}}
 	e.logger.Printf("handling new objective request for %s", objectiveId)
 	e.metrics.RecordObjectiveStarted(objectiveId)
 	defer or.SignalObjectiveStarted()
@@ -455,19 +453,19 @@ func (e *Engine) handleObjectiveRequest(or protocols.ObjectiveRequest) (EngineEv
 	case virtualfund.ObjectiveRequest:
 		vfo, err := virtualfund.NewObjective(request, true, myAddress, chainId, e.store.GetConsensusChannel)
 		if err != nil {
-			return EngineEvent{}, fmt.Errorf("handleAPIEvent: Could not create virtualfund objective for %+v: %w", request, err)
+			return failedEngineEvent, fmt.Errorf("handleAPIEvent: Could not create virtualfund objective for %+v: %w", request, err)
 		}
 		// Only Alice or Bob care about registering the objective and keeping track of vouchers
 		lastParticipant := uint(len(vfo.V.Participants) - 1)
 		if vfo.MyRole == lastParticipant || vfo.MyRole == payments.PAYER_INDEX {
 			err = e.registerPaymentChannel(vfo)
 			if err != nil {
-				return EngineEvent{}, fmt.Errorf("could not register channel with payment/receipt manager: %w", err)
+				return failedEngineEvent, fmt.Errorf("could not register channel with payment/receipt manager: %w", err)
 			}
 		}
 
 		if err != nil {
-			return EngineEvent{}, fmt.Errorf("could not register channel with payment/receipt manager: %w", err)
+			return failedEngineEvent, fmt.Errorf("could not register channel with payment/receipt manager: %w", err)
 		}
 		return e.attemptProgress(&vfo)
 
@@ -476,39 +474,37 @@ func (e *Engine) handleObjectiveRequest(or protocols.ObjectiveRequest) (EngineEv
 		if e.vm.ChannelRegistered(request.ChannelId) {
 			paid, err := e.vm.Paid(request.ChannelId)
 			if err != nil {
-				return EngineEvent{}, fmt.Errorf("handleAPIEvent: Could not create virtualdefund objective for %+v: %w", request, err)
+				return failedEngineEvent, fmt.Errorf("handleAPIEvent: Could not create virtualdefund objective for %+v: %w", request, err)
 			}
 			minAmount = paid
 		}
 		vdfo, err := virtualdefund.NewObjective(request, true, myAddress, minAmount, e.store.GetChannelById, e.store.GetConsensusChannel)
 		if err != nil {
-			return EngineEvent{}, fmt.Errorf("handleAPIEvent: Could not create virtualdefund objective for %+v: %w", request, err)
+			return failedEngineEvent, fmt.Errorf("handleAPIEvent: Could not create virtualdefund objective for %+v: %w", request, err)
 		}
 		return e.attemptProgress(&vdfo)
 
 	case directfund.ObjectiveRequest:
 		dfo, err := directfund.NewObjective(request, true, myAddress, chainId, e.store.GetChannelsByParticipant, e.store.GetConsensusChannel)
 		if err != nil {
-			return EngineEvent{}, fmt.Errorf("handleAPIEvent: Could not create directfund objective for %+v: %w", request, err)
+			return failedEngineEvent, fmt.Errorf("handleAPIEvent: Could not create directfund objective for %+v: %w", request, err)
 		}
 		return e.attemptProgress(&dfo)
 
 	case directdefund.ObjectiveRequest:
 		ddfo, err := directdefund.NewObjective(request, true, e.store.GetConsensusChannelById)
 		if err != nil {
-			return EngineEvent{
-				FailedObjectives: []protocols.ObjectiveId{objectiveId},
-			}, fmt.Errorf("handleAPIEvent: Could not create directdefund objective for %+v: %w", request, err)
+			return failedEngineEvent, fmt.Errorf("handleAPIEvent: Could not create directdefund objective for %+v: %w", request, err)
 		}
 		// If ddfo creation was successful, destroy the consensus channel to prevent it being used (a Channel will now take over governance)
 		err = e.store.DestroyConsensusChannel(request.ChannelId)
 		if err != nil {
-			return EngineEvent{}, fmt.Errorf("handleAPIEvent: Could not destroy consensus channel for %+v: %w", request, err)
+			return failedEngineEvent, fmt.Errorf("handleAPIEvent: Could not destroy consensus channel for %+v: %w", request, err)
 		}
 		return e.attemptProgress(&ddfo)
 
 	default:
-		return EngineEvent{}, fmt.Errorf("handleAPIEvent: Unknown objective type %T", request)
+		return failedEngineEvent, fmt.Errorf("handleAPIEvent: Unknown objective type %T", request)
 	}
 }
 
@@ -854,20 +850,7 @@ func (e *Engine) recordMessageMetrics(message protocols.Message) {
 
 func (e *Engine) checkError(err error) {
 	if err != nil {
-
 		e.logger.Err(err).Msgf("%s, error in run loop", e.store.GetAddress())
-
-		for _, nonFatalError := range nonFatalErrors {
-			if errors.Is(err, nonFatalError) {
-				return
-			}
-		}
-
 		<-time.After(1000 * time.Millisecond) // We wait for a bit so the previous log line has time to complete
-
-		// TODO instead of a panic, errors should be sent to the manager of the engine via a channel. At the moment,
-		// the engine manager is the nitro node.
-		panic(err)
-
 	}
 }

--- a/node/engine/store/durablestore.go
+++ b/node/engine/store/durablestore.go
@@ -589,18 +589,19 @@ func (ds *DurableStore) SetVoucherInfo(channelId types.Destination, v payments.V
 	})
 }
 
-func (ds *DurableStore) GetVoucherInfo(channelId types.Destination) (v *payments.VoucherInfo, ok bool) {
+func (ds *DurableStore) GetVoucherInfo(channelId types.Destination) (*payments.VoucherInfo, error) {
+	v := &payments.VoucherInfo{}
 	err := ds.vouchers.View(func(tx *buntdb.Tx) error {
 		vJSON, err := tx.Get(channelId.String())
 		if err != nil {
-			return nil
+			return err
 		}
-		return json.Unmarshal([]byte(vJSON), &v)
+		return json.Unmarshal([]byte(vJSON), v)
 	})
-	if err == nil {
-		ok = true
+	if err != nil {
+		return nil, err
 	}
-	return
+	return v, nil
 }
 
 func (ds *DurableStore) RemoveVoucherInfo(channelId types.Destination) error {

--- a/node/engine/store/durablestore.go
+++ b/node/engine/store/durablestore.go
@@ -594,7 +594,7 @@ func (ds *DurableStore) GetVoucherInfo(channelId types.Destination) (*payments.V
 	err := ds.vouchers.View(func(tx *buntdb.Tx) error {
 		vJSON, err := tx.Get(channelId.String())
 		if err != nil {
-			return err
+			return fmt.Errorf("channelId %s: %w", channelId.String(), ErrLoadVouchers)
 		}
 		return json.Unmarshal([]byte(vJSON), v)
 	})

--- a/node/engine/store/memstore.go
+++ b/node/engine/store/memstore.go
@@ -472,18 +472,18 @@ func (ms *MemStore) SetVoucherInfo(channelId types.Destination, v payments.Vouch
 	return nil
 }
 
-func (ms *MemStore) GetVoucherInfo(channelId types.Destination) (v *payments.VoucherInfo, ok bool) {
+func (ms *MemStore) GetVoucherInfo(channelId types.Destination) (*payments.VoucherInfo, error) {
 	data, ok := ms.vouchers.Load(channelId.String())
 	if !ok {
-		return nil, false
+		return nil, fmt.Errorf("could not load vouchers from memory")
 	}
 
-	v = &payments.VoucherInfo{}
+	v := &payments.VoucherInfo{}
 	err := json.Unmarshal(data, v)
 	if err != nil {
-		return nil, false
+		return nil, err
 	}
-	return v, true
+	return v, nil
 }
 
 func (ms *MemStore) RemoveVoucherInfo(channelId types.Destination) error {

--- a/node/engine/store/memstore.go
+++ b/node/engine/store/memstore.go
@@ -475,7 +475,7 @@ func (ms *MemStore) SetVoucherInfo(channelId types.Destination, v payments.Vouch
 func (ms *MemStore) GetVoucherInfo(channelId types.Destination) (*payments.VoucherInfo, error) {
 	data, ok := ms.vouchers.Load(channelId.String())
 	if !ok {
-		return nil, fmt.Errorf("could not load vouchers from memory")
+		return nil, fmt.Errorf("channelId %s: %w", channelId.String(), ErrLoadVouchers)
 	}
 
 	v := &payments.VoucherInfo{}

--- a/node/engine/store/store.go
+++ b/node/engine/store/store.go
@@ -15,6 +15,7 @@ import (
 var (
 	ErrNoSuchObjective error = errors.New("store: no such objective")
 	ErrNoSuchChannel   error = errors.New("store: failed to find required channel data")
+	ErrLoadVouchers    error = errors.New("store: could not load vouchers")
 )
 
 // Store is responsible for persisting objectives, objective metadata, states, signatures, private keys and blockchain data

--- a/payments/payments_test.go
+++ b/payments/payments_test.go
@@ -42,7 +42,7 @@ func (svs *simpleVoucherStore) SetVoucherInfo(channelId types.Destination, v Vou
 func (svs *simpleVoucherStore) GetVoucherInfo(channelId types.Destination) (*VoucherInfo, error) {
 	v, ok := svs.vouchers.Load(channelId.String())
 	if !ok {
-		return v, fmt.Errorf("could not load vouchers")
+		return v, fmt.Errorf("could not load vouchers from store for channelId %s", channelId.String())
 	}
 	return v, nil
 }

--- a/payments/payments_test.go
+++ b/payments/payments_test.go
@@ -39,8 +39,12 @@ func (svs *simpleVoucherStore) SetVoucherInfo(channelId types.Destination, v Vou
 	return nil
 }
 
-func (svs *simpleVoucherStore) GetVoucherInfo(channelId types.Destination) (v *VoucherInfo, ok bool) {
-	return svs.vouchers.Load(channelId.String())
+func (svs *simpleVoucherStore) GetVoucherInfo(channelId types.Destination) (*VoucherInfo, error) {
+	v, ok := svs.vouchers.Load(channelId.String())
+	if !ok {
+		return v, fmt.Errorf("could not load vouchers")
+	}
+	return v, nil
 }
 
 func (svs *simpleVoucherStore) RemoveVoucherInfo(channelId types.Destination) error {

--- a/payments/voucher_manager.go
+++ b/payments/voucher_manager.go
@@ -53,7 +53,7 @@ func (vm *VoucherManager) Remove(channelId types.Destination) error {
 func (vm *VoucherManager) Pay(channelId types.Destination, amount *big.Int, pk []byte) (Voucher, error) {
 	vInfo, err := vm.store.GetVoucherInfo(channelId)
 	if err != nil {
-		return Voucher{}, fmt.Errorf("channel not found")
+		return Voucher{}, fmt.Errorf("channel not registered: %w", err)
 	}
 
 	if types.Gt(amount, vInfo.Remaining()) {
@@ -83,7 +83,7 @@ func (vm *VoucherManager) Pay(channelId types.Destination, amount *big.Int, pk [
 func (vm *VoucherManager) Receive(voucher Voucher) (*big.Int, error) {
 	vInfo, err := vm.store.GetVoucherInfo(voucher.ChannelId)
 	if err != nil {
-		return &big.Int{}, fmt.Errorf("channel not registered")
+		return &big.Int{}, fmt.Errorf("channel not registered: %w", err)
 	}
 
 	// We only care about vouchers when we are the recipient of the payment
@@ -128,7 +128,7 @@ func (vm *VoucherManager) ChannelRegistered(channelId types.Destination) bool {
 func (vm *VoucherManager) Paid(chanId types.Destination) (*big.Int, error) {
 	v, err := vm.store.GetVoucherInfo(chanId)
 	if err != nil {
-		return &big.Int{}, fmt.Errorf("channel not registered")
+		return &big.Int{}, fmt.Errorf("channel not registered: %w", err)
 	}
 	return v.LargestVoucher.Amount, nil
 }
@@ -137,7 +137,7 @@ func (vm *VoucherManager) Paid(chanId types.Destination) (*big.Int, error) {
 func (vm *VoucherManager) Remaining(chanId types.Destination) (*big.Int, error) {
 	v, err := vm.store.GetVoucherInfo(chanId)
 	if err != nil {
-		return &big.Int{}, fmt.Errorf("channel not registered")
+		return &big.Int{}, fmt.Errorf("channel not registered: %w", err)
 	}
 	remaining := big.NewInt(0).Sub(v.StartingBalance, v.LargestVoucher.Amount)
 	return remaining, nil

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -17,6 +17,8 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
+var ErrLedgerChannelExists error = errors.New("directfund: ledger channel already exists")
+
 const (
 	WaitingForCompletePrefund  protocols.WaitingFor = "WaitingForCompletePrefund"
 	WaitingForMyTurnToFund     protocols.WaitingFor = "WaitingForMyTurnToFund"
@@ -85,7 +87,7 @@ func NewObjective(request ObjectiveRequest, preApprove bool, myAddress types.Add
 		return Objective{}, fmt.Errorf("counterparty check failed: %w", err)
 	}
 	if channelExists {
-		return Objective{}, fmt.Errorf("a channel already exists with counterparty %s", request.CounterParty)
+		return Objective{}, fmt.Errorf("counterparty %s: %w", request.CounterParty, ErrLedgerChannelExists)
 	}
 	return objective, nil
 }


### PR DESCRIPTION
Resolves https://github.com/statechannels/go-nitro/issues/1275

* First commit resolves https://github.com/statechannels/go-nitro/issues/1257
* Second commit resolves https://github.com/statechannels/go-nitro/issues/1263

Instead of the node engine panicking, errors are logged and are returned on the `toApi` chan as `FailedObjectives`.