### PR TITLE
remove mdns option from docker config files

### DIFF
--- a/docker/cloud/config.toml
+++ b/docker/cloud/config.toml
@@ -19,4 +19,3 @@ chainurl = "wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v0"
 chainauthtoken = ""
 
 bootpeers = ""
-usemdns = false

--- a/docker/local/config.toml
+++ b/docker/local/config.toml
@@ -19,4 +19,3 @@ chainurl = "wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v0"
 chainauthtoken = ""
 
 bootpeers = "/ip4/67.207.88.72/tcp/3005/p2p/16Uiu2HAmHQe7ej1swi9ghLwCi5jdSxLpGP3weBaE7j5ixBf5Hbzx"
-usemdns = false


### PR DESCRIPTION
This updates two docker config files to remove the defunct-ed `usemdns` config option. I must of missed these when I originally removed mdns in https://github.com/statechannels/go-nitro/pull/1534