### PR TITLE
Increase start-rpc-server timeout to reduce flicker

### DIFF
--- a/cmd/start-rpc-servers/main.go
+++ b/cmd/start-rpc-servers/main.go
@@ -130,7 +130,7 @@ func main() {
 			running = append(running, client)
 
 			const IVAN_ADDRESS = "http://127.0.0.1:4008/api/v1"
-			err = waitForRpcClient(IVAN_ADDRESS, 500*time.Millisecond, 1*time.Minute)
+			err = waitForRpcClient(IVAN_ADDRESS, 500*time.Millisecond, 5*time.Minute)
 			if err != nil {
 				utils.StopCommands(running...)
 				panic(err)


### PR DESCRIPTION
Fixes #1552 by increasing the timeout for `start-rpc-servers` to wait for Irene. Previously we were seeing failures where `start-rpc-servers` would timeout waiting for Irene to start(so she can be the boot peer).