### PR TITLE
feat: add support of directly funded channels

### DIFF
--- a/channel/state/state.go
+++ b/channel/state/state.go
@@ -204,7 +204,7 @@ func (s State) Clone() State {
 
 	// Variable part
 	if s.AppData != nil {
-		clone.AppData = make(types.Bytes, 0, len(s.AppData))
+		clone.AppData = make(types.Bytes, len(s.AppData))
 		copy(clone.AppData, s.AppData)
 	}
 	clone.Outcome = s.Outcome.Clone()

--- a/directs/helpers.go
+++ b/directs/helpers.go
@@ -1,0 +1,32 @@
+package directs
+
+import (
+	"bytes"
+
+	"github.com/statechannels/go-nitro/channel"
+	"github.com/statechannels/go-nitro/channel/state"
+)
+
+// GetLatestProposedStateByAppData returns the latest proposed state
+// (state that signed by one party and has bigger turn num than supported one)
+// with the given appData
+func GetLatestProposedStateByAppData(ch *channel.Channel, appData []byte) *state.State {
+	latestSupportedState, err := ch.LatestSupportedState()
+	if err != nil {
+		return nil
+	}
+
+	latestSignedState, err := ch.LatestSignedState()
+	if err != nil {
+		return nil
+	}
+
+	for i := latestSupportedState.TurnNum + 1; i <= latestSignedState.State().TurnNum; i++ {
+		s := ch.SignedStateForTurnNum[i].State()
+		if bytes.Equal(s.AppData, appData) {
+			return &s
+		}
+	}
+
+	return nil
+}

--- a/directs/updates.go
+++ b/directs/updates.go
@@ -1,0 +1,15 @@
+package directs
+
+import (
+	"github.com/statechannels/go-nitro/crypto"
+	"github.com/statechannels/go-nitro/types"
+)
+
+// A ChannelUpdate is a message sent by a participant to the client to either validate
+// data and countersign it or to notify the client, that other party agreed on the earlier
+// appdata change proposal.
+type ChannelUpdates struct {
+	ChannelId  types.Destination
+	AppData    types.Bytes
+	Signatures []crypto.Signature
+}

--- a/node_test/direct_integration_test.go
+++ b/node_test/direct_integration_test.go
@@ -1,0 +1,115 @@
+package node_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/internal/testactors"
+	"github.com/statechannels/go-nitro/internal/utils"
+	"github.com/statechannels/go-nitro/node"
+	"github.com/statechannels/go-nitro/node/engine/messageservice"
+	p2pms "github.com/statechannels/go-nitro/node/engine/messageservice/p2p-message-service"
+	"github.com/statechannels/go-nitro/node/query"
+	"github.com/statechannels/go-nitro/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirectIntegrationScenario(t *testing.T) {
+	directCase := TestCase{
+		Description:    "Direct test",
+		Chain:          MockChain,
+		MessageService: TestMessageService,
+		MessageDelay:   0,
+		LogName:        "direct_integration_run.log",
+		Participants: []TestParticipant{
+			{StoreType: MemStore, Actor: testactors.Alice},
+			{StoreType: MemStore, Actor: testactors.Bob},
+		},
+		Actions: []DirectTestCaseAction{
+			// Alice proposes a channel update, Bob agrees
+			{Initiator: 0, Responder: 1, ProposalAppData: types.Bytes{0}, IsResponderAgree: true, LatestSupportedAppData: types.Bytes{0}},
+			// Bob proposes a channel update, Alice agrees
+			{Initiator: 1, Responder: 0, ProposalAppData: types.Bytes{1}, IsResponderAgree: true, LatestSupportedAppData: types.Bytes{1}},
+			// Alice proposes a channel update, Bob disagrees
+			{Initiator: 0, Responder: 1, ProposalAppData: types.Bytes{2}, IsResponderAgree: false, LatestSupportedAppData: types.Bytes{1}},
+			// Alice proposes more channel updates, Bob continue to disagree
+			{Initiator: 0, Responder: 1, ProposalAppData: types.Bytes{3}, IsResponderAgree: false, LatestSupportedAppData: types.Bytes{1}},
+			{Initiator: 0, Responder: 1, ProposalAppData: types.Bytes{4}, IsResponderAgree: false, LatestSupportedAppData: types.Bytes{1}},
+			// Bob agrees on one of Alice's channel updates, Alice's agreement is not needed
+			{Initiator: 1, Responder: 0, ProposalAppData: types.Bytes{3}, IsResponderAgree: false, LatestSupportedAppData: types.Bytes{3}},
+			// Bob agrees on one of Alice's expired channel updates, so he creates a new one. Alice disagrees
+			{Initiator: 1, Responder: 0, ProposalAppData: types.Bytes{2}, IsResponderAgree: false, LatestSupportedAppData: types.Bytes{3}},
+			// Bob proposes another channel update, and Alice agrees, so all previous updates expire
+			{Initiator: 1, Responder: 0, ProposalAppData: types.Bytes{5}, IsResponderAgree: true, LatestSupportedAppData: types.Bytes{5}},
+		},
+	}
+
+	RunDirectIntegrationTestCase(directCase, t)
+}
+
+// RunDirectIntegrationTestCase runs the integration test case.
+func RunDirectIntegrationTestCase(tc TestCase, t *testing.T) {
+	// Clean up all the test data we create at the end of the test
+	defer os.RemoveAll(STORE_TEST_DATA_FOLDER)
+
+	t.Run(tc.Description, func(t *testing.T) {
+		err := tc.ValidateDirect()
+		if err != nil {
+			t.Fatal(err)
+		}
+		infra := setupSharedInfra(tc)
+		defer infra.Close(t)
+
+		msgServices := make([]messageservice.MessageService, 0)
+
+		// Setup clients
+		clientA, msgA, storeA := setupIntegrationNode(tc, tc.Participants[0], infra)
+		defer clientA.Close()
+		msgServices = append(msgServices, msgA)
+
+		clientB, msgB, storeB := setupIntegrationNode(tc, tc.Participants[1], infra)
+		defer clientB.Close()
+		msgServices = append(msgServices, msgB)
+
+		clients := []*node.Node{&clientA, &clientB}
+
+		if tc.MessageService == P2PMessageService {
+			p2pServices := make([]*p2pms.P2PMessageService, len(tc.Participants))
+			for i, msgService := range msgServices {
+				p2pServices[i] = msgService.(*p2pms.P2PMessageService)
+			}
+
+			utils.WaitForPeerInfoExchange(p2pServices...)
+		}
+
+		// Create direct channel between peers
+		asset := common.Address{}
+		customAppDef := common.HexToAddress("0x8D033747C268ef77460055Ff86CBB2643330D1A1") // Should not be empty
+		outcome := initialLedgerOutcome(*clientA.Address, *clientB.Address, asset)
+
+		channel := setupDirectChannel(t, clientA, clientB, asset, customAppDef, types.Bytes{})
+		checkLedgerChannel(t, channel, outcome, query.Open, clientA)
+
+		for _, act := range tc.Actions {
+			clients[act.Initiator].UpdateChannel(channel, act.ProposalAppData)
+
+			update := <-clients[act.Responder].ReceivedChannelUpdates()
+			if act.IsResponderAgree {
+				clients[act.Responder].UpdateChannel(update.ChannelId, update.AppData)
+				<-clients[act.Initiator].ReceivedChannelUpdates()
+			}
+
+			chA, _ := storeA.GetChannelById(channel)
+			lssA, _ := chA.LatestSupportedState()
+			require.Equal(t, act.LatestSupportedAppData, lssA.AppData)
+
+			chB, _ := storeB.GetChannelById(channel)
+			lssB, _ := chB.LatestSupportedState()
+			require.Equal(t, act.LatestSupportedAppData, lssB.AppData)
+		}
+
+		// TODO: finish closing channel after ledger channel refactoring
+		// closeDirectChannel(t, clientA, clientB, channel)
+	})
+}

