### PR TITLE
Split data in `Channel` class into `OnChain` and `OffChain` sub structs

### DIFF
--- a/channel/virtual.go
+++ b/channel/virtual.go
@@ -42,8 +42,8 @@ func (v *VirtualChannel) Clone() *VirtualChannel {
 }
 
 func (v *VirtualChannel) GetPaidAndRemaining() (*big.Int, *big.Int) {
-	remaining := v.SignedStateForTurnNum[v.latestSupportedStateTurnNum].State().Outcome[0].Allocations[0].Amount
-	paid := v.SignedStateForTurnNum[v.latestSupportedStateTurnNum].State().Outcome[0].Allocations[1].Amount
+	remaining := v.OffChain.SignedStateForTurnNum[v.OffChain.LatestSupportedStateTurnNum].State().Outcome[0].Allocations[0].Amount
+	paid := v.OffChain.SignedStateForTurnNum[v.OffChain.LatestSupportedStateTurnNum].State().Outcome[0].Allocations[1].Amount
 
 	return paid, remaining
 }

--- a/node/engine/chainservice/chainservice.go
+++ b/node/engine/chainservice/chainservice.go
@@ -66,6 +66,11 @@ type ConcludedEvent struct {
 	commonEvent
 }
 
+type ChallengeEvent struct {
+	commonEvent
+	// TODO fill out other fields
+}
+
 func (ce ConcludedEvent) String() string {
 	return "Channel " + ce.channelID.String() + " concluded at Block " + fmt.Sprint(ce.blockNum)
 }

--- a/protocols/directdefund/directdefund.go
+++ b/protocols/directdefund/directdefund.go
@@ -288,15 +288,15 @@ func CreateChannelFromConsensusChannel(cc consensus_channel.ConsensusChannel) (*
 	if err != nil {
 		return &channel.Channel{}, err
 	}
-	c.OnChainFunding = cc.OnChainFunding.Clone()
 	c.AddSignedState(cc.SupportedSignedState())
+	c.OnChain.Holdings = cc.OnChainFunding
 
 	return c, nil
 }
 
 // fullyWithdrawn returns true if the channel contains no assets on chain
 func (o *Objective) fullyWithdrawn() bool {
-	return !o.C.OnChainFunding.IsNonZero()
+	return !o.C.OnChain.Holdings.IsNonZero()
 }
 
 // clone returns a deep copy of the receiver.

--- a/protocols/directdefund/directdefund_test.go
+++ b/protocols/directdefund/directdefund_test.go
@@ -192,7 +192,7 @@ func TestCrankAlice(t *testing.T) {
 	}
 
 	// The third crank. Alice is expected to enter the terminal state of the defunding protocol.
