### PR TITLE
Switch websockets from github.com/nhooyr to github.com/gorilla/websocket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/nats-io/nats.go v1.21.0
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0
 	github.com/stretchr/testify v1.8.2
-	nhooyr.io/websocket v1.8.7
 )
 
 require (
@@ -137,6 +136,7 @@ require (
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.1.7 // indirect
+	nhooyr.io/websocket v1.8.7 // indirect
 )
 
 require (
@@ -148,7 +148,7 @@ require (
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/uuid v1.3.0 // indirect
-	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/gorilla/websocket v1.5.0
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
 	github.com/holiman/uint256 v1.2.0 // indirect
 	github.com/libp2p/go-libp2p v0.27.0

--- a/rpc/transport/ws/client.go
+++ b/rpc/transport/ws/client.go
@@ -2,14 +2,13 @@ package ws
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"net/http"
 	urlUtil "net/url"
 	"sync"
 
+	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
-	"nhooyr.io/websocket"
 )
 
 type clientWebSocketTransport struct {
@@ -30,7 +29,7 @@ func NewWebSocketTransportAsClient(url string) (*clientWebSocketTransport, error
 	if err != nil {
 		return nil, err
 	}
-	conn, _, err := websocket.Dial(context.Background(), subscribeUrl, &websocket.DialOptions{})
+	conn, _, err := websocket.DefaultDialer.Dial(subscribeUrl, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -66,8 +65,8 @@ func (wsc *clientWebSocketTransport) Subscribe() (<-chan []byte, error) {
 }
 
 func (wsc *clientWebSocketTransport) Close() error {
-	// This will also cause the go-routine to unblock waiting on `Read` and thus serves as a signal to exit
-	err := wsc.clientWebsocket.Close(websocket.StatusNormalClosure, "client initiated close")
+	// This will also cause the go-routine to unblock waiting on `ReadMessage` and thus serves as a signal to exit
+	err := wsc.clientWebsocket.Close()
 	if err != nil {
 		return err
 	}
@@ -79,9 +78,9 @@ func (wsc *clientWebSocketTransport) Close() error {
 
 func (wsc *clientWebSocketTransport) readMessages() {
 	for {
-
-		_, data, err := wsc.clientWebsocket.Read(context.Background())
-		if websocket.CloseStatus(err) == websocket.StatusNormalClosure {
+		_, data, err := wsc.clientWebsocket.ReadMessage()
+		if err != nil {
+			wsc.logger.Info().Msgf("Websocket read error: %s", err.Error())
 			wsc.wg.Done()
 			return
 		}


### PR DESCRIPTION
The primary reason for the change is that the websocket rpc client sometimes hangs on close. It is unclear whether this is due to an incorrect usage of the websocket library or an issue with the library itself.

Gorilla websockets is a popular library that is ergonomic to use. Unfortunately, the github repository is archived. However, it doesn't seem like these types of libraries see many updates anyways. Gorilla websockets was last updated in 7/2022 (https://github.com/gorilla/websocket/commits/master) and nhooyr websockets was last updated on 12/2022.