### PR TITLE
Add logline to help diagnose CI failure

### DIFF
--- a/rpc/transport/ws/client.go
+++ b/rpc/transport/ws/client.go
@@ -77,6 +77,7 @@ func (wsc *clientWebSocketTransport) Close() error {
 }
 
 func (wsc *clientWebSocketTransport) readMessages() {
+	wsc.logger.Debug().Msg("Starting to read websocket messages")
 	for {
 		_, data, err := wsc.clientWebsocket.ReadMessage()
 		if err != nil {


### PR DESCRIPTION
An example of the failure is: https://github.com/statechannels/go-nitro/actions/runs/5526357555/jobs/10081004704

We see:
```
rpc_test.go:523: bobLedger timed out waiting for notification(s): {"ID":"0xaf7e1900df182aae423420e5293540f68344ca62d4b1e3a9fbe5bde7a24ea03e", "Status":"Proposed","Balance":{"AssetAddress":"0x0000000000000000000000000000000000000000", "Me":"0x2b5ad5c4795c026514f8317c7a215e218dccd6cf","Them":"0x7e5f4552091a69125d5dfcb7b8c2659029395bdf", "MyBalance":"0x64","TheirBalance":"0x64"}}
```

The suspicion is that the rpc client starts listening for notifications too late and misses the first notification. The new logline should help to vet that theory.