### PR TITLE
Refactor RPC websocket client close

### DIFF
--- a/rpc/transport/ws/client.go
+++ b/rpc/transport/ws/client.go
@@ -3,6 +3,7 @@ package ws
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	urlUtil "net/url"
@@ -18,6 +19,7 @@ type clientWebSocketTransport struct {
 	url              string
 	ctx              context.Context
 	cancel           context.CancelFunc
+	closed           chan struct{}
 }
 
 // NewWebSocketTransportAsClient creates a websocket connection that can be used to send requests and listen for notifications
@@ -37,6 +39,7 @@ func NewWebSocketTransportAsClient(url string) (*clientWebSocketTransport, error
 	wsc.clientWebsocket = conn
 
 	wsc.ctx, wsc.cancel = context.WithCancel(context.Background())
+	wsc.closed = make(chan struct{})
 
 	go wsc.readMessages()
 
@@ -66,27 +69,30 @@ func (wsc *clientWebSocketTransport) Subscribe() (<-chan []byte, error) {
 
 func (wsc *clientWebSocketTransport) Close() error {
 	wsc.cancel()
-	// This will also cause the go-routine to unblock waiting on `Read` and thus serves as a signal to exit
 	err := wsc.clientWebsocket.Close(websocket.StatusNormalClosure, "client initiated close")
 	if err != nil {
-		return err
+		wsc.logger.Error().Err(err).Msgf("Error closing websocket %v", err)
 	}
-
-	return nil
+	<-wsc.closed
+	return err
 }
 
 func (wsc *clientWebSocketTransport) readMessages() {
+	defer close(wsc.closed)
+	defer close(wsc.notificationChan)
+
 	for {
-		_, data, err := wsc.clientWebsocket.Read(wsc.ctx)
+		//_, data, err := wsc.clientWebsocket.Read(wsc.ctx)
+		_, data, err := wsc.clientWebsocket.Read(context.Background())
+		fmt.Printf("Received message: %s %v \n", string(data), err)
 		if websocket.CloseStatus(err) == websocket.StatusNormalClosure {
 			break
 		}
 		if err != nil {
 			wsc.logger.Error().Err(err).Msgf("Error reading from websocket %v", err)
-			continue
+			break
 		}
 		wsc.logger.Trace().Msgf("Received message: %s", string(data))
 		wsc.notificationChan <- data
 	}
-	close(wsc.notificationChan)
 }

--- a/rpc/transport/ws/client.go
+++ b/rpc/transport/ws/client.go
@@ -65,12 +65,12 @@ func (wsc *clientWebSocketTransport) Subscribe() (<-chan []byte, error) {
 }
 
 func (wsc *clientWebSocketTransport) Close() error {
+	wsc.cancel()
 	// This will also cause the go-routine to unblock waiting on `Read` and thus serves as a signal to exit
 	err := wsc.clientWebsocket.Close(websocket.StatusNormalClosure, "client initiated close")
 	if err != nil {
 		return err
 	}
-	wsc.cancel()
 
 	return nil
 }


### PR DESCRIPTION
When developing https://github.com/statechannels/go-nitro/pull/1393, rpc clients hang on close. Breakpoints show that [websocket Close](https://github.com/statechannels/go-nitro/blob/cabce74d3a1e85a28bf0f2f89c79f32e8dd44cf2/rpc/transport/ws/client.go#L69) is being called. But the [webscoket Read](https://github.com/statechannels/go-nitro/blob/cabce74d3a1e85a28bf0f2f89c79f32e8dd44cf2/rpc/transport/ws/client.go#L80) never resolves.

This PR uses context to trigger websocket connection close. The code seems cleaner with context than with waitgroups and works.