### PR TITLE
Fix double close of websocket connection

### DIFF
--- a/rpc/transport/ws/server.go
+++ b/rpc/transport/ws/server.go
@@ -174,11 +174,13 @@ EventLoop:
 			break EventLoop
 		case <-r.Context().Done():
 			err = r.Context().Err()
+			// Initiate a websocket close from the server
 			defer c.Close(websocket.StatusInternalError, "server initiated websocket close")
 			break EventLoop
 		case notificationData := <-notificationChan:
 			err := c.Write(r.Context(), websocket.MessageText, notificationData)
 			if err != nil {
+				// Initiate a websocket close from the server
 				defer c.Close(websocket.StatusInternalError, "server initiated websocket close")
 				break EventLoop
 			}


### PR DESCRIPTION
Do not close the websocket connection from the server when the client initiated the websocket close.

When developing https://github.com/statechannels/go-nitro/pull/1393, rpc clients hang on close. Breakpoints show that [websocket Close](https://github.com/statechannels/go-nitro/blob/cabce74d3a1e85a28bf0f2f89c79f32e8dd44cf2/rpc/transport/ws/client.go#L69) is being called. But the [webscoket Read](https://github.com/statechannels/go-nitro/blob/cabce74d3a1e85a28bf0f2f89c79f32e8dd44cf2/rpc/transport/ws/client.go#L80) never resolves.