### PR TITLE
Use local `abigen` (dependency of `go-nitro`) to generate bindings

### DIFF
--- a/.github/workflows/bindings-check.yml
+++ b/.github/workflows/bindings-check.yml
@@ -14,7 +14,11 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "18.15.0"
-      - name: Install dependencies
+
+      - name: Install go-nitro dependencies (includes abigen)
+        run: go get .
+
+      - name: Install nitro-protocol dependencies
         run: |
           cd ./nitro-protocol
           npm ci --legacy-peer-deps
@@ -29,13 +33,6 @@ jobs:
           curl -o solc https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.17+commit.8df45f5f
           mv solc $GITHUB_WORKSPACE/bin
           sudo chmod +x $GITHUB_WORKSPACE/bin/solc
-
-      - name: Install abigen (part of go-ethereum)
-        run: |
-          curl -o geth.tar.gz https://gethstore.blob.core.windows.net/builds/geth-alltools-linux-amd64-1.10.8-26675454.tar.gz
-          tar -xzf geth.tar.gz
-          mv geth-alltools-linux-amd64-1.10.8-26675454/abigen $GITHUB_WORKSPACE/bin
-          sudo chmod +x $GITHUB_WORKSPACE/bin/abigen
 
       - name: Regenerate contract bindings
         run: sh ./generate-adjudicator-bindings.sh

--- a/.github/workflows/bindings-check.yml
+++ b/.github/workflows/bindings-check.yml
@@ -15,8 +15,8 @@ jobs:
         with:
           node-version: "18.15.0"
 
-      - name: Install go-nitro dependencies (includes abigen)
-        run: go get .
+      - name: Install go-ethereum (includes abigen)
+        run: go install github.com/ethereum/go-ethereum
 
       - name: Install nitro-protocol dependencies
         run: |

--- a/generate-adjudicator-bindings.sh
+++ b/generate-adjudicator-bindings.sh
@@ -31,7 +31,6 @@ runAbigen() {
     --bin=$TEMP_DIR/${1}.bin \
     --pkg=${1} \
     --out=$GONITRO_DIR/node/engine/chainservice/${2}/${1}.go 
-  cd ~-
 }
 
 echo "Using abigen from $GETH_DIR..."

--- a/generate-adjudicator-bindings.sh
+++ b/generate-adjudicator-bindings.sh
@@ -1,29 +1,42 @@
 set -e
 
+GONITRO_DIR=$(pwd)
+NITRO_PROTOCOL_DIR=$GONITRO_DIR/nitro-protocol
+TEMP_DIR=$NITRO_PROTOCOL_DIR/tmp-build
+GETH_DIR=$(go list -m -f '{{.Dir}}' github.com/ethereum/go-ethereum)
+
+
+
 trap '{
-rm -rf $(pwd)/tmp-build
+rm -rf $TEMP_DIR
 echo "Deleted tmp-build directory."
  }' EXIT
 
+echo "Compiling contracts..."
 
-cd nitro-protocol
-
-solc --base-path $(pwd) \
+solc --base-path $NITRO_PROTOCOL_DIR \
   @statechannels/exit-format/=node_modules/@statechannels/exit-format/ \
   @openzeppelin/contracts/=node_modules/@openzeppelin/contracts/ \
-  contracts/NitroAdjudicator.sol contracts/ConsensusApp.sol contracts/Token.sol contracts/VirtualPaymentApp.sol contracts/deploy/Create2Deployer.sol \
-  --optimize --bin --abi -o tmp-build --via-ir
+  $NITRO_PROTOCOL_DIR/contracts/NitroAdjudicator.sol \
+  $NITRO_PROTOCOL_DIR/contracts/ConsensusApp.sol \
+  $NITRO_PROTOCOL_DIR/contracts/Token.sol \
+  $NITRO_PROTOCOL_DIR/contracts/VirtualPaymentApp.sol \
+  $NITRO_PROTOCOL_DIR/contracts/deploy/Create2Deployer.sol \
+  --optimize --bin --abi -o $TEMP_DIR --via-ir
 
 runAbigen() {
-  abigen --abi=$(pwd)/tmp-build/${1}.abi \
-    --bin=$(pwd)/tmp-build/${1}.bin \
+  cd $GETH_DIR
+  go run ./cmd/abigen \
+    --abi=$TEMP_DIR/${1}.abi \
+    --bin=$TEMP_DIR/${1}.bin \
     --pkg=${1} \
-    --out=$(pwd)/../node/engine/chainservice/${2}/${1}.go 
+    --out=$GONITRO_DIR/node/engine/chainservice/${2}/${1}.go 
+  cd ~-
 }
