### PR TITLE
Use libp2p notifications

### DIFF
--- a/node/engine/messageservice/p2p-message-service/notifier.go
+++ b/node/engine/messageservice/p2p-message-service/notifier.go
@@ -1,0 +1,22 @@
+package p2pms
+
+import (
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/multiformats/go-multiaddr"
+)
+
+type NetworkNotifiee struct {
+	ms *P2PMessageService
+}
+
+func (nn *NetworkNotifiee) Connected(n network.Network, conn network.Conn) {
+	nn.ms.logger.Debug().Msgf("notification: connected to peer %s", conn.RemotePeer().Pretty())
+	go nn.ms.sendPeerInfo(conn.RemotePeer(), false)
+}
+
+func (nn NetworkNotifiee) Disconnected(n network.Network, conn network.Conn) {
+	nn.ms.logger.Debug().Msgf("notification: disconnected from peer: %s", conn.RemotePeer().Pretty())
+}
+
+func (nn NetworkNotifiee) Listen(network.Network, multiaddr.Multiaddr)      {}
+func (nn NetworkNotifiee) ListenClose(network.Network, multiaddr.Multiaddr) {}

--- a/node/engine/messageservice/p2p-message-service/notifier.go
+++ b/node/engine/messageservice/p2p-message-service/notifier.go
@@ -5,6 +5,8 @@ import (
 	"github.com/multiformats/go-multiaddr"
 )
 
+// Triggered by p2pHost.Network events. When new peers are connected, the
+// "Connected" notification handler will trigger nitro state channel address exchange
 type NetworkNotifiee struct {
 	ms *P2PMessageService
 }

