### PR TITLE
Update the TS Nitro RPC client to accept an amount when creating channels

### DIFF
--- a/packages/nitro-rpc-client/scripts/client-runner.ts
+++ b/packages/nitro-rpc-client/scripts/client-runner.ts
@@ -96,6 +96,18 @@ yargs(hideBin(process.argv))
           type: "number",
           default: 5,
         })
+        .option("ledgerdeposit", {
+          describe:
+            "The amount of wei for each participant to deposit into the ledger channel",
+          type: "number",
+          default: 1_000_000_000_000,
+        })
+        .option("virtualdeposit", {
+          describe:
+            "The amount of wei for each participant to deposit into a virtual channel",
+          type: "number",
+          default: 1_000_000,
+        })
         .option("numclosevirtual", {
           describe: "The number of virtual channels to close and defund.",
           type: "number",
@@ -150,8 +162,14 @@ yargs(hideBin(process.argv))
       if (yargs.createledgers) {
         // Setup ledger channels
         console.log("Constructing ledger channels");
-        const aliceLedger = await aliceClient.CreateLedgerChannel(ireneAddress);
-        const bobLedger = await ireneClient.CreateLedgerChannel(bobAddress);
+        const aliceLedger = await aliceClient.CreateLedgerChannel(
+          ireneAddress,
+          yargs.ledgerdeposit
+        );
+        const bobLedger = await ireneClient.CreateLedgerChannel(
+          bobAddress,
+          yargs.ledgerdeposit
+        );
 
         await Promise.all([
           aliceClient.WaitForObjective(aliceLedger.Id),
@@ -165,9 +183,11 @@ yargs(hideBin(process.argv))
       const virtualChannels: string[] = [];
       console.log(`Constructing ${yargs.numvirtual} virtual channels`);
       for (let i = 0; i < yargs.numvirtual; i++) {
-        const res = await aliceClient.CreatePaymentChannel(bobAddress, [
-          ireneAddress,
-        ]);
+        const res = await aliceClient.CreatePaymentChannel(
+          bobAddress,
+          [ireneAddress],
+          yargs.virtualdeposit
+        );
         await aliceClient.WaitForObjective(res.Id);
         console.log(`Virtual channel ${res.ChannelId} created`);
         virtualChannels.push(res.ChannelId);
@@ -239,7 +259,10 @@ yargs(hideBin(process.argv))
 
       // Setup ledger channels
       console.log("Constructing ledger channels");
-      const ledger = await leftClient.CreateLedgerChannel(rightAddress);
+      const ledger = await leftClient.CreateLedgerChannel(
+        rightAddress,
+        1_000_000
+      );
       await leftClient.WaitForObjective(ledger.Id);
       console.log(`Ledger channel ${ledger.ChannelId} created`);
 

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -101,11 +101,17 @@ yargs(hideBin(process.argv))
     "direct-fund <counterparty>",
     "Creates a directly funded ledger channel",
     (yargsBuilder) => {
-      return yargsBuilder.positional("counterparty", {
-        describe: "The counterparty's address",
-        type: "string",
-        demandOption: true,
-      });
+      return yargsBuilder
+        .positional("counterparty", {
+          describe: "The counterparty's address",
+          type: "string",
+          demandOption: true,
+        })
+        .option("amount", {
+          describe: "The amount to fund the channel with",
+          type: "number",
+          default: 1_000_000,
+        });
     },
     async (yargs) => {
       const rpcPort = yargs.p;
@@ -116,7 +122,8 @@ yargs(hideBin(process.argv))
       if (yargs.n) logOutChannelUpdates(rpcClient);
 
       const dfObjective = await rpcClient.CreateLedgerChannel(
-        yargs.counterparty
+        yargs.counterparty,
+        yargs.amount
       );
       const { Id } = dfObjective;
 
@@ -163,7 +170,12 @@ yargs(hideBin(process.argv))
           type: "string",
           demandOption: true,
         })
-        .array("intermediaries");
+        .array("intermediaries")
+        .option("amount", {
+          describe: "The amount to fund the channel with",
+          type: "number",
+          default: 1000,
+        });
     },
     async (yargs) => {
       const rpcPort = yargs.p;
@@ -184,7 +196,8 @@ yargs(hideBin(process.argv))
 
       const vfObjective = await rpcClient.CreatePaymentChannel(
         yargs.counterparty,
-        intermediaries
+        intermediaries,
+        yargs.amount
       );
 
       const { Id } = vfObjective;

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -83,7 +83,8 @@ export class NitroRpcClient {
    * @returns A promise that resolves to an objective response, containing the ID of the objective and the channel id.
    */
   public async CreateLedgerChannel(
-    counterParty: string
+    counterParty: string,
+    amount: number
   ): Promise<ObjectiveResponse> {
     const asset = `0x${"00".repeat(20)}`;
     const params: DirectFundParams = {
@@ -93,7 +94,7 @@ export class NitroRpcClient {
         asset,
         await this.GetAddress(),
         counterParty,
-        1_000_000
+        amount
       ),
       AppDefinition: asset,
       AppData: "0x00",
@@ -111,7 +112,8 @@ export class NitroRpcClient {
    */
   public async CreatePaymentChannel(
     counterParty: string,
-    intermediaries: string[]
+    intermediaries: string[],
+    amount: number
   ): Promise<ObjectiveResponse> {
     const asset = `0x${"00".repeat(20)}`;
     const params: VirtualFundParams = {
@@ -122,7 +124,7 @@ export class NitroRpcClient {
         asset,
         await this.GetAddress(),
         counterParty,
-        1_000
+        amount
       ),
       AppDefinition: asset,
       Nonce: Date.now(),


### PR DESCRIPTION
Instead of using a hard-coded amount when creating channels you can now specify the amount. This is useful for generating test data for demos.