### PR TITLE
Add rpc test cleanup log lines

### DIFF
--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -421,9 +421,14 @@ func setupNitroNodeWithRPCClient(
 	if err != nil {
 		panic(err)
 	}
+
 	cleanupFn := func() {
+		logger := testLogger(logDestination)
+		logger.Info().Str("pk", string(pk)).Msg("Starting rpc close")
 		rpcClient.Close()
+		logger.Info().Str("pk", string(pk)).Msg("Rpc client closed")
 		rpcServer.Close()
+		logger.Info().Str("pk", string(pk)).Msg("Rpc server closed")
 	}
 	return rpcClient, messageService, cleanupFn
 }


### PR DESCRIPTION
This should help diagnose deadlocks like https://github.com/statechannels/go-nitro/actions/runs/5525366833/jobs/10078937740