### PR TITLE
A more readable nats error message

### DIFF
--- a/rpc/transport/nats/client.go
+++ b/rpc/transport/nats/client.go
@@ -25,7 +25,7 @@ func NewNatsTransportAsClient(url string) (*natsTransportClient, error) {
 func (c *natsTransportClient) Request(data []byte) ([]byte, error) {
 	msg, err := c.nc.Request(nitroRequestTopic+apiVersionPath, data, 10*time.Second)
 	if msg == nil {
-		return nil, fmt.Errorf("received nill data for request %v with error %w", data, err)
+		return nil, fmt.Errorf("received nill data for request %v with error %w", string(data), err)
 	}
 	return msg.Data, err
 }


### PR DESCRIPTION
At the moment, the error message is not human readable. For example:

```
rpc_test.go:74: Test panicked: received nill data for request 
[123 34 106 115 111 110 114 112 99 34 58 34 50 46 48 34 44 34 105 100 34 58 49 51 50 54 48 55 52 52 56 48 51 53 49 48 49 54 54 55 52 51 44 34 109 101 116 104 111 100 34 58 34 103 101 116 95 97 100 100 114 101 115 115 34 44 34 112 97 114 97 109 115 34 58 123 125 125] 
with error nats: no responders available for request
```