### PR TITLE
Remove mdns peer discovery option from the p2p message service

### DIFF
--- a/cmd/start-rpc-servers/main.go
+++ b/cmd/start-rpc-servers/main.go
@@ -38,10 +38,7 @@ const (
 	gray    color = "[90m"
 )
 
-var (
-	participants     = []participant{alice, bob, irene, ivan}
-	participantColor = map[participant]color{alice: blue, irene: green, ivan: cyan, bob: yellow}
-)
+var participantColor = map[participant]color{alice: blue, irene: green, ivan: cyan, bob: yellow}
 
 const (
 	FUNDED_TEST_PK  = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"

--- a/cmd/start-rpc-servers/main.go
+++ b/cmd/start-rpc-servers/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/statechannels/go-nitro/cmd/utils"
 	"github.com/statechannels/go-nitro/internal/chain"
@@ -120,7 +121,21 @@ func main() {
 			}
 
 			hostUI := cCtx.Bool(HOST_UI)
-			for _, p := range participants {
+
+			for _, p := range []participant{ivan} {
+				client, err := setupRPCServer(p, participantColor[p], naAddress, vpaAddress, caAddress, chainUrl, chainAuthToken, dataFolder, hostUI)
+				if err != nil {
+					utils.StopCommands(running...)
+					panic(err)
+				}
+				running = append(running, client)
+			}
+
+			// TODO: There's not an easy way to detect when the server is up and running so we just sleep for now
+			time.Sleep(5 * time.Second)
+
+			for _, p := range []participant{alice, bob, irene} {
+
 				client, err := setupRPCServer(p, participantColor[p], naAddress, vpaAddress, caAddress, chainUrl, chainAuthToken, dataFolder, hostUI)
 				if err != nil {
 					utils.StopCommands(running...)

--- a/cmd/start-rpc-servers/main.go
+++ b/cmd/start-rpc-servers/main.go
@@ -121,14 +121,13 @@ func main() {
 
 			hostUI := cCtx.Bool(HOST_UI)
 
-			for _, p := range []participant{ivan} {
-				client, err := setupRPCServer(p, participantColor[p], naAddress, vpaAddress, caAddress, chainUrl, chainAuthToken, dataFolder, hostUI)
-				if err != nil {
-					utils.StopCommands(running...)
-					panic(err)
-				}
-				running = append(running, client)
+			// Setup Ivan first, he is the DHT boot peer
+			client, err := setupRPCServer(ivan, participantColor[ivan], naAddress, vpaAddress, caAddress, chainUrl, chainAuthToken, dataFolder, hostUI)
+			if err != nil {
+				utils.StopCommands(running...)
+				panic(err)
 			}
+			running = append(running, client)
 
 			const IVAN_ADDRESS = "http://127.0.0.1:4008/api/v1"
 			err = waitForRpcClient(IVAN_ADDRESS, 500*time.Millisecond, 1*time.Minute)

--- a/cmd/test-configs/alice.toml
+++ b/cmd/test-configs/alice.toml
@@ -17,4 +17,3 @@ chainauthtoken = ""
 
 # bootpeer = Ivan
 bootpeers = "/ip4/127.0.0.1/tcp/3008/p2p/16Uiu2HAm1hgN2MkrhGen8JPrBBYyXACbZtfqJmraN53XiHYCeoFi"
-usemdns = true

--- a/cmd/test-configs/bob.toml
+++ b/cmd/test-configs/bob.toml
@@ -2,9 +2,9 @@
 
 usedurablestore = true
 
+guiport = 5007
 msgport = 3007
 rpcport = 4007
-guiport = 5007
 
 # PeerID: 16Uiu2HAmJDxLM8rSybX78FH51iZq9PdrwCoCyyHRBCndNzcAYMes
 # SCAddr: 0xBBB676f9cFF8D242e9eaC39D063848807d3D1D94
@@ -12,9 +12,8 @@ pk = "0279651921cd800ac560c21ceea27aab0107b67daf436cdd25ce84cad30159b4"
 
 chainpk = "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
 
-chainurl = "ws://127.0.0.1:8545"
 chainauthtoken = ""
+chainurl = "ws://127.0.0.1:8545"
 
 # bootpeer = Ivan
 bootpeers = "/ip4/127.0.0.1/tcp/3008/p2p/16Uiu2HAm1hgN2MkrhGen8JPrBBYyXACbZtfqJmraN53XiHYCeoFi"
-usemdns = true

--- a/cmd/test-configs/irene.toml
+++ b/cmd/test-configs/irene.toml
@@ -16,4 +16,4 @@ chainurl = "ws://127.0.0.1:8545"
 chainauthtoken = ""
 
 bootpeers = ""
-usemdns = true
+

--- a/cmd/test-configs/irene.toml
+++ b/cmd/test-configs/irene.toml
@@ -2,9 +2,9 @@
 
 usedurablestore = true
 
+guiport = 5006
 msgport = 3006
 rpcport = 4006
-guiport = 5006
 
 # PeerID: 16Uiu2HAmHntR3SGeS7iF2tdeNBefSahXBhmTrqVozVLHydxzkaZn
 # SCAddr: 0x111A00868581f73AB42FEEF67D235Ca09ca1E8db
@@ -12,8 +12,8 @@ pk = "febb3b74b0b52d0976f6571d555f4ac8b91c308dfa25c7b58d1e6a7c3f50c781"
 
 chainpk = "7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6"
 
-chainurl = "ws://127.0.0.1:8545"
 chainauthtoken = ""
+chainurl = "ws://127.0.0.1:8545"
 
-bootpeers = ""
-
+# bootpeer = Ivan
+bootpeers = "/ip4/127.0.0.1/tcp/3008/p2p/16Uiu2HAm1hgN2MkrhGen8JPrBBYyXACbZtfqJmraN53XiHYCeoFi"

--- a/cmd/test-configs/ivan.toml
+++ b/cmd/test-configs/ivan.toml
@@ -16,4 +16,4 @@ chainurl = "ws://127.0.0.1:8545"
 chainauthtoken = ""
 
 bootpeers = ""
-usemdns = true
+

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,6 @@ require (
 	github.com/libp2p/go-netroute v0.2.1 // indirect
 	github.com/libp2p/go-reuseport v0.3.0 // indirect
 	github.com/libp2p/go-yamux/v4 v4.0.0 // indirect
-	github.com/libp2p/zeroconf/v2 v2.2.0 // indirect
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect

--- a/go.sum
+++ b/go.sum
@@ -523,8 +523,6 @@ github.com/libp2p/go-reuseport v0.3.0/go.mod h1:laea40AimhtfEqysZ71UpYj4S+R9VpH8
 github.com/libp2p/go-sockaddr v0.0.2/go.mod h1:syPvOmNs24S3dFVGJA1/mrqdeijPxLV2Le3BRLKd68k=
 github.com/libp2p/go-yamux/v4 v4.0.0 h1:+Y80dV2Yx/kv7Y7JKu0LECyVdMXm1VUoko+VQ9rBfZQ=
 github.com/libp2p/go-yamux/v4 v4.0.0/go.mod h1:NWjl8ZTLOGlozrXSOZ/HlfG++39iKNnM5wwmtQP1YB4=
-github.com/libp2p/zeroconf/v2 v2.2.0 h1:Cup06Jv6u81HLhIj1KasuNM/RHHrJ8T7wOTS4+Tv53Q=
-github.com/libp2p/zeroconf/v2 v2.2.0/go.mod h1:fuJqLnUwZTshS3U/bMRJ3+ow/v9oid1n0DmyYyNO1Xs=
 github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -563,7 +561,6 @@ github.com/mediocregopher/radix/v3 v3.4.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
-github.com/miekg/dns v1.1.43/go.mod h1:+evo5L0630/F6ca/Z9+GAqzhjGyn8/c+TBaOyfEl0V4=
 github.com/miekg/dns v1.1.54 h1:5jon9mWcb0sFJGpnI99tOMhCPyJ+RPVz5b63MQG0VWI=
 github.com/miekg/dns v1.1.54/go.mod h1:uInx36IzPl7FYnDcMeVWxj9byh7DutNykX4G9Sj60FY=
 github.com/miguelmota/go-ethereum-hdwallet v0.1.1 h1:zdXGlHao7idpCBjEGTXThVAtMKs+IxAgivZ75xqkWK0=
@@ -1003,7 +1000,6 @@ golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210220033124-5f55cee0dc0d/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.0.0-20210423184538-5f58ad60dda6/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20211008194852-3b03d305991f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
@@ -1073,7 +1069,6 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210420205809-ac73e9fd8988/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210426080607-c94f62235c83/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -24,7 +24,7 @@ import (
 
 func InitChainServiceAndRunRpcServer(pkString string, chainOpts chain.ChainOpts,
 	useDurableStore bool, durableStoreFolder string, useNats bool, msgPort int, rpcPort int,
-	bootPeers []string, useMdns bool,
+	bootPeers []string,
 ) (*rpc.RpcServer, *node.Node, *p2pms.P2PMessageService, error) {
 	if pkString == "" {
 		panic("pk must be set")
@@ -40,7 +40,7 @@ func InitChainServiceAndRunRpcServer(pkString string, chainOpts chain.ChainOpts,
 	if useNats {
 		transportType = transport.Nats
 	}
-	rpcServer, node, messageService, err := RunRpcServer(pk, chainService, useDurableStore, durableStoreFolder, msgPort, rpcPort, transportType, os.Stdout, bootPeers, useMdns)
+	rpcServer, node, messageService, err := RunRpcServer(pk, chainService, useDurableStore, durableStoreFolder, msgPort, rpcPort, transportType, os.Stdout, bootPeers)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -51,7 +51,7 @@ func InitChainServiceAndRunRpcServer(pkString string, chainOpts chain.ChainOpts,
 
 func RunRpcServer(pk []byte, chainService chainservice.ChainService,
 	useDurableStore bool, durableStoreFolder string, msgPort int, rpcPort int, transportType transport.TransportType, logDestination *os.File,
-	bootPeers []string, useMdns bool,
+	bootPeers []string,
 ) (*rpc.RpcServer, *node.Node, *p2pms.P2PMessageService, error) {
 	me := crypto.GetAddressFromSecretKeyBytes(pk)
 
@@ -78,7 +78,7 @@ func RunRpcServer(pk []byte, chainService chainservice.ChainService,
 	}
 
 	logger.Info().Msg("Initializing message service on port " + fmt.Sprint(msgPort) + "...")
-	messageService := p2pms.NewMessageService("127.0.0.1", msgPort, *ourStore.GetAddress(), pk, useMdns, logDestination, bootPeers)
+	messageService := p2pms.NewMessageService("127.0.0.1", msgPort, *ourStore.GetAddress(), pk, logDestination, bootPeers)
 	node := node.New(
 		messageService,
 		chainService,

--- a/main.go
+++ b/main.go
@@ -171,7 +171,7 @@ func main() {
 			if bootPeers != "" {
 				peerSlice = strings.Split(bootPeers, ",")
 			}
-			rpcServer, _, _, err := rpc.InitChainServiceAndRunRpcServer(pkString, chainOpts, useDurableStore, durableStoreFolder, useNats, msgPort, rpcPort, peerSlice, useMdns)
+			rpcServer, _, _, err := rpc.InitChainServiceAndRunRpcServer(pkString, chainOpts, useDurableStore, durableStoreFolder, useNats, msgPort, rpcPort, peerSlice)
 			if err != nil {
 				return err
 			}

--- a/main.go
+++ b/main.go
@@ -30,7 +30,6 @@ func main() {
 		RPC_PORT              = "rpcport"
 		GUI_PORT              = "guiport"
 		BOOT_PEERS            = "bootpeers"
-		USE_MDNS              = "usemdns"
 
 		// Keys
 		KEYS_CATEGORY = "Keys:"
@@ -44,7 +43,7 @@ func main() {
 	)
 	var pkString, chainUrl, chainAuthToken, naAddress, vpaAddress, caAddress, chainPk, durableStoreFolder, bootPeers string
 	var msgPort, rpcPort, guiPort int
-	var useNats, useDurableStore, useMdns bool
+	var useNats, useDurableStore bool
 
 	flags := []cli.Flag{
 		&cli.StringFlag{
@@ -65,13 +64,7 @@ func main() {
 			Value:       false,
 			Destination: &useDurableStore,
 		}),
-		altsrc.NewBoolFlag(&cli.BoolFlag{
-			Name:        USE_MDNS,
-			Usage:       "Specifies whether to use mDNS for peer discovery (if 'false', will use kademlia-dht)",
-			Category:    CONNECTIVITY_CATEGORY,
-			Value:       true,
-			Destination: &useMdns,
-		}),
+
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:        PK,
 			Usage:       "Specifies the private key used by the nitro node.",

--- a/node/engine/messageservice/p2p-message-service/service.go
+++ b/node/engine/messageservice/p2p-message-service/service.go
@@ -32,15 +32,14 @@ type basicPeerInfo struct {
 }
 
 const (
-	DHT_PROTOCOL_PREFIX          protocol.ID = "/nitro" // use /nitro/kad/1.0.0 instead of /ipfs/kad/1.0.0
-	GENERAL_MSG_PROTOCOL_ID      protocol.ID = "/nitro/msg/1.0.0"
-	PEER_EXCHANGE_PROTOCOL_ID    protocol.ID = "/nitro/peerinfo/1.0.0"
-	DELIMITER                                = '\n'
-	BUFFER_SIZE                              = 1_000
-	NUM_CONNECT_ATTEMPTS                     = 10
-	RETRY_SLEEP_DURATION                     = 5 * time.Second
-	PEER_EXCHANGE_SLEEP_DURATION             = 10 * time.Second       // how often we attempt FindPeers
-	BOOTSTRAP_SLEEP_DURATION                 = 100 * time.Millisecond // how often we check for bootpeers in Peerstore
+	DHT_PROTOCOL_PREFIX     protocol.ID = "/nitro" // use /nitro/kad/1.0.0 instead of /ipfs/kad/1.0.0
+	GENERAL_MSG_PROTOCOL_ID protocol.ID = "/nitro/msg/1.0.0"
+
+	DELIMITER                = '\n'
+	BUFFER_SIZE              = 1_000
+	NUM_CONNECT_ATTEMPTS     = 10
+	RETRY_SLEEP_DURATION     = 5 * time.Second
+	BOOTSTRAP_SLEEP_DURATION = 100 * time.Millisecond // how often we check for bootpeers in Peerstore
 )
 
 // P2PMessageService is a rudimentary message service that uses TCP to send and receive messages.

--- a/node/engine/messageservice/p2p-message-service/service.go
+++ b/node/engine/messageservice/p2p-message-service/service.go
@@ -160,9 +160,7 @@ func (ms *P2PMessageService) setupDht(bootPeers []string) error {
 	go func() {
 		ticker := time.NewTicker(BOOTSTRAP_SLEEP_DURATION)
 		for range ticker.C {
-			dhtSize := ms.dht.RoutingTable().Size()
-			ms.logger.Info().Msgf("routing table size: %d", dhtSize)
-			if dhtSize > 0 {
+			if ms.dht.RoutingTable().Size() > 0 {
 				ms.addScaddrDhtRecord(ctx)
 				ticker.Stop()
 				close(ms.initComplete)

--- a/node/engine/messageservice/p2p-message-service/service.go
+++ b/node/engine/messageservice/p2p-message-service/service.go
@@ -17,7 +17,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/protocol"
-	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/rs/zerolog"
@@ -54,7 +53,6 @@ type P2PMessageService struct {
 	me          types.Address
 	key         p2pcrypto.PrivKey
 	p2pHost     host.Host
-	mdns        mdns.Service
 	dht         *dht.IpfsDHT
 	newPeerInfo chan basicPeerInfo
 	logger      zerolog.Logger
@@ -382,13 +380,6 @@ func (ms *P2PMessageService) Out() <-chan protocols.Message {
 
 // Close closes the P2PMessageService
 func (ms *P2PMessageService) Close() error {
-	// The mdns service is optional so we only close it if it exists
-	if ms.mdns != nil {
-		err := ms.mdns.Close()
-		if err != nil {
-			return err
-		}
-	}
 	ms.p2pHost.RemoveStreamHandler(GENERAL_MSG_PROTOCOL_ID)
 	return ms.p2pHost.Close()
 }

--- a/node/engine/messageservice/p2p-message-service/service.go
+++ b/node/engine/messageservice/p2p-message-service/service.go
@@ -39,8 +39,8 @@ const (
 	BUFFER_SIZE                              = 1_000
 	NUM_CONNECT_ATTEMPTS                     = 10
 	RETRY_SLEEP_DURATION                     = 5 * time.Second
-	PEER_EXCHANGE_SLEEP_DURATION             = 10 * time.Second // how often we attempt FindPeers
-	BOOTSTRAP_SLEEP_DURATION                 = 1 * time.Second  // how often we check for bootpeers in Peerstore
+	PEER_EXCHANGE_SLEEP_DURATION             = 10 * time.Second       // how often we attempt FindPeers
+	BOOTSTRAP_SLEEP_DURATION                 = 100 * time.Millisecond // how often we check for bootpeers in Peerstore
 )
 
 // P2PMessageService is a rudimentary message service that uses TCP to send and receive messages.

--- a/node_test/helpers_test.go
+++ b/node_test/helpers_test.go
@@ -70,7 +70,7 @@ func setupMessageService(tc TestCase, tp TestParticipant, si sharedTestInfrastru
 	case TestMessageService:
 		return messageservice.NewTestMessageService(tp.Address(), *si.broker, tc.MessageDelay), ""
 
-	case DhtMessageService:
+	case P2PMessageService:
 		ms := p2pms.NewMessageService(
 			"127.0.0.1",
 			int(tp.Port),

--- a/node_test/helpers_test.go
+++ b/node_test/helpers_test.go
@@ -69,25 +69,13 @@ func setupMessageService(tc TestCase, tp TestParticipant, si sharedTestInfrastru
 	switch tc.MessageService {
 	case TestMessageService:
 		return messageservice.NewTestMessageService(tp.Address(), *si.broker, tc.MessageDelay), ""
-	case MdnsMessageService:
-		ms := p2pms.NewMessageService(
-			"127.0.0.1",
-			int(tp.Port),
-			tp.Address(),
-			tp.PrivateKey,
-			true,
-			logWriter,
-			[]string{},
-		)
 
-		return ms, ""
 	case DhtMessageService:
 		ms := p2pms.NewMessageService(
 			"127.0.0.1",
 			int(tp.Port),
 			tp.Address(),
 			tp.PrivateKey,
-			false,
 			logWriter,
 			bootPeers,
 		)

--- a/node_test/integration_test.go
+++ b/node_test/integration_test.go
@@ -76,7 +76,7 @@ func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 		intermediaries := make([]node.Node, 0)
 		bootPeers := make([]string, 0)
 		for _, intermediary := range tc.Participants[2:] {
-			clientI, msgI, multiAddr := setupIntegrationNode(tc, intermediary, infra, bootPeers)
+			clientI, msgI, multiAddr := setupIntegrationNode(tc, intermediary, infra, []string{})
 
 			intermediaries = append(intermediaries, clientI)
 			msgServices = append(msgServices, msgI)

--- a/node_test/integration_test.go
+++ b/node_test/integration_test.go
@@ -40,7 +40,7 @@ func TestComplexIntegrationScenario(t *testing.T) {
 	complexCase := TestCase{
 		Description:    "Complex test",
 		Chain:          SimulatedChain,
-		MessageService: DhtMessageService,
+		MessageService: P2PMessageService,
 		NumOfChannels:  5,
 		MessageDelay:   0,
 		LogName:        "complex_integration",

--- a/node_test/integration_test.go
+++ b/node_test/integration_test.go
@@ -56,26 +56,6 @@ func TestComplexIntegrationScenario(t *testing.T) {
 	RunIntegrationTestCase(complexCase, t)
 }
 
-func TestKademliaDhtIntegrationScenario(t *testing.T) {
-	complexCase := TestCase{
-		Description:    "Kademlia-DHT test",
-		Chain:          SimulatedChain,
-		MessageService: DhtMessageService,
-		NumOfChannels:  5,
-		MessageDelay:   0,
-		LogName:        "dht_integration",
-		NumOfHops:      2,
-		NumOfPayments:  5,
-		Participants: []TestParticipant{
-			{StoreType: DurableStore, Actor: testactors.Alice},
-			{StoreType: DurableStore, Actor: testactors.Bob},
-			{StoreType: DurableStore, Actor: testactors.Irene},
-			{StoreType: DurableStore, Actor: testactors.Ivan},
-		},
-	}
-	RunIntegrationTestCase(complexCase, t)
-}
-
 // RunIntegrationTestCase runs the integration test case.
 func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 	// Clean up all the test data we create at the end of the test

--- a/node_test/integration_test.go
+++ b/node_test/integration_test.go
@@ -40,7 +40,7 @@ func TestComplexIntegrationScenario(t *testing.T) {
 	complexCase := TestCase{
 		Description:    "Complex test",
 		Chain:          SimulatedChain,
-		MessageService: MdnsMessageService,
+		MessageService: DhtMessageService,
 		NumOfChannels:  5,
 		MessageDelay:   0,
 		LogName:        "complex_integration",

--- a/node_test/reverseproxy_test.go
+++ b/node_test/reverseproxy_test.go
@@ -238,10 +238,11 @@ func setupNitroClients(t *testing.T, logDestination *os.File) (alice, irene, bob
 	aliceChainService := chainservice.NewMockChainService(chain, ta.Alice.Address())
 	bobChainService := chainservice.NewMockChainService(chain, ta.Bob.Address())
 	ireneChainService := chainservice.NewMockChainService(chain, ta.Irene.Address())
+	ireneClient, msgIrene, ireneCleanup := setupNitroNodeWithRPCClient(t, ta.Irene.PrivateKey, 3106, 4106, ireneChainService, logDestination, "ws", []string{})
+	bootPeers := []string{msgIrene.MultiAddr}
+	aliceClient, msgAlice, aliceCleanup := setupNitroNodeWithRPCClient(t, ta.Alice.PrivateKey, 3105, 4105, aliceChainService, logDestination, "ws", bootPeers)
 
-	aliceClient, msgAlice, aliceCleanup := setupNitroNodeWithRPCClient(t, ta.Alice.PrivateKey, 3105, 4105, aliceChainService, logDestination, "ws")
-	ireneClient, msgIrene, ireneCleanup := setupNitroNodeWithRPCClient(t, ta.Irene.PrivateKey, 3106, 4106, ireneChainService, logDestination, "ws")
-	bobClient, msgBob, bobCleanup := setupNitroNodeWithRPCClient(t, ta.Bob.PrivateKey, 3107, 4107, bobChainService, logDestination, "ws")
+	bobClient, msgBob, bobCleanup := setupNitroNodeWithRPCClient(t, ta.Bob.PrivateKey, 3107, 4107, bobChainService, logDestination, "ws", bootPeers)
 
 	logger.Info().Msg("Clients created")
 

--- a/node_test/types_test.go
+++ b/node_test/types_test.go
@@ -43,7 +43,7 @@ type MessageService string
 
 const (
 	TestMessageService MessageService = "TestMessageService"
-	DhtMessageService  MessageService = "DhtMessageService"
+	P2PMessageService  MessageService = "P2PMessageService"
 )
 
 // TestCase is a test case for the node integration test.

--- a/node_test/types_test.go
+++ b/node_test/types_test.go
@@ -43,7 +43,6 @@ type MessageService string
 
 const (
 	TestMessageService MessageService = "TestMessageService"
-	MdnsMessageService MessageService = "MdnsMessageService"
 	DhtMessageService  MessageService = "DhtMessageService"
 )
 


### PR DESCRIPTION
Fixes #1507 

This removes the option of `mdns` from the message service. This helps simplify the p2p message service and also forces us to rely on DHT, which is what we expect to run in production.

