### PR TITLE
Fix: initialize rpc websocket logger

### DIFF
--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -398,6 +398,8 @@ func setupNitroNodeWithRPCClient(
 		t.Fatal(err)
 	}
 
+	clientLogger := createLogger(logDestination, rpcServer.Address().Hex(), "client")
+
 	var clientConnection transport.Requester
 	switch connectionType {
 	case "nats":
@@ -408,7 +410,7 @@ func setupNitroNodeWithRPCClient(
 		}
 	case "ws":
 
-		clientConnection, err = ws.NewWebSocketTransportAsClient(rpcServer.Url())
+		clientConnection, err = ws.NewWebSocketTransportAsClient(rpcServer.Url(), clientLogger)
 		if err != nil {
 			panic(err)
 		}
@@ -417,7 +419,7 @@ func setupNitroNodeWithRPCClient(
 		panic(err)
 	}
 
-	rpcClient, err := rpc.NewRpcClient(createLogger(logDestination, rpcServer.Address().Hex(), "client"), clientConnection)
+	rpcClient, err := rpc.NewRpcClient(clientLogger, clientConnection)
 	if err != nil {
 		panic(err)
 	}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -61,24 +61,12 @@ func NewRpcClient(logger zerolog.Logger, trans transport.Requester) (*RpcClient,
 
 // NewHttpRpcClient creates a new RpcClient using an http transport
 func NewHttpRpcClient(rpcServerUrl string) (*RpcClient, error) {
-	transport, err := ws.NewWebSocketTransportAsClient(rpcServerUrl)
+	logger := zerolog.New(os.Stdout)
+	transport, err := ws.NewWebSocketTransportAsClient(rpcServerUrl, logger)
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-
-	c := &RpcClient{transport, zerolog.New(os.Stdout), &safesync.Map[chan struct{}]{}, &safesync.Map[chan query.LedgerChannelInfo]{}, &safesync.Map[chan query.PaymentChannelInfo]{}, cancel, &sync.WaitGroup{}, common.Address{}}
-
-	notificationChan, err := c.transport.Subscribe()
-	if err != nil {
-		return nil, err
-	}
-	c.wg.Add(1)
-	go c.subscribeToNotifications(ctx, notificationChan)
-	if err != nil {
-		return nil, err
-	}
-	return c, nil
+	return NewRpcClient(logger, transport)
 }
 
 // Address returns the address of the the nitro node

--- a/rpc/transport/ws/client.go
+++ b/rpc/transport/ws/client.go
@@ -20,11 +20,7 @@ type clientWebSocketTransport struct {
 }
 
 // NewWebSocketTransportAsClient creates a websocket connection that can be used to send requests and listen for notifications
-func NewWebSocketTransportAsClient(url string) (*clientWebSocketTransport, error) {
-	wsc := &clientWebSocketTransport{}
-	wsc.notificationChan = make(chan []byte, 10)
-	wsc.url = url
-
+func NewWebSocketTransportAsClient(url string, logger zerolog.Logger) (*clientWebSocketTransport, error) {
 	subscribeUrl, err := urlUtil.JoinPath("ws://", url, "subscribe")
 	if err != nil {
 		return nil, err
@@ -33,9 +29,8 @@ func NewWebSocketTransportAsClient(url string) (*clientWebSocketTransport, error
 	if err != nil {
 		return nil, err
 	}
-	wsc.clientWebsocket = conn
 
-	wsc.wg = &sync.WaitGroup{}
+	wsc := &clientWebSocketTransport{logger: logger, notificationChan: make(chan []byte, 10), clientWebsocket: conn, url: url, wg: &sync.WaitGroup{}}
 
 	wsc.wg.Add(1)
 	go wsc.readMessages()
@@ -85,7 +80,7 @@ func (wsc *clientWebSocketTransport) readMessages() {
 			wsc.wg.Done()
 			return
 		}
-		wsc.logger.Trace().Msgf("Received message: %s", string(data))
+		wsc.logger.Trace().Str("data", string(data)).Msg("Websocket received message")
 		wsc.notificationChan <- data
 	}
 }


### PR DESCRIPTION
The logger for websocket rpc transport is never initialized. This PR fixes this issues as well as removes the unused `NewHttpRpcClient` function.