### PR TITLE
Allow `Channels` to handle `ChainEvents` without help of `Objectives`

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -327,7 +327,7 @@ func (c *Channel) SignAndAddState(s state.State, sk *[]byte) (state.SignedState,
 
 // UpdateWithChainEvent mutates the receiver if provided with a "new" chain event (with a greater block number than previously seen)
 func (c *Channel) UpdateWithChainEvent(event chainservice.Event) (*Channel, error) {
-	if event.BlockNum() <= c.latestBlockNumber {
+	if event.BlockNum() < c.latestBlockNumber {
 		return c, nil // ignore stale information TODO: is this reorg safe?
 	}
 	c.latestBlockNumber = event.BlockNum()

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/node/engine/chainservice"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -17,7 +18,8 @@ type Channel struct {
 	Id      types.Destination
 	MyIndex uint
 
-	OnChainFunding types.Funds
+	OnChainFunding    types.Funds
+	latestBlockNumber uint64 // the latest block number we've seen
 
 	state.FixedPart
 	// Support []uint64 // TODO: this property will be important, and allow the Channel to store the necessary data to close out the channel on chain
@@ -128,6 +130,7 @@ func (c *Channel) Clone() *Channel {
 		d.SignedStateForTurnNum[i] = ss.Clone()
 	}
 	d.OnChainFunding = c.OnChainFunding.Clone()
+	d.latestBlockNumber = c.latestBlockNumber
 	d.FixedPart = c.FixedPart.Clone()
 	return d
 }
@@ -320,4 +323,23 @@ func (c *Channel) SignAndAddState(s state.State, sk *[]byte) (state.SignedState,
 		return state.SignedState{}, fmt.Errorf("could not add signed state to channel %w", err)
 	}
 	return ss, nil
+}
+
+func (c *Channel) UpdateWithChainEvent(event chainservice.Event) (*Channel, error) {
+	updated := c.Clone()
+	if event.BlockNum() <= updated.latestBlockNumber {
+		return c, nil // ignore stale information TODO: is this reorg safe?
+	}
+	updated.latestBlockNumber = event.BlockNum()
+	switch e := event.(type) {
+	case chainservice.AllocationUpdatedEvent:
+		updated.OnChainFunding[e.AssetAddress] = e.AssetAmount
+	case chainservice.DepositedEvent:
+		updated.OnChainFunding[e.Asset] = e.NowHeld
+	case chainservice.ConcludedEvent:
+		break
+	default:
+		return updated, fmt.Errorf("channel %+v cannot handle event %+v", updated, event)
+	}
+	return updated, nil
 }

--- a/node/engine/chainservice/chainservice.go
+++ b/node/engine/chainservice/chainservice.go
@@ -47,7 +47,7 @@ type DepositedEvent struct {
 }
 
 func (de DepositedEvent) String() string {
-	return "Deposited " + de.Asset.String() + " leaving " + de.NowHeld.String() + " now held against channel " + de.channelID.String() + " at Block " + fmt.Sprint(de.BlockNum)
+	return "Deposited " + de.Asset.String() + " leaving " + de.NowHeld.String() + " now held against channel " + de.channelID.String() + " at Block " + fmt.Sprint(de.blockNum)
 }
 
 // AllocationUpdated is an internal representation of the AllocationUpdated blockchain event
@@ -58,7 +58,7 @@ type AllocationUpdatedEvent struct {
 }
 
 func (aue AllocationUpdatedEvent) String() string {
-	return "Channel " + aue.channelID.String() + " has had allocation updated to " + aue.assetAndAmount.String() + " at Block " + fmt.Sprint(aue.BlockNum)
+	return "Channel " + aue.channelID.String() + " has had allocation updated to " + aue.assetAndAmount.String() + " at Block " + fmt.Sprint(aue.blockNum)
 }
 
 // ConcludedEvent is an internal representation of the Concluded blockchain event
@@ -67,7 +67,7 @@ type ConcludedEvent struct {
 }
 
 func (ce ConcludedEvent) String() string {
-	return "Channel " + ce.channelID.String() + " concluded at Block " + fmt.Sprint(ce.BlockNum)
+	return "Channel " + ce.channelID.String() + " concluded at Block " + fmt.Sprint(ce.blockNum)
 }
 
 func NewDepositedEvent(channelId types.Destination, blockNum uint64, assetAddress common.Address, nowHeld *big.Int) DepositedEvent {

--- a/node/engine/chainservice/chainservice.go
+++ b/node/engine/chainservice/chainservice.go
@@ -13,16 +13,21 @@ import (
 // Event dictates which methods all chain events must implement
 type Event interface {
 	ChannelID() types.Destination
+	BlockNum() uint64
 }
 
 // commonEvent declares fields shared by all chain events
 type commonEvent struct {
 	channelID types.Destination
-	BlockNum  uint64
+	blockNum  uint64
 }
 
 func (ce commonEvent) ChannelID() types.Destination {
 	return ce.channelID
+}
+
+func (ce commonEvent) BlockNum() uint64 {
+	return ce.blockNum
 }
 
 type assetAndAmount struct {

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -253,7 +253,7 @@ func (ecs *EthChainService) dispatchChainEvents(logs []ethTypes.Log) error {
 				return fmt.Errorf("error in ParseConcluded: %w", err)
 			}
 
-			event := ConcludedEvent{commonEvent: commonEvent{channelID: ce.ChannelId, BlockNum: l.BlockNumber}}
+			event := ConcludedEvent{commonEvent: commonEvent{channelID: ce.ChannelId, blockNum: l.BlockNumber}}
 			ecs.out <- event
 
 		case challengeRegisteredTopic:

--- a/node/engine/chainservice/eth_chainservice_FEVM_test.go
+++ b/node/engine/chainservice/eth_chainservice_FEVM_test.go
@@ -195,7 +195,7 @@ func testAgainstEndpoint(t *testing.T, endpoint string, logFile string, pk *ecds
 			}
 
 		case ConcludedEvent:
-			expectedEvent := ConcludedEvent{commonEvent: commonEvent{channelID: cId, BlockNum: 3}}
+			expectedEvent := ConcludedEvent{commonEvent: commonEvent{channelID: cId, blockNum: 3}}
 			if diff := cmp.Diff(expectedEvent, receivedEvent,
 				cmp.AllowUnexported(ConcludedEvent{}, commonEvent{}),
 				ignoreBlockNum, ignoreNowHeld); diff != "" {

--- a/node/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/node/engine/chainservice/simulated_backend_chainservice_test.go
@@ -123,7 +123,7 @@ func TestSimulatedBackendChainService(t *testing.T) {
 	}
 	// Check that the recieved event matches the expected event
 	concludedEvent := <-out
-	expectedEvent := ConcludedEvent{commonEvent: commonEvent{channelID: cId, BlockNum: 5}}
+	expectedEvent := ConcludedEvent{commonEvent: commonEvent{channelID: cId, blockNum: 5}}
 	if diff := cmp.Diff(expectedEvent, concludedEvent, cmp.AllowUnexported(ConcludedEvent{}, commonEvent{})); diff != "" {
 		t.Fatalf("Received event did not match expectation; (-want +got):\n%s", diff)
 	}

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -428,7 +428,11 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 	if err != nil {
 		return EngineEvent{}, err
 	}
-	e.store.SetChannel(updatedChannel)
+
+	err = e.store.SetChannel(updatedChannel)
+	if err != nil {
+		return EngineEvent{}, err
+	}
 
 	objective, ok := e.store.GetObjectiveByChannelId(chainEvent.ChannelID())
 

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -28,13 +28,13 @@ import (
 
 // ErrUnhandledChainEvent is an engine error when the the engine cannot process a chain event
 type ErrUnhandledChainEvent struct {
-	event     chainservice.Event
-	objective protocols.Objective
-	reason    string
+	event   chainservice.Event
+	channel channel.Channel
+	reason  string
 }
 
 func (uce *ErrUnhandledChainEvent) Error() string {
-	return fmt.Sprintf("chain event %#v could not be handled by objective %#v due to: %s", uce.event, uce.objective, uce.reason)
+	return fmt.Sprintf("chain event %#v could not be handled by channel %#v due to: %s", uce.event, uce.channel, uce.reason)
 }
 
 type ErrGetObjective struct {
@@ -414,7 +414,9 @@ func (e *Engine) handleMessage(message protocols.Message) (EngineEvent, error) {
 func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, error) {
 	defer e.metrics.RecordFunctionDuration()()
 	e.logger.Printf("handling chain event: %v", chainEvent)
-	objective, ok := e.store.GetObjectiveByChannelId(chainEvent.ChannelID())
+
+	c, ok := e.store.GetChannelById(chainEvent.ChannelID())
+
 	if !ok {
 		// TODO: Right now the chain service returns chain events for ALL channels even those we aren't involved in
 		// for now we can ignore channels we aren't involved in
@@ -422,15 +424,18 @@ func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, e
 		return EngineEvent{}, nil
 	}
 
-	eventHandler, ok := objective.(chainservice.ChainEventHandler)
-	if !ok {
-		return EngineEvent{}, &ErrUnhandledChainEvent{event: chainEvent, objective: objective, reason: "objective does not handle chain events"}
-	}
-	updatedEventHandler, err := eventHandler.UpdateWithChainEvent(chainEvent)
+	updatedChannel, err := c.UpdateWithChainEvent(chainEvent)
 	if err != nil {
 		return EngineEvent{}, err
 	}
-	return e.attemptProgress(updatedEventHandler)
+	e.store.SetChannel(updatedChannel)
+
+	objective, ok := e.store.GetObjectiveByChannelId(chainEvent.ChannelID())
+
+	if ok {
+		return e.attemptProgress(objective)
+	}
+	return EngineEvent{}, nil
 }
 
 // handleObjectiveRequest handles an ObjectiveRequest (triggered by a client API call).

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -219,19 +219,12 @@ func (o *Objective) Update(p protocols.ObjectivePayload) (protocols.Objective, e
 	return &updated, nil
 }
 
-// UpdateWithChainEvent updates the objective with observed on-chain data.
-//
-// Only Allocation Updated events are currently handled.
+// UpdateWithChainEvent updates the underlying channel with observed on-chain data.
 func (o *Objective) UpdateWithChainEvent(event chainservice.Event) (protocols.Objective, error) {
 	updated := o.clone()
-	switch e := event.(type) {
-	case chainservice.AllocationUpdatedEvent:
-		// todo: check block number
-		updated.C.OnChainFunding[e.AssetAddress] = e.AssetAmount
-	case chainservice.ConcludedEvent:
-		break
-	default:
-		return &updated, fmt.Errorf("objective %+v cannot handle event %+v", updated, event)
+	_, err := updated.C.UpdateWithChainEvent(event)
+	if err != nil {
+		return &Objective{}, err
 	}
 	return &updated, nil
 }

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -12,7 +12,6 @@ import (
 	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
-	"github.com/statechannels/go-nitro/node/engine/chainservice"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -216,16 +215,6 @@ func (o *Objective) Update(p protocols.ObjectivePayload) (protocols.Objective, e
 	updated := o.clone()
 	updated.C.AddSignedState(ss)
 
-	return &updated, nil
-}
-
-// UpdateWithChainEvent updates the underlying channel with observed on-chain data.
-func (o *Objective) UpdateWithChainEvent(event chainservice.Event) (protocols.Objective, error) {
-	updated := o.clone()
-	_, err := updated.C.UpdateWithChainEvent(event)
-	if err != nil {
-		return &Objective{}, err
-	}
 	return &updated, nil
 }
 

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -275,7 +275,7 @@ func TestCrankBob(t *testing.T) {
 	}
 
 	// The third crank. Bob is expected to enter the terminal state of the defunding protocol.
-	updated, err = updated.(*Objective).UpdateWithChainEvent(chainservice.NewAllocationUpdatedEvent(types.Destination{}, 1, common.Address{}, common.Big0))
+	_, err = updated.(*Objective).C.UpdateWithChainEvent(chainservice.NewAllocationUpdatedEvent(types.Destination{}, 1, common.Address{}, common.Big0))
 
 	if err != nil {
 		t.Error(err)

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -275,7 +275,7 @@ func TestCrankBob(t *testing.T) {
 	}
 
 	// The third crank. Bob is expected to enter the terminal state of the defunding protocol.
-	updated, err = updated.(*Objective).UpdateWithChainEvent(chainservice.NewAllocationUpdatedEvent(types.Destination{}, 0, common.Address{}, common.Big0))
+	updated, err = updated.(*Objective).UpdateWithChainEvent(chainservice.NewAllocationUpdatedEvent(types.Destination{}, 1, common.Address{}, common.Big0))
 
 	if err != nil {
 		t.Error(err)

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -12,7 +12,6 @@ import (
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
-	"github.com/statechannels/go-nitro/node/engine/chainservice"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -272,16 +271,6 @@ func (o *Objective) Update(p protocols.ObjectivePayload) (protocols.Objective, e
 		}
 	}
 	updated.C.AddSignedState(ss)
-	return &updated, nil
-}
-
-// UpdateWithChainEvent updates the underlying channel with observed on-chain data.
-func (o *Objective) UpdateWithChainEvent(event chainservice.Event) (protocols.Objective, error) {
-	updated := o.clone()
-	_, err := updated.C.UpdateWithChainEvent(event)
-	if err != nil {
-		return &Objective{}, err
-	}
 	return &updated, nil
 }
 

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -275,9 +275,7 @@ func (o *Objective) Update(p protocols.ObjectivePayload) (protocols.Objective, e
 	return &updated, nil
 }
 
-// UpdateWithChainEvent updates the objective with observed on-chain data.
-//
-// Only Channel Deposit events are currently handled.
+// UpdateWithChainEvent updates the underlying channel with observed on-chain data.
 func (o *Objective) UpdateWithChainEvent(event chainservice.Event) (protocols.Objective, error) {
 	updated := o.clone()
 	_, err := updated.C.UpdateWithChainEvent(event)

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -156,7 +156,7 @@ func TestUpdate(t *testing.T) {
 		common.Address{}: big.NewInt(3),
 	}
 	highBlockNum := uint64(200)
-	updatedObjective, err = s.UpdateWithChainEvent(
+	_, err = updated.C.UpdateWithChainEvent(
 		chainservice.NewDepositedEvent(
 			types.Destination{}, highBlockNum, common.Address{}, big.NewInt(3),
 		),
@@ -174,11 +174,14 @@ func TestUpdate(t *testing.T) {
 	staleFunding[common.Address{}] = big.NewInt(2)
 	lowBlockNum := uint64(100)
 
-	updatedObjective, _ = updated.UpdateWithChainEvent(
+	_, err = updated.C.UpdateWithChainEvent(
 		chainservice.NewDepositedEvent(
 			types.Destination{}, uint64(lowBlockNum), common.Address{}, big.NewInt(2),
 		),
 	)
+	if err != nil {
+		t.Error(err)
+	}
 
 	updated = updatedObjective.(*Objective)
 

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -168,9 +168,6 @@ func TestUpdate(t *testing.T) {
 	if !updated.C.OnChainFunding.Equal(newFunding) {
 		t.Error(`Objective data not updated as expected`, updated.C.OnChainFunding, newFunding)
 	}
-	if updated.latestBlockNumber != uint64(highBlockNum) {
-		t.Error("Latest block number not updated as expected", updated.latestBlockNumber, highBlockNum)
-	}
 
 	// Update with stale funding information should be ignored
 	staleFunding := types.Funds{}
@@ -187,9 +184,6 @@ func TestUpdate(t *testing.T) {
 
 	if updated.C.OnChainFunding.Equal(staleFunding) {
 		t.Error("OnChainFunding was updated to stale funding information", updated.C.OnChainFunding, staleFunding)
-	}
-	if updated.latestBlockNumber == uint64(lowBlockNum) {
-		t.Error("latestBlockNumber was updated to stale block number", updated.latestBlockNumber, lowBlockNum)
 	}
 }
 

--- a/protocols/directfund/serde.go
+++ b/protocols/directfund/serde.go
@@ -17,7 +17,6 @@ type jsonObjective struct {
 	MyDepositSafetyThreshold types.Funds
 	MyDepositTarget          types.Funds
 	FullyFundedThreshold     types.Funds
-	LatestBlockNumber        uint64
 	TransactionSumbmitted    bool
 }
 
@@ -31,7 +30,6 @@ func (o Objective) MarshalJSON() ([]byte, error) {
 		o.myDepositSafetyThreshold,
 		o.myDepositTarget,
 		o.fullyFundedThreshold,
-		o.latestBlockNumber,
 		o.transactionSubmitted,
 	}
 	return json.Marshal(jsonDFO)
@@ -59,7 +57,6 @@ func (o *Objective) UnmarshalJSON(data []byte) error {
 	o.fullyFundedThreshold = jsonDFO.FullyFundedThreshold
 	o.myDepositTarget = jsonDFO.MyDepositTarget
 	o.myDepositSafetyThreshold = jsonDFO.MyDepositSafetyThreshold
-	o.latestBlockNumber = jsonDFO.LatestBlockNumber
 	o.transactionSubmitted = jsonDFO.TransactionSumbmitted
 
 	return nil


### PR DESCRIPTION
This has the advantage of centralising our logic around chain event handling / block number checks and so on. 

It also means that we don't rely on a particular objective being active / approved / to catch information from the chain. 

Towards #1531 