### PR TITLE
Check if start-rpc-servers fails

### DIFF
--- a/.github/workflows/ts-rpc-test.yml
+++ b/.github/workflows/ts-rpc-test.yml
@@ -32,17 +32,17 @@ jobs:
           echo "NITRO_PID=$!" >> $GITHUB_ENV
       - name: Check that start-rpc-servers has started
         run: |
-          {
-            # Check that start-rpc-server is running every 5 seconds 6 times
-            for i in {1..6}; do
-            if ! ps -p $NITRO_PID > /dev/null; then
-                # If the process is not running, exit with an error
-                echo "start-rpc-servers not running!"
-                exit 1
-            fi
-            sleep 5
-            done
-          } &
+
+          echo $NITRO_PID
+          # Check that start-rpc-server is running every 5 seconds 6 times
+          for i in {1..6}; do
+          if ! ps -p $NITRO_PID > /dev/null; then
+              # If the process is not running, exit with an error
+              echo "start-rpc-servers not running!"
+              exit 1
+          fi
+          sleep 5
+          done
 
       - name: Run Create Channels script
         # TODO: We could write a test specific script that creates channels and checks the results

--- a/.github/workflows/ts-rpc-test.yml
+++ b/.github/workflows/ts-rpc-test.yml
@@ -26,27 +26,19 @@ jobs:
       - name: Build UI
         run: make ui/build
 
-      - name: Run go-nitro RPC servers with GUI
+      - name: Run go-nitro RPC servers and check if they crashed
         run: |
           go run ./cmd/start-rpc-servers -ui=true &> output.log &
-
-          NITRO_PID=$!
-
-          # Periodically check the status of the start-rpc-server process
-          while true; do
-          # Check if the process is still running
+          echo "NITRO_PID=$!" >> $GITHUB_ENV
+      - name: Check that start-rpc-servers has started
+        run: |
+          for i in {1..5}; do
           if ! ps -p $NITRO_PID > /dev/null; then
-              # If the process has stopped, check its exit code
-              wait $NITRO_PID
-              EXIT_CODE=$?
-              if [ $EXIT_CODE -ne 0 ]; then
-              echo "start-rpc-servers has failed with exit code $EXIT_CODE"
-              exit $EXIT_CODE
-              fi
-              break
+              # If the process is not running, exit with an error
+              echo "start-rpc-servers not running!"
+              exit 1
           fi
-          # Sleep for a short duration before checking again
-          sleep 5
+          sleep 2  
           done
 
       - name: Run Create Channels script

--- a/.github/workflows/ts-rpc-test.yml
+++ b/.github/workflows/ts-rpc-test.yml
@@ -27,7 +27,27 @@ jobs:
         run: make ui/build
 
       - name: Run go-nitro RPC servers with GUI
-        run: go run ./cmd/start-rpc-servers -ui=true &> output.log &
+        run: |
+          go run ./cmd/start-rpc-servers -ui=true &> output.log &
+
+          NITRO_PID=$!
+
+          # Periodically check the status of the start-rpc-server process
+          while true; do
+          # Check if the process is still running
+          if ! ps -p $NITRO_PID > /dev/null; then
+              # If the process has stopped, check its exit code
+              wait $NITRO_PID
+              EXIT_CODE=$?
+              if [ $EXIT_CODE -ne 0 ]; then
+              echo "start-rpc-servers has failed with exit code $EXIT_CODE"
+              exit $EXIT_CODE
+              fi
+              break
+          fi
+          # Sleep for a short duration before checking again
+          sleep 5
+          done
 
       - name: Run Create Channels script
         # TODO: We could write a test specific script that creates channels and checks the results

--- a/.github/workflows/ts-rpc-test.yml
+++ b/.github/workflows/ts-rpc-test.yml
@@ -32,14 +32,17 @@ jobs:
           echo "NITRO_PID=$!" >> $GITHUB_ENV
       - name: Check that start-rpc-servers has started
         run: |
-          for i in {1..5}; do
-          if ! ps -p $NITRO_PID > /dev/null; then
-              # If the process is not running, exit with an error
-              echo "start-rpc-servers not running!"
-              exit 1
-          fi
-          sleep 2  
-          done
+          {
+            # Check that start-rpc-server is running every 5 seconds 6 times
+            for i in {1..6}; do
+            if ! ps -p $NITRO_PID > /dev/null; then
+                # If the process is not running, exit with an error
+                echo "start-rpc-servers not running!"
+                exit 1
+            fi
+            sleep 5
+            done
+          } &
 
       - name: Run Create Channels script
         # TODO: We could write a test specific script that creates channels and checks the results

--- a/cmd/start-rpc-servers/main.go
+++ b/cmd/start-rpc-servers/main.go
@@ -96,6 +96,9 @@ func main() {
 		Flags: flags,
 
 		Action: func(cCtx *cli.Context) error {
+			if !cCtx.Bool("should-not-crash") {
+				panic("SOME CRITICAL ERROR TO CATCH")
+			}
 			running := []*exec.Cmd{}
 			if cCtx.Bool(START_ANVIL) {
 				anvilCmd, err := chain.StartAnvil()
@@ -150,6 +153,7 @@ func main() {
 			return nil
 		},
 	}
+
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/start-rpc-servers/main.go
+++ b/cmd/start-rpc-servers/main.go
@@ -130,7 +130,7 @@ func main() {
 			running = append(running, client)
 
 			const IVAN_ADDRESS = "http://127.0.0.1:4008/api/v1"
-			err = waitForRpcClient(IVAN_ADDRESS, 500*time.Millisecond, 1*time.Minute)
+			err = waitForRpcClient(IVAN_ADDRESS, 500*time.Millisecond, 5*time.Minute)
 			if err != nil {
 				utils.StopCommands(running...)
 				panic(err)


### PR DESCRIPTION
It's possible to add an action that runs in the background and periodically checks if the start-rpc-server script crashes.