### PR TITLE
Use the SC key as the message key and derive a SC address from peer.ID

### DIFF
--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -78,7 +78,7 @@ func RunRpcServer(pk []byte, chainService chainservice.ChainService,
 	}
 
 	logger.Info().Msg("Initializing message service on port " + fmt.Sprint(msgPort) + "...")
-	messageService := p2pms.NewMessageService("127.0.0.1", msgPort, *ourStore.GetAddress(), pk, useMdns, logDestination, bootPeers)
+	messageService := p2pms.NewMessageService("127.0.0.1", msgPort, pk, useMdns, logDestination, bootPeers)
 	node := node.New(
 		messageService,
 		chainService,

--- a/node/engine/messageservice/p2p-message-service/service.go
+++ b/node/engine/messageservice/p2p-message-service/service.go
@@ -182,11 +182,13 @@ func (ms *P2PMessageService) setupDht(bootPeers []string) {
 
 // HandlePeerFound is called when a peer is discovered.
 func (ms *P2PMessageService) HandlePeerFound(pi peer.AddrInfo) {
-	ms.logger.Debug().Msgf("Attempting to add peer")
+	ms.logger.Debug().Str("peer-id", pi.ID.Pretty()).Str("multiaddress", pi.Addrs[0].String()).Msgf("Attempting to add peer")
 	ms.p2pHost.Peerstore().AddAddr(pi.ID, pi.Addrs[0], peerstore.PermanentAddrTTL)
 
 	a, err := addressFromPeerID(pi.ID)
 	ms.checkError(err)
+	ms.logger.Debug().Str("peer-id", pi.ID.Pretty()).Str("sc-address", a.String()).Msgf("Derived SC address from peer ID")
+
 	ms.peers.Store(a.String(), pi.ID)
 	ms.newPeerInfo <- basicPeerInfo{Id: pi.ID, Address: a}
 }

--- a/node_test/helpers_test.go
+++ b/node_test/helpers_test.go
@@ -72,7 +72,6 @@ func setupMessageService(tc TestCase, tp TestParticipant, si sharedTestInfrastru
 		ms := p2pms.NewMessageService(
 			"127.0.0.1",
 			int(tp.Port),
-			tp.Address(),
 			tp.PrivateKey,
 			true,
 			logWriter,
@@ -84,7 +83,6 @@ func setupMessageService(tc TestCase, tp TestParticipant, si sharedTestInfrastru
 		ms := p2pms.NewMessageService(
 			"127.0.0.1",
 			int(tp.Port),
-			tp.Address(),
 			tp.PrivateKey,
 			false,
 			logWriter,


### PR DESCRIPTION
See #1495 for the context.