### PR TITLE
Use temp folders for the durable store and enable the durable store for the RPC test

### DIFF
--- a/cmd/start-rpc-servers/main.go
+++ b/cmd/start-rpc-servers/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/statechannels/go-nitro/cmd/utils"
 	"github.com/statechannels/go-nitro/internal/chain"
+	"github.com/statechannels/go-nitro/internal/testhelpers"
 	"github.com/statechannels/go-nitro/types"
 	"github.com/urfave/cli/v2"
 )
@@ -105,7 +106,7 @@ func main() {
 				}
 				running = append(running, anvilCmd)
 			}
-			dataFolder, cleanup := generateTempStoreFolder()
+			dataFolder, cleanup := testhelpers.GenerateTempStoreFolder()
 			defer cleanup()
 			fmt.Printf("Using data folder %s\n", dataFolder)
 
@@ -205,25 +206,6 @@ func newColorWriter(c color, w io.Writer) colorWriter {
 		writer: w,
 		color:  c,
 	}
-}
-
-// generateTempStoreFolder generates a temporary folder for storing store data and a cleanup function to clean up the folder
-func generateTempStoreFolder() (dataFolder string, cleanup func()) {
-	var err error
-
-	dataFolder, err = os.MkdirTemp("", "nitro-store-*")
-	if err != nil {
-		panic(err)
-	}
-
-	cleanup = func() {
-		err := os.RemoveAll(dataFolder)
-		if err != nil {
-			panic(err)
-		}
-	}
-
-	return
 }
 
 // waitForRpcClient waits for an RPC to be available at the given url

