### PR TITLE
Simplify logging by using slog

### DIFF
--- a/cmd/create-channel/main.go
+++ b/cmd/create-channel/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/BurntSushi/toml"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/cmd/utils"
+	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/rpc"
 	"github.com/statechannels/go-nitro/rpc/transport/ws"
 )
@@ -31,15 +33,15 @@ func main() {
 	if _, err := toml.DecodeFile(CONFIG_FILE, &participantOpts); err != nil {
 		panic(err)
 	}
-	logger, logFile := utils.CreateLogger(LOG_FILE, "alice")
-	defer logFile.Close()
+
+	logging.SetupDefaultFileLogger(LOG_FILE, slog.LevelDebug)
 
 	url := fmt.Sprintf(":%d/api/v1", participantOpts.RpcPort)
-	clientConnection, err := ws.NewWebSocketTransportAsClient(url, logger)
+	clientConnection, err := ws.NewWebSocketTransportAsClient(url)
 	if err != nil {
 		panic(err)
 	}
-	client, err := rpc.NewRpcClient(logger, clientConnection)
+	client, err := rpc.NewRpcClient(clientConnection)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/create-channels/main.go
+++ b/cmd/create-channels/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/BurntSushi/toml"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/cmd/utils"
+	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/rpc"
 	"github.com/statechannels/go-nitro/rpc/transport/ws"
@@ -34,15 +36,14 @@ func createChannels() error {
 			return err
 		}
 
-		logger, logFile := utils.CreateLogger(LOG_FILE, participant)
-		defer logFile.Close()
+		logging.SetupDefaultFileLogger(LOG_FILE, slog.LevelDebug)
 
 		url := fmt.Sprintf(":%d/api/v1", participantOpts.RpcPort)
-		clientConnection, err := ws.NewWebSocketTransportAsClient(url, logger)
+		clientConnection, err := ws.NewWebSocketTransportAsClient(url)
 		if err != nil {
 			return err
 		}
-		clients[participant], err = rpc.NewRpcClient(logger, clientConnection)
+		clients[participant], err = rpc.NewRpcClient(clientConnection)
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/start-reverse-payment-proxy/main.go
+++ b/cmd/start-reverse-payment-proxy/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"log"
+	"log/slog"
 	"os"
 
-	"github.com/rs/zerolog"
 	"github.com/statechannels/go-nitro/cmd/utils"
+	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/reverseproxy"
 	"github.com/urfave/cli/v2"
 )
@@ -52,15 +53,14 @@ func main() {
 			proxyEndpoint := c.String(PROXY_ADDRESS)
 			nitroEndpoint := c.String(NITRO_ENDPOINT)
 
-			// For now we just log to stdout
-			logger := zerolog.New(os.Stdout).Level(zerolog.DebugLevel)
+			logging.SetupDefaultLogger(os.Stdout, slog.LevelDebug)
 
 			rProxy = reverseproxy.NewReversePaymentProxy(
 				proxyEndpoint,
 				nitroEndpoint,
 				c.String(DESTINATION_URL),
 				c.Uint64(COST_PER_BYTE),
-				logger)
+			)
 
 			return rProxy.Start()
 		},

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -8,8 +8,7 @@ import (
 	"syscall"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/rs/zerolog"
-	"github.com/statechannels/go-nitro/internal/logging"
+
 	"github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/rpc"
 	"github.com/statechannels/go-nitro/types"
@@ -36,18 +35,6 @@ func StopCommands(cmds ...*exec.Cmd) {
 			panic(err)
 		}
 	}
