### PR TITLE
Create github action to deploy cloud node to Digital Ocean

### DIFF
--- a/.github/workflows/deploy-cloud-node.yml
+++ b/.github/workflows/deploy-cloud-node.yml
@@ -24,10 +24,7 @@ jobs:
         env:
           SSH_PRIVATE_KEY: ${{ secrets.DO_SSH_PRIVATE_KEY }}
         run: |
-          echo "$SSH_PRIVATE_KEY" > private_key.pem
-          chmod 600 private_key.pem
-          scp -o StrictHostKeyChecking=no -i private_key.pem docker-compose.yml root@67.207.88.72:~/
-          ssh -o StrictHostKeyChecking=no -i private_key.pem root@67.207.88.72 <<'ENDSSH'
+          echo "$SSH_PRIVATE_KEY" | ssh -o StrictHostKeyChecking=no -i /dev/stdin root@67.207.88.72 <<'ENDSSH'
             docker pull registry.digitalocean.com/magmo/go-nitro:latest
             docker run -it -d -p 3005:3005 -p 4005:4005 -p 5005:5005 -e SC_PK=$DO_SC_PK -e CHAIN_PK=$DO_CHAIN_PK registry.digitalocean.com/magmo/go-nitro:latest
           ENDSSH

--- a/.github/workflows/deploy-cloud-node.yml
+++ b/.github/workflows/deploy-cloud-node.yml
@@ -29,5 +29,5 @@ jobs:
           scp -o StrictHostKeyChecking=no -i private_key.pem docker-compose.yml root@67.207.88.72:~/
           ssh -o StrictHostKeyChecking=no -i private_key.pem root@67.207.88.72 <<'ENDSSH'
             docker pull registry.digitalocean.com/magmo/go-nitro:latest
-            docker run -it -d -p 3005:3005 -p 4005:4005 -e SC_PK=$DO_SC_PK -e CHAIN_PK=$DO_CHAIN_PK registry.digitalocean.com/magmo/go-nitro:latest
+            docker run -it -d -p 3005:3005 -p 4005:4005 -p 5005:5005 -e SC_PK=$DO_SC_PK -e CHAIN_PK=$DO_CHAIN_PK registry.digitalocean.com/magmo/go-nitro:latest
           ENDSSH

--- a/.github/workflows/deploy-cloud-node.yml
+++ b/.github/workflows/deploy-cloud-node.yml
@@ -1,0 +1,33 @@
+name: Deploy to DigitalOcean
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Build Docker image
+        run: make docker/cloud/build
+
+      - name: Login to DigitalOcean Docker Registry
+        run: docker login -u ${{ secrets.DO_API_KEY }} -p ${{ secrets.DO_API_KEY }} registry.digitalocean.com
+
+      - name: Push Docker image to DigitalOcean
+        run: make docker/cloud/push
+
+      - name: Deploy to Droplet
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.DO_SSH_PRIVATE_KEY }}
+        run: |
+          echo "$SSH_PRIVATE_KEY" > private_key.pem
+          chmod 600 private_key.pem
+          scp -o StrictHostKeyChecking=no -i private_key.pem docker-compose.yml root@67.207.88.72:~/
+          ssh -o StrictHostKeyChecking=no -i private_key.pem root@67.207.88.72 <<'ENDSSH'
+            docker pull registry.digitalocean.com/magmo/go-nitro:latest
+            docker run -it -d -p 3005:3005 -p 4005:4005 -e SC_PK=$DO_SC_PK -e CHAIN_PK=$DO_CHAIN_PK registry.digitalocean.com/magmo/go-nitro:latest
+          ENDSSH

--- a/.github/workflows/deploy-cloud-node.yml
+++ b/.github/workflows/deploy-cloud-node.yml
@@ -24,7 +24,10 @@ jobs:
         env:
           SSH_PRIVATE_KEY: ${{ secrets.DO_SSH_PRIVATE_KEY }}
         run: |
-          echo "$SSH_PRIVATE_KEY" | ssh -o StrictHostKeyChecking=no -i /dev/stdin root@67.207.88.72 <<'ENDSSH'
+          echo "$SSH_PRIVATE_KEY" > private_key.pem
+          chmod 600 private_key.pem
+          ssh -o StrictHostKeyChecking=no -i private_key.pem root@67.207.88.72 <<'ENDSSH'
             docker pull registry.digitalocean.com/magmo/go-nitro:latest
             docker run -it -d -p 3005:3005 -p 4005:4005 -p 5005:5005 -e SC_PK=$DO_SC_PK -e CHAIN_PK=$DO_CHAIN_PK registry.digitalocean.com/magmo/go-nitro:latest
           ENDSSH
+          rm private_key.pem

--- a/main.go
+++ b/main.go
@@ -45,6 +45,12 @@ func main() {
 	var msgPort, rpcPort, guiPort int
 	var useNats, useDurableStore bool
 
+	// urfave default precedence for flag value sources (highest to lowest):
+	// 1. Command line flag value
+	// 2. Environment variable (if specified)
+	// 3. Configuration file (if specified)
+	// 4. Default defined on the flag
+
 	flags := []cli.Flag{
 		&cli.StringFlag{
 			Name:  CONFIG,
@@ -70,6 +76,7 @@ func main() {
 			Usage:       "Specifies the private key used by the nitro node.",
 			Category:    KEYS_CATEGORY,
 			Destination: &pkString,
+			EnvVars:     []string{"SC_PK"},
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:        CHAIN_URL,
@@ -90,6 +97,7 @@ func main() {
 			Usage:       "Specifies the private key to use when interacting with the chain.",
 			Category:    KEYS_CATEGORY,
 			Destination: &chainPk,
+			EnvVars:     []string{"CHAIN_PK"},
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:        NA_ADDRESS,


### PR DESCRIPTION
In order to securely configure our cloud node, we need to be able to pass the `pk` and `chainpk` values as env vars instead of reading them from a config file (which is stored on github and is therefore visible to anyone who views this repo). I added this comment to `main.go` to remind us about the default order of precedence:
```
	// urfave default precedence for flag value sources (highest to lowest):
	// 1. Command line flag value
	// 2. Environment variable (if specified)
	// 3. Configuration file (if specified)
	// 4. Default defined on the flag
```

This PR also adds a github action .yml file to automatically deploy the nitro node to Digital Ocean. Complementary work for this PR was to store the following values in in github secrets. 

* `DO_API_KEY`
* `DO_SSH_PRIVATE_KEY`
* `DO_SC_PK`
* `DO_CHAIN_PK`

`DO_SC_PK` and `DO_CHAIN_PK` are passed as env vars to the docker container running inside our Digital Ocean droplet.