--- a/internal/testhelpers/testhelpers.go
+++ b/internal/testhelpers/testhelpers.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -105,4 +106,23 @@ func SignState(ss *state.SignedState, secretKey *[]byte) {
 	if err != nil {
 		panic(fmt.Errorf("SignAndAdd failed to sign the state: %w", err))
 	}
+}
+
+// GenerateTempStoreFolder generates a temporary folder for storing store data and a cleanup function to clean up the folder
+func GenerateTempStoreFolder() (dataFolder string, cleanup func()) {
+	var err error
+
+	dataFolder, err = os.MkdirTemp("", "nitro-store-*")
+	if err != nil {
+		panic(err)
+	}
+
+	cleanup = func() {
+		err := os.RemoveAll(dataFolder)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return
 }

--- a/node/engine/store/store_test.go
+++ b/node/engine/store/store_test.go
@@ -1,12 +1,9 @@
 package store_test
 
 import (
-	"fmt"
 	"math"
 	"math/big"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/go-cmp/cmp"
@@ -17,6 +14,7 @@ import (
 	nc "github.com/statechannels/go-nitro/crypto"
 	ta "github.com/statechannels/go-nitro/internal/testactors"
 	td "github.com/statechannels/go-nitro/internal/testdata"
+	"github.com/statechannels/go-nitro/internal/testhelpers"
 	"github.com/statechannels/go-nitro/node/engine/store"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/protocols/directfund"
@@ -24,8 +22,6 @@ import (
 	"github.com/statechannels/go-nitro/types"
 	"github.com/tidwall/buntdb"
 )
-
-const STORE_TEST_DATA_FOLDER = "../data/store_test"
 
 func compareObjectives(a, b protocols.Objective) string {
 	return cmp.Diff(&a, &b, cmp.AllowUnexported(
@@ -223,7 +219,8 @@ func TestGetChannelsByParticipant(t *testing.T) {
 func TestBigNumberStorage(t *testing.T) {
 	pk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
 
-	dataFolder := fmt.Sprintf("%s/%d%d", STORE_TEST_DATA_FOLDER, rand.Uint64(), time.Now().UnixNano())
+	dataFolder, cleanup := testhelpers.GenerateTempStoreFolder()
+	defer cleanup()
 	durableStore, err := store.NewDurableStore(pk, dataFolder, buntdb.Config{})
 	if err != nil {
 		t.Fatal(err)

--- a/node_test/integration_test.go
+++ b/node_test/integration_test.go
@@ -2,12 +2,12 @@ package node_test
 
 import (
 	"math/big"
-	"os"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/internal/testactors"
 	td "github.com/statechannels/go-nitro/internal/testdata"
+	"github.com/statechannels/go-nitro/internal/testhelpers"
 	"github.com/statechannels/go-nitro/node"
 	"github.com/statechannels/go-nitro/node/engine/messageservice"
 	p2pms "github.com/statechannels/go-nitro/node/engine/messageservice/p2p-message-service"
@@ -58,8 +58,8 @@ func TestComplexIntegrationScenario(t *testing.T) {
 
 // RunIntegrationTestCase runs the integration test case.
 func RunIntegrationTestCase(tc TestCase, t *testing.T) {
-	// Clean up all the test data we create at the end of the test
-	defer os.RemoveAll(STORE_TEST_DATA_FOLDER)
+	dataFolder, cleanup := testhelpers.GenerateTempStoreFolder()
+	defer cleanup()
 
 	t.Run(tc.Description, func(t *testing.T) {
 		err := tc.Validate()
@@ -76,7 +76,7 @@ func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 		intermediaries := make([]node.Node, 0)
 		bootPeers := make([]string, 0)
 		for _, intermediary := range tc.Participants[2:] {
-			clientI, msgI, multiAddr := setupIntegrationNode(tc, intermediary, infra, []string{})
+			clientI, msgI, multiAddr := setupIntegrationNode(tc, intermediary, infra, []string{}, dataFolder)
 
 			intermediaries = append(intermediaries, clientI)
 			msgServices = append(msgServices, msgI)
@@ -90,11 +90,11 @@ func RunIntegrationTestCase(tc TestCase, t *testing.T) {
 		}()
 		t.Log("Intermediary node(s) setup complete")
 
-		clientA, msgA, _ := setupIntegrationNode(tc, tc.Participants[0], infra, bootPeers)
+		clientA, msgA, _ := setupIntegrationNode(tc, tc.Participants[0], infra, bootPeers, dataFolder)
 		defer clientA.Close()
 		msgServices = append(msgServices, msgA)
 
-		clientB, msgB, _ := setupIntegrationNode(tc, tc.Participants[1], infra, bootPeers)
+		clientB, msgB, _ := setupIntegrationNode(tc, tc.Participants[1], infra, bootPeers, dataFolder)
 		defer clientB.Close()
 		msgServices = append(msgServices, msgB)
 

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -17,6 +17,7 @@ import (
 	interRpc "github.com/statechannels/go-nitro/internal/rpc"
 	ta "github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/internal/testdata"
+	"github.com/statechannels/go-nitro/internal/testhelpers"
 	"github.com/statechannels/go-nitro/node/engine/chainservice"
 	p2pms "github.com/statechannels/go-nitro/node/engine/messageservice/p2p-message-service"
 	"github.com/statechannels/go-nitro/node/query"
@@ -410,7 +411,8 @@ func setupNitroNodeWithRPCClient(
 	bootPeers []string,
 ) (rpc.RpcClientApi, *p2pms.P2PMessageService, func()) {
 	var err error
-	rpcServer, _, messageService, err := interRpc.RunRpcServer(pk, chain, false, "", msgPort, rpcPort, connectionType, logDestination, bootPeers)
+	dataFolder, cleanupData := testhelpers.GenerateTempStoreFolder()
+	rpcServer, _, messageService, err := interRpc.RunRpcServer(pk, chain, false, dataFolder, msgPort, rpcPort, connectionType, logDestination, bootPeers)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -448,6 +450,7 @@ func setupNitroNodeWithRPCClient(
 		logger.Info().Str("pk", string(pk)).Msg("Rpc client closed")
 		rpcServer.Close()
 		logger.Info().Str("pk", string(pk)).Msg("Rpc server closed")
+		cleanupData()
 	}
 	return rpcClient, messageService, cleanupFn
 }

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -412,7 +412,7 @@ func setupNitroNodeWithRPCClient(
 ) (rpc.RpcClientApi, *p2pms.P2PMessageService, func()) {
 	var err error
 	dataFolder, cleanupData := testhelpers.GenerateTempStoreFolder()
-	rpcServer, _, messageService, err := interRpc.RunRpcServer(pk, chain, false, dataFolder, msgPort, rpcPort, connectionType, logDestination, bootPeers)
+	rpcServer, _, messageService, err := interRpc.RunRpcServer(pk, chain, true, dataFolder, msgPort, rpcPort, connectionType, logDestination, bootPeers)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/node_test/types_test.go
+++ b/node_test/types_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 const (
-	MAX_PARTICIPANTS = 4
-
+	MAX_PARTICIPANTS      = 4
 	ledgerChannelDeposit  = 5_000_000
 	defaultTimeout        = 10 * time.Second
 	virtualChannelDeposit = 5000

--- a/node_test/types_test.go
+++ b/node_test/types_test.go
@@ -12,12 +12,12 @@ import (
 )
 
 const (
-	MAX_PARTICIPANTS       = 4
-	STORE_TEST_DATA_FOLDER = "../data/store_test"
-	ledgerChannelDeposit   = 5_000_000
-	defaultTimeout         = 10 * time.Second
-	virtualChannelDeposit  = 5000
-	DURABLE_STORE_FOLDER   = "../data/node_test"
+	MAX_PARTICIPANTS = 4
+
+	ledgerChannelDeposit  = 5_000_000
+	defaultTimeout        = 10 * time.Second
+	virtualChannelDeposit = 5000
+	DURABLE_STORE_FOLDER  = "../data/node_test"
 )
 
 type StoreType string


### PR DESCRIPTION
This PR has two main changes:
1. It takes the `generateTempStoreFolder` function from start-rpc-servers and moves it to to `testHelpers`. Any test code that uses a DurableStore now using `GenerateTempStoreFolder`  instead of relying on a variety of consts and folder naming schemas.
2. Enables the RPC test to use the durable store instead of the mem store. This helps make the RPC test slightly more realistic.