### PR TITLE
Format server error objects to match jsonrpc spec

### DIFF
--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -45,12 +45,12 @@ func sendRequestAndExpectError(t *testing.T, request []byte, expectedError types
 
 	response := mockResponder.Handler(request)
 
-	jsonError := types.JsonRpcError{}
-	err = json.Unmarshal(response, &jsonError)
+	jsonResponse := types.JsonRpcResponse{}
+	err = json.Unmarshal(response, &jsonResponse)
 	if err != nil {
 		t.Error(err)
 	}
-	assert.Equal(t, expectedError, jsonError)
+	assert.Equal(t, expectedError, jsonResponse.ErrorObj)
 }
 
 func TestRpcParseError(t *testing.T) {
@@ -78,7 +78,6 @@ func TestRpcWrongVersion(t *testing.T) {
 		t.Error(err)
 	}
 	expectedError := types.InvalidRequestError
-	expectedError.Id = 2
 	sendRequestAndExpectError(t, jsonRequest, expectedError)
 }
 
@@ -107,18 +106,16 @@ func TestRpcMissingMethod(t *testing.T) {
 		t.Error(err)
 	}
 	expectedError := types.InvalidRequestError
-	expectedError.Id = 2
 	sendRequestAndExpectError(t, jsonRequest, expectedError)
 }
 
 func TestRpcMethodNotFound(t *testing.T) {
-	request := serde.JsonRpcRequest[serde.PaymentRequest]{Jsonrpc: "2.0", Id: 2, Method: "direct_funds"}
+	request := serde.JsonRpcRequest[serde.PaymentRequest]{Jsonrpc: "2.0", Id: 2, Method: "fake_method"}
 	jsonRequest, err := json.Marshal(request)
 	if err != nil {
 		t.Error(err)
 	}
 	expectedError := types.MethodNotFoundError
-	expectedError.Id = 2
 	sendRequestAndExpectError(t, jsonRequest, expectedError)
 }
 
@@ -129,7 +126,6 @@ func TestRpcGetPaymentChannelMissingParam(t *testing.T) {
 		t.Error(err)
 	}
 	expectedError := types.InvalidParamsError
-	expectedError.Id = 2
 	sendRequestAndExpectError(t, jsonRequest, expectedError)
 }
 
@@ -151,6 +147,5 @@ func TestRpcPayInvalidParam(t *testing.T) {
 		t.Error(err)
 	}
 	expectedError := types.InvalidParamsError
-	expectedError.Id = 2
 	sendRequestAndExpectError(t, jsonRequest, expectedError)
 }

--- a/types/serde.go
+++ b/types/serde.go
@@ -17,11 +17,24 @@ func (d *Destination) UnmarshalText(text []byte) error {
 	return nil
 }
 
+type JsonRpcRequest struct {
+	Jsonrpc string      `json:"jsonrpc"`
+	Id      uint64      `json:"id"`
+	Method  string      `json:"code"`
+	Params  interface{} `json:"params"`
+}
+
+type JsonRpcResponse struct {
+	Jsonrpc  string       `json:"jsonrpc"`
+	Id       uint64       `json:"id"`
+	Result   interface{}  `json:"result"`
+	ErrorObj JsonRpcError `json:"error"`
+}
+
 type JsonRpcError struct {
 	Code    int64       `json:"code"`
 	Message string      `json:"message"`
 	Data    interface{} `json:"data"`
-	Id      uint64      `json:"id"`
 }
 
 func (e JsonRpcError) Error() string {


### PR DESCRIPTION
Previously the jsonrpc server was not returning json responses that adhered to the jsonrpc spec. This PR fixes that, which is a first step to providing our jsonrpc clients (go and TS) a reliable way to detect errors when they make requests.