### PR TITLE
Refactor rpc server start into infra.go

### DIFF
--- a/internal/infra/infra.go
+++ b/internal/infra/infra.go
@@ -1,0 +1,86 @@
+package infra
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/rs/zerolog"
+	"github.com/statechannels/go-nitro/crypto"
+	"github.com/statechannels/go-nitro/node"
+	"github.com/statechannels/go-nitro/node/engine"
+	"github.com/statechannels/go-nitro/node/engine/chainservice"
+	p2pms "github.com/statechannels/go-nitro/node/engine/messageservice/p2p-message-service"
+	"github.com/statechannels/go-nitro/node/engine/store"
+	"github.com/statechannels/go-nitro/rpc"
+	"github.com/statechannels/go-nitro/rpc/transport"
+	"github.com/statechannels/go-nitro/rpc/transport/nats"
+	"github.com/statechannels/go-nitro/rpc/transport/ws"
+	"github.com/tidwall/buntdb"
+)
+
+func InitializeRpcServer(pk []byte, chainService chainservice.ChainService,
+	useDurableStore bool, msgPort int, rpcPort int, transportType transport.TransportType,
+) (*rpc.RpcServer, *p2pms.P2PMessageService, error) {
+	me := crypto.GetAddressFromSecretKeyBytes(pk)
+
+	logDestination := os.Stdout
+
+	var ourStore store.Store
+	var err error
+
+	if useDurableStore {
+		fmt.Println("Initialising durable store...")
+		dataFolder := fmt.Sprintf("./data/nitro-service/%s", me.String())
+		ourStore, err = store.NewDurableStore(pk, dataFolder, buntdb.Config{})
+		if err != nil {
+			return nil, nil, err
+		}
+
+	} else {
+		fmt.Println("Initialising mem store...")
+		ourStore = store.NewMemStore(pk)
+	}
+
+	fmt.Println("Initializing message service on port " + fmt.Sprint(msgPort) + "...")
+	messageService := p2pms.NewMessageService("127.0.0.1", msgPort, *ourStore.GetAddress(), pk, true, logDestination)
+	node := node.New(
+		messageService,
+		chainService,
+		ourStore,
+		logDestination,
+		&engine.PermissivePolicy{},
+		nil)
+
+	var transport transport.Responder
+
+	switch transportType {
+	case "nats":
+
+		fmt.Println("Initializing NATS RPC transport...")
+		transport, err = nats.NewNatsTransportAsServer(rpcPort)
+	case "ws":
+		fmt.Println("Initializing websocket RPC transport...")
+		transport, err = ws.NewWebSocketTransportAsServer(fmt.Sprint(rpcPort))
+	default:
+		err = fmt.Errorf("unknown transport type %s", transportType)
+	}
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	logger := zerolog.New(logDestination).
+		Level(zerolog.TraceLevel).
+		With().
+		Timestamp().
+		Str("node", ourStore.GetAddress().String()).
+		Str("rpc", "server").
+		Str("scope", "").
+		Logger()
+
+	rpcServer, err := rpc.NewRpcServer(&node, &logger, transport)
+	if err != nil {
+		return nil, nil, err
+	}
+	return rpcServer, messageService, nil
+}

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -13,14 +13,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/rs/zerolog"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
-	"github.com/statechannels/go-nitro/crypto"
+	"github.com/statechannels/go-nitro/internal/infra"
 	ta "github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/internal/testdata"
-	"github.com/statechannels/go-nitro/node"
-	"github.com/statechannels/go-nitro/node/engine"
 	"github.com/statechannels/go-nitro/node/engine/chainservice"
 	p2pms "github.com/statechannels/go-nitro/node/engine/messageservice/p2p-message-service"
-	"github.com/statechannels/go-nitro/node/engine/store"
 	"github.com/statechannels/go-nitro/node/query"
 	"github.com/statechannels/go-nitro/protocols/directfund"
 	"github.com/statechannels/go-nitro/protocols/virtualfund"
