### PR TITLE
Increase race condition detector timeout

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Check for race conditions
         # Only executes when triggered by a push to the main branch
         if: ${{ github.ref_name == 'main' }}
-        run: go test ./... -timeout 2m -v -failfast -race
+        run: go test ./... -timeout 4m -v -failfast -race
 
       - name: Archive logs
         if: always()


### PR DESCRIPTION
Successfull runs take can last over 2 minutes. Here is an example: https://github.com/statechannels/go-nitro/actions/runs/5906523948/job/16022715635