### PR TITLE
Update DeployContracts to wait for transactions to be mined

### DIFF
--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	b "github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
@@ -91,7 +90,7 @@ type contractBackend interface {
 type deployFunc[T contractBackend] func(auth *b.TransactOpts, backend b.ContractBackend) (common.Address, *ethTypes.Transaction, *T, error)
 
 // deployContract deploys a contract and waits for the transaction to be mined.
-func deployContract[T contractBackend](ctx context.Context, name string, ethClient *ethclient.Client, txSubmitter *bind.TransactOpts, deploy deployFunc[T]) (types.Address, error) {
+func deployContract[T contractBackend](ctx context.Context, name string, ethClient *ethclient.Client, txSubmitter *b.TransactOpts, deploy deployFunc[T]) (types.Address, error) {
 	a, tx, _, err := deploy(txSubmitter, ethClient)
 	if err != nil {
 		return types.Address{}, err


### PR DESCRIPTION
When running against a local filecoin devnet I would occasionally see a `panic: no contract code at given address` if I started using `go-nitro` right after the deployment script succeed.

As @geoknee pointed out this is because we're not waiting for the transaction to be mined/confirmed(I'm not sure which is the correct term these days?) This PR updates the `DeployContract` function to call [WaitMined](https://github.com/ethereum/go-ethereum/blob/afe344bcf31bfb477a6e1ad5b862a70fc5c1a22b/accounts/abi/bind/util.go#L32) to wait for the deployment transaction to be mined.  I've also done a slight refactor with generics to DRY things out a bit.

Locally I'm no longer able to reproduce `panic: no contract code at given address` against a local filecoin devnet with this change. I've also verified this works when run against `anvil`
