### PR TITLE
Standardize address logging

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/rs/zerolog"
+	"github.com/statechannels/go-nitro/types"
 )
 
 var once sync.Once
@@ -48,4 +49,9 @@ func NewLogWriter(logDir, logFile string) *os.File {
 	}
 
 	return logDestination
+}
+
+// WithAddress adds a formatted address field to a logger
+func WithAddress(c zerolog.Context, address *types.Address) zerolog.Context {
+	return c.Str("address", address.String()[0:8])
 }

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/statechannels/go-nitro/crypto"
 	"github.com/statechannels/go-nitro/internal/chain"
+	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/node"
 	"github.com/statechannels/go-nitro/node/engine"
 	"github.com/statechannels/go-nitro/node/engine/chainservice"
@@ -107,12 +108,11 @@ func RunRpcServer(pk []byte, chainService chainservice.ChainService,
 		return nil, nil, nil, err
 	}
 
-	serverLogger := zerolog.New(logDestination).
+	serverLogger := logging.WithAddress(zerolog.New(logDestination).
 		Level(zerolog.TraceLevel).
 		With().
 		Timestamp().
-		Str("node", ourStore.GetAddress().String()).
-		Str("rpc", "server").
+		Str("rpc", "server"), ourStore.GetAddress()).
 		Logger()
 
 	rpcServer, err := rpc.NewRpcServer(&node, &serverLogger, transport)

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -148,7 +148,7 @@ func New(vm *payments.VoucherManager, msg messageservice.MessageService, chain c
 	e.toApi = make(chan EngineEvent, 100)
 
 	logging.ConfigureZeroLogger()
-	e.logger = zerolog.New(logDestination).With().Timestamp().Str("engine", e.store.GetAddress().String()[0:8]).Caller().Logger()
+	e.logger = logging.WithAddress(zerolog.New(logDestination).With().Timestamp(), e.store.GetAddress()).Caller().Logger()
 
 	e.policymaker = policymaker
 

--- a/node/engine/messageservice/p2p-message-service/service.go
+++ b/node/engine/messageservice/p2p-message-service/service.go
@@ -72,7 +72,7 @@ func NewMessageService(ip string, port int, me types.Address, pk []byte, useMdns
 		newPeerInfo: make(chan basicPeerInfo, BUFFER_SIZE),
 		peers:       &safesync.Map[basicPeerInfo]{},
 		me:          me,
-		logger:      zerolog.New(logWriter).With().Timestamp().Str("message-service", me.String()[0:8]).Caller().Logger(),
+		logger:      logging.WithAddress(zerolog.New(logWriter).With().Timestamp(), &me).Caller().Logger(),
 	}
 
 	messageKey, err := p2pcrypto.UnmarshalSecp256k1PrivateKey(pk)

--- a/node/node.go
+++ b/node/node.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/internal/safesync"
 	"github.com/statechannels/go-nitro/node/engine"
 	"github.com/statechannels/go-nitro/node/engine/chainservice"
@@ -63,7 +64,7 @@ func New(messageService messageservice.MessageService, chainservice chainservice
 	n.chainId = chainId
 	n.store = store
 	n.vm = payments.NewVoucherManager(*store.GetAddress(), store)
-	n.logger = zerolog.New(logDestination).With().Timestamp().Str("nitro node", n.Address.String()[0:8]).Caller().Logger()
+	n.logger = logging.WithAddress(zerolog.New(logDestination).With().Timestamp(), n.Address).Caller().Logger()
 
 	n.engine = engine.New(n.vm, messageService, chainservice, store, logDestination, policymaker, metricsApi)
 	n.completedObjectives = &safesync.Map[chan struct{}]{}

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -33,13 +33,12 @@ func simpleOutcome(a, b types.Address, aBalance, bBalance uint) outcome.Exit {
 	return testdata.Outcomes.Create(a, b, aBalance, bBalance, types.Address{})
 }
 
-func createLogger(logDestination *os.File, clientName, rpcRole string) zerolog.Logger {
-	return zerolog.New(logDestination).
+func createLogger(logDestination *os.File, clientName *types.Address, rpcRole string) zerolog.Logger {
+	return logging.WithAddress(zerolog.New(logDestination).
 		Level(zerolog.TraceLevel).
 		With().
 		Timestamp().
-		Str("client", clientName).
-		Str("rpc", rpcRole).
+		Str("rpc", rpcRole), clientName).
 		Logger()
 }
 
@@ -399,7 +398,7 @@ func setupNitroNodeWithRPCClient(
 		t.Fatal(err)
 	}
 
-	clientLogger := createLogger(logDestination, rpcServer.Address().Hex(), "client")
+	clientLogger := createLogger(logDestination, rpcServer.Address(), "client")
 
 	var clientConnection transport.Requester
 	switch connectionType {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -173,7 +173,7 @@ func (rc *RpcClient) subscribeToNotifications(ctx context.Context, notificationC
 			rc.wg.Done()
 			return
 		case data := <-notificationChan:
-			rc.logger.Trace().Bytes("data", data).Msg("Received notification")
+			rc.logger.Trace().RawJSON("data", data).Msg("Received notification")
 			method, err := getNotificationMethod(data)
 			if err != nil {
 				panic(err)


### PR DESCRIPTION
This change allows us to use tools like jq more effectively to filter logs by a state channel participant address.