### PR TITLE
Use a consistent node version: 18.15.0

### DIFF
--- a/.github/workflows/ts-rpc-test.yml
+++ b/.github/workflows/ts-rpc-test.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: "yarn"
+          node-version: "18.15.0"
 
       # Install foundry so we can use it to run a chain instance
       - name: Install Foundry

--- a/.github/workflows/yarn-build.yml
+++ b/.github/workflows/yarn-build.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: 'yarn'
+          node-version: "18.15.0"
       - name: Install dependencies
         run: yarn
       - name: Build everything

--- a/nitro-protocol/package.json
+++ b/nitro-protocol/package.json
@@ -11,6 +11,9 @@
     "contracts",
     "dist"
   ],
+  "engines": {
+    "node": ">=18.5.0"
+  },
   "types": "dist/src/index.d.ts",
   "scripts": {
     "build:typescript": "rm -rf dist; npx tsc",

--- a/packages/nitro-gui/package.json
+++ b/packages/nitro-gui/package.json
@@ -51,6 +51,9 @@
     "typescript": "^5.0.2",
     "vite": "^4.3.2"
   },
+  "engines": {
+    "node": ">=18.5.0"
+  },
   "msw": {
     "workerDirectory": "public"
   }

--- a/packages/nitro-rpc-client/package.json
+++ b/packages/nitro-rpc-client/package.json
@@ -47,5 +47,8 @@
     "prettier-plugin-packagejson": "^2.2.18",
     "ts-jest": "^29.1.0",
     "yargs": "^17.7.1"
+  },
+  "engines": {
+    "node": ">=18.5.0"
   }
 }

--- a/packages/payment-proxy-client/package.json
+++ b/packages/payment-proxy-client/package.json
@@ -25,5 +25,8 @@
     "eslint-plugin-react-refresh": "^0.3.4",
     "typescript": "^5.0.2",
     "vite": "^4.3.9"
+  },
+  "engines": {
+    "node": ">=18.5.0"
   }
 }


### PR DESCRIPTION
This PR has two main changes:
- It updates our CI scripts so we use the same node version in every github workflow
- Add the version of node supported to our package.json files, so it's easy to know which version to use.

I've chosen to use version 18.5.0, since that was what some of our [existing CI scripts](https://github.com/statechannels/go-nitro/blob/ea5aa984773edfe024a76c2d8ddc0c6ba5e01655/.github/workflows/node.yml#L19)