### PR TITLE
Fix github action for deploying cloud node

### DIFF
--- a/.github/workflows/deploy-cloud-node.yml
+++ b/.github/workflows/deploy-cloud-node.yml
@@ -28,6 +28,7 @@ jobs:
           chmod 600 private_key.pem
           ssh -o StrictHostKeyChecking=no -i private_key.pem root@67.207.88.72 <<'ENDSSH'
             docker pull registry.digitalocean.com/magmo/go-nitro:latest
-            docker run -it -d -p 3005:3005 -p 4005:4005 -p 5005:5005 -e SC_PK=$DO_SC_PK -e CHAIN_PK=$DO_CHAIN_PK registry.digitalocean.com/magmo/go-nitro:latest
+            docker stop nitro_iris || true
+            docker run -it -d --name nitro_iris -p 3005:3005 -p 4005:4005 -p 5005:5005 -e SC_PK=$DO_SC_PK -e CHAIN_PK=$DO_CHAIN_PK registry.digitalocean.com/magmo/go-nitro:latest
           ENDSSH
           rm private_key.pem


### PR DESCRIPTION
We need to stop the previous docker container (if there is one running) before starting the new one.