@@ -302,40 +299,23 @@ func setupNitroNodeWithRPCClient(
 	logDestination *os.File,
 	connectionType transport.TransportType,
 ) (*rpc.RpcClient, *p2pms.P2PMessageService, func()) {
-	messageservice := p2pms.NewMessageService("127.0.0.1",
-		msgPort,
-		crypto.GetAddressFromSecretKeyBytes(pk),
-		pk,
-		true,
-		logDestination)
-	storeA := store.NewMemStore(pk)
-	node := node.New(
-		messageservice,
-		chain,
-		storeA,
-		logDestination,
-		&engine.PermissivePolicy{},
-		nil)
-
-	var serverConnection transport.Responder
-	var clientConnection transport.Requester
 	var err error
+	rpcServer, messageService, err := infra.InitializeRpcServer(pk, chain, false, msgPort, rpcPort, connectionType)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var clientConnection transport.Requester
 	switch connectionType {
 	case "nats":
-		serverConnection, err = natstrans.NewNatsTransportAsServer(rpcPort)
-		if err != nil {
-			panic(err)
-		}
-		clientConnection, err = natstrans.NewNatsTransportAsClient(serverConnection.Url())
+
+		clientConnection, err = natstrans.NewNatsTransportAsClient(rpcServer.Url())
 		if err != nil {
 			panic(err)
 		}
 	case "ws":
-		serverConnection, err = ws.NewWebSocketTransportAsServer(fmt.Sprint(rpcPort))
-		if err != nil {
-			panic(err)
-		}
-		clientConnection, err = ws.NewWebSocketTransportAsClient(serverConnection.Url())
+
+		clientConnection, err = ws.NewWebSocketTransportAsClient(rpcServer.Url())
 		if err != nil {
 			panic(err)
 		}
@@ -344,12 +324,7 @@ func setupNitroNodeWithRPCClient(
 		panic(err)
 	}
 
-	logger := createLogger(logDestination, node.Address.Hex(), "server")
-	rpcServer, err := rpc.NewRpcServer(&node, &logger, serverConnection)
-	if err != nil {
-		panic(err)
-	}
-	rpcClient, err := rpc.NewRpcClient(rpcServer.Url(), createLogger(logDestination, node.Address.Hex(), "client"), clientConnection)
+	rpcClient, err := rpc.NewRpcClient(rpcServer.Url(), createLogger(logDestination, rpcServer.Address().Hex(), "client"), clientConnection)
 	if err != nil {
 		panic(err)
 	}
@@ -357,7 +332,7 @@ func setupNitroNodeWithRPCClient(
 		rpcClient.Close()
 		rpcServer.Close()
 	}
-	return rpcClient, messageservice, cleanupFn
+	return rpcClient, messageService, cleanupFn
 }
 
 type channelInfo interface {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -33,6 +33,10 @@ func (rs *RpcServer) Url() string {
 	return rs.transport.Url()
 }
 
+func (rs *RpcServer) Address() *types.Address {
+	return rs.node.Address
+}
+
 func (rs *RpcServer) Close() error {
 	rs.cancel()
 	rs.wg.Wait()


### PR DESCRIPTION
For dockerized go-nitro, we'll write a coordinator that starts 3 go-nitro rpc servers and open a virtual channel between 2 nodes. At the moment, we have 2 ways to start a nitro rpc server:
1. [go-nitro in node_test](https://github.com/statechannels/go-nitro/blob/217e0b49f03a72b4e37884b1bf6b62b12632c08d/node_test/rpc_test.go#L296).
1. [Executable go-nitro](https://github.com/statechannels/go-nitro/blob/main/main.go).


Neither one of these approaches is a good fit for the coordinator. The coordinator is not a unit test (so the first start option doesn't fit). But it would be nice for the coordinator to have deeper control than simply spinning up a nitro server executable and retaining a handle on the process. For example, the coordinator should be able to wait for peerInfoExchange like done [here](https://github.com/statechannels/go-nitro/blob/217e0b49f03a72b4e37884b1bf6b62b12632c08d/node_test/rpc_test.go#L112). So the second start option is not a great fit.

Instead of copy/pasting code related to running and managing rpc servers for the third time, this PR factors out the code in the `internal` package. The coordinator will use the factored out rpc server initialization code. 