--- a/node/engine/messageservice/p2p-message-service/service.go
+++ b/node/engine/messageservice/p2p-message-service/service.go
@@ -93,7 +93,7 @@ func NewMessageService(ip string, port int, me types.Address, pk []byte, useMdns
 	ms.key = messageKey
 	options := []libp2p.Option{
 		libp2p.Identity(messageKey),
-		libp2p.ListenAddrStrings(fmt.Sprintf("/ip4/%s/tcp/%d", "0.0.0.0", port)),
+		libp2p.ListenAddrStrings(fmt.Sprintf("/ip4/%s/tcp/%d", ip, port)),
 		libp2p.Transport(tcp.NewTCPTransport),
 		libp2p.NATPortMap(),
 		libp2p.DefaultMuxers,
@@ -106,6 +106,16 @@ func NewMessageService(ip string, port int, me types.Address, pk []byte, useMdns
 	ms.p2pHost = host
 	ms.p2pHost.SetStreamHandler(PROTOCOL_ID, ms.msgStreamHandler)
 	ms.p2pHost.SetStreamHandler(PEER_EXCHANGE_PROTOCOL_ID, ms.receivePeerInfo)
+
+	// Print out my own peerInfo
+	peerInfo := peer.AddrInfo{
+		ID:    ms.p2pHost.ID(),
+		Addrs: ms.p2pHost.Addrs(),
+	}
+	addrs, err := peer.AddrInfoToP2pAddrs(&peerInfo)
+	ms.checkError(err)
+	ms.MultiAddr = addrs[0].String()
+	ms.logger.Debug().Msgf("libp2p node multiaddrs: %v", addrs)
 
 	if useMdnsPeerDiscovery {
 		ms.setupMdns()
@@ -133,16 +143,6 @@ func (ms *P2PMessageService) setupDht(bootPeers []string) {
 	kademliaDHT, err := dht.New(ctx, ms.p2pHost, options...)
 	ms.checkError(err)
 	ms.dht = kademliaDHT
-
-	// Print out my own peerInfo
-	peerInfo := peer.AddrInfo{
-		ID:    ms.p2pHost.ID(),
-		Addrs: ms.p2pHost.Addrs(),
-	}
-	addrs, err := peer.AddrInfoToP2pAddrs(&peerInfo)
-	ms.checkError(err)
-	ms.MultiAddr = addrs[0].String()
-	ms.logger.Debug().Msgf("libp2p node multiaddrs: %v", addrs)
 
 	// Setup notifications so we exchange nitro signing addresses when connected
 	n := &NetworkNotifiee{ms: ms}

--- a/node/engine/messageservice/p2p-message-service/service.go
+++ b/node/engine/messageservice/p2p-message-service/service.go
@@ -41,8 +41,9 @@ type peerExchangeMessage struct {
 }
 
 const (
-	PROTOCOL_ID                  protocol.ID = "/go-nitro/msg/1.0.0"
-	PEER_EXCHANGE_PROTOCOL_ID    protocol.ID = "/go-nitro/peerinfo/1.0.0"
+	DHT_PROTOCOL_PREFIX          protocol.ID = "/nitro" // use /nitro/kad/1.0.0 instead of /ipfs/kad/1.0.0
+	PROTOCOL_ID                  protocol.ID = "/nitro/msg/1.0.0"
+	PEER_EXCHANGE_PROTOCOL_ID    protocol.ID = "/nitro/peerinfo/1.0.0"
 	DELIMITER                                = '\n'
 	BUFFER_SIZE                              = 1_000
 	NUM_CONNECT_ATTEMPTS                     = 20
@@ -91,12 +92,11 @@ func NewMessageService(ip string, port int, me types.Address, pk []byte, useMdns
 	ms.checkError(err)
 
 	ms.key = messageKey
-
 	options := []libp2p.Option{
 		libp2p.Identity(messageKey),
-		libp2p.ListenAddrStrings(fmt.Sprintf("/ip4/%s/tcp/%d", ip, port)),
+		libp2p.ListenAddrStrings(fmt.Sprintf("/ip4/%s/tcp/%d", "0.0.0.0", port)),
 		libp2p.Transport(tcp.NewTCPTransport),
-		libp2p.NoSecurity,
+		libp2p.NATPortMap(),
 		libp2p.DefaultMuxers,
 	}
 	host, err := libp2p.New(options...)
@@ -128,9 +128,9 @@ func (ms *P2PMessageService) setupMdns() {
 func (ms *P2PMessageService) setupDht(bootPeers []string) {
 	ctx := context.Background()
 	var options []dht.Option
-	if len(bootPeers) == 0 {
-		options = append(options, dht.Mode(dht.ModeServer)) // Server mode: allows other peers to connect to this node
-	}
+	options = append(options, dht.BucketSize(20))
+	options = append(options, dht.Mode(dht.ModeServer)) // allows other peers to connect to this node
+
 	kademliaDHT, err := dht.New(ctx, ms.p2pHost, options...)
 	ms.checkError(err)
 	ms.dht = kademliaDHT
@@ -143,19 +143,21 @@ func (ms *P2PMessageService) setupDht(bootPeers []string) {
 	addrs, err := peer.AddrInfoToP2pAddrs(&peerInfo)
 	ms.checkError(err)
 	ms.MultiAddr = addrs[0].String()
-	ms.logger.Debug().Msgf("libp2p node address: %s", ms.MultiAddr)
+	ms.logger.Debug().Msgf("libp2p node multiaddrs: %v", addrs)
 
-	// Add bootstrap peers
-	err = ms.dht.Bootstrap(ctx)
-	ms.checkError(err)
+	// Setup notifications so we exchange nitro signing addresses when connected
+	n := &NetworkNotifiee{ms: ms}
+	ms.p2pHost.Network().Notify(n)
+
 	ms.addBootPeers(bootPeers)
 
 	expectedPeers := len(bootPeers)
 	if expectedPeers > 0 {
+		ms.logger.Debug().Msgf("waiting for %d bootpeer connections", expectedPeers)
 		ticker := time.NewTicker(BOOTSTRAP_SLEEP_DURATION)
 		for range ticker.C {
-			peers := ms.p2pHost.Peerstore().Peers()
-			actualPeers := len(peers) - 1 // subtract one to ignore self
+			peers := ms.p2pHost.Network().Peers()
+			actualPeers := len(peers)
 			ms.logger.Debug().Msgf("found peers: %v, expected peers: %d", actualPeers, expectedPeers)
 			for _, peer := range peers {
 				ms.logger.Debug().Msgf("peer info: %v", peer)
@@ -168,8 +170,11 @@ func (ms *P2PMessageService) setupDht(bootPeers []string) {
 				break
 			}
 		}
-		go ms.discoverPeers(ctx, string(PEER_EXCHANGE_PROTOCOL_ID)) // This will fail if DHT is empty (aka expectedPeers == 0)
+		// go ms.discoverPeers(ctx, string(PEER_EXCHANGE_PROTOCOL_ID)) // This will fail if DHT is empty (aka expectedPeers == 0)
 	}
+
+	err = ms.dht.Bootstrap(ctx) // Runs periodically to maintain a healthy routing table
+	ms.checkError(err)
 
 	ms.logger.Debug().Msgf("DHT setup complete")
 }
@@ -285,34 +290,34 @@ func (ms *P2PMessageService) Send(msg protocols.Message) {
 }
 
 // checkError panics if the message service is running and there is an error, otherwise it just returns
-func (s *P2PMessageService) checkError(err error) {
+func (ms *P2PMessageService) checkError(err error) {
 	if err == nil {
 		return
 	}
-	panic(err)
+	ms.logger.Panic().Msg(err.Error())
 }
 
 // Out returns a channel that can be used to receive messages from the message service
-func (s *P2PMessageService) Out() <-chan protocols.Message {
-	return s.toEngine
+func (ms *P2PMessageService) Out() <-chan protocols.Message {
+	return ms.toEngine
 }
 
 // Close closes the P2PMessageService
-func (s *P2PMessageService) Close() error {
+func (ms *P2PMessageService) Close() error {
 	// The mdns service is optional so we only close it if it exists
-	if s.mdns != nil {
-		err := s.mdns.Close()
+	if ms.mdns != nil {
+		err := ms.mdns.Close()
 		if err != nil {
 			return err
 		}
 	}
-	s.p2pHost.RemoveStreamHandler(PROTOCOL_ID)
-	return s.p2pHost.Close()
+	ms.p2pHost.RemoveStreamHandler(PROTOCOL_ID)
+	return ms.p2pHost.Close()
 }
 
 // PeerInfoReceived returns a channel that receives a PeerInfo when a peer is discovered
-func (s *P2PMessageService) PeerInfoReceived() <-chan basicPeerInfo {
-	return s.newPeerInfo
+func (ms *P2PMessageService) PeerInfoReceived() <-chan basicPeerInfo {
+	return ms.newPeerInfo
 }
 
 func (ms *P2PMessageService) addBootPeers(peers []string) {
@@ -323,7 +328,7 @@ func (ms *P2PMessageService) addBootPeers(peers []string) {
 		peer, err := peer.AddrInfoFromP2pAddr(addr)
 		ms.checkError(err)
 
-		err = ms.p2pHost.Connect(context.Background(), *peer) // Adds peerInfo to Peerstore
+		err = ms.p2pHost.Connect(context.Background(), *peer) // Adds peerInfo to local Peerstore
 		ms.checkError(err)
 		ms.logger.Debug().Msgf("connected to boot peer: %v", p)
 
@@ -344,7 +349,9 @@ func (ms *P2PMessageService) discoverPeers(ctx context.Context, topic string) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-
+			// FindPeers automatically updates the following data stores:
+			// 1. Peerstore: adds peer ID, public key, and multiaddresses
+			// 2. RoutingTable: adds peers that satify "distance" criteria
 			peersChan, err := routingDiscovery.FindPeers(ctx, topic)
 			ms.checkError(err)
 
@@ -352,14 +359,15 @@ func (ms *P2PMessageService) discoverPeers(ctx context.Context, topic string) {
 				if p.ID == ms.p2pHost.ID() {
 					continue
 				}
-				ms.logger.Debug().Msgf("inspecting peer found through discovery: %v (status: %v)", p.ID, ms.p2pHost.Network().Connectedness(p.ID))
-				if ms.p2pHost.Network().Connectedness(p.ID) != network.Connected {
-					err = ms.p2pHost.Connect(ctx, p) // Adds peerInfo to Peerstore
-					ms.checkError(err)
-					ms.logger.Debug().Msgf("connected to new peer: %+v", p)
+				ms.p2pHost.Peerstore().AddAddrs(p.ID, p.Addrs, peerstore.PermanentAddrTTL)
+				// ms.logger.Debug().Msgf("inspecting peer found through discovery: %v (status: %v)", p.ID, ms.p2pHost.Network().Connectedness(p.ID))
+				// if ms.p2pHost.Network().Connectedness(p.ID) != network.Connected {
+				// err = ms.p2pHost.Connect(ctx, p) // Adds peerInfo to local Peerstore
+				// ms.checkError(err)
+				// ms.logger.Debug().Msgf("connected to new peer: %+v", p)
 
-					ms.sendPeerInfo(p.ID, true)
-				}
+				//ms.sendPeerInfo(p.ID, true)
+				//}
 			}
 		}
 	}

--- a/node_test/helpers_test.go
+++ b/node_test/helpers_test.go
@@ -102,7 +102,7 @@ func setupChainService(tc TestCase, tp TestParticipant, si sharedTestInfrastruct
 	case MockChain:
 		return chainservice.NewMockChainService(si.mockChain, tp.Address())
 	case SimulatedChain:
-		logDestination := logging.NewLogWriter("../artifacts", tc.LogName)
+		logDestination := logging.NewLogWriter("../artifacts", tc.LogName+"_chain_"+string(tp.Name)+".log")
 
 		ethAccountIndex := tp.Port - testactors.START_PORT
 		cs, err := chainservice.NewSimulatedBackendChainService(si.simulatedChain, *si.bindings, si.ethAccounts[ethAccountIndex], logDestination)
@@ -132,11 +132,10 @@ func setupStore(tc TestCase, tp TestParticipant, si sharedTestInfrastructure) st
 }
 
 func setupIntegrationNode(tc TestCase, tp TestParticipant, si sharedTestInfrastructure, bootPeers []string) (node.Node, messageservice.MessageService, string) {
-	// messageService, multiAddr := setupMessageService(tc, tp, si, bootPeers, newLogWriter(tc.LogName))
-	messageService, multiAddr := setupMessageService(tc, tp, si, bootPeers, logging.NewLogWriter("../artifacts", tc.LogName))
+	messageService, multiAddr := setupMessageService(tc, tp, si, bootPeers, logging.NewLogWriter("../artifacts", tc.LogName+"_message_"+string(tp.Name)+".log"))
 	cs := setupChainService(tc, tp, si)
 	store := setupStore(tc, tp, si)
-	n := node.New(messageService, cs, store, logging.NewLogWriter("../artifacts", tc.LogName), &engine.PermissivePolicy{}, nil)
+	n := node.New(messageService, cs, store, logging.NewLogWriter("../artifacts", tc.LogName+"_engine_"+string(tp.Name)+".log"), &engine.PermissivePolicy{}, nil)
 	return n, messageService, multiAddr
 }
 

--- a/node_test/integration_test.go
+++ b/node_test/integration_test.go
@@ -23,7 +23,7 @@ func TestSimpleIntegrationScenario(t *testing.T) {
 		MessageService: TestMessageService,
 		NumOfChannels:  1,
 		MessageDelay:   0,
-		LogName:        "simple_integration_run.log",
+		LogName:        "simple_integration",
 		NumOfHops:      1,
 		NumOfPayments:  1,
 		Participants: []TestParticipant{
@@ -43,7 +43,7 @@ func TestComplexIntegrationScenario(t *testing.T) {
 		MessageService: MdnsMessageService,
 		NumOfChannels:  5,
 		MessageDelay:   0,
-		LogName:        "complex_integration_run.log",
+		LogName:        "complex_integration",
 		NumOfHops:      2,
 		NumOfPayments:  5,
 		Participants: []TestParticipant{
@@ -63,7 +63,7 @@ func TestKademliaDhtIntegrationScenario(t *testing.T) {
 		MessageService: DhtMessageService,
 		NumOfChannels:  5,
 		MessageDelay:   0,
-		LogName:        "dht_integration_run.log",
+		LogName:        "dht_integration",
 		NumOfHops:      2,
 		NumOfPayments:  5,
 		Participants: []TestParticipant{
@@ -92,6 +92,7 @@ func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 		msgServices := make([]messageservice.MessageService, 0)
 
 		// Setup clients
+		t.Log("Initalizing intermediary node(s)...")
 		intermediaries := make([]node.Node, 0)
 		bootPeers := make([]string, 0)
 		for _, intermediary := range tc.Participants[2:] {
@@ -107,6 +108,7 @@ func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 				intermediaries[i].Close()
 			}
 		}()
+		t.Log("Intermediary node(s) setup complete")
 
 		clientA, msgA, _ := setupIntegrationNode(tc, tc.Participants[0], infra, bootPeers)
 		defer clientA.Close()


### PR DESCRIPTION
This PR makes the following changes:
* Update libp2p configuration to work for both mDNS and dht mode
* Use libp2p connection notifications to trigger state channel signing address exchange instead of `discoverPeers` method (improves reliability/timing of peer info exchange during node initialization)
* Modify integration tests to store logs in separate files to prevent them from overwriting each other