### PR TITLE
Update proxy test to wait until servers are ready

### DIFF
--- a/node_test/reverseproxy_test.go
+++ b/node_test/reverseproxy_test.go
@@ -359,6 +359,7 @@ func waitForServer(t *testing.T, url string, timeout time.Duration) {
 			_, err := http.Get(url)
 			if err == nil {
 				isReady <- struct{}{}
+				return
 			}
 
 			time.Sleep(10 * time.Millisecond)

--- a/node_test/reverseproxy_test.go
+++ b/node_test/reverseproxy_test.go
@@ -34,6 +34,7 @@ const (
 	otherParamValue            = "2"
 	testFileContent            = "This a simple test file used in the reverse payment proxy"
 	testFileName               = "test_file.txt"
+	serverReadyMaxWait         = 2 * time.Second
 )
 
 func setupTestFile(t *testing.T) func() {
@@ -93,7 +94,7 @@ func TestReversePaymentProxy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error starting proxy: %v", err)
 	}
-	waitForServer(t, fmt.Sprintf("http://%s/", proxyAddress), 1*time.Second)
+	waitForServer(t, fmt.Sprintf("http://%s/", proxyAddress), serverReadyMaxWait)
 
 	voucher := createVoucher(t, aliceClient, paymentChannel, 5)
 	resp := performGetRequest(t, "", fmt.Sprintf("http://%s/resource?channelId=%s&amount=%d&signature=%s", proxyAddress, voucher.ChannelId, voucher.Amount.Int64(), voucher.Signature.ToHexString()))
@@ -343,7 +344,7 @@ func runDestinationServer(t *testing.T, port uint) (destUrl string, cleanup func
 
 	url := fmt.Sprintf("http://localhost:%d", port)
 
-	waitForServer(t, url, 10*time.Second)
+	waitForServer(t, url, serverReadyMaxWait)
 
 	return url, func() {
 		server.Close()

--- a/node_test/reverseproxy_test.go
+++ b/node_test/reverseproxy_test.go
@@ -358,7 +358,7 @@ func waitForServer(t *testing.T, url string, timeout time.Duration) {
 		for {
 			_, err := http.Get(url)
 			if err == nil {
-				isReady <- struct{}{}
+				close(isReady)
 				return
 			}
 

--- a/node_test/reverseproxy_test.go
+++ b/node_test/reverseproxy_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/rs/zerolog"
@@ -92,6 +93,7 @@ func TestReversePaymentProxy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error starting proxy: %v", err)
 	}
+	waitForServer(t, fmt.Sprintf("http://%s/", proxyAddress), 1*time.Second)
 
 	voucher := createVoucher(t, aliceClient, paymentChannel, 5)
 	resp := performGetRequest(t, "", fmt.Sprintf("http://%s/resource?channelId=%s&amount=%d&signature=%s", proxyAddress, voucher.ChannelId, voucher.Amount.Int64(), voucher.Signature.ToHexString()))
@@ -338,7 +340,34 @@ func runDestinationServer(t *testing.T, port uint) (destUrl string, cleanup func
 		err := server.ListenAndServe()
 		checkError(err)
 	}()
-	return fmt.Sprintf("http://localhost:%d", port), func() {
+
+	url := fmt.Sprintf("http://localhost:%d", port)
+
+	waitForServer(t, url, 10*time.Second)
+
+	return url, func() {
 		server.Close()
+	}
+}
+
+// waitForServer waits for the given url to be available by performing GET requests
+func waitForServer(t *testing.T, url string, timeout time.Duration) {
+	isReady := make(chan struct{})
+	go func() {
+		for {
+			_, err := http.Get(url)
+			if err == nil {
+				isReady <- struct{}{}
+			}
+
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	select {
+	case <-isReady:
+		return
+	case <-time.After(timeout):
+		t.Fatalf("server did not reply after %v", timeout)
 	}
 }


### PR DESCRIPTION
It looks like there is a [flicker in the proxy test](https://github.com/statechannels/go-nitro/actions/runs/5753709336/attempts/1). Based on the logs it looks like we attempt to connect to the payment proxy before it's ready:
```
{"level":"debug","message":"Starting to read websocket messages"}
    reverseproxy_test.go:204: Error performing request: Get "http://:5511/resource?channelId=0x1607b9445bf3c907f8e8f06c1279762e1d9c36f926e5a892eb6f038fcfc6e4e2&amount=5&signature=0xe18bfc518982b086d198823bf34b755be213c9eea792002414e96df797995a3f36748c63b6086ce53e20569ad318e1cd56d9da6bba64a198e8a8f9e7be44c8511c": dial tcp :5511: connect: connection refused
```

To address this PR adds a `waitForServer` function that blocks until it successfully makes a GET request against the provided url. This is used to block until both the payment proxy and destination servers are up and running.