### PR TITLE
Close related tweaks

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -248,10 +248,10 @@ func (rs *RpcServer) sendNotifications(ctx context.Context,
 	ledgerUpdatesChan <-chan query.LedgerChannelInfo,
 	paymentUpdatesChan <-chan query.PaymentChannelInfo,
 ) {
+	defer rs.wg.Done()
 	for {
 		select {
 		case <-ctx.Done():
-			rs.wg.Done()
 			return
 
 		case completedObjective, ok := <-completedObjChan:

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -42,7 +42,10 @@ func (rs *RpcServer) Close() error {
 	rs.cancel()
 	rs.wg.Wait()
 
-	rs.transport.Close()
+	err := rs.transport.Close()
+	if err != nil {
+		return err
+	}
 	return rs.node.Close()
 }
 

--- a/rpc/transport/ws/server.go
+++ b/rpc/transport/ws/server.go
@@ -62,17 +62,14 @@ func NewWebSocketTransportAsServer(port string) (*serverWebSocketTransport, erro
 }
 
 func (wsc *serverWebSocketTransport) serveHttp(tcpListener net.Listener) {
-	for {
+	defer wsc.wg.Done()
 
-		err := wsc.httpServer.Serve(tcpListener)
-		if err != nil && errors.Is(err, http.ErrServerClosed) {
-			wsc.wg.Done()
-			return
-		}
-		if err != nil {
-			panic(err)
-		}
-
+	err := wsc.httpServer.Serve(tcpListener)
+	if err != nil && errors.Is(err, http.ErrServerClosed) {
+		return
+	}
+	if err != nil {
+		panic(err)
 	}
 }
 


### PR DESCRIPTION
This makes a few minor changes around closing to rule out some possible errors and deadlocks:
- https://github.com/statechannels/go-nitro/commit/b58b513b47790e1b03f4ebe2a5f7050f7c5960cf: Updates `RPCServer.Close `to return the error from `tranport.Close` instead of swallowing it.
- [71efb4d](https://github.com/statechannels/go-nitro/pull/1432/commits/71efb4d39d173d5a4ef87f4ad232bbd464ec317b) : Updates the call to `wg.Done` to use a defer statement so we're sure to call `wg.Done` no matter how we exit the function. This prevents a deadlock if we happen to exit the function using a different `case` (like the ones that log a warning message)
- https://github.com/statechannels/go-nitro/commit/43955e573ab7a70f47da97e2e6f913cbd760af80 : Remove the for loop since the call to `wsc.httpServer.Serve` is blocking and we don't need to try and run it multiple times.