### PR TITLE
Parse Address from Peer ID

### DIFF
--- a/node/engine/messageservice/p2p-message-service/notifier.go
+++ b/node/engine/messageservice/p2p-message-service/notifier.go
@@ -1,6 +1,8 @@
 package p2pms
 
 import (
+	"fmt"
+
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/multiformats/go-multiaddr"
 )
@@ -12,6 +14,11 @@ type NetworkNotifiee struct {
 }
 
 func (nn *NetworkNotifiee) Connected(n network.Network, conn network.Conn) {
+	a, err := addressFromPeerID(conn.RemotePeer())
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Peer SC address %s\n", a.String())
 	nn.ms.logger.Debug().Msgf("notification: connected to peer %s", conn.RemotePeer().String())
 	go nn.ms.sendPeerInfo(conn.RemotePeer(), false)
 }


### PR DESCRIPTION
This just shows a brief example of how we can derive a SC address from a libp2p `peer.ID`.

```
Running tool: /opt/homebrew/bin/go test -timeout 30s -run ^TestKademliaDhtIntegrationScenario/Kademlia-DHT_test$ github.com/statechannels/go-nitro/node_test

=== RUN   TestKademliaDhtIntegrationScenario
=== RUN   TestKademliaDhtIntegrationScenario/Kademlia-DHT_test
    /Users/lagap/code/go-nitro/node_test/integration_test.go:95: Initalizing intermediary node(s)...
Peer SC address 0x111A00868581f73AB42FEEF67D235Ca09ca1E8db
Peer SC address 0xA8d2D06aCE9c7FFc24Ee785C2695678aeCDfd7A0
    /Users/lagap/code/go-nitro/node_test/integration_test.go:111: Intermediary node(s) setup complete
Peer SC address 0x111A00868581f73AB42FEEF67D235Ca09ca1E8db
Peer SC address 0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE
Peer SC address 0xA8d2D06aCE9c7FFc24Ee785C2695678aeCDfd7A0
Peer SC address 0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE
Peer SC address 0x111A00868581f73AB42FEEF67D235Ca09ca1E8db
Peer SC address 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94
Peer SC address 0xA8d2D06aCE9c7FFc24Ee785C2695678aeCDfd7A0
Peer SC address 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94
Peer SC address 0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE
Peer SC address 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94
    /Users/lagap/code/go-nitro/node_test/integration_test.go:127: Waiting for peer info exchange...
Service num: 0, peer num: 0, peerInfo: {16Uiu2HAm1hgN2MkrhGen8JPrBBYyXACbZtfqJmraN53XiHYCeoFi 0xA8d2D06aCE9c7FFc24Ee785C2695678aeCDfd7A0}
Service num: 0, peer num: 1, peerInfo: {16Uiu2HAmSjXJqsyBJgcBUU2HQmykxGseafSatbpq5471XmuaUqyv 0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE}
Service num: 0, peer num: 2, peerInfo: {16Uiu2HAmJDxLM8rSybX78FH51iZq9PdrwCoCyyHRBCndNzcAYMes 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94}
Service num: 1, peer num: 0, peerInfo: {16Uiu2HAmHntR3SGeS7iF2tdeNBefSahXBhmTrqVozVLHydxzkaZn 0x111A00868581f73AB42FEEF67D235Ca09ca1E8db}
Service num: 1, peer num: 1, peerInfo: {16Uiu2HAmSjXJqsyBJgcBUU2HQmykxGseafSatbpq5471XmuaUqyv 0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE}
Service num: 1, peer num: 2, peerInfo: {16Uiu2HAmJDxLM8rSybX78FH51iZq9PdrwCoCyyHRBCndNzcAYMes 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94}
Service num: 2, peer num: 0, peerInfo: {16Uiu2HAmHntR3SGeS7iF2tdeNBefSahXBhmTrqVozVLHydxzkaZn 0x111A00868581f73AB42FEEF67D235Ca09ca1E8db}
Service num: 2, peer num: 1, peerInfo: {16Uiu2HAm1hgN2MkrhGen8JPrBBYyXACbZtfqJmraN53XiHYCeoFi 0xA8d2D06aCE9c7FFc24Ee785C2695678aeCDfd7A0}
Service num: 2, peer num: 2, peerInfo: {16Uiu2HAmJDxLM8rSybX78FH51iZq9PdrwCoCyyHRBCndNzcAYMes 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94}
Service num: 3, peer num: 0, peerInfo: {16Uiu2HAmHntR3SGeS7iF2tdeNBefSahXBhmTrqVozVLHydxzkaZn 0x111A00868581f73AB42FEEF67D235Ca09ca1E8db}
Service num: 3, peer num: 1, peerInfo: {16Uiu2HAm1hgN2MkrhGen8JPrBBYyXACbZtfqJmraN53XiHYCeoFi 0xA8d2D06aCE9c7FFc24Ee785C2695678aeCDfd7A0}
Service num: 3, peer num: 2, peerInfo: {16Uiu2HAmSjXJqsyBJgcBUU2HQmykxGseafSatbpq5471XmuaUqyv 0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE}
    /Users/lagap/code/go-nitro/node_test/integration_test.go:129: Peer info exchange complete
--- PASS: TestKademliaDhtIntegrationScenario/Kademlia-DHT_test (3.23s)
--- PASS: TestKademliaDhtIntegrationScenario (3.23s)
PASS
ok      github.com/statechannels/go-nitro/node_test     3.559s
```