### PR TITLE
Allow for manual voucher exchange

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -196,6 +196,18 @@ func (c *Node) ReceivedVouchers() <-chan payments.Voucher {
 	return c.receivedVouchers
 }
 
+// CreateVoucher creates a voucher for the given channelId and amount and returns it.
+// It is the responsibility of the caller to send the voucher to the payee.
+func (c *Node) CreateVoucher(channelId types.Destination, amount *big.Int) (payments.Voucher, error) {
+	return c.vm.Pay(channelId, amount, *c.store.GetChannelSecretKey())
+}
+
+// ReceiveVoucher receives a voucher and returns the amount that was paid.
+// It can be used to add a voucher that was sent outside of the go-nitro system.
+func (c *Node) ReceiveVoucher(v payments.Voucher) (*big.Int, error) {
+	return c.vm.Receive(v)
+}
+
 // CreatePaymentChannel creates a virtual channel with the counterParty using ledger channels
 // with the supplied intermediaries.
 func (c *Node) CreatePaymentChannel(Intermediaries []types.Address, CounterParty types.Address, ChallengeDuration uint32, Outcome outcome.Exit) (virtualfund.ObjectiveResponse, error) {

--- a/node/node.go
+++ b/node/node.go
@@ -196,7 +196,7 @@ func (c *Node) ReceivedVouchers() <-chan payments.Voucher {
 	return c.receivedVouchers
 }
 
-// CreateVoucher creates a voucher for the given channelId and amount and returns it.
+// CreateVoucher creates and returns a voucher for the given channelId which increments the redeemable balance by amount.
 // It is the responsibility of the caller to send the voucher to the payee.
 func (c *Node) CreateVoucher(channelId types.Destination, amount *big.Int) (payments.Voucher, error) {
 	return c.vm.Pay(channelId, amount, *c.store.GetChannelSecretKey())

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -47,14 +47,17 @@ func TestRpcWithNats(t *testing.T) {
 	executeNRpcTest(t, "nats", 2, false)
 	executeNRpcTest(t, "nats", 3, false)
 	executeNRpcTest(t, "nats", 4, false)
-	executeNRpcTest(t, "nats", 4, true)
 }
 
 func TestRpcWithWebsockets(t *testing.T) {
 	executeNRpcTest(t, "ws", 2, false)
 	executeNRpcTest(t, "ws", 3, false)
 	executeNRpcTest(t, "ws", 4, false)
+}
+
+func TestRPCWithManualVoucherExchange(t *testing.T) {
 	executeNRpcTest(t, "ws", 4, true)
+	executeNRpcTest(t, "nats", 4, true)
 }
 
 func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int, manualVoucherExchange bool) {

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -202,7 +202,7 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 		v := aliceClient.CreateVoucher(vabCreateResponse.ChannelId, 1)
 
 		rec := bobClient.ReceiveVoucher(v)
-		if rec != 1 {
+		if rec.Cmp(big.NewInt(1)) != 0 {
 			t.Errorf("expected 1, got %d", rec)
 		}
 	} else {

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -47,9 +47,6 @@ func TestRpcWithNats(t *testing.T) {
 	executeNRpcTest(t, "nats", 2, false)
 	executeNRpcTest(t, "nats", 3, false)
 	executeNRpcTest(t, "nats", 4, false)
-
-	executeNRpcTest(t, "nats", 2, true)
-	executeNRpcTest(t, "nats", 3, true)
 	executeNRpcTest(t, "nats", 4, true)
 }
 
@@ -57,9 +54,6 @@ func TestRpcWithWebsockets(t *testing.T) {
 	executeNRpcTest(t, "ws", 2, false)
 	executeNRpcTest(t, "ws", 3, false)
 	executeNRpcTest(t, "ws", 4, false)
-
-	executeNRpcTest(t, "ws", 2, true)
-	executeNRpcTest(t, "ws", 3, true)
 	executeNRpcTest(t, "ws", 4, true)
 }
 

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -83,9 +83,8 @@ func NewHttpRpcClient(rpcServerUrl string) (*RpcClient, error) {
 // CreateVoucher creates a voucher for the given channelId and amount and returns it.
 // It is the responsibility of the caller to send the voucher to the payee.
 func (rc *RpcClient) CreateVoucher(chId types.Destination, amount uint64) payments.Voucher {
-	req := serde.CreateVoucherRequest{ChannelId: chId, Amount: amount}
-
-	return waitForRequest[serde.CreateVoucherRequest, payments.Voucher](rc, serde.CreateVoucherRequestMethod, req)
+	req := serde.PaymentRequest{Channel: chId, Amount: amount}
+	return waitForRequest[serde.PaymentRequest, payments.Voucher](rc, serde.CreateVoucherRequestMethod, req)
 }
 
 // ReceiveVoucher receives a voucher and returns the amount that was paid.

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"os"
 	"sync"
 
@@ -89,8 +90,11 @@ func (rc *RpcClient) CreateVoucher(chId types.Destination, amount uint64) paymen
 
 // ReceiveVoucher receives a voucher and returns the amount that was paid.
 // It can be used to add a voucher that was sent outside of the go-nitro system.
-func (rc *RpcClient) ReceiveVoucher(v payments.Voucher) uint64 {
-	return waitForRequest[payments.Voucher, uint64](rc, serde.ReceiveVoucherRequestMethod, v)
+func (rc *RpcClient) ReceiveVoucher(v payments.Voucher) *big.Int {
+	bigIntString := waitForRequest[payments.Voucher, string](rc, serde.ReceiveVoucherRequestMethod, v)
+	a := big.NewInt(0)
+	a.SetString(bigIntString, 16)
+	return a
 }
 
 func (rc *RpcClient) GetPaymentChannel(chId types.Destination) query.PaymentChannelInfo {

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -87,8 +87,6 @@ type JsonRpcRequest[T RequestPayload | NotificationPayload] struct {
 	Params  T      `json:"params"`
 }
 
-type VersionResponse = string
-
 type (
 	GetAllLedgersResponse              = []query.LedgerChannelInfo
 	GetPaymentChannelsByLedgerResponse = []query.PaymentChannelInfo
@@ -101,11 +99,10 @@ type ResponsePayload interface {
 		PaymentRequest |
 		query.PaymentChannelInfo |
 		query.LedgerChannelInfo |
-		VersionResponse |
 		GetAllLedgersResponse |
 		GetPaymentChannelsByLedgerResponse |
 		payments.Voucher |
-		uint64
+		string
 }
 
 type JsonRpcResponse[T ResponsePayload] struct {

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -61,11 +61,6 @@ type (
 	NoPayloadRequest = struct{}
 )
 
-type CreateVoucherRequest struct {
-	ChannelId types.Destination
-	Amount    uint64
-}
-
 type RequestPayload interface {
 	directfund.ObjectiveRequest |
 		directdefund.ObjectiveRequest |
@@ -76,8 +71,7 @@ type RequestPayload interface {
 		GetPaymentChannelRequest |
 		GetPaymentChannelsByLedgerRequest |
 		NoPayloadRequest |
-		payments.Voucher |
-		CreateVoucherRequest
+		payments.Voucher
 }
 
 type NotificationPayload interface {

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -2,6 +2,7 @@ package serde
 
 import (
 	"github.com/statechannels/go-nitro/node/query"
+	"github.com/statechannels/go-nitro/payments"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/protocols/directdefund"
 	"github.com/statechannels/go-nitro/protocols/directfund"
@@ -24,6 +25,8 @@ const (
 	GetLedgerChannelRequestMethod     RequestMethod = "get_ledger_channel"
 	GetPaymentChannelsByLedgerMethod  RequestMethod = "get_payment_channels_by_ledger"
 	GetAllLedgerChannelsMethod        RequestMethod = "get_all_ledger_channels"
+	CreateVoucherRequestMethod        RequestMethod = "create_voucher"
+	ReceiveVoucherRequestMethod       RequestMethod = "receive_voucher"
 )
 
 type NotificationMethod string
@@ -58,6 +61,11 @@ type (
 	NoPayloadRequest = struct{}
 )
 
+type CreateVoucherRequest struct {
+	ChannelId types.Destination
+	Amount    uint64
+}
+
 type RequestPayload interface {
 	directfund.ObjectiveRequest |
 		directdefund.ObjectiveRequest |
@@ -67,7 +75,9 @@ type RequestPayload interface {
 		GetLedgerChannelRequest |
 		GetPaymentChannelRequest |
 		GetPaymentChannelsByLedgerRequest |
-		NoPayloadRequest
+		NoPayloadRequest |
+		payments.Voucher |
+		CreateVoucherRequest
 }
 
 type NotificationPayload interface {
@@ -99,7 +109,9 @@ type ResponsePayload interface {
 		query.LedgerChannelInfo |
 		VersionResponse |
 		GetAllLedgersResponse |
-		GetPaymentChannelsByLedgerResponse
+		GetPaymentChannelsByLedgerResponse |
+		payments.Voucher |
+		uint64
 }
 
 type JsonRpcResponse[T ResponsePayload] struct {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -88,8 +88,8 @@ func (rs *RpcServer) registerHandlers() (err error) {
 
 		switch serde.RequestMethod(jsonrpcReq.Method) {
 		case serde.CreateVoucherRequestMethod:
-			return processRequest(rs, requestData, func(req serde.CreateVoucherRequest) (payments.Voucher, error) {
-				v, err := rs.node.CreateVoucher(req.ChannelId, big.NewInt(int64(req.Amount)))
+			return processRequest(rs, requestData, func(req serde.PaymentRequest) (payments.Voucher, error) {
+				v, err := rs.node.CreateVoucher(req.Channel, big.NewInt(int64(req.Amount)))
 				if err != nil {
 					return payments.Voucher{}, err
 				}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rs/zerolog"
 	nitro "github.com/statechannels/go-nitro/node"
 	"github.com/statechannels/go-nitro/node/query"
+	"github.com/statechannels/go-nitro/payments"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/protocols/directdefund"
 	"github.com/statechannels/go-nitro/protocols/directfund"
@@ -86,6 +87,22 @@ func (rs *RpcServer) registerHandlers() (err error) {
 		}
 
 		switch serde.RequestMethod(jsonrpcReq.Method) {
+		case serde.CreateVoucherRequestMethod:
+			return processRequest(rs, requestData, func(req serde.CreateVoucherRequest) (payments.Voucher, error) {
+				v, err := rs.node.CreateVoucher(req.ChannelId, big.NewInt(int64(req.Amount)))
+				if err != nil {
+					return payments.Voucher{}, err
+				}
+				return v, nil
+			})
+		case serde.ReceiveVoucherRequestMethod:
+			return processRequest(rs, requestData, func(req payments.Voucher) (uint64, error) {
+				a, err := rs.node.ReceiveVoucher(req)
+				if err != nil {
+					return 0, err
+				}
+				return a.Uint64(), nil
+			})
 		case serde.GetAddressMethod:
 			return processRequest(rs, requestData, func(req serde.NoPayloadRequest) (string, error) {
 				return rs.node.Address.Hex(), nil
@@ -246,6 +263,7 @@ func (rs *RpcServer) sendNotifications(ctx context.Context) {
 		case <-ctx.Done():
 			rs.wg.Done()
 			return
+
 		case completedObjective, ok := <-rs.node.CompletedObjectives():
 			if !ok {
 				rs.logger.Warn().Msg("CompletedObjectives channel closed, exiting sendNotifications")

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -96,12 +96,12 @@ func (rs *RpcServer) registerHandlers() (err error) {
 				return v, nil
 			})
 		case serde.ReceiveVoucherRequestMethod:
-			return processRequest(rs, requestData, func(req payments.Voucher) (uint64, error) {
+			return processRequest(rs, requestData, func(req payments.Voucher) (string, error) {
 				a, err := rs.node.ReceiveVoucher(req)
 				if err != nil {
-					return 0, err
+					return big.NewInt(0).String(), err
 				}
-				return a.Uint64(), nil
+				return a.String(), nil
 			})
 		case serde.GetAddressMethod:
 			return processRequest(rs, requestData, func(req serde.NoPayloadRequest) (string, error) {


### PR DESCRIPTION
Based on this [comment](https://github.com/statechannels/go-nitro/pull/1370#discussion_r1244528266) I took a stab at avoiding the engine to create and receive vouchers. Instead the go-nitro node directly calls into the voucher manger to add or create vouchers.

I've created #1389 as tech debt to consider this approach vs #1370