### PR TITLE
Retry nats request once

### DIFF
--- a/rpc/transport/nats/client.go
+++ b/rpc/transport/nats/client.go
@@ -38,7 +38,7 @@ func (c *natsTransportClient) Request(data []byte) ([]byte, error) {
 
 		// Skip sleep after the last try
 		lastTry := i == numTries-1
-		if lastTry {
+		if lastTry := i == numTries-1; lastTry {
 			break
 		}
 

--- a/rpc/transport/nats/client.go
+++ b/rpc/transport/nats/client.go
@@ -37,7 +37,6 @@ func (c *natsTransportClient) Request(data []byte) ([]byte, error) {
 		}
 
 		// Skip sleep after the last try
-		lastTry := i == numTries-1
 		if lastTry := i == numTries-1; lastTry {
 			break
 		}


### PR DESCRIPTION
We sometimes see "Test panicked: received nill data for request ... with error nats: no responders available for request" in [CI tests](https://github.com/statechannels/go-nitro/actions/runs/5522572367/jobs/10072347583).

It seems that an RPC client is making a nats request before the server has subscribed for the nats topic. This PR adds a client retry after 500 milliseconds to give the server time to register.