### PR TITLE
Add test for node to handle duplicate ledger channel

### DIFF
--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -147,13 +147,13 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 	// handles error without panicking
 	{
 		outcome := simpleOutcome(actors[0].Address(), actors[1].Address(), 100, 100)
-		duplicateLedgerChannel := clients[0].CreateLedgerChannel(actors[1].Address(), 100, outcome)
+		duplicateLedgerChannelObjective := clients[0].CreateLedgerChannel(actors[1].Address(), 100, outcome)
 
-		if !directfund.IsDirectFundObjective(duplicateLedgerChannel.Id) {
-			t.Errorf("expected direct fund objective, got %s", duplicateLedgerChannel.Id)
+		if !directfund.IsDirectFundObjective(duplicateLedgerChannelObjective.Id) {
+			t.Errorf("expected direct fund objective, got %s", duplicateLedgerChannelObjective.Id)
 		}
 
-		duplicateLedgerChannelInfo := clients[0].GetLedgerChannel(duplicateLedgerChannel.ChannelId)
+		duplicateLedgerChannelInfo := clients[0].GetLedgerChannel(duplicateLedgerChannelObjective.ChannelId)
 
 		zeroDestination := types.Destination{0x0}
 		if duplicateLedgerChannelInfo.ID != zeroDestination {

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -143,6 +143,24 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 	}
 	t.Log("Ledger channels created")
 
+	// try to create duplicate ledger channel to ensure node correctly
+	// handles error without panicking
+	{
+		outcome := simpleOutcome(actors[0].Address(), actors[1].Address(), 100, 100)
+		duplicateLedgerChannel := clients[0].CreateLedgerChannel(actors[1].Address(), 100, outcome)
+
+		if !directfund.IsDirectFundObjective(duplicateLedgerChannel.Id) {
+			t.Errorf("expected direct fund objective, got %s", duplicateLedgerChannel.Id)
+		}
+
+		duplicateLedgerChannelInfo := clients[0].GetLedgerChannel(duplicateLedgerChannel.ChannelId)
+
+		zeroDestination := types.Destination{0x0}
+		if duplicateLedgerChannelInfo.ID != zeroDestination {
+			t.Errorf("expected duplicate ledger channel ID to be 0x0, got %s", duplicateLedgerChannelInfo.ID)
+		}
+	}
+
 	// assert existence & reporting of expected ledger channels
 	for i, client := range clients {
 		if i != 0 {

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -63,7 +63,7 @@ func NewObjective(request ObjectiveRequest, preApprove bool, myAddress types.Add
 		return Objective{}, fmt.Errorf("counterparty check failed: %w", err)
 	}
 	if channelExists {
-		return Objective{}, fmt.Errorf("a channel already exists with counterparty %s", request.CounterParty)
+		return Objective{}, fmt.Errorf("counterparty %s: %w", request.CounterParty, ErrLedgerChannelExists)
 	}
 
 	initialState := state.State{


### PR DESCRIPTION
This will allow us to notice if the node engine's code to handle errors without panicking breaks at any point in the future.