### PR TITLE
Tweak godoc in `directdefund`

### DIFF
--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -40,7 +40,8 @@ type Objective struct {
 	Status                       protocols.ObjectiveStatus
 	C                            *channel.Channel
 	finalTurnNum                 uint64
-	withdrawTransactionSubmitted bool // whether a withdraw transaction has been declared as a side effect in a previous crank
+	// whether a withdraw transaction has been declared as a side effect in a previous crank
+	withdrawTransactionSubmitted bool
 }
 
 // isInConsensusOrFinalState returns true if the channel has a final state or latest state that is supported

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -249,7 +249,7 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 		return &updated, sideEffects, WaitingForNothing, errors.New("the channel must contain at least one signed state to crank the defund objective")
 	}
 
-	// Finalize and sign a state if no supported, finalized state exists
+	// Sign a final state if no supported, final state exists
 	if !latestSignedState.State().IsFinal || !latestSignedState.HasSignatureForParticipant(updated.C.MyIndex) {
 		stateToSign := latestSignedState.State().Clone()
 		if !stateToSign.IsFinal {

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -37,10 +37,11 @@ const (
 
 // Objective is a cache of data computed by reading from the store. It stores (potentially) infinite data
 type Objective struct {
-	Status                       protocols.ObjectiveStatus
-	C                            *channel.Channel
-	finalTurnNum                 uint64
-	// whether a withdraw transaction has been declared as a side effect in a previous crank
+	Status       protocols.ObjectiveStatus
+	C            *channel.Channel
+	finalTurnNum uint64
+
+	// Whether a withdraw transaction has been declared as a side effect in a previous crank
 	withdrawTransactionSubmitted bool
 }
 

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -177,7 +177,7 @@ func TestCrankAlice(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !updated.(*Objective).transactionSubmitted {
+	if !updated.(*Objective).withdrawTransactionSubmitted {
 		t.Fatalf("Expected transactionSubmitted flag to be set to true")
 	}
 
@@ -260,7 +260,7 @@ func TestCrankBob(t *testing.T) {
 		t.Error(err)
 	}
 
-	if updated.(*Objective).transactionSubmitted {
+	if updated.(*Objective).withdrawTransactionSubmitted {
 		t.Fatalf("Expected transactionSubmitted flag to be set to false")
 	}
 

--- a/protocols/directdefund/serde.go
+++ b/protocols/directdefund/serde.go
@@ -25,7 +25,7 @@ func (o Objective) MarshalJSON() ([]byte, error) {
 		o.Status,
 		o.C.Id,
 		o.finalTurnNum,
-		o.transactionSubmitted,
+		o.withdrawTransactionSubmitted,
 	}
 
 	return json.Marshal(jsonDDFO)
@@ -51,7 +51,7 @@ func (o *Objective) UnmarshalJSON(data []byte) error {
 	o.Status = jsonDDFO.Status
 	o.C.Id = jsonDDFO.C
 	o.finalTurnNum = jsonDDFO.FinalTurnNum
-	o.transactionSubmitted = jsonDDFO.TransactionSumbmitted
+	o.withdrawTransactionSubmitted = jsonDDFO.TransactionSumbmitted
 
 	return nil
 }


### PR DESCRIPTION
Tidying this up in preparation for #1521.

There's an unfortunate similarity between:
* Signing an `isFinal=true` state https://docs.statechannels.org/protocol-tutorial/0010-states-channels/#isfinal and
* A state finalizing on chain.  https://docs.statechannels.org/protocol-tutorial/0070-finalizing-a-channel/

The concepts are obviously related, but distinct.

We could consider renaming `isFinal` to `instantCheckout` or something to disambiguate?