### PR TITLE
Return the amount added by a voucher

### DIFF
--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -382,7 +382,7 @@ func (e *Engine) handleMessage(message protocols.Message) (EngineEvent, error) {
 	for _, voucher := range message.Payments {
 
 		// TODO: return the amount we paid?
-		_, err := e.vm.Receive(voucher)
+		_, _, err := e.vm.Receive(voucher)
 
 		allCompleted.ReceivedVouchers = append(allCompleted.ReceivedVouchers, voucher)
 		if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -204,7 +204,7 @@ func (c *Node) CreateVoucher(channelId types.Destination, amount *big.Int) (paym
 
 // ReceiveVoucher receives a voucher and returns the amount that was paid.
 // It can be used to add a voucher that was sent outside of the go-nitro system.
-func (c *Node) ReceiveVoucher(v payments.Voucher) (*big.Int, error) {
+func (c *Node) ReceiveVoucher(v payments.Voucher) (total *big.Int, fromVoucher *big.Int, err error) {
 	return c.vm.Receive(v)
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -204,7 +204,7 @@ func (c *Node) CreateVoucher(channelId types.Destination, amount *big.Int) (paym
 
 // ReceiveVoucher receives a voucher and returns the amount that was paid.
 // It can be used to add a voucher that was sent outside of the go-nitro system.
-func (c *Node) ReceiveVoucher(v payments.Voucher) (total *big.Int, fromVoucher *big.Int, err error) {
+func (c *Node) ReceiveVoucher(v payments.Voucher) (total *big.Int, delta *big.Int, err error) {
 	return c.vm.Receive(v)
 }
 

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -212,10 +212,18 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 	if manualVoucherExchange {
 		v := aliceClient.CreateVoucher(vabCreateResponse.ChannelId, 1)
 
-		rec := bobClient.ReceiveVoucher(v)
-		if rec.Cmp(big.NewInt(1)) != 0 {
-			t.Errorf("expected 1, got %d", rec)
+		total, fromVoucher := bobClient.ReceiveVoucher(v)
+		if total.Cmp(big.NewInt(1)) != 0 {
+			t.Errorf("expected a total of 1 got %d", total)
 		}
+		if fromVoucher.Cmp(big.NewInt(1)) != 0 {
+			t.Errorf("expected a fromVoucher of 1 got %d", fromVoucher)
+		}
+		_, fromVoucher = bobClient.ReceiveVoucher(v)
+		if fromVoucher.Cmp(big.NewInt(0)) != 0 {
+			t.Errorf("adding the same voucher should result in a fromVoucher of 0, got %d", fromVoucher)
+		}
+
 	} else {
 		aliceClient.Pay(vabCreateResponse.ChannelId, 1)
 	}

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -212,16 +212,16 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 	if manualVoucherExchange {
 		v := aliceClient.CreateVoucher(vabCreateResponse.ChannelId, 1)
 
-		total, fromVoucher := bobClient.ReceiveVoucher(v)
+		total, delta := bobClient.ReceiveVoucher(v)
 		if total.Cmp(big.NewInt(1)) != 0 {
 			t.Errorf("expected a total of 1 got %d", total)
 		}
-		if fromVoucher.Cmp(big.NewInt(1)) != 0 {
-			t.Errorf("expected a fromVoucher of 1 got %d", fromVoucher)
+		if delta.Cmp(big.NewInt(1)) != 0 {
+			t.Errorf("expected a delta of 1 got %d", delta)
 		}
-		_, fromVoucher = bobClient.ReceiveVoucher(v)
-		if fromVoucher.Cmp(big.NewInt(0)) != 0 {
-			t.Errorf("adding the same voucher should result in a fromVoucher of 0, got %d", fromVoucher)
+		_, delta = bobClient.ReceiveVoucher(v)
+		if delta.Cmp(big.NewInt(0)) != 0 {
+			t.Errorf("adding the same voucher should result in a delta of 0, got %d", delta)
 		}
 
 	} else {

--- a/payments/payments_test.go
+++ b/payments/payments_test.go
@@ -110,16 +110,16 @@ func TestPaymentManager(t *testing.T) {
 	_ = receiptMgr.Register(channelId, testactors.Alice.Address(), testactors.Bob.Address(), deposit)
 	Equals(t, startingBalance, getBalance(receiptMgr))
 
-	received, fromVoucher, err := receiptMgr.Receive(firstVoucher)
+	received, delta, err := receiptMgr.Receive(firstVoucher)
 	Ok(t, err)
 	Equals(t, received, payment)
-	Equals(t, fromVoucher, payment)
+	Equals(t, delta, payment)
 	Equals(t, onePaymentMade, getBalance(receiptMgr))
 	// Receiving a voucher is idempotent
-	received, fromVoucher, err = receiptMgr.Receive(firstVoucher)
+	received, delta, err = receiptMgr.Receive(firstVoucher)
 	Ok(t, err)
 	Equals(t, received, payment)
-	Equals(t, fromVoucher, big.NewInt(0))
+	Equals(t, delta, big.NewInt(0))
 	Equals(t, onePaymentMade, getBalance(receiptMgr))
 
 	// paying twice returns a larger voucher
@@ -129,10 +129,10 @@ func TestPaymentManager(t *testing.T) {
 	Equals(t, twoPaymentsMade, getBalance(paymentMgr))
 
 	// Receiving a new voucher increases amount received
-	received, fromVoucher, err = receiptMgr.Receive(secondVoucher)
+	received, delta, err = receiptMgr.Receive(secondVoucher)
 	Ok(t, err)
 	Equals(t, doublePayment, received)
-	Equals(t, fromVoucher, payment)
+	Equals(t, delta, payment)
 	Equals(t, twoPaymentsMade, getBalance(receiptMgr))
 
 	// re-registering a channel doesn't reset its balance
@@ -145,10 +145,10 @@ func TestPaymentManager(t *testing.T) {
 	Equals(t, twoPaymentsMade, getBalance(receiptMgr))
 
 	// Receiving old vouchers is ok
-	received, fromVoucher, err = receiptMgr.Receive(firstVoucher)
+	received, delta, err = receiptMgr.Receive(firstVoucher)
 	Ok(t, err)
 	Equals(t, doublePayment, received)
-	Equals(t, fromVoucher, big.NewInt(0))
+	Equals(t, delta, big.NewInt(0))
 	Equals(t, twoPaymentsMade, getBalance(receiptMgr))
 
 	// Only the payer can sign vouchers

--- a/payments/payments_test.go
+++ b/payments/payments_test.go
@@ -104,20 +104,22 @@ func TestPaymentManager(t *testing.T) {
 	// Happy path: receipt manager can receive vouchers
 	receiptMgr := NewVoucherManager(testactors.Bob.Address(), newSimpleVoucherStore())
 
-	_, err = receiptMgr.Receive(firstVoucher)
+	_, _, err = receiptMgr.Receive(firstVoucher)
 	Assert(t, err != nil, "channel must be registered to receive vouchers")
 
 	_ = receiptMgr.Register(channelId, testactors.Alice.Address(), testactors.Bob.Address(), deposit)
 	Equals(t, startingBalance, getBalance(receiptMgr))
 
-	received, err := receiptMgr.Receive(firstVoucher)
+	received, fromVoucher, err := receiptMgr.Receive(firstVoucher)
 	Ok(t, err)
 	Equals(t, received, payment)
+	Equals(t, fromVoucher, payment)
 	Equals(t, onePaymentMade, getBalance(receiptMgr))
 	// Receiving a voucher is idempotent
-	received, err = receiptMgr.Receive(firstVoucher)
+	received, fromVoucher, err = receiptMgr.Receive(firstVoucher)
 	Ok(t, err)
 	Equals(t, received, payment)
+	Equals(t, fromVoucher, big.NewInt(0))
 	Equals(t, onePaymentMade, getBalance(receiptMgr))
 
 	// paying twice returns a larger voucher
@@ -127,9 +129,10 @@ func TestPaymentManager(t *testing.T) {
 	Equals(t, twoPaymentsMade, getBalance(paymentMgr))
 
 	// Receiving a new voucher increases amount received
-	received, err = receiptMgr.Receive(secondVoucher)
+	received, fromVoucher, err = receiptMgr.Receive(secondVoucher)
 	Ok(t, err)
 	Equals(t, doublePayment, received)
+	Equals(t, fromVoucher, payment)
 	Equals(t, twoPaymentsMade, getBalance(receiptMgr))
 
 	// re-registering a channel doesn't reset its balance
@@ -142,9 +145,10 @@ func TestPaymentManager(t *testing.T) {
 	Equals(t, twoPaymentsMade, getBalance(receiptMgr))
 
 	// Receiving old vouchers is ok
-	received, err = receiptMgr.Receive(firstVoucher)
+	received, fromVoucher, err = receiptMgr.Receive(firstVoucher)
 	Ok(t, err)
 	Equals(t, doublePayment, received)
+	Equals(t, fromVoucher, big.NewInt(0))
 	Equals(t, twoPaymentsMade, getBalance(receiptMgr))
 
 	// Only the payer can sign vouchers
@@ -154,19 +158,19 @@ func TestPaymentManager(t *testing.T) {
 	Assert(t, err != nil, "only payer can sign vouchers")
 
 	// Receiving a voucher for an unknown channel fails
-	_, err = receiptMgr.Receive(testVoucher(wrongChannelId, payment, testactors.Alice))
+	_, _, err = receiptMgr.Receive(testVoucher(wrongChannelId, payment, testactors.Alice))
 	Assert(t, err != nil, "expected an error")
 	Equals(t, twoPaymentsMade, getBalance(receiptMgr))
 
 	// Receiving a voucher that's too large fails
-	_, err = receiptMgr.Receive(testVoucher(channelId, overPayment, testactors.Alice))
+	_, _, err = receiptMgr.Receive(testVoucher(channelId, overPayment, testactors.Alice))
 	Assert(t, err != nil, "expected an error")
 	Equals(t, twoPaymentsMade, getBalance(receiptMgr))
 
 	// Receiving a voucher with the wrong signature fails
 	voucher := testVoucher(channelId, payment, testactors.Alice)
 	voucher.Amount = triplePayment
-	_, err = receiptMgr.Receive(voucher)
+	_, _, err = receiptMgr.Receive(voucher)
 	Assert(t, err != nil, "expected an error")
 	Equals(t, twoPaymentsMade, getBalance(receiptMgr))
 }

--- a/payments/voucher_manager.go
+++ b/payments/voucher_manager.go
@@ -80,7 +80,7 @@ func (vm *VoucherManager) Pay(channelId types.Destination, amount *big.Int, pk [
 }
 
 // Receive validates the incoming voucher, and returns the total amount received so far as well as the amount received from the voucher
-func (vm *VoucherManager) Receive(voucher Voucher) (total *big.Int, fromVoucher *big.Int, err error) {
+func (vm *VoucherManager) Receive(voucher Voucher) (total *big.Int, delta *big.Int, err error) {
 	vInfo, err := vm.store.GetVoucherInfo(voucher.ChannelId)
 	if err != nil {
 		return &big.Int{}, &big.Int{}, fmt.Errorf("channel not registered: %w", err)
@@ -108,7 +108,7 @@ func (vm *VoucherManager) Receive(voucher Voucher) (total *big.Int, fromVoucher 
 		return &big.Int{}, &big.Int{}, fmt.Errorf("wrong signer: %+v, %+v", signer, vInfo.ChannelPayer)
 	}
 	// Check the difference between our largest voucher and this new one
-	fromVoucher = big.NewInt(0).Sub(voucher.Amount, total)
+	delta = big.NewInt(0).Sub(voucher.Amount, total)
 
 	total = voucher.Amount
 	vInfo.LargestVoucher = voucher
@@ -117,7 +117,7 @@ func (vm *VoucherManager) Receive(voucher Voucher) (total *big.Int, fromVoucher 
 	if err != nil {
 		return nil, nil, err
 	}
-	return total, fromVoucher, nil
+	return total, delta, nil
 }
 
 // ChannelRegistered returns  whether a channel has been registered with the voucher manager or not

--- a/payments/voucher_manager.go
+++ b/payments/voucher_manager.go
@@ -79,43 +79,45 @@ func (vm *VoucherManager) Pay(channelId types.Destination, amount *big.Int, pk [
 	return voucher, nil
 }
 
-// Receive validates the incoming voucher, and returns the total amount received so far
-func (vm *VoucherManager) Receive(voucher Voucher) (*big.Int, error) {
+// Receive validates the incoming voucher, and returns the total amount received so far as well as the amount received from the voucher
+func (vm *VoucherManager) Receive(voucher Voucher) (total *big.Int, fromVoucher *big.Int, err error) {
 	vInfo, err := vm.store.GetVoucherInfo(voucher.ChannelId)
 	if err != nil {
-		return &big.Int{}, fmt.Errorf("channel not registered: %w", err)
+		return &big.Int{}, &big.Int{}, fmt.Errorf("channel not registered: %w", err)
 	}
 
 	// We only care about vouchers when we are the recipient of the payment
 	if vInfo.ChannelPayee != vm.me {
-		return &big.Int{}, nil
-	}
-	received := &big.Int{}
-	received.Set(voucher.Amount)
-	if types.Gt(received, vInfo.StartingBalance) {
-		return &big.Int{}, fmt.Errorf("channel has insufficient funds")
+		return &big.Int{}, &big.Int{}, nil
 	}
 
-	receivedSoFar := vInfo.LargestVoucher.Amount
-	if !types.Gt(received, receivedSoFar) {
-		return receivedSoFar, nil
+	if types.Gt(voucher.Amount, vInfo.StartingBalance) {
+		return &big.Int{}, &big.Int{}, fmt.Errorf("channel has insufficient funds")
+	}
+
+	total = vInfo.LargestVoucher.Amount
+	if !types.Gt(voucher.Amount, total) {
+		return total, big.NewInt(0), nil
 	}
 
 	signer, err := voucher.RecoverSigner()
 	if err != nil {
-		return &big.Int{}, err
+		return &big.Int{}, &big.Int{}, err
 	}
 	if signer != vInfo.ChannelPayer {
-		return &big.Int{}, fmt.Errorf("wrong signer: %+v, %+v", signer, vInfo.ChannelPayer)
+		return &big.Int{}, &big.Int{}, fmt.Errorf("wrong signer: %+v, %+v", signer, vInfo.ChannelPayer)
 	}
+	// Check the difference between our largest voucher and this new one
+	fromVoucher = big.NewInt(0).Sub(voucher.Amount, total)
 
+	total = voucher.Amount
 	vInfo.LargestVoucher = voucher
 
 	err = vm.store.SetVoucherInfo(voucher.ChannelId, *vInfo)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return received, nil
+	return total, fromVoucher, nil
 }
 
 // ChannelRegistered returns  whether a channel has been registered with the voucher manager or not

--- a/payments/voucher_manager.go
+++ b/payments/voucher_manager.go
@@ -88,7 +88,7 @@ func (vm *VoucherManager) Receive(voucher Voucher) (total *big.Int, delta *big.I
 
 	// We only care about vouchers when we are the recipient of the payment
 	if vInfo.ChannelPayee != vm.me {
-		return &big.Int{}, &big.Int{}, nil
+		return &big.Int{}, &big.Int{}, fmt.Errorf("can only receive vouchers if we're the payee")
 	}
 
 	if types.Gt(voucher.Amount, vInfo.StartingBalance) {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -97,13 +97,12 @@ func (rc *RpcClient) CreateVoucher(chId types.Destination, amount uint64) paymen
 	return waitForRequest[serde.PaymentRequest, payments.Voucher](rc, serde.CreateVoucherRequestMethod, req)
 }
 
-// ReceiveVoucher receives a voucher and returns the amount that was paid.
+// ReceiveVoucher receives a voucher and adds it to the go-nitro store.
+// It returns the total amount received so far and the amount received from the voucher supplied.
 // It can be used to add a voucher that was sent outside of the go-nitro system.
-func (rc *RpcClient) ReceiveVoucher(v payments.Voucher) *big.Int {
-	bigIntString := waitForRequest[payments.Voucher, string](rc, serde.ReceiveVoucherRequestMethod, v)
-	a := big.NewInt(0)
-	a.SetString(bigIntString, 16)
-	return a
+func (rc *RpcClient) ReceiveVoucher(v payments.Voucher) (total *big.Int, fromVoucher *big.Int) {
+	vr := waitForRequest[payments.Voucher, serde.ReceiveVoucherResponse](rc, serde.ReceiveVoucherRequestMethod, v)
+	return vr.Total, vr.FromVoucher
 }
 
 func (rc *RpcClient) GetPaymentChannel(chId types.Destination) query.PaymentChannelInfo {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -100,9 +100,9 @@ func (rc *RpcClient) CreateVoucher(chId types.Destination, amount uint64) paymen
 // ReceiveVoucher receives a voucher and adds it to the go-nitro store.
 // It returns the total amount received so far and the amount received from the voucher supplied.
 // It can be used to add a voucher that was sent outside of the go-nitro system.
-func (rc *RpcClient) ReceiveVoucher(v payments.Voucher) (total *big.Int, fromVoucher *big.Int) {
+func (rc *RpcClient) ReceiveVoucher(v payments.Voucher) (total *big.Int, delta *big.Int) {
 	vr := waitForRequest[payments.Voucher, serde.ReceiveVoucherResponse](rc, serde.ReceiveVoucherRequestMethod, v)
-	return vr.Total, vr.FromVoucher
+	return vr.Total, vr.Delta
 }
 
 func (rc *RpcClient) GetPaymentChannel(chId types.Destination) query.PaymentChannelInfo {

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -1,7 +1,10 @@
 package serde
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/statechannels/go-nitro/node/query"
 	"github.com/statechannels/go-nitro/payments"
 	"github.com/statechannels/go-nitro/protocols"
@@ -93,6 +96,11 @@ type (
 	GetPaymentChannelsByLedgerResponse = []query.PaymentChannelInfo
 )
 
+type ReceiveVoucherResponse struct {
+	Total       *big.Int
+	FromVoucher *big.Int
+}
+
 type ResponsePayload interface {
 	directfund.ObjectiveResponse |
 		protocols.ObjectiveId |
@@ -104,7 +112,8 @@ type ResponsePayload interface {
 		GetPaymentChannelsByLedgerResponse |
 		payments.Voucher |
 		common.Address |
-		string
+		string |
+		ReceiveVoucherResponse
 }
 
 type JsonRpcResponse[T ResponsePayload] struct {

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -97,8 +97,8 @@ type (
 )
 
 type ReceiveVoucherResponse struct {
-	Total       *big.Int
-	FromVoucher *big.Int
+	Total *big.Int
+	Delta *big.Int
 }
 
 type ResponsePayload interface {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -96,12 +96,16 @@ func (rs *RpcServer) registerHandlers() (err error) {
 				return v, nil
 			})
 		case serde.ReceiveVoucherRequestMethod:
-			return processRequest(rs, requestData, func(req payments.Voucher) (string, error) {
-				a, err := rs.node.ReceiveVoucher(req)
+			return processRequest(rs, requestData, func(req payments.Voucher) (serde.ReceiveVoucherResponse, error) {
+				total, fromVoucher, err := rs.node.ReceiveVoucher(req)
 				if err != nil {
-					return big.NewInt(0).String(), err
+					return serde.ReceiveVoucherResponse{}, err
 				}
-				return a.String(), nil
+				r := serde.ReceiveVoucherResponse{
+					Total:       total,
+					FromVoucher: fromVoucher,
+				}
+				return r, nil
 			})
 		case serde.GetAddressMethod:
 			return processRequest(rs, requestData, func(req serde.NoPayloadRequest) (string, error) {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -97,13 +97,13 @@ func (rs *RpcServer) registerHandlers() (err error) {
 			})
 		case serde.ReceiveVoucherRequestMethod:
 			return processRequest(rs, requestData, func(req payments.Voucher) (serde.ReceiveVoucherResponse, error) {
-				total, fromVoucher, err := rs.node.ReceiveVoucher(req)
+				total, delta, err := rs.node.ReceiveVoucher(req)
 				if err != nil {
 					return serde.ReceiveVoucherResponse{}, err
 				}
 				r := serde.ReceiveVoucherResponse{
-					Total:       total,
-					FromVoucher: fromVoucher,
+					Total: total,
+					Delta: delta,
 				}
 				return r, nil
 			})


### PR DESCRIPTION
Previously when receiving a voucher, our voucher manager/API just returns the total payment made on the channel (aka the largest voucher we've received).  However that doesn't let us know the change in balance due to the voucher, meaning we don't know how much the voucher was "worth".  If we want to know that we have to keep track of the channel balance before  and after`ReceiveVoucher` is called and compare the difference.

This PR updates the voucher manager and API's `ReceiveVoucher` to  return the difference between the incoming voucher and the largest voucher we have (alongside the total value). This helps simplify payment checks as you can easily check if a voucher resulted in a payment of `x`.