+
+echo "Using abigen from $GETH_DIR..."
 
 runAbigen "NitroAdjudicator" "adjudicator"
 runAbigen "ConsensusApp" "consensusapp"
 runAbigen "Token" "erc20"
 runAbigen "VirtualPaymentApp" "virtualpaymentapp"
-
-

--- a/node/engine/chainservice/adjudicator/NitroAdjudicator.go
+++ b/node/engine/chainservice/adjudicator/NitroAdjudicator.go
@@ -26,6 +26,7 @@ var (
 	_ = common.Big1
 	_ = types.BloomLookup
 	_ = event.NewSubscription
+	_ = abi.ConvertType
 )
 
 // ExitFormatAllocation is an auto generated low-level Go binding around an user-defined struct.
@@ -218,11 +219,11 @@ func NewNitroAdjudicatorFilterer(address common.Address, filterer bind.ContractF
 
 // bindNitroAdjudicator binds a generic wrapper to an already deployed contract.
 func bindNitroAdjudicator(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
-	parsed, err := abi.JSON(strings.NewReader(NitroAdjudicatorABI))
+	parsed, err := NitroAdjudicatorMetaData.GetAbi()
 	if err != nil {
 		return nil, err
 	}
-	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
 }
 
 // Call invokes the (constant) contract method with params as input values and

--- a/node/engine/chainservice/consensusapp/ConsensusApp.go
+++ b/node/engine/chainservice/consensusapp/ConsensusApp.go
@@ -26,6 +26,7 @@ var (
 	_ = common.Big1
 	_ = types.BloomLookup
 	_ = event.NewSubscription
+	_ = abi.ConvertType
 )
 
 // ExitFormatAllocation is an auto generated low-level Go binding around an user-defined struct.
@@ -199,11 +200,11 @@ func NewConsensusAppFilterer(address common.Address, filterer bind.ContractFilte
 
 // bindConsensusApp binds a generic wrapper to an already deployed contract.
 func bindConsensusApp(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
-	parsed, err := abi.JSON(strings.NewReader(ConsensusAppABI))
+	parsed, err := ConsensusAppMetaData.GetAbi()
 	if err != nil {
 		return nil, err
 	}
-	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
 }
 
 // Call invokes the (constant) contract method with params as input values and

--- a/node/engine/chainservice/erc20/Token.go
+++ b/node/engine/chainservice/erc20/Token.go
@@ -26,6 +26,7 @@ var (
 	_ = common.Big1
 	_ = types.BloomLookup
 	_ = event.NewSubscription
+	_ = abi.ConvertType
 )
 
 // TokenMetaData contains all meta data concerning the Token contract.
@@ -156,11 +157,11 @@ func NewTokenFilterer(address common.Address, filterer bind.ContractFilterer) (*
 
 // bindToken binds a generic wrapper to an already deployed contract.
 func bindToken(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
-	parsed, err := abi.JSON(strings.NewReader(TokenABI))
+	parsed, err := TokenMetaData.GetAbi()
 	if err != nil {
 		return nil, err
 	}
-	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
 }
 
 // Call invokes the (constant) contract method with params as input values and

--- a/node/engine/chainservice/virtualpaymentapp/VirtualPaymentApp.go
+++ b/node/engine/chainservice/virtualpaymentapp/VirtualPaymentApp.go
@@ -26,6 +26,7 @@ var (
 	_ = common.Big1
 	_ = types.BloomLookup
 	_ = event.NewSubscription
+	_ = abi.ConvertType
 )
 
 // ExitFormatAllocation is an auto generated low-level Go binding around an user-defined struct.
@@ -199,11 +200,11 @@ func NewVirtualPaymentAppFilterer(address common.Address, filterer bind.Contract
 
 // bindVirtualPaymentApp binds a generic wrapper to an already deployed contract.
 func bindVirtualPaymentApp(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
-	parsed, err := abi.JSON(strings.NewReader(VirtualPaymentAppABI))
+	parsed, err := VirtualPaymentAppMetaData.GetAbi()
 	if err != nil {
 		return nil, err
 	}
-	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
 }
 
 // Call invokes the (constant) contract method with params as input values and


### PR DESCRIPTION
In our github action to regenerate and validate bindings, we install abigen from a hardcoded URL. These means we are tracking another dependency on geth (which abigen is part of) alongside the one specified in our `go.mod`.

This PR changes the github action to use the version specified in `go.mod`. This means developers do not need to worry about another way to install `abigen`.
