### PR TITLE
Use t.Run for rpc subtests

### DIFF
--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -53,20 +53,27 @@ func testLogger(logDestination *os.File) zerolog.Logger {
 }
 
 func TestRpcWithNats(t *testing.T) {
-	executeNRpcTest(t, "nats", 2, false)
-	executeNRpcTest(t, "nats", 3, false)
-	executeNRpcTest(t, "nats", 4, false)
+	for _, n := range []int{2, 3, 4} {
+		executeNRpcTestWrapper(t, "nats", n, false)
+	}
 }
 
 func TestRpcWithWebsockets(t *testing.T) {
-	executeNRpcTest(t, "ws", 2, false)
-	executeNRpcTest(t, "ws", 3, false)
-	executeNRpcTest(t, "ws", 4, false)
+	for _, n := range []int{2, 3, 4} {
+		executeNRpcTestWrapper(t, "ws", n, false)
+	}
 }
 
 func TestRPCWithManualVoucherExchange(t *testing.T) {
-	executeNRpcTest(t, "ws", 4, true)
-	executeNRpcTest(t, "nats", 4, true)
+	executeNRpcTestWrapper(t, "ws", 4, true)
+	executeNRpcTestWrapper(t, "nats", 4, true)
+}
+
+func executeNRpcTestWrapper(t *testing.T, connectionType transport.TransportType, n int, manualVoucherExchange bool) {
+	testName := fmt.Sprintf("%d_clients", n)
+	t.Run(testName, func(t *testing.T) {
+		executeNRpcTest(t, connectionType, n, manualVoucherExchange)
+	})
 }
 
 func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int, manualVoucherExchange bool) {


### PR DESCRIPTION
This allows us to invoked a subtest individually using `-run` test flag. Also, the verbose output is more clear:

```
=== RUN   TestRpcWithNats
=== RUN   TestRpcWithNats/2_clients
    rpc_test.go:197: Ledger channels queried
    rpc_test.go:254: Payment channels queried
    rpc_test.go:285: Vouchers sent/received
    rpc_test.go:300: Ledger/virtual channels closed
=== RUN   TestRpcWithNats/3_clients
    rpc_test.go:197: Ledger channels queried
    rpc_test.go:254: Payment channels queried
    rpc_test.go:285: Vouchers sent/received
    rpc_test.go:300: Ledger/virtual channels closed
=== RUN   TestRpcWithNats/4_clients
    rpc_test.go:197: Ledger channels queried
    rpc_test.go:254: Payment channels queried
    rpc_test.go:285: Vouchers sent/received
    rpc_test.go:300: Ledger/virtual channels closed
--- PASS: TestRpcWithNats (0.12s)
```

The output without the subtest is:
```
=== RUN   TestRpcWithNats
    rpc_test.go:189: Ledger channels queried
    rpc_test.go:246: Payment channels queried
    rpc_test.go:277: Vouchers sent/received
    rpc_test.go:292: Ledger/virtual channels closed
    rpc_test.go:189: Ledger channels queried
    rpc_test.go:246: Payment channels queried
    rpc_test.go:277: Vouchers sent/received
    rpc_test.go:292: Ledger/virtual channels closed
    rpc_test.go:189: Ledger channels queried
    rpc_test.go:246: Payment channels queried
    rpc_test.go:277: Vouchers sent/received
    rpc_test.go:292: Ledger/virtual channels closed
--- PASS: TestRpcWithNats (0.40s)
```