### PR TITLE
Add constant error declations

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -17,14 +17,14 @@ import (
 
 type ledgerIndex uint
 
-var (
-	ErrIncorrectChannelID = fmt.Errorf("proposal ID and channel ID do not match")
-	ErrIncorrectTurnNum   = fmt.Errorf("incorrect turn number")
-	ErrInvalidDeposit     = fmt.Errorf("unable to divert to guarantee: invalid deposit")
-	ErrInsufficientFunds  = fmt.Errorf("insufficient funds")
-	ErrDuplicateGuarantee = fmt.Errorf("duplicate guarantee detected")
-	ErrGuaranteeNotFound  = fmt.Errorf("guarantee not found")
-	ErrInvalidAmount      = fmt.Errorf("left amount is greater than the guarantee amount")
+const (
+	ErrIncorrectChannelID = types.ConstError("proposal ID and channel ID do not match")
+	ErrIncorrectTurnNum   = types.ConstError("incorrect turn number")
+	ErrInvalidDeposit     = types.ConstError("unable to divert to guarantee: invalid deposit")
+	ErrInsufficientFunds  = types.ConstError("insufficient funds")
+	ErrDuplicateGuarantee = types.ConstError("duplicate guarantee detected")
+	ErrGuaranteeNotFound  = types.ConstError("guarantee not found")
+	ErrInvalidAmount      = types.ConstError("left amount is greater than the guarantee amount")
 )
 
 const (

--- a/channel/consensus_channel/follower_channel.go
+++ b/channel/consensus_channel/follower_channel.go
@@ -4,16 +4,17 @@ import (
 	"fmt"
 
 	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/types"
 )
 
-var (
-	ErrNotFollower                 = fmt.Errorf("method may only be called by channel follower")
-	ErrNoProposals                 = fmt.Errorf("no proposals in the queue")
-	ErrUnsupportedQueuedProposal   = fmt.Errorf("only Add proposal is supported for queued proposals")
-	ErrUnsupportedExpectedProposal = fmt.Errorf("only Add proposal is supported for expected update")
-	ErrNonMatchingProposals        = fmt.Errorf("expected proposal does not match first proposal in the queue")
-	ErrInvalidProposalSignature    = fmt.Errorf("invalid signature for proposal")
-	ErrInvalidTurnNum              = fmt.Errorf("the proposal turn number is not the next turn number")
+const (
+	ErrNotFollower                 = types.ConstError("method may only be called by channel follower")
+	ErrNoProposals                 = types.ConstError("no proposals in the queue")
+	ErrUnsupportedQueuedProposal   = types.ConstError("only Add proposal is supported for queued proposals")
+	ErrUnsupportedExpectedProposal = types.ConstError("only Add proposal is supported for expected update")
+	ErrNonMatchingProposals        = types.ConstError("expected proposal does not match first proposal in the queue")
+	ErrInvalidProposalSignature    = types.ConstError("invalid signature for proposal")
+	ErrInvalidTurnNum              = types.ConstError("the proposal turn number is not the next turn number")
 )
 
 // NewFollowerChannel constructs a new FollowerChannel

--- a/channel/consensus_channel/leader_channel.go
+++ b/channel/consensus_channel/leader_channel.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 
 	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/types"
 )
 
-var (
-	ErrNotLeader              = fmt.Errorf("method may only be called by the channel leader")
-	ErrProposalQueueExhausted = fmt.Errorf("proposal queue exhausted")
-	ErrWrongSigner            = fmt.Errorf("proposal incorrectly signed")
+const (
+	ErrNotLeader              = types.ConstError("method may only be called by the channel leader")
+	ErrProposalQueueExhausted = types.ConstError("proposal queue exhausted")
+	ErrWrongSigner            = types.ConstError("proposal incorrectly signed")
 )
 
 // NewLeaderChannel constructs a new LeaderChannel

--- a/node/engine/store/store.go
+++ b/node/engine/store/store.go
@@ -2,7 +2,6 @@
 package store // import "github.com/statechannels/go-nitro/node/engine/store"
 
 import (
-	"errors"
 	"io"
 
 	"github.com/statechannels/go-nitro/channel"
@@ -12,10 +11,10 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-var (
-	ErrNoSuchObjective error = errors.New("store: no such objective")
-	ErrNoSuchChannel   error = errors.New("store: failed to find required channel data")
-	ErrLoadVouchers    error = errors.New("store: could not load vouchers")
+const (
+	ErrNoSuchObjective = types.ConstError("store: no such objective")
+	ErrNoSuchChannel   = types.ConstError("store: failed to find required channel data")
+	ErrLoadVouchers    = types.ConstError("store: could not load vouchers")
 )
 
 // Store is responsible for persisting objectives, objective metadata, states, signatures, private keys and blockchain data

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -29,10 +29,10 @@ const (
 
 const ObjectivePrefix = "DirectDefunding-"
 
-var (
-	ErrChannelUpdateInProgress = errors.New("can only defund a channel when the latest state is supported or when the channel has a final state")
-	ErrNoFinalState            = errors.New("cannot spawn direct defund objective without a final state")
-	ErrNotEmpty                = errors.New("ledger channel has running guarantees")
+const (
+	ErrChannelUpdateInProgress = types.ConstError("can only defund a channel when the latest state is supported or when the channel has a final state")
+	ErrNoFinalState            = types.ConstError("cannot spawn direct defund objective without a final state")
+	ErrNotEmpty                = types.ConstError("ledger channel has running guarantees")
 )
 
 // Objective is a cache of data computed by reading from the store. It stores (potentially) infinite data

--- a/types/types.go
+++ b/types/types.go
@@ -27,3 +27,8 @@ type Uint256 = big.Int
 
 // A {tokenAddress: amount} map. Address 0 represents a chain's native token (ETH, FIL, etc)
 type Funds map[common.Address]*big.Int
+
+// ConstError is a const-friendly error type.
+type ConstError string
+
+func (c ConstError) Error() string { return string(c) }


### PR DESCRIPTION
In a standup discussion, @kerzhner commented that some exported variables would be batter as `const`s than `var`s.

It turns out that golang doesn't agree with the naive approach.

```golang
const SomeNonCompilingErr = fmt.Errorf("I can't be a declared constant because Errorf is a function that has to execute at runtime")
const SomeOtherNonCompilingErr = errors.New("Me too - same reason")
```

A workaround, from [here](https://smyrman.medium.com/writing-constant-errors-with-go-1-13-10c4191617), is to define an error type that alias's `string` and satisfies the `error` interface.

```
type ConstError string

func (c ConstError) Error() string { return string(c) }

const SomeConstError = ConstError("I'm not a function - this is a type conversion of the string literal")
```

PR does this and converts `var` error declarations to `const`.