### PR TITLE
Mock chain protects state with a mutex

### DIFF
--- a/node/engine/chainservice/mock_chain.go
+++ b/node/engine/chainservice/mock_chain.go
@@ -15,7 +15,7 @@ import (
 type MockChain struct {
 	blockNum uint64
 	// holdings tracks funds for each channel.
-	holdings safesync.Map[types.Funds]
+	holdings map[types.Destination]types.Funds
 	// out maps addresses to an Event channel. Given that MockChainServices only subscribe
 	// (and never unsubscribe) to events, this can be converted to a list.
 	out safesync.Map[chan Event]
@@ -27,7 +27,7 @@ type MockChain struct {
 func NewMockChain() *MockChain {
 	chain := MockChain{}
 	chain.blockNum = 1
-	chain.holdings = safesync.Map[types.Funds]{}
+	chain.holdings = map[types.Destination]types.Funds{}
 	chain.out = safesync.Map[chan Event]{}
 	return &chain
 }
@@ -38,12 +38,11 @@ func (mc *MockChain) SubmitTransaction(tx protocols.ChainTransaction) error {
 	eventsToBroadcast := []Event{}
 	mc.txMutex.Lock()
 	mc.blockNum++
-	channelIdString := tx.ChannelId().String()
-	h, _ := mc.holdings.Load(channelIdString) // ignore `ok` because the returned zero-value is what we want
+	h := mc.holdings[tx.ChannelId()] // ignore `ok` because the returned zero-value is what we want
 	switch tx := tx.(type) {
 	case protocols.DepositTransaction:
 		if tx.Deposit.IsNonZero() {
-			mc.holdings.Store(channelIdString, h.Add(tx.Deposit))
+			mc.holdings[tx.ChannelId()] = h.Add(tx.Deposit)
 		}
 
 		for address := range tx.Deposit {
@@ -55,7 +54,7 @@ func (mc *MockChain) SubmitTransaction(tx protocols.ChainTransaction) error {
 			event := NewAllocationUpdatedEvent(tx.ChannelId(), mc.blockNum, assetAddress, common.Big0)
 			eventsToBroadcast = append(eventsToBroadcast, event)
 		}
-		mc.holdings.Store(channelIdString, types.Funds{})
+		mc.holdings[tx.ChannelId()] = types.Funds{}
 	default:
 		return fmt.Errorf("unexpected transaction type %T", tx)
 	}


### PR DESCRIPTION
This PR adds a mutex that protects updating chain state. The mutex is released before chain events are sent to avoid the following deadlock:
1. Transaction is submitted.
2. Mutex is locked.
3. A chain event is broadcast.
4. A listener to the event submits another transaction.
5. A deadlock occurs since the mutex is already locked.

Given that step 3 (event broadcast) is a send on a channel, this deadlock will not occur with the current code base. This mutex approach protects against implementation changes to event broadcasting.

https://github.com/statechannels/go-nitro/actions/runs/5905501765/job/16019700856 failure is addressed with this PR.