### PR TITLE
Add gui to cloud docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,6 @@
 artifacts
 data
+docs
 
 .adr
-.yarn
-docs
-node_modules
-packages
+.github

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 artifacts
 data
+node_modules
 docs
 
 .adr

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 docker/cloud/build:
 	docker build -f docker/cloud/Dockerfile -t go-nitro-cloud .
 
+docker/cloud/start:
+	docker remove go-nitro-cloud || true
+	docker run -it -d --name go-nitro-cloud -p 3005:3005 -p 4005:4005 -p 5005:5005 go-nitro-cloud
+
 docker/cloud/push:
 	docker tag go-nitro-cloud:latest registry.digitalocean.com/magmo/go-nitro:latest
 	docker push registry.digitalocean.com/magmo/go-nitro:latest

--- a/docker/cloud/Dockerfile
+++ b/docker/cloud/Dockerfile
@@ -1,17 +1,34 @@
 FROM golang:1.20-bullseye AS builder
+
+# Install Node.js v18.x
+RUN apt-get update && apt-get install -y curl
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
+RUN apt-get install -y nodejs
+
+# Install Yarn v3.5.1
+RUN corepack enable
+RUN yarn set version 3.5.1
+RUN yarn --version
+
+# Copy files into image
 WORKDIR /app
 COPY . .
 COPY ./docker/cloud/config.toml .
-RUN go build -v -o nitro .
 
+# Build the binary
+RUN yarn workspace nitro-gui install
+RUN yarn workspace nitro-gui build
+RUN go build -v -o nitro -tags embed_ui .
+
+# Reduce image size
 FROM debian:bullseye-slim
 RUN apt-get update
 RUN apt-get install -y ca-certificates
 RUN rm -rf /var/lib/apt/lists/*
-WORKDIR /app/
+WORKDIR /app
 COPY --from=builder /app/nitro .
 COPY --from=builder /app/config.toml .
 
-EXPOSE 3005 4005
+EXPOSE 3005 4005 5005
 
 CMD ["./nitro", "--config", "./config.toml"]

--- a/docker/cloud/config.toml
+++ b/docker/cloud/config.toml
@@ -4,10 +4,10 @@ msgport = 3005
 rpcport = 4005
 guiport = 5005
 
-# State Channel Public Address: 0x69Ae2DF44965e6f87b25bc648E097B00762583Dc
+# State Channel Public Address: 0x89825D58A7E2C198a06125be9CD0631317f9A07B
 pk = ""
 
-# Chain Public Address: 0x8571687Bdc6F3ff6ba5d8E97B59cB62A7d638B4b
+# Chain Public Address: 0x16e43DDc5FE417046Da7A0C469cCD4DE6b4764fA
 chainpk = ""
 
 naaddress = "0x86dbCA138C8aF6f9710d17F892bA788e87BeF000"

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -341,14 +341,12 @@ out:
 				errorChan <- fmt.Errorf("subscribeNewHead failed on resubscribe: %w", err)
 				break out
 			}
-			ecs.logger.Trace().Msg("resubscribed to new blocks")
+			ecs.logger.Debug().Msg("resubscribed to new blocks")
 
 		case newBlock := <-newBlockChan:
 			newBlockNum := newBlock.Number.Uint64()
 			ecs.logger.Debug().Msgf("detected new block: %d", newBlockNum)
 			ecs.updateEventTracker(errorChan, &newBlockNum, nil)
-
-			ecs.logger.Debug().Msgf("detected new block: %d", newBlockNum)
 		}
 	}
 }


### PR DESCRIPTION
Updates the `docker/cloud/Dockerfile` to build the `nitro-gui` package. The gui then gets included in the `go build` and is exposed on port 5005 of the docker image.

This change increased the docker image size from 145MB --> 164MB.