### PR TITLE
Log to a log file instead of stdout for rpc tests

### DIFF
--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -37,7 +37,7 @@ func InitChainServiceAndRunRpcServer(pkString string, chainOpts chain.ChainOpts,
 	if useNats {
 		transportType = transport.Nats
 	}
-	rpcServer, node, messageService, err := RunRpcServer(pk, chainService, useDurableStore, msgPort, rpcPort, transportType)
+	rpcServer, node, messageService, err := RunRpcServer(pk, chainService, useDurableStore, msgPort, rpcPort, transportType, os.Stdout)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -47,11 +47,9 @@ func InitChainServiceAndRunRpcServer(pkString string, chainOpts chain.ChainOpts,
 }
 
 func RunRpcServer(pk []byte, chainService chainservice.ChainService,
-	useDurableStore bool, msgPort int, rpcPort int, transportType transport.TransportType,
+	useDurableStore bool, msgPort int, rpcPort int, transportType transport.TransportType, logDestination *os.File,
 ) (*rpc.RpcServer, *node.Node, *p2pms.P2PMessageService, error) {
 	me := crypto.GetAddressFromSecretKeyBytes(pk)
-
-	logDestination := os.Stdout
 
 	var ourStore store.Store
 	var err error

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -478,7 +478,7 @@ func checkNotifications[T channelInfo](t *testing.T, logger zerolog.Logger, clie
 			// Log both to the test log file and to stdout
 			failMsg := fmt.Sprintf("%s timed out waiting for notification(s): \n%v", client, incompleteRequired(acceptableNotifications))
 			logger.Error().Msgf(failMsg)
-			t.Fatalf("%s timed out waiting for notification(s): \n%v", client, incompleteRequired(acceptableNotifications))
+			t.Fatalf(failMsg)
 		}
 	}
 	if len(unexpectedNotifications) > 0 {

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -475,6 +475,9 @@ func checkNotifications[T channelInfo](t *testing.T, logger zerolog.Logger, clie
 
 		case <-time.After(timeout):
 			logUnexpected()
+			// Log both to the test log file and to stdout
+			failMsg := fmt.Sprintf("%s timed out waiting for notification(s): \n%v", client, incompleteRequired(acceptableNotifications))
+			logger.Error().Msgf(failMsg)
 			t.Fatalf("%s timed out waiting for notification(s): \n%v", client, incompleteRequired(acceptableNotifications))
 		}
 	}

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -348,7 +348,7 @@ func setupNitroNodeWithRPCClient(
 	connectionType transport.TransportType,
 ) (*rpc.RpcClient, *p2pms.P2PMessageService, func()) {
 	var err error
-	rpcServer, _, messageService, err := interRpc.RunRpcServer(pk, chain, false, msgPort, rpcPort, connectionType)
+	rpcServer, _, messageService, err := interRpc.RunRpcServer(pk, chain, false, msgPort, rpcPort, connectionType, logDestination)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -86,7 +86,6 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 	// Setup
 	//////////////////////
 
-	t.Logf("Starting test with %d clients", n)
 	logFile := fmt.Sprintf("test_%d_rpc_clients_over_%s.log", n, connectionType)
 	logDestination := newLogWriter(logFile)
 	defer logDestination.Close()

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -44,6 +44,14 @@ func createLogger(logDestination *os.File, clientName, rpcRole string) zerolog.L
 		Logger()
 }
 
+func testLogger(logDestination *os.File) zerolog.Logger {
+	return zerolog.New(logDestination).
+		Level(zerolog.TraceLevel).
+		With().
+		Timestamp().
+		Logger()
+}
+
 func TestRpcWithNats(t *testing.T) {
 	executeNRpcTest(t, "nats", 2, false)
 	executeNRpcTest(t, "nats", 3, false)
@@ -82,6 +90,8 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 	logFile := fmt.Sprintf("test_%d_rpc_clients_over_%s.log", n, connectionType)
 	logDestination := newLogWriter(logFile)
 	defer logDestination.Close()
+	logger := testLogger(logDestination)
+	logger.Info().Msgf("Starting test with %d clients", n)
 
 	chain := chainservice.NewMockChain()
 	defer chain.Close()
@@ -94,7 +104,7 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 			PrivateKey: common.Hex2Bytes(sk),
 		}
 	}
-	t.Logf("%d actors created", n)
+	logger.Info().Msgf("%d actors created", n)
 
 	chainServices := make([]*chainservice.MockChainService, n)
 	for i := 0; i < n; i++ {
@@ -110,9 +120,9 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 		msgServices[i] = msg
 		defer cleanup()
 	}
-	t.Logf("%d Clients created", n)
+	logger.Info().Msgf("%d Clients created", n)
 
