### PR TITLE
CI checks for race conditions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,6 +33,11 @@ jobs:
       - name: Test
         run: go test ./... -count=2 -shuffle=on -timeout 1m -v -failfast
 
+      - name: Check for race conditions
+        # Only executes when triggered by a push to the main branch
+        if: ${{ github.ref_name == 'main' }}
+        run: go test ./... -timeout 2m -v -failfast -race
+
       - name: Archive logs
         if: always()
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
When a commit is pushed to the `main` branch, we run our standard Go unit test CI with an additional test run that checks for race conditions.