### PR TITLE
streamline Typescript RPC Client Test GHA

### DIFF
--- a/.github/workflows/ts-rpc-test.yml
+++ b/.github/workflows/ts-rpc-test.yml
@@ -2,7 +2,6 @@ name: TypeScript RPC Client Test
 
 on:
   pull_request:
-    paths: ["packages/nitro-rpc-client", ".github/workflows/ts-rpc-test.yml"]
   workflow_dispatch:
 jobs:
   run-rpc-test:

--- a/.github/workflows/ts-rpc-test.yml
+++ b/.github/workflows/ts-rpc-test.yml
@@ -20,9 +20,6 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
-      - name: Tidy
-        run: go mod tidy
-
       - name: Run go-nitro RPC servers
         run: go run ./scripts/start-rpc-servers.go &> output.log &
 

--- a/.github/workflows/ts-rpc-test.yml
+++ b/.github/workflows/ts-rpc-test.yml
@@ -2,7 +2,7 @@ name: TypeScript RPC Client Test
 
 on:
   pull_request:
-    paths: ['packages/nitro-rpc-client', '.github/workflows/ts-rpc-test.yml']
+    paths: ["packages/nitro-rpc-client", ".github/workflows/ts-rpc-test.yml"]
   workflow_dispatch:
 jobs:
   run-rpc-test:
@@ -10,29 +10,21 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.20.0'
+          go-version: "^1.20.0"
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          cache: 'yarn'
+          cache: "yarn"
 
       # Install foundry so we can use it to run a chain instance
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
-      # Get go-nitro
-      - uses: actions/checkout@v3
-        with:
-          repository: 'statechannels/go-nitro'
-          path: 'code/go-nitro'
-
       - name: Tidy
         run: go mod tidy
-        working-directory: code/go-nitro
 
       - name: Run go-nitro RPC servers
         run: go run ./scripts/start-rpc-servers.go &> output.log &
-        working-directory: code/go-nitro
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
This script pulls from github twice, which it no longer needs to do (and shouldn't, to avoid problems). 

Also, it won't currently run unless the ts client itself changes, so we won't catch breaking changes made on the server side. I fixed that. 