-}
-
-func CreateLogger(logFileName string, clientName string) (zerolog.Logger, *os.File) {
-	logDestination := logging.NewLogWriter("./artifacts", logFileName)
-
-	return zerolog.New(logDestination).
-		Level(zerolog.TraceLevel).
-		With().
-		Timestamp().
-		Str("client", clientName).
-		Str("rpc", "client").
-		Logger(), logDestination
 }
 
 func CreateLedgerChannel(client rpc.RpcClientApi, counterPartyAddress common.Address) error {

--- a/contributing.md
+++ b/contributing.md
@@ -164,30 +164,17 @@ We run deeper tests of the code on your PR using a hosted [testground](https://d
 
 # Logs
 
-Go-nitro uses a configurable logger. It outputs [ndjson](http://ndjson.org/) which is optimized for machine-readability. Integration tests typically write logs from several go-nitro nodes to a single file in the `artifacts` directory.
+Go-nitro uses the [log/slog](https://pkg.go.dev/log/slog) package to output structured logging. Integration tests typically write logs from several go-nitro nodes to a single file in the `artifacts` directory.
 
 A typical log line is
 
 ```json
 {
-  "level": "debug",
-  "engine": "0x111A00",
-  "time": 1681911828835,
-  "caller": "engine.go:115",
-  "message": "Constructed Engine"
+  "time": "2023-08-23T11:23:55.727269-07:00",
+  "level": "INFO",
+  "msg": "Constructed Engine",
+  "address": "0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE"
 }
-```
-
-To make parsing logs easier for humans, install [`pino-pretty`](https://github.com/pinojs/pino-pretty) and do something like:
-
-```shell
-cat artifacts/simple_integration_run.log | pino-pretty -S -o "{engine} {To} < {From}" > output.log
-```
-
-You may then view `output.log` in VSCode. A typical log line is then:
-
-```log
-[14:37:36.517] DEBUG <engine.go:114>: 0x111A00  <  {"engine":"0x111A00","message":"Constructed Engine"}
 ```
 
 ### Start RPC servers with Docker

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/libp2p/go-libp2p-kad-dht v0.24.2
 	github.com/tidwall/buntdb v1.2.10
 	github.com/urfave/cli/v2 v2.25.3
+
 )
 
 require (
@@ -83,7 +84,6 @@ require (
 	github.com/libp2p/go-reuseport v0.4.0 // indirect
 	github.com/libp2p/go-yamux/v4 v4.0.1 // indirect
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/miekg/dns v1.1.55 // indirect
@@ -171,7 +171,6 @@ require (
 	github.com/miguelmota/go-ethereum-hdwallet v0.1.1
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/rs/zerolog v1.28.0
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	github.com/tklauser/go-sysconf v0.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,7 +145,6 @@ github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8Nz
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
-github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
@@ -516,7 +515,6 @@ github.com/mattn/go-colorable v0.1.0/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
-github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
@@ -528,7 +526,6 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
-github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -708,9 +705,6 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
-github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
-github.com/rs/zerolog v1.28.0 h1:MirSo27VyNi7RJYP3078AA1+Cyzd2GB66qy3aUHvsWY=
-github.com/rs/zerolog v1.28.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6usyD0=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
@@ -1054,7 +1048,6 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -34,14 +34,14 @@ func InitializeEthChainService(chainOpts ChainOpts) (*chainservice.EthChainServi
 	}
 
 	fmt.Println("Initializing chain service and connecting to " + chainOpts.ChainUrl + "...")
+
 	return chainservice.NewEthChainService(
 		chainOpts.ChainUrl,
 		chainOpts.ChainAuthToken,
 		chainOpts.ChainPk,
 		chainOpts.NaAddress,
 		chainOpts.CaAddress,
-		chainOpts.VpaAddress,
-		os.Stdout)
+		chainOpts.VpaAddress)
 }
 
 func StartAnvil() (*exec.Cmd, error) {

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"log/slog"
 	"os"
 	"os/signal"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/internal/chain"
+	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/internal/rpc"
 	"github.com/urfave/cli/v2"
 	"github.com/urfave/cli/v2/altsrc"
@@ -172,6 +174,9 @@ func main() {
 			if bootPeers != "" {
 				peerSlice = strings.Split(bootPeers, ",")
 			}
+
+			logging.SetupDefaultLogger(os.Stdout, slog.LevelDebug)
+
 			rpcServer, _, _, err := rpc.InitChainServiceAndRunRpcServer(pkString, chainOpts, useDurableStore, durableStoreFolder, useNats, msgPort, rpcPort, peerSlice)
 			if err != nil {
 				return err

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -108,7 +108,7 @@ func newEthChainService(chain ethChain, na *NitroAdjudicator.NitroAdjudicator,
 ) (*EthChainService, error) {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
-	logger := slog.Default().With("tx-signer", txSigner)
+	logger := slog.Default().With("tx-signer", txSigner.From.String())
 
 	eventQueue := EventQueue{}
 	heap.Init(&eventQueue)

--- a/node/engine/chainservice/eth_chainservice_FEVM_test.go
+++ b/node/engine/chainservice/eth_chainservice_FEVM_test.go
@@ -18,7 +18,6 @@ import (
 	hdwallet "github.com/miguelmota/go-ethereum-hdwallet"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
-	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/internal/testactors"
 	NitroAdjudicator "github.com/statechannels/go-nitro/node/engine/chainservice/adjudicator"
 	"github.com/statechannels/go-nitro/protocols"
@@ -90,8 +89,7 @@ func testAgainstEndpoint(t *testing.T, endpoint string, logFile string, pk *ecds
 		t.Fatal(err)
 	}
 
-	logDestination := logging.NewLogWriter("../artifacts", logFile)
-	cs, err := newEthChainService(client, na, naAddress, caAddress, vpaAddress, txSubmitter, logDestination)
+	cs, err := newEthChainService(client, na, naAddress, caAddress, vpaAddress, txSubmitter)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/node/engine/chainservice/simulated_backend_chainservice.go
+++ b/node/engine/chainservice/simulated_backend_chainservice.go
@@ -3,7 +3,6 @@ package chainservice
 import (
 	"context"
 	"errors"
-	"io"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -60,15 +59,14 @@ type SimulatedBackendChainService struct {
 // NewSimulatedBackendChainService constructs a chain service that submits transactions to a NitroAdjudicator
 // and listens to events from an eventSource
 func NewSimulatedBackendChainService(sim SimulatedChain, bindings Bindings,
-	txSigner *bind.TransactOpts, logDestination io.Writer,
+	txSigner *bind.TransactOpts,
 ) (ChainService, error) {
 	ethChainService, err := newEthChainService(sim,
 		bindings.Adjudicator.Contract,
 		bindings.Adjudicator.Address,
 		bindings.ConsensusApp.Address,
 		bindings.VirtualPaymentApp.Address,
-		txSigner,
-		logDestination)
+		txSigner)
 	if err != nil {
 		return &SimulatedBackendChainService{}, err
 	}

--- a/node/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/node/engine/chainservice/simulated_backend_chainservice_test.go
@@ -52,7 +52,7 @@ func TestSimulatedBackendChainService(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cs, err := NewSimulatedBackendChainService(sim, bindings, ethAccounts[0], NoopLogger{})
+	cs, err := NewSimulatedBackendChainService(sim, bindings, ethAccounts[0])
 	defer closeChainService(t, cs)
 	if err != nil {
 		t.Fatal(err)

--- a/node/engine/chainservice/utils/utils.go
+++ b/node/engine/chainservice/utils/utils.go
@@ -3,6 +3,7 @@ package chainutils
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
@@ -16,7 +17,7 @@ func ConnectToChain(ctx context.Context, chainUrl, chainAuthToken string, chainP
 	var err error
 
 	if chainAuthToken != "" {
-		fmt.Println("Adding bearer token authorization header to chain service")
+		slog.Info("Adding bearer token authorization header to chain service")
 		options := rpc.WithHeader("Authorization", "Bearer "+chainAuthToken)
 		rpcClient, err = rpc.DialOptions(ctx, chainUrl, options)
 	} else {
@@ -27,13 +28,13 @@ func ConnectToChain(ctx context.Context, chainUrl, chainAuthToken string, chainP
 	}
 
 	client := ethclient.NewClient(rpcClient)
-	fmt.Println("Connected to ethclient at url: " + chainUrl)
+	slog.Info("Connected to ethclient", "url", chainUrl)
 
 	foundChainId, err := client.ChainID(context.Background())
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not get chain id: %w", err)
 	}
-	fmt.Printf("Found chain id: %v\n", foundChainId)
+	slog.Info("Found chain id", "chainId", foundChainId)
 
 	key, err := ethcrypto.ToECDSA(chainPK)
 	if err != nil {

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -28,6 +28,8 @@ import (
 	natstrans "github.com/statechannels/go-nitro/rpc/transport/nats"
 	"github.com/statechannels/go-nitro/rpc/transport/ws"
 	"github.com/statechannels/go-nitro/types"
+
+	"github.com/statechannels/go-nitro/crypto"
 )
 
 func simpleOutcome(a, b types.Address, aBalance, bBalance uint) outcome.Exit {
@@ -424,11 +426,15 @@ func setupNitroNodeWithRPCClient(
 	}
 
 	cleanupFn := func() {
-		slog.Info("Starting rpc close", "pk", common.Bytes2Hex(pk))
+		// Setup a logger with the address of the node so we know who is closing
+		me := crypto.GetAddressFromSecretKeyBytes(pk)
+		logger := logging.LoggerWithAddress(slog.Default(), me)
+		logger.Info("Starting rpc close")
 		rpcClient.Close()
-		slog.Info("Rpc client closed", "pk", common.Bytes2Hex(pk))
+		logger.Info("Rpc client closed")
 		rpcServer.Close()
-		slog.Info("Rpc server closed", "pk", common.Bytes2Hex(pk))
+		logger.Info("Rpc server closed")
+
 		cleanupData()
 	}
 	return rpcClient, messageService, cleanupFn

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -3,15 +3,15 @@ package node_test
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"math/big"
-	"os"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/go-cmp/cmp"
-	"github.com/rs/zerolog"
+
 	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/internal/logging"
 	interRpc "github.com/statechannels/go-nitro/internal/rpc"
@@ -32,23 +32,6 @@ import (
 
 func simpleOutcome(a, b types.Address, aBalance, bBalance uint) outcome.Exit {
 	return testdata.Outcomes.Create(a, b, aBalance, bBalance, types.Address{})
-}
-
-func createLogger(logDestination *os.File, clientName *types.Address, rpcRole string) zerolog.Logger {
-	return logging.WithAddress(zerolog.New(logDestination).
-		Level(zerolog.TraceLevel).
-		With().
-		Timestamp().
-		Str("rpc", rpcRole), clientName).
-		Logger()
-}
-
-func testLogger(logDestination *os.File) zerolog.Logger {
-	return zerolog.New(logDestination).
-		Level(zerolog.TraceLevel).
-		With().
-		Timestamp().
-		Logger()
 }
 
 func TestRpcWithNats(t *testing.T) {
@@ -97,10 +80,9 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 		manVoucherStr = ""
 	}
 	logFile := fmt.Sprintf("test_%d_rpc_clients_over_%s%s.log", n, connectionType, manVoucherStr)
-	logDestination := logging.NewLogWriter("../artifacts", logFile)
-	defer logDestination.Close()
-	logger := testLogger(logDestination)
-	logger.Info().Msgf("Starting test with %d clients", n)
+	logging.SetupDefaultFileLogger(logFile, slog.LevelDebug)
+
+	slog.Info("Starting test", "num-clients", n)
 
 	chain := chainservice.NewMockChain()
 	defer chain.Close()
@@ -113,7 +95,7 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 			PrivateKey: common.Hex2Bytes(sk),
 		}
 	}
-	logger.Info().Msgf("%d actors created", n)
+	slog.Info("Actors created", "num-actors", n)
 
 	chainServices := make([]*chainservice.MockChainService, n)
 	for i := 0; i < n; i++ {
@@ -126,7 +108,7 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 	// Set up the intermediaries
 	if n > 2 {
 		for i := 1; i < n-1; i++ {
-			rpcClient, msg, cleanup := setupNitroNodeWithRPCClient(t, actors[i].PrivateKey, 3105+i, 4105+i, chainServices[i], logDestination, connectionType, []string{})
+			rpcClient, msg, cleanup := setupNitroNodeWithRPCClient(t, actors[i].PrivateKey, 3105+i, 4105+i, chainServices[i], connectionType, []string{})
 			clients[i] = rpcClient
 			msgServices[i] = msg
 			bootPeers = append(bootPeers, msg.MultiAddr)
@@ -136,7 +118,7 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 
 	// Set up the first and last client
 	for i := 0; i < n; i = i + (n - 1) {
-		rpcClient, msg, cleanup := setupNitroNodeWithRPCClient(t, actors[i].PrivateKey, 3105+i, 4105+i, chainServices[i], logDestination, connectionType, bootPeers)
+		rpcClient, msg, cleanup := setupNitroNodeWithRPCClient(t, actors[i].PrivateKey, 3105+i, 4105+i, chainServices[i], connectionType, bootPeers)
 		clients[i] = rpcClient
 		msgServices[i] = msg
 		defer cleanup()
@@ -146,9 +128,9 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 		}
 	}
 
-	logger.Info().Msgf("%d Clients created", n)
+	slog.Info("Clients created", "num-clients", n)
 
-	logger.Info().Msg("Verify that each rpc client fetches the correct address")
+	slog.Info("Verify that each rpc client fetches the correct address")
 	for i := 0; i < n; i++ {
 		clientAddress, _ := clients[i].Address()
 		if !cmp.Equal(actors[i].Address(), clientAddress) {
@@ -157,7 +139,7 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 	}
 
 	waitForPeerInfoExchange(msgServices...)
-	logger.Info().Msg("Peer exchange complete")
+	slog.Info("Peer exchange complete")
 
 	// create n-1 ledger channels
 	ledgerChannels := make([]directfund.ObjectiveResponse, n-1)
@@ -180,7 +162,7 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 			<-client.ObjectiveCompleteChan(ledgerChannels[i].Id) // right channel
 		}
 	}
-	logger.Info().Msg("Ledger channels created")
+	slog.Info("Ledger channels created")
 
 	// try to create duplicate ledger channel to ensure node correctly
 	// handles error without panicking
@@ -354,7 +336,7 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 			{99, 101, query.Complete},
 		},
 	)[alice.Address()]
-	checkNotifications(t, logger, "aliceLedger", expectedAliceLedgerNotifs, []query.LedgerChannelInfo{}, aliceLedgerNotifs, defaultTimeout)
+	checkNotifications(t, "aliceLedger", expectedAliceLedgerNotifs, []query.LedgerChannelInfo{}, aliceLedgerNotifs, defaultTimeout)
 
 	bobLedgerNotifs := bobClient.LedgerChannelUpdatesChan(bobLedger.ChannelId)
 	expectedBobLedgerNotifs := createLedgerStory(
@@ -372,7 +354,7 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 			createLedgerInfo(bobLedger.ChannelId, simpleOutcome(actors[n-2].Address(), bob.Address(), 99, 101), query.Closing, bob.Address()),
 		)
 	}
-	checkNotifications(t, logger, "bobLedger", expectedBobLedgerNotifs, []query.LedgerChannelInfo{}, bobLedgerNotifs, defaultTimeout)
+	checkNotifications(t, "bobLedger", expectedBobLedgerNotifs, []query.LedgerChannelInfo{}, bobLedgerNotifs, defaultTimeout)
 
 	requiredVCNotifs := createPaychStory(
 		vabCreateResponse.ChannelId, alice.Address(), bob.Address(),
@@ -394,9 +376,9 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 	)
 
 	aliceVirtualNotifs := aliceClient.PaymentChannelUpdatesChan(vabCreateResponse.ChannelId)
-	checkNotifications(t, logger, "aliceVirtual", requiredVCNotifs, optionalVCNotifs, aliceVirtualNotifs, defaultTimeout)
+	checkNotifications(t, "aliceVirtual", requiredVCNotifs, optionalVCNotifs, aliceVirtualNotifs, defaultTimeout)
 	bobVirtualNotifs := bobClient.PaymentChannelUpdatesChan(vabCreateResponse.ChannelId)
-	checkNotifications(t, logger, "bobVirtual", requiredVCNotifs, optionalVCNotifs, bobVirtualNotifs, defaultTimeout)
+	checkNotifications(t, "bobVirtual", requiredVCNotifs, optionalVCNotifs, bobVirtualNotifs, defaultTimeout)
 }
 
 // setupNitroNodeWithRPCClient is a helper function that spins up a Nitro Node RPC Server and returns an RPC client connected to it.
@@ -406,18 +388,16 @@ func setupNitroNodeWithRPCClient(
 	msgPort int,
 	rpcPort int,
 	chain *chainservice.MockChainService,
-	logDestination *os.File,
 	connectionType transport.TransportType,
 	bootPeers []string,
 ) (rpc.RpcClientApi, *p2pms.P2PMessageService, func()) {
 	var err error
+
 	dataFolder, cleanupData := testhelpers.GenerateTempStoreFolder()
-	rpcServer, _, messageService, err := interRpc.RunRpcServer(pk, chain, true, dataFolder, msgPort, rpcPort, connectionType, logDestination, bootPeers)
+	rpcServer, _, messageService, err := interRpc.RunRpcServer(pk, chain, true, dataFolder, msgPort, rpcPort, connectionType, bootPeers)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	clientLogger := createLogger(logDestination, rpcServer.Address(), "client")
 
 	var clientConnection transport.Requester
 	switch connectionType {
@@ -429,7 +409,7 @@ func setupNitroNodeWithRPCClient(
 		}
 	case "ws":
 
-		clientConnection, err = ws.NewWebSocketTransportAsClient(rpcServer.Url(), clientLogger)
+		clientConnection, err = ws.NewWebSocketTransportAsClient(rpcServer.Url())
 		if err != nil {
 			panic(err)
 		}
@@ -438,18 +418,17 @@ func setupNitroNodeWithRPCClient(
 		panic(err)
 	}
 
-	rpcClient, err := rpc.NewRpcClient(clientLogger, clientConnection)
+	rpcClient, err := rpc.NewRpcClient(clientConnection)
 	if err != nil {
 		panic(err)
 	}
 
 	cleanupFn := func() {
-		logger := testLogger(logDestination)
-		logger.Info().Str("pk", string(pk)).Msg("Starting rpc close")
+		slog.Info("Starting rpc close", "pk", common.Bytes2Hex(pk))
 		rpcClient.Close()
-		logger.Info().Str("pk", string(pk)).Msg("Rpc client closed")
+		slog.Info("Rpc client closed", "pk", common.Bytes2Hex(pk))
 		rpcServer.Close()
-		logger.Info().Str("pk", string(pk)).Msg("Rpc server closed")
+		slog.Info("Rpc server closed", "pk", common.Bytes2Hex(pk))
 		cleanupData()
 	}
 	return rpcClient, messageService, cleanupFn
@@ -505,7 +484,7 @@ func marshalToJson[T channelInfo](t *testing.T, info T) string {
 // if any of these notifications are not received.
 //
 // If a notification is received that is neither in required or optional, checkNotifications will fail.
-func checkNotifications[T channelInfo](t *testing.T, logger zerolog.Logger, client string, required []T, optional []T, notifChan <-chan T, timeout time.Duration) {
+func checkNotifications[T channelInfo](t *testing.T, client string, required []T, optional []T, notifChan <-chan T, timeout time.Duration) {
 	// This is map containing both required and optional notifications.
 	// We use the json representation of the notification as the key and a boolean as the value.
 	// The boolean value is true if the notification is required and false if it is optional.
@@ -514,7 +493,7 @@ func checkNotifications[T channelInfo](t *testing.T, logger zerolog.Logger, clie
 	unexpectedNotifications := make(map[string]bool)
 	logUnexpected := func() {
 		for notif := range unexpectedNotifications {
-			logger.Info().Msgf("%s received unexpected notification: %v", client, notif)
+			slog.Info("Unexpected notification", "client", client, "notification", notif)
 		}
 	}
 
@@ -530,7 +509,7 @@ func checkNotifications[T channelInfo](t *testing.T, logger zerolog.Logger, clie
 		case info := <-notifChan:
 
 			notifJSON := marshalToJson(t, info)
-			logger.Info().Msgf("%s received %v+", client, info)
+			slog.Info("Received notification", "client", client, "notification", info)
 
 			// Check that the notification is a required or optional one.
 			_, isExpected := acceptableNotifications[notifJSON]
@@ -546,7 +525,7 @@ func checkNotifications[T channelInfo](t *testing.T, logger zerolog.Logger, clie
 			logUnexpected()
 			// Log both to the test log file and to stdout
 			failMsg := fmt.Sprintf("%s timed out waiting for notification(s): \n%v", client, incompleteRequired(acceptableNotifications))
-			logger.Error().Msgf(failMsg)
+			slog.Error(failMsg)
 			t.Fatalf(failMsg)
 		}
 	}

--- a/protocols/messages.go
+++ b/protocols/messages.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/rs/zerolog"
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/payments"
 	"github.com/statechannels/go-nitro/types"
@@ -215,43 +214,4 @@ func (m Message) Summarize() MessageSummary {
 
 type Summary interface {
 	ObjectivePayloadSummary | ProposalSummary | PaymentSummary | string
-}
-
-func (m MessageSummary) MarshalZerologObject(e *zerolog.Event) {
-	e.Str("To", m.To).
-		Str("From", m.From).
-		Array("PayloadSummaries", marshalCollection(m.PayloadSummaries)).
-		Array("ProposalSummaries", marshalCollection(m.ProposalSummaries)).
-		Array("Payments", marshalCollection(m.Payments)).
-		Array("RejectedObjectives", marshalIds(m.RejectedObjectives))
-}
-
-// marshalIds returns a zerolog.LogArrayMarshaler for the passed ids.
-func marshalIds(ids []string) zerolog.LogArrayMarshaler {
-	a := zerolog.Arr()
-	for _, id := range ids {
-		a.Str(id)
-	}
-	return a
-}
-
-// marshalCollection returns a zerolog.LogArrayMarshaler for the passed collection.
-func marshalCollection[T zerolog.LogObjectMarshaler](col []T) zerolog.LogArrayMarshaler {
-	a := zerolog.Arr()
-	for _, p := range col {
-		a.Object(p)
-	}
-	return a
-}
-
-func (p PaymentSummary) MarshalZerologObject(e *zerolog.Event) {
-	e.Str("ChannelId", p.ChannelId).Uint64("Amount", p.Amount)
-}
-
-func (o ObjectivePayloadSummary) MarshalZerologObject(e *zerolog.Event) {
-	e.Str("ObjectiveId", o.ObjectiveId).Str("Type", o.Type).Uint("PayloadDataSize", uint(o.PayloadDataSize))
-}
-
-func (o ProposalSummary) MarshalZerologObject(e *zerolog.Event) {
-	e.Str("ObjectiveId", o.ObjectiveId).Str("LedgerId", o.LedgerId).Str("ProposalType", o.ProposalType).Uint64("TurnNum", o.TurnNum)
 }

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
+	"log/slog"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/rs/zerolog"
 
 	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/internal/safesync"
 	"github.com/statechannels/go-nitro/node/query"
 	"github.com/statechannels/go-nitro/payments"
@@ -83,13 +83,13 @@ type RpcClientApi interface {
 // rpcClient is the implementation
 type rpcClient struct {
 	transport             transport.Requester
-	logger                zerolog.Logger
 	completedObjectives   *safesync.Map[chan struct{}]
 	ledgerChannelUpdates  *safesync.Map[chan query.LedgerChannelInfo]
 	paymentChannelUpdates *safesync.Map[chan query.PaymentChannelInfo]
 	cancel                context.CancelFunc
 	wg                    *sync.WaitGroup
 	nodeAddress           common.Address
+	logger                *slog.Logger
 }
 
 // response includes a payload or an error.
@@ -99,9 +99,10 @@ type response[T serde.ResponsePayload] struct {
 }
 
 // NewRpcClient creates a new RpcClient
-func NewRpcClient(logger zerolog.Logger, trans transport.Requester) (RpcClientApi, error) {
+func NewRpcClient(trans transport.Requester) (RpcClientApi, error) {
 	ctx, cancel := context.WithCancel(context.Background())
-	c := &rpcClient{trans, logger, &safesync.Map[chan struct{}]{}, &safesync.Map[chan query.LedgerChannelInfo]{}, &safesync.Map[chan query.PaymentChannelInfo]{}, cancel, &sync.WaitGroup{}, common.Address{}}
+
+	c := &rpcClient{trans, &safesync.Map[chan struct{}]{}, &safesync.Map[chan query.LedgerChannelInfo]{}, &safesync.Map[chan query.PaymentChannelInfo]{}, cancel, &sync.WaitGroup{}, common.Address{}, slog.Default()}
 
 	notificationChan, err := c.transport.Subscribe()
 	if err != nil {
@@ -115,18 +116,25 @@ func NewRpcClient(logger zerolog.Logger, trans transport.Requester) (RpcClientAp
 
 // NewHttpRpcClient creates a new rpcClient using an http transport
 func NewHttpRpcClient(rpcServerUrl string) (RpcClientApi, error) {
-	logger := zerolog.New(os.Stdout)
-	transport, err := ws.NewWebSocketTransportAsClient(rpcServerUrl, logger)
+	transport, err := ws.NewWebSocketTransportAsClient(rpcServerUrl)
 	if err != nil {
 		return nil, err
 	}
-	return NewRpcClient(logger, transport)
+	return NewRpcClient(transport)
 }
 
 // Address returns the address of the the nitro node
 func (rc *rpcClient) Address() (common.Address, error) {
 	if (rc.nodeAddress == common.Address{}) {
-		return waitForRequest[serde.NoPayloadRequest, common.Address](rc, serde.GetAddressMethod, serde.NoPayloadRequest{})
+		res, err := waitForRequest[serde.NoPayloadRequest, common.Address](rc, serde.GetAddressMethod, serde.NoPayloadRequest{})
+		if err != nil {
+			return res, err
+		}
+		fmt.Println()
+		// Update the logger so we output the address
+		rc.nodeAddress = res
+		rc.logger = logging.LoggerWithAddress(rc.logger, rc.nodeAddress)
+		return res, nil
 	}
 	return rc.nodeAddress, nil
 }
@@ -220,15 +228,17 @@ func (rc *rpcClient) Close() error {
 }
 
 func (rc *rpcClient) subscribeToNotifications(ctx context.Context, notificationChan <-chan []byte) {
-	rc.logger.Trace().Msg("Subscribed to notifications")
+	rc.logger.Debug("Subscribed to notifications")
 	for {
 		select {
 		case <-ctx.Done():
 			rc.wg.Done()
 			return
 		case data := <-notificationChan:
-			rc.logger.Trace().RawJSON("data", data).Msg("Received notification")
+
 			method, err := getNotificationMethod(data)
+			rc.logger.Debug("Received notification", "method", method)
+
 			if err != nil {
 				panic(err)
 			}
@@ -299,7 +309,7 @@ func waitForRequest[T serde.RequestPayload, U serde.ResponsePayload](rc *rpcClie
 //     [1] the request fails to send
 //     [2] the response cannot be parsed
 //   - Otherwise, returns the JSONRPC server's response
-func sendRequest[T serde.RequestPayload, U serde.ResponsePayload](trans transport.Requester, method serde.RequestMethod, reqPayload T, logger zerolog.Logger, wg *sync.WaitGroup) (response[U], error) {
+func sendRequest[T serde.RequestPayload, U serde.ResponsePayload](trans transport.Requester, method serde.RequestMethod, reqPayload T, logger *slog.Logger, wg *sync.WaitGroup) (response[U], error) {
 	requestId := rand.Uint64()
 	message := serde.NewJsonRpcSpecificRequest(requestId, method, reqPayload)
 	data, err := json.Marshal(message)
@@ -307,7 +317,8 @@ func sendRequest[T serde.RequestPayload, U serde.ResponsePayload](trans transpor
 		return response[U]{}, err
 	}
 
-	logger.Trace().Str("method", string(method)).Msg("sent message")
+	logger.Debug("sent message", "method", string(method))
+
 	responseData, err := trans.Request(data)
 	if err != nil {
 		return response[U]{}, err

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -237,8 +237,6 @@ func (rc *rpcClient) subscribeToNotifications(ctx context.Context, notificationC
 		case data := <-notificationChan:
 
 			method, err := getNotificationMethod(data)
-			rc.logger.Debug("Received notification", "method", method)
-
 			if err != nil {
 				panic(err)
 			}
@@ -246,6 +244,7 @@ func (rc *rpcClient) subscribeToNotifications(ctx context.Context, notificationC
 			case serde.ObjectiveCompleted:
 				rpcRequest := serde.JsonRpcSpecificRequest[protocols.ObjectiveId]{}
 				err := json.Unmarshal(data, &rpcRequest)
+				rc.logger.Debug("Received notification", "method", method, "data", rpcRequest)
 				if err != nil {
 					panic(err)
 				}
@@ -254,6 +253,7 @@ func (rc *rpcClient) subscribeToNotifications(ctx context.Context, notificationC
 			case serde.LedgerChannelUpdated:
 				rpcRequest := serde.JsonRpcSpecificRequest[query.LedgerChannelInfo]{}
 				err := json.Unmarshal(data, &rpcRequest)
+				rc.logger.Debug("Received notification", "method", method, "data", rpcRequest)
 				if err != nil {
 					panic(err)
 				}
@@ -263,6 +263,7 @@ func (rc *rpcClient) subscribeToNotifications(ctx context.Context, notificationC
 			case serde.PaymentChannelUpdated:
 				rpcRequest := serde.JsonRpcSpecificRequest[query.PaymentChannelInfo]{}
 				err := json.Unmarshal(data, &rpcRequest)
+				rc.logger.Debug("Received notification", "method", method, "data", rpcRequest)
 				if err != nil {
 					panic(err)
 				}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -130,7 +130,7 @@ func (rc *rpcClient) Address() (common.Address, error) {
 		if err != nil {
 			return res, err
 		}
-		fmt.Println()
+
 		// Update the logger so we output the address
 		rc.nodeAddress = res
 		rc.logger = logging.LoggerWithAddress(rc.logger, rc.nodeAddress)

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -3,10 +3,11 @@ package rpc
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"math/big"
 	"sync"
 
-	"github.com/rs/zerolog"
+	"github.com/statechannels/go-nitro/internal/logging"
 	nitro "github.com/statechannels/go-nitro/node"
 	"github.com/statechannels/go-nitro/node/query"
 	"github.com/statechannels/go-nitro/payments"
@@ -25,7 +26,7 @@ import (
 type RpcServer struct {
 	transport transport.Responder
 	node      *nitro.Node
-	logger    *zerolog.Logger
+	logger    *slog.Logger
 	cancel    context.CancelFunc
 	wg        *sync.WaitGroup
 }
@@ -50,8 +51,18 @@ func (rs *RpcServer) Close() error {
 }
 
 // newRpcServerWithoutNotifications creates a new rpc server without notifications enabled
-func newRpcServerWithoutNotifications(nitroNode *nitro.Node, logger *zerolog.Logger, trans transport.Responder) (*RpcServer, error) {
-	rs := &RpcServer{trans, nitroNode, logger, func() {}, &sync.WaitGroup{}}
+func newRpcServerWithoutNotifications(nitroNode *nitro.Node, trans transport.Responder) (*RpcServer, error) {
+	logger := slog.Default()
+	if hasNitroAddress := (nitroNode.Address != nil) && (nitroNode.Address != &types.Address{}); hasNitroAddress {
+		logger = logging.LoggerWithAddress(slog.Default(), *nitroNode.Address)
+	}
+	rs := &RpcServer{
+		transport: trans,
+		node:      nitroNode,
+		cancel:    func() {},
+		wg:        &sync.WaitGroup{},
+		logger:    logger,
+	}
 
 	err := rs.registerHandlers()
 	if err != nil {
@@ -61,9 +72,15 @@ func newRpcServerWithoutNotifications(nitroNode *nitro.Node, logger *zerolog.Log
 	return rs, nil
 }
 
-func NewRpcServer(nitroNode *nitro.Node, logger *zerolog.Logger, trans transport.Responder) (*RpcServer, error) {
+func NewRpcServer(nitroNode *nitro.Node, trans transport.Responder) (*RpcServer, error) {
 	ctx, cancel := context.WithCancel(context.Background())
-	rs := &RpcServer{trans, nitroNode, logger, cancel, &sync.WaitGroup{}}
+	rs := &RpcServer{
+		transport: trans,
+		node:      nitroNode,
+		cancel:    cancel,
+		wg:        &sync.WaitGroup{},
+		logger:    logging.LoggerWithAddress(slog.Default(), *nitroNode.Address),
+	}
 
 	rs.wg.Add(1)
 
@@ -86,17 +103,18 @@ func NewRpcServer(nitroNode *nitro.Node, logger *zerolog.Logger, trans transport
 // registerHandlers registers the handlers for the rpc server
 func (rs *RpcServer) registerHandlers() (err error) {
 	handlerV1 := func(requestData []byte) []byte {
-		rs.logger.Trace().RawJSON("requestData", requestData).Msg("Rpc server received request")
+		rs.logger.Debug("Rpc server received request", "requestData", string(requestData))
 
 		if !json.Valid(requestData) {
-			rs.logger.Error().Msg("request is not valid json")
+			rs.logger.Error("request is not valid json")
 			errRes := serde.NewJsonRpcErrorResponse(0, serde.ParseError)
-			return marshalResponse(errRes, rs.logger)
+			return marshalResponse(errRes)
 		}
 
-		jsonrpcReq, errRes := validateJsonrpcRequest(requestData, rs.logger)
+		jsonrpcReq, errRes := validateJsonrpcRequest(requestData)
 		if errRes != nil {
-			rs.logger.Error().Msg("could not validate jsonrpc request")
+			rs.logger.Error("could not validate jsonrpc request")
+
 			return errRes
 		}
 
@@ -165,7 +183,7 @@ func (rs *RpcServer) registerHandlers() (err error) {
 			})
 		default:
 			errRes := serde.NewJsonRpcErrorResponse(jsonrpcReq.Id, serde.MethodNotFoundError)
-			return marshalResponse(errRes, rs.logger)
+			return marshalResponse(errRes)
 		}
 	}
 
@@ -180,7 +198,7 @@ func processRequest[T serde.RequestPayload, U serde.ResponsePayload](rs *RpcServ
 	err := json.Unmarshal(requestData, &rpcRequest)
 	if err != nil {
 		response := serde.NewJsonRpcErrorResponse(rpcRequest.Id, serde.ParamsUnmarshalError)
-		return marshalResponse(response, rs.logger)
+		return marshalResponse(response)
 	}
 
 	payload := rpcRequest.Params
@@ -194,29 +212,29 @@ func processRequest[T serde.RequestPayload, U serde.ResponsePayload](rs *RpcServ
 		}
 
 		response := serde.NewJsonRpcErrorResponse(rpcRequest.Id, responseErr)
-		return marshalResponse(response, rs.logger)
+		return marshalResponse(response)
 	}
 
 	response := serde.NewJsonRpcResponse(rpcRequest.Id, processedResponse)
-	return marshalResponse(response, rs.logger)
+	return marshalResponse(response)
 }
 
 // Marshal and return response data
-func marshalResponse(response any, log *zerolog.Logger) []byte {
+func marshalResponse(response any) []byte {
 	responseData, err := json.Marshal(response)
 	if err != nil {
-		log.Panic().Err(err).Msg("Could not marshal response")
+		slog.Error("Could not marshal response", "error", err)
 	}
 	return responseData
 }
 
-func validateJsonrpcRequest(requestData []byte, logger *zerolog.Logger) (serde.JsonRpcGeneralRequest, []byte) {
+func validateJsonrpcRequest(requestData []byte) (serde.JsonRpcGeneralRequest, []byte) {
 	var request map[string]interface{}
 	vr := serde.JsonRpcGeneralRequest{}
 	err := json.Unmarshal(requestData, &request)
 	if err != nil {
 		errRes := serde.NewJsonRpcErrorResponse(0, serde.RequestUnmarshalError)
-		return serde.JsonRpcGeneralRequest{}, marshalResponse(errRes, logger)
+		return serde.JsonRpcGeneralRequest{}, marshalResponse(errRes)
 	}
 
 	// jsonrpc spec says id can be a string, number.
@@ -226,20 +244,20 @@ func validateJsonrpcRequest(requestData []byte, logger *zerolog.Logger) (serde.J
 	fRequestId, ok := requestId.(float64)
 	if !ok || fRequestId != float64(uint64(fRequestId)) {
 		errRes := serde.NewJsonRpcErrorResponse(0, serde.InvalidRequestError)
-		return serde.JsonRpcGeneralRequest{}, marshalResponse(errRes, logger)
+		return serde.JsonRpcGeneralRequest{}, marshalResponse(errRes)
 	}
 	vr.Id = uint64(fRequestId)
 
 	sJsonrpc, ok := request["jsonrpc"].(string)
 	if !ok || sJsonrpc != "2.0" {
 		errRes := serde.NewJsonRpcErrorResponse(vr.Id, serde.InvalidRequestError)
-		return serde.JsonRpcGeneralRequest{}, marshalResponse(errRes, logger)
+		return serde.JsonRpcGeneralRequest{}, marshalResponse(errRes)
 	}
 
 	sMethod, ok := request["method"].(string)
 	if !ok {
 		errRes := serde.NewJsonRpcErrorResponse(vr.Id, serde.InvalidRequestError)
-		return serde.JsonRpcGeneralRequest{}, marshalResponse(errRes, logger)
+		return serde.JsonRpcGeneralRequest{}, marshalResponse(errRes)
 	}
 	vr.Method = sMethod
 
@@ -259,7 +277,7 @@ func (rs *RpcServer) sendNotifications(ctx context.Context,
 
 		case completedObjective, ok := <-completedObjChan:
 			if !ok {
-				rs.logger.Warn().Msg("CompletedObjectives channel closed, exiting sendNotifications")
+				rs.logger.Warn("CompletedObjectives channel closed, exiting sendNotifications")
 				return
 			}
 			err := sendNotification(rs, serde.ObjectiveCompleted, completedObjective)
@@ -268,7 +286,7 @@ func (rs *RpcServer) sendNotifications(ctx context.Context,
 			}
 		case ledgerInfo, ok := <-ledgerUpdatesChan:
 			if !ok {
-				rs.logger.Warn().Msg("LedgerUpdates channel closed, exiting sendNotifications")
+				rs.logger.Warn("LedgerUpdates channel closed, exiting sendNotifications")
 				return
 			}
 			err := sendNotification(rs, serde.LedgerChannelUpdated, ledgerInfo)
@@ -277,7 +295,7 @@ func (rs *RpcServer) sendNotifications(ctx context.Context,
 			}
 		case paymentInfo, ok := <-paymentUpdatesChan:
 			if !ok {
-				rs.logger.Warn().Msg("PaymentUpdates channel closed, exiting sendNotifications")
+				rs.logger.Warn("PaymentUpdates channel closed, exiting sendNotifications")
 				return
 			}
 			err := sendNotification(rs, serde.PaymentChannelUpdated, paymentInfo)
@@ -289,7 +307,8 @@ func (rs *RpcServer) sendNotifications(ctx context.Context,
 }
 
 func sendNotification[T serde.NotificationMethod, U serde.NotificationPayload](rs *RpcServer, method T, payload U) error {
-	rs.logger.Trace().Interface("payload", payload).Msg("Sending notification")
+	rs.logger.Debug("Sending notification", "method", method, "payload", payload)
+
 	request := serde.NewJsonRpcSpecificRequest(rand.Uint64(), method, payload)
 	data, err := json.Marshal(request)
 	if err != nil {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -103,8 +103,6 @@ func NewRpcServer(nitroNode *nitro.Node, trans transport.Responder) (*RpcServer,
 // registerHandlers registers the handlers for the rpc server
 func (rs *RpcServer) registerHandlers() (err error) {
 	handlerV1 := func(requestData []byte) []byte {
-		rs.logger.Debug("Rpc server received request", "requestData", string(requestData))
-
 		if !json.Valid(requestData) {
 			rs.logger.Error("request is not valid json")
 			errRes := serde.NewJsonRpcErrorResponse(0, serde.ParseError)
@@ -112,6 +110,7 @@ func (rs *RpcServer) registerHandlers() (err error) {
 		}
 
 		jsonrpcReq, errRes := validateJsonrpcRequest(requestData)
+		rs.logger.Debug("Rpc server received request", "request", jsonrpcReq)
 		if errRes != nil {
 			rs.logger.Error("could not validate jsonrpc request")
 

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/rs/zerolog"
 	nitro "github.com/statechannels/go-nitro/node"
 	"github.com/statechannels/go-nitro/rpc/serde"
 	"github.com/statechannels/go-nitro/types"
@@ -34,11 +33,11 @@ func (*mockResponder) Notify([]byte) error {
 
 func sendRequestAndExpectError(t *testing.T, request []byte, expectedError serde.JsonRpcError) {
 	mockNode := &nitro.Node{}
-	mockLogger := &zerolog.Logger{}
+
 	mockResponder := &mockResponder{}
 	// Since we're using an empty node we want to disable notifications
 	// otherwise the server will try to send notifications to the node and fail
-	_, err := newRpcServerWithoutNotifications(mockNode, mockLogger, mockResponder)
+	_, err := newRpcServerWithoutNotifications(mockNode, mockResponder)
 	if err != nil {
 		t.Error(err)
 	}

--- a/rpc/transport/nats/server.go
+++ b/rpc/transport/nats/server.go
@@ -1,9 +1,10 @@
 package nats
 
 import (
+	"log/slog"
+
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
-	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -37,7 +38,8 @@ func (c *natsTransport) Close() error {
 	for _, sub := range c.natsSubscriptions {
 		err := c.unsubscribeFromTopic(sub, 3)
 		if err != nil {
-			log.Error().Err(err).Msgf("failed to unsubscribe from a topic: %s", sub.Subject)
+			slog.Error("failed to unsubscribe from a topic", "topic", sub.Subject, "error", err)
+
 			return err
 		}
 	}


### PR DESCRIPTION
Fixes #1571 

This PR updates go-nitro to use `slog` instead of `zerolog` with the goal of simplifying our logging.  Instead of having to pass loggers or log destinations around we now rely on setting a global [DefaultLogger](https://pkg.go.dev/golang.org/x/exp/slog#SetDefault).


# How does it work?

1. A test or CLI sets up a default logger. This can done by calling [logging.SetupDefaultFileLogger](https://github.com/statechannels/go-nitro/blob/a5861561e6d4b5590e5746655c60f472f4bc4fe3/internal/logging/logging.go#L58).  This means any log statements will be output to the specified file.
2. Optionally, components create a sub logger off the default logger that includes additional information. [For example in the engine we create a sub-logger that includes the address information.](https://github.com/statechannels/go-nitro/blob/004c58cae6d322eb8c426e7a0fdea1e64485b50e/node/engine/engine.go#L129.) Whenever the engine's logger is used it will include the address as part of the structured log output.
3. Log things out using by using a components sub logger (IE: `e.logger.Info("Engine started")`). If there is no sub-logger, you can just use `slog` which will resolve to the default logger (IE:`slog.Info("Hello World")`)


# What does it look like?
```
{"time":"2023-08-22T10:36:00.075628-07:00","level":"DEBUG","msg":"Received notification","address":"0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf","method":"ledger_channel_updated"}
{"time":"2023-08-22T10:36:00.075727-07:00","level":"DEBUG","msg":"Received notification","address":"0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF","method":"objective_completed"}
{"time":"2023-08-22T10:36:00.075741-07:00","level":"DEBUG","msg":"Received notification","address":"0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF","method":"ledger_channel_updated"}
{"time":"2023-08-22T10:36:00.075744-07:00","level":"INFO","msg":"Ledger channels created"}
{"time":"2023-08-22T10:36:00.075908-07:00","level":"DEBUG","msg":"sent message","address":"0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf","method":"create_ledger_channel"}
{"time":"2023-08-22T10:36:00.076021-07:00","level":"DEBUG","msg":"Rpc server received request","address":"0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf","requestData":"{\"jsonrpc\":\"2.0\",\"id\":17534221248848771042,\"method\":\"create_ledger_channel\",\"params\":{\"CounterParty\":\"0x2b5ad5c4795c026514f8317c7a215e218dccd6cf\",\"ChallengeDuration\":100,\"Outcome\":[{\"Asset\":\"0x0000000000000000000000000000000000000000\",\"AssetMetadata\":{\"AssetType\":0,\"Metadata\":null},\"Allocations\":[{\"Destination\":\"0x0000000000000000000000007e5f4552091a69125d5dfcb7b8c2659029395bdf\",\"Amount\":100,\"AllocationType\":0,\"Metadata\":null},{\"Destination\":\"0x0000000000000000000000002b5ad5c4795c026514f8317c7a215e218dccd6cf\",\"Amount\":100,\"AllocationType\":0,\"Metadata\":null}]}],\"AppDefinition\":\"0x0000000000000000000000000000000000000000\",\"AppData\":null,\"Nonce\":1818302577464476722}}"}
{"time":"2023-08-22T10:36:00.076091-07:00","level":"ERROR","msg":"directfund: channel already exists","error":"directfund: ledger channel already exists"}
{"time":"2023-08-22T10:36:00.076389-07:00","level":"DEBUG","msg":"sent message","address":"0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf","method":"get_ledger_channel"}
{"time":"2023-08-22T10:36:00.076481-07:00","level":"DEBUG","msg":"Rpc server received request","address":"0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf","requestData":"{\"jsonrpc\":\"2.0\",\"id\":7267307661299658688,\"method\":\"get_ledger_channel\",\"params\":{\"Id\":\"0x1a6e7b5ffdd17823b2b2f3dc68f18b780f826a59c31d61d3dff3ef06e437f28a\"}}"}
{"time":"2023-08-22T10:36:00.076765-07:00","level":"DEBUG","msg":"sent message","address":"0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF","method":"get_ledger_channel"}
{"time":"2023-08-22T10:36:00.076841-07:00","level":"DEBUG","msg":"Rpc server received request","address":"0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF","requestData":"{\"jsonrpc\":\"2.0\",\"id\":2612235265012651114,\"method\":\"get_ledger_channel\",\"params\":{\"Id\":\"0x1a6e7b5ffdd17823b2b2f3dc68f18b780f826a59c31d61d3dff3ef06e437f28a\"}}"}
{"time":"2023-08-22T10:36:00.077152-07:00","level":"DEBUG","msg":"sent message","address":"0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf","method":"create_payment_channel"}
{"time":"2023-08-22T10:36:00.07725-07:00","level":"DEBUG","msg":"Rpc server received request","address":"0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf","requestData":"{\"jsonrpc\":\"2.0\",\"id\":6459807816628571679,\"method\":\"create_payment_channel\",\"params\":{\"Intermediaries\":[],\"CounterParty\":\"0x2b5ad5c4795c026514f8317c7a215e218dccd6cf\",\"ChallengeDuration\":100,\"Outcome\":[{\"Asset\":\"0x0000000000000000000000000000000000000000\",\"AssetMetadata\":{\"AssetType\":0,\"Metadata\":null},\"Allocations\":[{\"Destination\":\"0x0000000000000000000000007e5f4552091a69125d5dfcb7b8c2659029395bdf\",\"Amount\":100,\"AllocationType\":0,\"Metadata\":null},{\"Destination\":\"0x0000000000000000000000002b5ad5c4795c026514f8317c7a215e218dccd6cf\",\"Amount\":0,\"AllocationType\":0,\"Metadata\":null}]}],\"Nonce\":8948917128598512239,\"AppDefinition\":\"0x0000000000000000000000000000000000000000\"}}"}
{"time":"2023-08-22T10:36:00.0773-07:00","level":"INFO","msg":"handling new objective request","address":"0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf","objective-id":"VirtualFund-0x6c939195be84d39af44fe6a9f21cf25a779ac1e0f7b7f477b3429947235ba9a4"}
{"time":"2023-08-22T10:36:00.077605-07:00","level":"INFO","msg":"Objective cranked","address":"0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf","objective-id":"VirtualFund-0x6c939195be84d39af44fe6a9f21cf25a779ac1e0f7b7f477b3429947235ba9a4","waiting-for":"WaitingForCompletePrefund"}
{"time":"2023-08-22T10:36:00.077615-07:00","level":"DEBUG","msg":"Sending notification","address":"0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf","method":"payment_channel_updated","payload":{"ID":"0x6c939195be84d39af44fe6a9f21cf25a779ac1e0f7b7f477b3429947235ba9a4","Status":"Proposed","Balance":{"AssetAddress":"0x0000000000000000000000000000000000000000","Payee":"0x2b5ad5c4795c026514f8317c7a215e218dccd6cf","Payer":"0x7e5f4552091a69125d5dfcb7b8c2659029395bdf","PaidSoFar":"0x0","RemainingFunds":"0x64"}}}
{"time":"2023-08-22T10:36:00.077625-07:00","level":"DEBUG","msg":"Sent message","address":"0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf","msg":{"To":"0x2B5AD5","From":"0x7E5F45","PayloadSummaries":[{"ObjectiveId":"VirtualFund-0x6c939195be84d39af44fe6a9f21cf25a779ac1e0f7b7f477b3429947235ba9a4","Type":"SignedStatePayload","PayloadDataSize":823}],"ProposalSummaries":[],"Payments":[],"RejectedObjectives":[]}}
{"time":"2023-08-22T10:36:00.077726-07:00","level":"DEBUG","msg":"Received notification","address":"0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf","method":"payment_channel_updated"}
{"time":"2023-08-22T10:36:00.077766-07:00","level":"DEBUG","msg":"Received message","address":"0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF","msg":{"To":"0x2B5AD5","From":"0x7E5F45","PayloadSummaries":[{"ObjectiveId":"VirtualFund-0x6c939195be84d39af44fe6a9f21cf25a779ac1e0f7b7f477b3429947235ba9a4","Type":"SignedStatePayload","PayloadDataSize":823}],"ProposalSummaries":[],"Payments":[],"RejectedObjectives":[]}}
{"time":"2023-08-22T10:36:00.077782-07:00","level":"INFO","msg":"Constructing objective from message","address":"0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF","objective-id":"VirtualFund-0x6c939195be84d39af44fe6a9f21cf25a779ac1e0f7b7f477b3429947235ba9a4"}
{"time":"2023-08-22T10:36:00.077771-07:00","level":"DEBUG","msg":"sent message","address":"0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf","method":"get_payment_channel"}
{"time":"2023-08-22T10:36:00.077872-07:00","level":"INFO","msg":"Created new objective from message","address":"0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF","id":"VirtualFund-0x6c939195be84d39af44fe6a9f21cf25a779ac1e0f7b7f477b3429947235ba9a4"}
{"time":"2023-08-22T10:36:00.077878-07:00","level":"INFO","msg":"Policymaker for objective","address":"0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF","policy-maker":{},"objective-id":"VirtualFund-0x6c939195be84d39af44fe6a9f21cf25a779ac1e0f7b7f477b3429947235ba9a4"}
{"time":"2023-08-22T10:36:00.077891-07:00","level":"DEBUG","msg":"Rpc server received request","address":"0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf","requestData":"{\"jsonrpc\":\"2.0\",\"id\":17345848871230467025,\"method\":\"get_payment_channel\",\"params\":{\"Id\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}}"}
{"time":"2023-08-22T10:36:00.07823-07:00","level":"INFO","msg":"Objective cranked","address":"0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF","objective-id":"VirtualFund-0x6c939195be84d39af44fe6a9f21cf25a779ac1e0f7b7f477b3429947235ba9a4","waiting-for":"WaitingForCompleteFunding"}
{"time":"2023-08-22T10:36:00.07824-07:00","level":"DEBUG","msg":"Sending notification","address":"0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF","method":"payment_channel_updated","payload":{"ID":"0x6c939195be84d39af44fe6a9f21cf25a779ac1e0f7b7f477b3429947235ba9a4","Status":"Proposed","Balance":{"AssetAddress":"0x0000000000000000000000000000000000000000","Payee":"0x2b5ad5c4795c026514f8317c7a215e218dccd6cf","Payer":"0x7e5f4552091a69125d5dfcb7b8c2659029395bdf","PaidSoFar":"0x0","RemainingFunds":"0x64"}}}
{"time":"2023-08-22T10:36:00.07825-07:00","level":"DEBUG","msg":"Sent message","address":"0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF","msg":{"To":"0x7E5F45","From":"0x2B5AD5","PayloadSummaries":[{"ObjectiveId":"VirtualFund-0x6c939195be84d39af44fe6a9f21cf25a779ac1e0f7b7f477b3429947235ba9a4","Type":"SignedStatePayload","PayloadDataSize":823}],"ProposalSummaries":[],"Payments":[],"RejectedObjectives":[]}}
{"time":"2023-08-22T10:36:00.07834-07:00","level":"DEBUG","msg":"Received notification","address":"0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF","method":"payment_channel_updated"}
```

# Performance
Based on the [benchmarks maintained by zap](https://github.com/uber-go/zap#performance) it looks like `slog` is slower than `zerolog` but relatively close to other logging frameworks.