-	t.Log("Verify that each rpc client fetches the correct address")
+	logger.Info().Msgf("Verify that each rpc client fetches the correct address")
 	for i := 0; i < n; i++ {
 		if !cmp.Equal(actors[i].Address(), clients[i].Address()) {
 			t.Fatalf("expected address %s, got %s", actors[i].Address(), clients[i].Address())
@@ -120,7 +130,7 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 	}
 
 	utils.WaitForPeerInfoExchange(msgServices...)
-	t.Logf("Peer exchange complete")
+	logger.Info().Msgf("Peer exchange complete")
 
 	// create n-1 ledger channels
 	ledgerChannels := make([]directfund.ObjectiveResponse, n-1)
@@ -141,7 +151,7 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 			<-client.ObjectiveCompleteChan(ledgerChannels[i].Id) // right channel
 		}
 	}
-	t.Log("Ledger channels created")
+	logger.Info().Msgf("Ledger channels created")
 
 	// try to create duplicate ledger channel to ensure node correctly
 	// handles error without panicking
@@ -292,7 +302,7 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 			{99, 101, query.Complete},
 		},
 	)[alice.Address()]
-	checkNotifications(t, "aliceLedger", expectedAliceLedgerNotifs, []query.LedgerChannelInfo{}, aliceLedgerNotifs, defaultTimeout)
+	checkNotifications(t, logger, "aliceLedger", expectedAliceLedgerNotifs, []query.LedgerChannelInfo{}, aliceLedgerNotifs, defaultTimeout)
 
 	bobLedgerNotifs := bobClient.LedgerChannelUpdatesChan(bobLedger.ChannelId)
 	expectedBobLedgerNotifs := createLedgerStory(
@@ -310,7 +320,7 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 			createLedgerInfo(bobLedger.ChannelId, simpleOutcome(actors[n-2].Address(), bob.Address(), 99, 101), query.Closing, bob.Address()),
 		)
 	}
-	checkNotifications(t, "bobLedger", expectedBobLedgerNotifs, []query.LedgerChannelInfo{}, bobLedgerNotifs, defaultTimeout)
+	checkNotifications(t, logger, "bobLedger", expectedBobLedgerNotifs, []query.LedgerChannelInfo{}, bobLedgerNotifs, defaultTimeout)
 
 	requiredVCNotifs := createPaychStory(
 		vabCreateResponse.ChannelId, alice.Address(), bob.Address(),
@@ -332,9 +342,9 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 	)
 
 	aliceVirtualNotifs := aliceClient.PaymentChannelUpdatesChan(vabCreateResponse.ChannelId)
-	checkNotifications(t, "aliceVirtual", requiredVCNotifs, optionalVCNotifs, aliceVirtualNotifs, defaultTimeout)
+	checkNotifications(t, logger, "aliceVirtual", requiredVCNotifs, optionalVCNotifs, aliceVirtualNotifs, defaultTimeout)
 	bobVirtualNotifs := bobClient.PaymentChannelUpdatesChan(vabCreateResponse.ChannelId)
-	checkNotifications(t, "bobVirtual", requiredVCNotifs, optionalVCNotifs, bobVirtualNotifs, defaultTimeout)
+	checkNotifications(t, logger, "bobVirtual", requiredVCNotifs, optionalVCNotifs, bobVirtualNotifs, defaultTimeout)
 }
 
 // setupNitroNodeWithRPCClient is a helper function that spins up a Nitro Node RPC Server and returns an RPC client connected to it.
@@ -427,7 +437,7 @@ func marshalToJson[T channelInfo](t *testing.T, info T) string {
 // if any of these notifications are not received.
 //
 // If a notification is received that is neither in required or optional, checkNotifications will fail.
-func checkNotifications[T channelInfo](t *testing.T, client string, required []T, optional []T, notifChan <-chan T, timeout time.Duration) {
+func checkNotifications[T channelInfo](t *testing.T, logger zerolog.Logger, client string, required []T, optional []T, notifChan <-chan T, timeout time.Duration) {
 	// This is map containing both required and optional notifications.
 	// We use the json representation of the notification as the key and a boolean as the value.
 	// The boolean value is true if the notification is required and false if it is optional.
@@ -436,7 +446,7 @@ func checkNotifications[T channelInfo](t *testing.T, client string, required []T
 	unexpectedNotifications := make(map[string]bool)
 	logUnexpected := func() {
 		for notif := range unexpectedNotifications {
-			t.Logf("%s received unexpected notification: %v", client, notif)
+			logger.Info().Msgf("%s received unexpected notification: %v", client, notif)
 		}
 	}
 
@@ -452,7 +462,7 @@ func checkNotifications[T channelInfo](t *testing.T, client string, required []T
 		case info := <-notifChan:
 
 			notifJSON := marshalToJson(t, info)
-			t.Logf("%s received %v+", client, info)
+			logger.Info().Msgf("%s received %v+", client, info)
 
 			// Check that the notification is a required or optional one.
 			_, isExpected := acceptableNotifications[notifJSON]


### PR DESCRIPTION
When tests are run via github actions, stdout is polluted to the point where it is difficult to diagnose what test fails. This PR shifts the log lines to an artifact log file.