### PR TITLE
GUI Server exposes RPC port information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,6 @@ docker/restart: docker/stop docker/start
 
 docker/attach:
 	docker exec -it go-nitro bash
+
+ui/build:
+	yarn workspace nitro-gui build

--- a/embed-ui.go
+++ b/embed-ui.go
@@ -13,16 +13,22 @@ import (
 //go:embed packages/nitro-gui/dist/*
 var staticSiteRaw embed.FS
 
-func hostNitroUI(port uint) {
+func hostNitroUI(guiPort uint, rpcPort uint) {
 	staticSite, err := fs.Sub(fs.FS(staticSiteRaw), "packages/nitro-gui/dist")
 	if err != nil {
 		log.Fatalf("Error parsing static site: %s", err)
 	}
 
-	http.Handle("/", http.FileServer(http.FS(staticSite)))
-	serverAddress := fmt.Sprintf(":%d", port)
+	fs := http.FileServer(http.FS(staticSite))
+	http.Handle("/", fs)
 
-	url := fmt.Sprintf("http://localhost:%d/", port)
+	http.HandleFunc("/rpc-port", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "%d", rpcPort)
+	})
+
+	serverAddress := fmt.Sprintf(":%d", guiPort)
+
+	url := fmt.Sprintf("http://localhost:%d/", guiPort)
 
 	fmt.Printf("Hosting UI at %s\n", url)
 	http.ListenAndServe(serverAddress, nil)

--- a/main.go
+++ b/main.go
@@ -179,7 +179,7 @@ func main() {
 				return err
 			}
 
-			hostNitroUI(uint(guiPort))
+			hostNitroUI(uint(guiPort), uint(rpcPort))
 
 			stopChan := make(chan os.Signal, 2)
 			signal.Notify(stopChan, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)

--- a/packages/nitro-gui/.env.development
+++ b/packages/nitro-gui/.env.development
@@ -1,0 +1,1 @@
+VITE_RPC_HOST=localhost:4005

--- a/packages/nitro-gui/.env.development
+++ b/packages/nitro-gui/.env.development
@@ -1,1 +1,0 @@
-VITE_RPC_HOST=localhost:4005

--- a/packages/nitro-gui/src/App.tsx
+++ b/packages/nitro-gui/src/App.tsx
@@ -29,16 +29,24 @@ async function getRpcPort(): Promise<string> {
   });
 }
 
+async function getRpcHost(): Promise<string> {
+  if (import.meta.env.VITE_RPC_HOST) {
+    return import.meta.env.VITE_RPC_HOST;
+  } else {
+    return getRpcPort().then(
+      (rpcPort) => window.location.hostname + ":" + rpcPort
+    );
+  }
+}
+
 function App() {
   const [nitroClient, setNitroClient] = useState<NitroRpcClient | null>(null);
   const [ledgerChannels, setLedgerChannels] = useState<LedgerChannelInfo[]>([]);
   const [focusedLedgerChannel, setFocusedLedgerChannel] = useState<string>("");
 
   useEffect(() => {
-    getRpcPort().then((rpcPort) => {
-      NitroRpcClient.CreateHttpNitroClient(
-        window.location.hostname + ":" + rpcPort + "/api/v1"
-      ).then((c) => {
+    getRpcHost().then((rpcHost) => {
+      NitroRpcClient.CreateHttpNitroClient(rpcHost + "/api/v1").then((c) => {
         setNitroClient(c);
         fetchAndSetLedgerChannels(c, setLedgerChannels);
         c.Notifications.on("objective_completed", () =>

--- a/skip-ui.go
+++ b/skip-ui.go
@@ -4,6 +4,6 @@ package main
 
 import "fmt"
 
-func hostNitroUI(port uint) {
+func hostNitroUI(uint, uint) {
 	fmt.Println("Not hosting UI.")
 }


### PR DESCRIPTION
Closes #1479

There are a number of ways of resolving the difference between `guiPort` and `rpcPort` (we decided to not unify these, because it required some workarounds we would rather not do). 

In the recent past we have used a constant offset to compute one port from the other. 
Then, we decided to allow both `guiPort` and `rpcPort` to be set indepdently in config. 

So, the approach here is to have the gui server know about the `rpcPort`, and serve that information to the gui client, so that it can construct an appropriate rpc client. 

**Pros**
Allows any choice of port configuration.

**Cons**
Does introduce an extra roundtrip before the GUI can start working. Probably only an issue when the nitro node is not local.