### PR TITLE
Allow store data folder to be specified as a CLI arg

### DIFF
--- a/internal/nitro-network/main.go
+++ b/internal/nitro-network/main.go
@@ -75,7 +75,11 @@ func InitializeNitroNetwork() error {
 			CaAddress:      caAddress,
 			VpaAddress:     vpaAddress,
 		}
-		server, node, msgService, err := interRpc.InitChainServiceAndRunRpcServer(nodeOpts.Pk, chainOpts, nodeOpts.UseDurableStore, false, nodeOpts.MsgPort, nodeOpts.RpcPort)
+
+		dataFolder, cleanup := utils.GenerateTempStoreFolder()
+		defer cleanup()
+
+		server, node, msgService, err := interRpc.InitChainServiceAndRunRpcServer(nodeOpts.Pk, chainOpts, nodeOpts.UseDurableStore, dataFolder, false, nodeOpts.MsgPort, nodeOpts.RpcPort)
 		if err != nil {
 			return err
 		}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"syscall"
 
@@ -30,4 +31,23 @@ func StopCommands(cmds ...*exec.Cmd) {
 			panic(err)
 		}
 	}
+}
+
+// GenerateTempStoreFolder generates a temporary folder for storing store data and a cleanup function to clean up the folder
+func GenerateTempStoreFolder() (dataFolder string, cleanup func()) {
+	var err error
+
+	dataFolder, err = os.MkdirTemp("", "nitro-store-*")
+	if err != nil {
+		panic(err)
+	}
+
+	cleanup = func() {
+		err := os.RemoveAll(dataFolder)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return
 }

--- a/main.go
+++ b/main.go
@@ -15,20 +15,21 @@ import (
 
 func main() {
 	const (
-		CONFIG            = "config"
-		USE_NATS          = "usenats"
-		USE_DURABLE_STORE = "usedurablestore"
-		PK                = "pk"
-		CHAIN_URL         = "chainurl"
-		CHAIN_AUTH_TOKEN  = "chainauthtoken"
-		CHAIN_PK          = "chainpk"
-		NA_ADDRESS        = "naaddress"
-		VPA_ADDRESS       = "vpaaddress"
-		CA_ADDRESS        = "caaddress"
-		MSG_PORT          = "msgport"
-		RPC_PORT          = "rpcport"
+		CONFIG               = "config"
+		USE_NATS             = "usenats"
+		USE_DURABLE_STORE    = "usedurablestore"
+		PK                   = "pk"
+		CHAIN_URL            = "chainurl"
+		CHAIN_AUTH_TOKEN     = "chainauthtoken"
+		CHAIN_PK             = "chainpk"
+		NA_ADDRESS           = "naaddress"
+		VPA_ADDRESS          = "vpaaddress"
+		CA_ADDRESS           = "caaddress"
+		MSG_PORT             = "msgport"
+		RPC_PORT             = "rpcport"
+		DURABLE_STORE_FOLDER = "durablestorefolder"
 	)
-	var pkString, chainUrl, chainAuthToken, naAddress, vpaAddress, caAddress, chainPk string
+	var pkString, chainUrl, chainAuthToken, naAddress, vpaAddress, caAddress, chainPk, durableStoreFolder string
 	var msgPort, rpcPort int
 	var useNats, useDurableStore bool
 
@@ -47,7 +48,7 @@ func main() {
 		altsrc.NewBoolFlag(&cli.BoolFlag{
 			Name:        USE_DURABLE_STORE,
 			Usage:       "Specifies whether to use a durable store or an in-memory store.",
-			Category:    "Storage",
+			Category:    "Storage:",
 			Value:       false,
 			Destination: &useDurableStore,
 		}),
@@ -112,6 +113,13 @@ func main() {
 			Category:    "Connectivity:",
 			Destination: &rpcPort,
 		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:        DURABLE_STORE_FOLDER,
+			Usage:       "Specifies the folder for the durable store data storage.",
+			Category:    "Storage:",
+			Destination: &durableStoreFolder,
+			Value:       "./data/nitro-store",
+		}),
 	}
 	app := &cli.App{
 		Name:   "go-nitro",
@@ -128,7 +136,7 @@ func main() {
 				CaAddress:      common.HexToAddress(caAddress),
 			}
 
-			rpcServer, _, _, err := rpc.InitChainServiceAndRunRpcServer(pkString, chainOpts, useDurableStore, useNats, msgPort, rpcPort)
+			rpcServer, _, _, err := rpc.InitChainServiceAndRunRpcServer(pkString, chainOpts, useDurableStore, durableStoreFolder, useNats, msgPort, rpcPort)
 			if err != nil {
 				return err
 			}

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -383,7 +383,7 @@ func setupNitroNodeWithRPCClient(
 	connectionType transport.TransportType,
 ) (*rpc.RpcClient, *p2pms.P2PMessageService, func()) {
 	var err error
-	rpcServer, _, messageService, err := interRpc.RunRpcServer(pk, chain, false, msgPort, rpcPort, connectionType, logDestination)
+	rpcServer, _, messageService, err := interRpc.RunRpcServer(pk, chain, false, "", msgPort, rpcPort, connectionType, logDestination)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scripts/start-rpc-servers.go
+++ b/scripts/start-rpc-servers.go
@@ -102,6 +102,13 @@ func main() {
 				running = append(running, anvilCmd)
 			}
 
+			dataFolder := "./data/nitro-service"
+			fmt.Printf("Removing data folder %s\n", dataFolder)
+			err := os.RemoveAll(dataFolder)
+			if err != nil {
+				utils.StopCommands(running...)
+				panic(err)
+			}
 			chainAuthToken := cCtx.String(CHAIN_AUTH_TOKEN)
 			chainUrl := cCtx.String(CHAIN_URL)
 			chainPk := cCtx.String(DEPLOYER_PK)


### PR DESCRIPTION
This updates go-nitro to accept a `durablestorefolder` that it will use for the durable store. Our scripting has been updated to take advantage of that by using a random temp folder for the store and ensuring it gets removed when the script is stopped.