-	updated.(*Objective).C.OnChainFunding = types.Funds{}
+	updated.(*Objective).C.OnChain.Holdings = types.Funds{}
 	_, se, wf, err = updated.Crank(&alice.PrivateKey)
 	if err != nil {
 		t.Error(err)

--- a/protocols/directfund/directfund.go
+++ b/protocols/directfund/directfund.go
@@ -216,7 +216,7 @@ func (dfo *Objective) CreateConsensusChannel() (*consensus_channel.ConsensusChan
 
 	if ledger.MyIndex == uint(consensus_channel.Leader) {
 		con, err := consensus_channel.NewLeaderChannel(ledger.FixedPart, turnNum, outcome, signatures)
-		con.OnChainFunding = ledger.OnChainFunding.Clone() // Copy OnChainFunding so we don't lose this information
+		con.OnChainFunding = ledger.OnChain.Holdings.Clone() // Copy OnChain.Holdings so we don't lose this information
 		if err != nil {
 			return nil, fmt.Errorf("could not create consensus channel as leader: %w", err)
 		}
@@ -224,7 +224,7 @@ func (dfo *Objective) CreateConsensusChannel() (*consensus_channel.ConsensusChan
 
 	} else {
 		con, err := consensus_channel.NewFollowerChannel(ledger.FixedPart, turnNum, outcome, signatures)
-		con.OnChainFunding = ledger.OnChainFunding.Clone() // Copy OnChainFunding so we don't lose this information
+		con.OnChainFunding = ledger.OnChain.Holdings.Clone() // Copy OnChain.Holdings so we don't lose this information
 		if err != nil {
 			return nil, fmt.Errorf("could not create consensus channel as follower: %w", err)
 		}
@@ -364,7 +364,7 @@ func (o *Objective) Related() []protocols.Storable {
 // fundingComplete returns true if the recorded OnChainHoldings are greater than or equal to the threshold for being fully funded.
 func (o *Objective) fundingComplete() bool {
 	for asset, threshold := range o.fullyFundedThreshold {
-		chainHolding, ok := o.C.OnChainFunding[asset]
+		chainHolding, ok := o.C.OnChain.Holdings[asset]
 
 		if !ok {
 			return false
@@ -382,7 +382,7 @@ func (o *Objective) fundingComplete() bool {
 func (o *Objective) safeToDeposit() bool {
 	for asset, safetyThreshold := range o.myDepositSafetyThreshold {
 
-		chainHolding, ok := o.C.OnChainFunding[asset]
+		chainHolding, ok := o.C.OnChain.Holdings[asset]
 
 		if !ok {
 			return false // nil chainHolding for asset
@@ -398,10 +398,10 @@ func (o *Objective) safeToDeposit() bool {
 
 // amountToDeposit computes the appropriate amount to deposit given the current recorded OnChainHoldings
 func (o *Objective) amountToDeposit() types.Funds {
-	deposits := make(types.Funds, len(o.C.OnChainFunding))
+	deposits := make(types.Funds, len(o.C.OnChain.Holdings))
 
 	for asset, target := range o.myDepositTarget {
-		holding, ok := o.C.OnChainFunding[asset]
+		holding, ok := o.C.OnChain.Holdings[asset]
 		if !ok {
 			holding = big.NewInt(0)
 		}

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -165,8 +165,8 @@ func TestUpdate(t *testing.T) {
 		t.Error(err)
 	}
 	updated = updatedObjective.(*Objective)
-	if !updated.C.OnChainFunding.Equal(newFunding) {
-		t.Error(`Objective data not updated as expected`, updated.C.OnChainFunding, newFunding)
+	if !updated.C.OnChain.Holdings.Equal(newFunding) {
+		t.Error(`Objective data not updated as expected`, updated.C.OnChain.Holdings, newFunding)
 	}
 
 	// Update with stale funding information should be ignored
@@ -185,8 +185,8 @@ func TestUpdate(t *testing.T) {
 
 	updated = updatedObjective.(*Objective)
 
-	if updated.C.OnChainFunding.Equal(staleFunding) {
-		t.Error("OnChainFunding was updated to stale funding information", updated.C.OnChainFunding, staleFunding)
+	if updated.C.OnChain.Holdings.Equal(staleFunding) {
+		t.Error("OnChain.Holdings was updated to stale funding information", updated.C.OnChain.Holdings, staleFunding)
 	}
 }
 
@@ -269,7 +269,7 @@ func TestCrank(t *testing.T) {
 	}
 
 	// Manually make the first "deposit"
-	o.C.OnChainFunding[testState.Outcome[0].Asset] = testState.Outcome[0].Allocations[0].Amount
+	o.C.OnChain.Holdings[testState.Outcome[0].Asset] = testState.Outcome[0].Allocations[0].Amount
 	updated, sideEffects, waitingFor, err := o.Crank(&alice.PrivateKey)
 
 	if !updated.(*Objective).transactionSubmitted {
@@ -288,7 +288,7 @@ func TestCrank(t *testing.T) {
 
 	// Manually make the second "deposit"
 	totalAmountAllocated := testState.Outcome[0].TotalAllocated()
-	o.C.OnChainFunding[testState.Outcome[0].Asset] = totalAmountAllocated
+	o.C.OnChain.Holdings[testState.Outcome[0].Asset] = totalAmountAllocated
 	_, sideEffects, waitingFor, err = o.Crank(&alice.PrivateKey)
 	if err != nil {
 		t.Error(err)
@@ -305,7 +305,7 @@ func TestCrank(t *testing.T) {
 	o.C.AddStateWithSignature(o.C.PostFundState(), correctSignatureByBobOnPostFund)
 
 	// This should be the final crank
-	o.C.OnChainFunding[testState.Outcome[0].Asset] = totalAmountAllocated
+	o.C.OnChain.Holdings[testState.Outcome[0].Asset] = totalAmountAllocated
 	_, _, waitingFor, err = o.Crank(&alice.PrivateKey)
 	if err != nil {
 		t.Error(err)

--- a/protocols/virtualdefund/virtualdefund.go
+++ b/protocols/virtualdefund/virtualdefund.go
@@ -194,7 +194,7 @@ func IsVirtualDefundObjective(id protocols.ObjectiveId) bool {
 
 // finalState returns the final state for the virtual channel
 func (o *Objective) finalState() state.State {
-	return o.V.SignedStateForTurnNum[FinalTurnNum].State()
+	return o.V.OffChain.SignedStateForTurnNum[FinalTurnNum].State()
 }
 
 func (o *Objective) initialOutcome() outcome.SingleAssetExit {
@@ -313,7 +313,7 @@ func (o *Objective) otherParticipants() []types.Address {
 }
 
 func (o *Objective) hasFinalStateFromAlice() bool {
-	ss, ok := o.V.SignedStateForTurnNum[FinalTurnNum]
+	ss, ok := o.V.OffChain.SignedStateForTurnNum[FinalTurnNum]
 	return ok && ss.State().IsFinal && !isZero(ss.Signatures()[0])
 }
 

--- a/protocols/virtualdefund/virtualdefund_test.go
+++ b/protocols/virtualdefund/virtualdefund_test.go
@@ -82,7 +82,7 @@ func testUpdateAs(my ta.Actor) func(t *testing.T) {
 		updatedObj, err := virtualDefund.Update(e)
 		testhelpers.Ok(t, err)
 		updated := updatedObj.(*Objective)
-		ss, ok := updated.V.SignedStateForTurnNum[FinalTurnNum]
+		ss, ok := updated.V.OffChain.SignedStateForTurnNum[FinalTurnNum]
 		if !ok {
 			t.Fatal(err)
 		}

--- a/protocols/virtualfund/virtualfund_single_hop_test.go
+++ b/protocols/virtualfund/virtualfund_single_hop_test.go
@@ -470,13 +470,13 @@ func TestCrankAsP1(t *testing.T) {
 // assertSupportedPrefund checks that all three participants have signed the prefund. It
 // is used to manually inspect the objective after Update receives counterparty signatures.
 func assertSupportedPrefund(o *Objective, t *testing.T) {
-	if !o.V.SignedStateForTurnNum[0].HasSignatureForParticipant(alice.Role) {
+	if !o.V.OffChain.SignedStateForTurnNum[0].HasSignatureForParticipant(alice.Role) {
 		t.Fatal(`Objective prefund state not signed by alice`)
 	}
-	if !o.V.SignedStateForTurnNum[0].HasSignatureForParticipant(bob.Role) {
+	if !o.V.OffChain.SignedStateForTurnNum[0].HasSignatureForParticipant(bob.Role) {
 		t.Fatal(`Objective prefund state not signed by bob`)
 	}
-	if !o.V.SignedStateForTurnNum[0].HasSignatureForParticipant(p1.Role) {
+	if !o.V.OffChain.SignedStateForTurnNum[0].HasSignatureForParticipant(p1.Role) {
 		t.Fatal(`Objective prefund state not signed by p1`)
 	}
 }


### PR DESCRIPTION
Towards #1531 

Working on this has made me think we need to audit:
* on chain events (does `Concluded` give sufficient information to subsequently call `transfer`? Does `Challenge` need to be so verbose / heavy?)
* extent to which we rely on parsing the call data instead of re-emitting that information . 