### PR TITLE
Add buffer to notification channel

### DIFF
--- a/rpc/transport/ws/client.go
+++ b/rpc/transport/ws/client.go
@@ -22,7 +22,7 @@ type clientWebSocketTransport struct {
 // NewWebSocketTransportAsClient creates a websocket connection that can be used to send requests and listen for notifications
 func NewWebSocketTransportAsClient(url string) (*clientWebSocketTransport, error) {
 	wsc := &clientWebSocketTransport{}
-	wsc.notificationChan = make(chan []byte)
+	wsc.notificationChan = make(chan []byte, 10)
 	wsc.url = url
 
 	subscribeUrl, err := urlUtil.JoinPath("ws://", url, "subscribe")


### PR DESCRIPTION
We are currently seeing deadlocks where a goroutine is blocked on sending to the notification channel.

```
goroutine 13030 [chan send]:
github.com/statechannels/go-nitro/rpc/transport/ws.(*clientWebSocketTransport).readMessages(0xc0035d8900)
	/home/runner/work/go-nitro/go-nitro/rpc/transport/ws/client.go:88 +0xa5
created by github.com/statechannels/go-nitro/rpc/transport/ws.NewWebSocketTransportAsClient
	/home/runner/work/go-nitro/go-nitro/rpc/transport/ws/client.go:41 +0x1b7
```

https://github.com/statechannels/go-nitro/actions/runs/5526236952/jobs/10080745506