--- a/node_test/integration_test.go
+++ b/node_test/integration_test.go
@@ -74,17 +74,17 @@ func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 
 		// Setup clients
 		// NOTE: We rely on the convention that Alice is the first participant, Bob the second, and the intermediaries afterwards.
-		clientA, msgA := setupIntegrationNode(tc, tc.Participants[0], infra)
+		clientA, msgA, _ := setupIntegrationNode(tc, tc.Participants[0], infra)
 		defer clientA.Close()
 		msgServices = append(msgServices, msgA)
 
-		clientB, msgB := setupIntegrationNode(tc, tc.Participants[1], infra)
+		clientB, msgB, _ := setupIntegrationNode(tc, tc.Participants[1], infra)
 		defer clientB.Close()
 		msgServices = append(msgServices, msgB)
 
 		intermediaries := make([]node.Node, 0)
 		for _, intermediary := range tc.Participants[2:] {
-			clientI, msgI := setupIntegrationNode(tc, intermediary, infra)
+			clientI, msgI, _ := setupIntegrationNode(tc, intermediary, infra)
 
 			intermediaries = append(intermediaries, clientI)
 			msgServices = append(msgServices, msgI)

--- a/node_test/types_test.go
+++ b/node_test/types_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/node/engine/chainservice"
 	"github.com/statechannels/go-nitro/node/engine/messageservice"
+	"github.com/statechannels/go-nitro/types"
 )
 
 const (
@@ -46,17 +47,30 @@ const (
 	P2PMessageService  MessageService = "P2PMessageService"
 )
 
+type DirectTestCaseAction struct {
+	Initiator              int
+	Responder              int
+	ProposalAppData        types.Bytes
+	IsResponderAgree       bool
+	LatestSupportedAppData types.Bytes
+}
+
 // TestCase is a test case for the node integration test.
 type TestCase struct {
 	Description    string
 	Chain          ChainType
 	MessageService MessageService
-	NumOfChannels  uint
-	NumOfPayments  uint
 	MessageDelay   time.Duration
 	LogName        string
-	NumOfHops      uint
 	Participants   []TestParticipant
+
+	// Virtual test props
+	NumOfChannels uint
+	NumOfPayments uint
+	NumOfHops     uint
+
+	// Direct test props
+	Actions []DirectTestCaseAction
 }
 
 // Validate validates the test case and makes sure that the current test supports the test case.
@@ -70,6 +84,17 @@ func (tc *TestCase) Validate() error {
 	}
 	if tc.NumOfChannels < 1 || tc.NumOfChannels > 9 {
 		return fmt.Errorf("NumOfChannels must be greater than 0 and less than 10. Supplied %d", tc.NumOfChannels)
+	}
+	if tc.MessageDelay > 5*time.Second {
+		return fmt.Errorf("MessageDelay must be smaller than 5s")
+	}
+	return nil
+}
+
+// ValidateDirect validates the test case and makes sure that the current test supports the test case.
+func (tc *TestCase) ValidateDirect() error {
+	if len(tc.Actions) < 1 {
+		return fmt.Errorf("ProposedAppData must be greater than 0")
 	}
 	if tc.MessageDelay > 5*time.Second {
 		return fmt.Errorf("MessageDelay must be smaller than 5s")

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -470,6 +470,7 @@ func NewObjectiveRequest(
 	outcome outcome.Exit,
 	nonce uint64,
 	appDefinition types.Address,
+	appData types.Bytes,
 ) ObjectiveRequest {
 	return ObjectiveRequest{
 		CounterParty:      counterparty,
@@ -477,8 +478,20 @@ func NewObjectiveRequest(
 		Outcome:           outcome,
 		Nonce:             nonce,
 		AppDefinition:     appDefinition,
+		AppData:           appData,
 		objectiveStarted:  make(chan struct{}),
 	}
+}
+
+// NewConsensusObjectiveRequest creates a new ObjectiveRequest for a consensus objective, with an empty appData.
+func NewConsensusObjectiveRequest(
+	counterparty types.Address,
+	challengeDuration uint32,
+	outcome outcome.Exit,
+	nonce uint64,
+	appDefinition types.Address,
+) ObjectiveRequest {
+	return NewObjectiveRequest(counterparty, challengeDuration, outcome, nonce, appDefinition, []byte{})
 }
 
 // SignalObjectiveStarted is used by the engine to signal the objective has been started.

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -56,7 +56,7 @@ func TestNew(t *testing.T) {
 	getByConsensus := func(id types.Address) (*consensus_channel.ConsensusChannel, bool) {
 		return nil, false
 	}
-	request := NewObjectiveRequest(
+	request := NewConsensusObjectiveRequest(
 		testState.Participants[1],
 		testState.ChallengeDuration,
 		testState.Outcome,

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -35,6 +35,12 @@ func CreateObjectivePayload(id ObjectiveId, payloadType PayloadType, p interface
 	return ObjectivePayload{PayloadData: b, ObjectiveId: id, Type: payloadType}, nil
 }
 
+// ChannelUpdatePayload is a message containing a signed channel update.
+type ChannelUpdatePayload struct {
+	// StateData is the serialized state.State
+	StateData []byte
+}
+
 // Message is an object to be sent across the wire.
 type Message struct {
 	To   types.Address
@@ -50,6 +56,8 @@ type Message struct {
 	Payments []payments.Voucher
 	// RejectedObjectives is a collection of objectives that have been rejected.
 	RejectedObjectives []ObjectiveId
+	// ChannelUpdates contains a collection of channel updates.
+	ChannelUpdatePayloads []ChannelUpdatePayload
 }
 
 // Serialize serializes the message into a string.
@@ -132,6 +140,10 @@ func CreateVoucherMessage(voucher payments.Voucher, recipients ...types.Address)
 	}
 
 	return messages
+}
+
+func CreateChannelUpdateMessage(recipient types.Address, stateData []byte) Message {
+	return Message{To: recipient, ChannelUpdatePayloads: []ChannelUpdatePayload{{StateData: stateData}}}
 }
 
 // DeserializeMessage deserializes the passed string into a protocols.Message.

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -150,7 +150,7 @@ func (rc *RpcClient) GetPaymentChannelsByLedger(ledgerId types.Destination) []qu
 
 // CreateLedger creates a new ledger channel
 func (rc *RpcClient) CreateLedgerChannel(counterparty types.Address, ChallengeDuration uint32, outcome outcome.Exit) directfund.ObjectiveResponse {
-	objReq := directfund.NewObjectiveRequest(
+	objReq := directfund.NewConsensusObjectiveRequest(
 		counterparty,
 		100,
 		outcome,

--- a/rpc/serde/serde_test.go
+++ b/rpc/serde/serde_test.go
@@ -16,7 +16,7 @@ var someRequest JsonRpcRequest[directfund.ObjectiveRequest] = JsonRpcRequest[dir
 	Jsonrpc: JsonRpcVersion,
 	Id:      123,
 	Method:  "CreateLedgerChannel",
-	Params: directfund.NewObjectiveRequest(
+	Params: directfund.NewConsensusObjectiveRequest(
 		testactors.Alice.Address(),
 		345,
 		testdata.Outcomes.Create(


### PR DESCRIPTION
Towards #1411 
Implement support of directly funded channels 

Yellow Network needs an node API to create, update and close direct channels (more specs here https://github.com/statechannels/go-nitro/issues/1411)

The summary may omit some of these details if this PR fixes a single ticket that includes these details.

**⚠️ Does this require multiple approvals?**

- [ ] Is it security related?
- [X] Is it a significant process change?
- [ ] Is it a significant change to architecture or design?

---

#### Code quality

- [ ] I have written clear commit messages
- [ ] I have performed a self-review of my own code
- [ ] This change does not have an unduly wide scope
- [ ] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [ ] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
- [ ] I have added comprehensive [godoc](https://go.dev/blog/godoc) comments 

#### Project management

- [ ] I have assigned myself to this PR
- [ ] I have linked the appropriate github issue
- [ ] I have assigned this PR to the appropriate GitHub project
- [ ] I have assigned this PR to the appropriate GitHub Milestone
