### PR TITLE
Add micropayment support to proxy client

### DIFF
--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -201,7 +201,6 @@ function App() {
           value={fileUrl}
         ></TextField>
       </Box>
-      <br></br>
       <FormControlLabel
         label="Use micropayments"
         control={

--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -15,6 +15,7 @@ import {
   InputLabel,
   Checkbox,
   FormControlLabel,
+  LinearProgress,
 } from "@mui/material";
 
 const QUERY_KEY = "rpcUrl";
@@ -49,7 +50,7 @@ function App() {
   const [errorText, setErrorText] = useState<string>("");
   const [chunkSize, setChunkSize] = useState<number>(100);
   const [useMicroPayments, setUseMicroPayments] = useState<boolean>(false);
-
+  const [microPaymentProgress, setMicroPaymentProgress] = useState<number>(0);
   useEffect(() => {
     NitroRpcClient.CreateHttpNitroClient(url)
       .then((c) => setNitroClient(c))
@@ -116,13 +117,15 @@ function App() {
     }
 
     try {
+      setMicroPaymentProgress(0);
       const file = useMicroPayments
         ? await fetchFileInChunks(
             chunkSize,
             fileUrl,
             costPerByte,
             selectedChannel,
-            nitroClient
+            nitroClient,
+            setMicroPaymentProgress
           )
         : await fetchFile(
             fileUrl,
@@ -256,9 +259,14 @@ function App() {
           type="number"
         ></TextField>
       </Box>
+
       <Button onClick={fetchAndDownloadFile}>
         {useMicroPayments ? "Fetch with micropayments" : "Fetch"}
       </Button>
+      <Box visibility={useMicroPayments ? "visible" : "hidden"}>
+        <LinearProgress value={microPaymentProgress} variant="determinate" />
+      </Box>
+
       <Box>{errorText}</Box>
     </Box>
   );

--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -21,8 +21,7 @@ import {
 const QUERY_KEY = "rpcUrl";
 
 import "./App.css";
-import { fetchFile } from "./file";
-
+import { fetchFile, fetchFileInChunks } from "./file";
 const provider = "0xbbb676f9cff8d242e9eac39d063848807d3d1d94";
 const hub = "0x111a00868581f73ab42feef67d235ca09ca1e8db";
 const defaultNitroRPCUrl = "localhost:4005/api/v1";
@@ -129,8 +128,7 @@ function App() {
           )
         : await fetchFile(
             fileUrl,
-            costPerByte,
-            dataSize,
+            costPerByte * dataSize,
             selectedChannel,
             nitroClient
           );

--- a/packages/payment-proxy-client/src/file.ts
+++ b/packages/payment-proxy-client/src/file.ts
@@ -4,13 +4,10 @@ import { Voucher } from "@statechannels/nitro-rpc-client/src/types";
 export async function fetchFile(
   url: string,
   paymentAmount: number,
-  selectedChannel: string,
+  channelId: string,
   nitroClient: NitroRpcClient
 ): Promise<File> {
-  const voucher = await nitroClient.CreateVoucher(
-    selectedChannel,
-    paymentAmount
-  );
+  const voucher = await nitroClient.CreateVoucher(channelId, paymentAmount);
 
   const response = await fetch(addVoucherToUrl(url, voucher));
 
@@ -22,7 +19,7 @@ export async function fetchFileInChunks(
   chunkSize: number,
   url: string,
   costPerByte: number,
-  selectedChannel: string,
+  channelId: string,
   nitroClient: NitroRpcClient,
   updateProgress: (progress: number) => void
 ): Promise<File> {
@@ -33,7 +30,7 @@ export async function fetchFileInChunks(
     chunkSize - 1,
     url,
     costPerByte,
-    selectedChannel,
+    channelId,
     nitroClient
   );
 
@@ -71,7 +68,7 @@ export async function fetchFileInChunks(
       stop,
       url,
       costPerByte,
-      selectedChannel,
+      channelId,
       nitroClient
     );
 
@@ -87,7 +84,7 @@ export async function fetchFileInChunks(
       stop,
       url,
       costPerByte,
-      selectedChannel,
+      channelId,
       nitroClient
     );
     fileContents.set(data, start);
@@ -104,13 +101,13 @@ async function fetchChunk(
   stop: number,
   url: string,
   costPerByte: number,
-  selectedChannel: string,
+  channelId: string,
   nitroClient: NitroRpcClient
 ): Promise<{ data: Uint8Array; contentLength: number; fileName: string }> {
   const dataLength = stop - start + 1; // +1 because stop is inclusive
   const chunkCost = dataLength * costPerByte;
 
-  const voucher = await nitroClient.CreateVoucher(selectedChannel, chunkCost);
+  const voucher = await nitroClient.CreateVoucher(channelId, chunkCost);
 
   const req = new Request(addVoucherToUrl(url, voucher));
   req.headers.set("Range", `bytes=${start}-${stop}`);

--- a/packages/payment-proxy-client/src/file.ts
+++ b/packages/payment-proxy-client/src/file.ts
@@ -84,7 +84,7 @@ export async function fetchFileChunk(
   nitroClient: NitroRpcClient
 ): Promise<{ data: Uint8Array; contentLength: number; fileName: string }> {
   const dataLength = stop - start + 1; // +1 because stop is inclusive
-  console.log(dataLength);
+
   const chunkCost = dataLength * costPerByte;
 
   const voucher = await nitroClient.CreateVoucher(selectedChannel, chunkCost);
@@ -103,7 +103,6 @@ export async function fetchFileChunk(
     throw new Error(`Response status ${response.status}`);
   }
   const result = await response.body.getReader().read();
-  console.log(...response.headers);
 
   return {
     data: result.value || new Uint8Array(),

--- a/packages/payment-proxy-client/src/file.ts
+++ b/packages/payment-proxy-client/src/file.ts
@@ -50,8 +50,14 @@ export async function fetchFileInChunks(
     nitroClient
   );
 
+  console.log(
+    `Fetched the first chunk of the file using a chunk size of ${chunkSize} bytes`
+  );
+
   const { contentLength, fileName } = firstChunk;
   const remainingChunks = Math.ceil(contentLength / chunkSize) - 1;
+  console.log(`The total length of the file is ${contentLength} bytes`);
+  console.log(`We have ${remainingChunks} more chunks to fetch`);
 
   const fileContents = new Uint8Array(contentLength);
   fileContents.set(firstChunk.data);
@@ -69,9 +75,11 @@ export async function fetchFileInChunks(
       nitroClient
     );
 
+    console.log(`Fetched chunk ${i + 1} of ${remainingChunks + 1}`);
     fileContents.set(data, i * chunkSize);
   }
 
+  console.log("Finished fetching all chunks");
   return new File([fileContents], fileName);
 }
 

--- a/packages/payment-proxy-client/src/file.ts
+++ b/packages/payment-proxy-client/src/file.ts
@@ -39,7 +39,8 @@ export async function fetchFileInChunks(
   baseUrl: string,
   costPerByte: number,
   selectedChannel: string,
-  nitroClient: NitroRpcClient
+  nitroClient: NitroRpcClient,
+  updateProgress: (progress: number) => void
 ): Promise<File> {
   const firstChunk = await fetchFileChunk(
     0,
@@ -65,6 +66,7 @@ export async function fetchFileInChunks(
 
   if (remainingContentLength <= 0) {
     console.log("We have fetched the entire file in 1 chunk");
+    updateProgress(100);
     return new File([fileContents], fileName);
   }
 
@@ -73,6 +75,7 @@ export async function fetchFileInChunks(
       remainingContentLength / chunkSize
     )} chunks`
   );
+  updateProgress(100 - (remainingContentLength / contentLength) * 100);
 
   while (remainingContentLength > chunkSize) {
     const start = contentLength - remainingContentLength;
@@ -89,6 +92,9 @@ export async function fetchFileInChunks(
 
     fileContents.set(data, start);
     remainingContentLength -= chunkSize;
+
+    updateProgress(100 - (remainingContentLength / contentLength) * 100);
+
     console.log(
       `We have ${remainingContentLength} bytes to fetch in ${Math.ceil(
         remainingContentLength / chunkSize
@@ -111,7 +117,7 @@ export async function fetchFileInChunks(
 
     console.log(`Fetched final chunk of size ${remainingContentLength} bytes`);
   }
-
+  updateProgress(100);
   console.log("Finished fetching all chunks");
   return new File([fileContents], fileName);
 }

--- a/packages/payment-proxy-client/src/file.ts
+++ b/packages/payment-proxy-client/src/file.ts
@@ -16,14 +16,9 @@ export async function fetchFile(
     `${baseUrl}?channelId=${voucher.ChannelId}&amount=${voucher.Amount}&signature=${voucher.Signature}`
   );
 
-  try {
-    const fileName = parseFileNameFromUrl(response.url);
-    console.log(fileName);
-    return new File([await response.blob()], fileName);
-  } catch (e) {
-    console.log(e);
-    throw e;
-  }
+  const fileName = parseFileNameFromUrl(response.url);
+
+  return new File([await response.blob()], fileName);
 }
 
 function parseFileNameFromUrl(url: string): string {
@@ -37,4 +32,92 @@ function parseFileNameFromUrl(url: string): string {
     // If we can't parse the URL, just return a default file name
     return "fetched-file";
   }
+}
+
+export async function fetchFileInChunks(
+  chunkSize: number,
+  baseUrl: string,
+  costPerByte: number,
+  selectedChannel: string,
+  nitroClient: NitroRpcClient
+): Promise<File> {
+  const firstChunk = await fetchFileChunk(
+    0,
+    chunkSize - 1,
+    baseUrl,
+    costPerByte,
+    selectedChannel,
+    nitroClient
+  );
+
+  const { contentLength, fileName } = firstChunk;
+  const remainingChunks = Math.ceil(contentLength / chunkSize) - 1;
+
+  const fileContents = new Uint8Array(contentLength);
+  fileContents.set(firstChunk.data);
+
+  for (let i = 1; i <= remainingChunks; i++) {
+    const start = i * chunkSize;
+    const stop = start + chunkSize - 1;
+
+    const { data } = await fetchFileChunk(
+      start,
+      stop,
+      baseUrl,
+      costPerByte,
+      selectedChannel,
+      nitroClient
+    );
+
+    fileContents.set(data, i * chunkSize);
+  }
+
+  return new File([fileContents], fileName);
+}
+
+export async function fetchFileChunk(
+  start: number,
+  stop: number,
+  baseUrl: string,
+  costPerByte: number,
+  selectedChannel: string,
+  nitroClient: NitroRpcClient
+): Promise<{ data: Uint8Array; contentLength: number; fileName: string }> {
+  const dataLength = stop - start + 1; // +1 because stop is inclusive
+  console.log(dataLength);
+  const chunkCost = dataLength * costPerByte;
+
+  const voucher = await nitroClient.CreateVoucher(selectedChannel, chunkCost);
+
+  const req = new Request(
+    `${baseUrl}?channelId=${voucher.ChannelId}&amount=${voucher.Amount}&signature=${voucher.Signature}`
+  );
+  req.headers.set("Range", `bytes=${start}-${stop}`);
+
+  const response = await fetch(req);
+  if (!response.body) {
+    throw new Error("Response body is null");
+  }
+
+  if (!response.ok) {
+    throw new Error(`Response status ${response.status}`);
+  }
+  const result = await response.body.getReader().read();
+  console.log(...response.headers);
+
+  return {
+    data: result.value || new Uint8Array(),
+    contentLength: parseTotalSizeFromContentRange(
+      response.headers.get("Content-Range") || ""
+    ),
+    fileName: parseFileNameFromUrl(response.url),
+  };
+}
+
+function parseTotalSizeFromContentRange(contentRange: string): number {
+  const match = /^.*\/([0-9]*)$/.exec(contentRange);
+  if (!match) {
+    throw new Error(`Could not parse content range ${contentRange}`);
+  }
+  return parseInt(match[1]);
 }


### PR DESCRIPTION
Fixes #1503 

This adds support to the proxy client UI to use [HTTP range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) to request (and pay for) a file over multiple http requests. 


The client can specify the chunk size (in bytes) they want to use.
![micropayment_v2](https://github.com/statechannels/go-nitro/assets/1620336/8fb7f030-f1f8-4970-a08a-7c667e5960ff)

