### PR TITLE
Store lastBlockSeen value

### DIFF
--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -189,7 +189,7 @@ func (e *Engine) run(ctx context.Context) {
 		case pr := <-e.PaymentRequestsFromAPI:
 			res, err = e.handlePaymentRequest(pr)
 		case chainEvent := <-e.fromChain:
-			err = e.store.SetLastBlockSeen(chainEvent.BlockNum())
+			err = e.store.SetLastBlockNumSeen(chainEvent.BlockNum())
 			e.checkError(err)
 			res, err = e.handleChainEvent(chainEvent)
 		case message := <-e.fromMsg:

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -189,7 +189,7 @@ func (e *Engine) run(ctx context.Context) {
 		case pr := <-e.PaymentRequestsFromAPI:
 			res, err = e.handlePaymentRequest(pr)
 		case chainEvent := <-e.fromChain:
-			err = e.store.SetLastBlockProcessed(chainEvent.BlockNum())
+			err = e.store.SetLastBlockSeen(chainEvent.BlockNum())
 			e.checkError(err)
 			res, err = e.handleChainEvent(chainEvent)
 		case message := <-e.fromMsg:

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -189,6 +189,8 @@ func (e *Engine) run(ctx context.Context) {
 		case pr := <-e.PaymentRequestsFromAPI:
 			res, err = e.handlePaymentRequest(pr)
 		case chainEvent := <-e.fromChain:
+			err = e.store.SetLastBlockProcessed(chainEvent.BlockNum())
+			e.checkError(err)
 			res, err = e.handleChainEvent(chainEvent)
 		case message := <-e.fromMsg:
 			res, err = e.handleMessage(message)

--- a/node/engine/store/durablestore.go
+++ b/node/engine/store/durablestore.go
@@ -27,7 +27,7 @@ type DurableStore struct {
 	consensusChannels  *buntdb.DB
 	channelToObjective *buntdb.DB
 	vouchers           *buntdb.DB
-	blocks             *buntdb.DB
+	lastBlockSeen      *buntdb.DB
 
 	key     string // the signing key of the store's engine
 	address string // the (Ethereum) address associated to the signing key
@@ -68,7 +68,7 @@ func NewDurableStore(key []byte, folder string, config buntdb.Config) (Store, er
 		return nil, err
 	}
 
-	ps.blocks, err = ps.openDB("blocks", config)
+	ps.lastBlockSeen, err = ps.openDB("lastBlockSeen", config)
 	if err != nil {
 		return nil, err
 	}
@@ -217,10 +217,10 @@ func (ds *DurableStore) SetObjective(obj protocols.Objective) error {
 	return nil
 }
 
-// GetLastBlockSeen retrieves the last blockchain block processed by this node
-func (ds *DurableStore) GetLastBlockSeen() (uint64, error) {
+// GetLastBlockNumSeen retrieves the last blockchain block processed by this node
+func (ds *DurableStore) GetLastBlockNumSeen() (uint64, error) {
 	var result uint64
-	err := ds.blocks.View(func(tx *buntdb.Tx) error {
+	err := ds.lastBlockSeen.View(func(tx *buntdb.Tx) error {
 		val, err := tx.Get(lastBlockSeenKey)
 		if err != nil {
 			return err
@@ -231,9 +231,9 @@ func (ds *DurableStore) GetLastBlockSeen() (uint64, error) {
 	return result, err
 }
 
-// SetLastBlockSeen sets the last blockchain block processed by this node
-func (ds *DurableStore) SetLastBlockSeen(blockNumber uint64) error {
-	return ds.blocks.Update(func(tx *buntdb.Tx) error {
+// SetLastBlockNumSeen sets the last blockchain block processed by this node
+func (ds *DurableStore) SetLastBlockNumSeen(blockNumber uint64) error {
+	return ds.lastBlockSeen.Update(func(tx *buntdb.Tx) error {
 		_, _, err := tx.Set(lastBlockSeenKey, strconv.FormatUint(blockNumber, 10), nil)
 		return err
 	})

--- a/node/engine/store/durablestore.go
+++ b/node/engine/store/durablestore.go
@@ -27,7 +27,7 @@ type DurableStore struct {
 	consensusChannels  *buntdb.DB
 	channelToObjective *buntdb.DB
 	vouchers           *buntdb.DB
-	lastBlockSeen      *buntdb.DB
+	lastBlockNumSeen   *buntdb.DB
 
 	key     string // the signing key of the store's engine
 	address string // the (Ethereum) address associated to the signing key
@@ -68,7 +68,7 @@ func NewDurableStore(key []byte, folder string, config buntdb.Config) (Store, er
 		return nil, err
 	}
 
-	ps.lastBlockSeen, err = ps.openDB("lastBlockSeen", config)
+	ps.lastBlockNumSeen, err = ps.openDB("lastBlockNumSeen", config)
 	if err != nil {
 		return nil, err
 	}
@@ -220,8 +220,8 @@ func (ds *DurableStore) SetObjective(obj protocols.Objective) error {
 // GetLastBlockNumSeen retrieves the last blockchain block processed by this node
 func (ds *DurableStore) GetLastBlockNumSeen() (uint64, error) {
 	var result uint64
-	err := ds.lastBlockSeen.View(func(tx *buntdb.Tx) error {
-		val, err := tx.Get(lastBlockSeenKey)
+	err := ds.lastBlockNumSeen.View(func(tx *buntdb.Tx) error {
+		val, err := tx.Get(lastBlockNumSeenKey)
 		if err != nil {
 			return err
 		}
@@ -233,8 +233,8 @@ func (ds *DurableStore) GetLastBlockNumSeen() (uint64, error) {
 
 // SetLastBlockNumSeen sets the last blockchain block processed by this node
 func (ds *DurableStore) SetLastBlockNumSeen(blockNumber uint64) error {
-	return ds.lastBlockSeen.Update(func(tx *buntdb.Tx) error {
-		_, _, err := tx.Set(lastBlockSeenKey, strconv.FormatUint(blockNumber, 10), nil)
+	return ds.lastBlockNumSeen.Update(func(tx *buntdb.Tx) error {
+		_, _, err := tx.Set(lastBlockNumSeenKey, strconv.FormatUint(blockNumber, 10), nil)
 		return err
 	})
 }

--- a/node/engine/store/durablestore.go
+++ b/node/engine/store/durablestore.go
@@ -217,11 +217,11 @@ func (ds *DurableStore) SetObjective(obj protocols.Objective) error {
 	return nil
 }
 
-// GetLastBlockProcessed retrieves the last blockchain block processed by this node
-func (ds *DurableStore) GetLastBlockProcessed() (uint64, error) {
+// GetLastBlockSeen retrieves the last blockchain block processed by this node
+func (ds *DurableStore) GetLastBlockSeen() (uint64, error) {
 	var result uint64
 	err := ds.blocks.View(func(tx *buntdb.Tx) error {
-		val, err := tx.Get(lastBlockProcessedKey)
+		val, err := tx.Get(lastBlockSeenKey)
 		if err != nil {
 			return err
 		}
@@ -231,10 +231,10 @@ func (ds *DurableStore) GetLastBlockProcessed() (uint64, error) {
 	return result, err
 }
 
-// SetLastBlockProcessed sets the last blockchain block processed by this node
-func (ds *DurableStore) SetLastBlockProcessed(blockNumber uint64) error {
+// SetLastBlockSeen sets the last blockchain block processed by this node
+func (ds *DurableStore) SetLastBlockSeen(blockNumber uint64) error {
 	return ds.blocks.Update(func(tx *buntdb.Tx) error {
-		_, _, err := tx.Set(lastBlockProcessedKey, strconv.FormatUint(blockNumber, 10), nil)
+		_, _, err := tx.Set(lastBlockSeenKey, strconv.FormatUint(blockNumber, 10), nil)
 		return err
 	})
 }

--- a/node/engine/store/memstore.go
+++ b/node/engine/store/memstore.go
@@ -24,7 +24,7 @@ type MemStore struct {
 	consensusChannels  safesync.Map[[]byte]
 	channelToObjective safesync.Map[protocols.ObjectiveId]
 	vouchers           safesync.Map[[]byte]
-	blocks             safesync.Map[uint64]
+	lastBlockProcessed uint64
 
 	key     string // the signing key of the store's engine
 	address string // the (Ethereum) address associated to the signing key
@@ -40,7 +40,7 @@ func NewMemStore(key []byte) Store {
 	ms.consensusChannels = safesync.Map[[]byte]{}
 	ms.channelToObjective = safesync.Map[protocols.ObjectiveId]{}
 	ms.vouchers = safesync.Map[[]byte]{}
-	ms.blocks = safesync.Map[uint64]{}
+	ms.lastBlockProcessed = 0
 	return &ms
 }
 
@@ -129,18 +129,13 @@ func (ms *MemStore) SetObjective(obj protocols.Objective) error {
 
 // SetLastBlockProcessed
 func (ms *MemStore) SetLastBlockProcessed(blockNumber uint64) error {
-	ms.blocks.Store(lastBlockProcessedKey, blockNumber)
+	ms.lastBlockProcessed = blockNumber
 	return nil
 }
 
 // GetLastBlockProcessed
 func (ms *MemStore) GetLastBlockProcessed() (uint64, error) {
-	blockNumber, ok := ms.blocks.Load(lastBlockProcessedKey)
-	if !ok {
-		return 0, fmt.Errorf("could not retrieve lastBlockSeen from memstore")
-	}
-
-	return blockNumber, nil
+	return ms.lastBlockProcessed, nil
 }
 
 // SetChannel sets the channel in the store.

--- a/node/engine/store/memstore.go
+++ b/node/engine/store/memstore.go
@@ -127,14 +127,14 @@ func (ms *MemStore) SetObjective(obj protocols.Objective) error {
 	return nil
 }
 
-// SetLastBlockSeen
-func (ms *MemStore) SetLastBlockSeen(blockNumber uint64) error {
+// SetLastBlockNumSeen
+func (ms *MemStore) SetLastBlockNumSeen(blockNumber uint64) error {
 	ms.lastBlockSeen = blockNumber
 	return nil
 }
 
-// GetLastBlockSeen
-func (ms *MemStore) GetLastBlockSeen() (uint64, error) {
+// GetLastBlockNumSeen
+func (ms *MemStore) GetLastBlockNumSeen() (uint64, error) {
 	return ms.lastBlockSeen, nil
 }
 

--- a/node/engine/store/memstore.go
+++ b/node/engine/store/memstore.go
@@ -24,7 +24,7 @@ type MemStore struct {
 	consensusChannels  safesync.Map[[]byte]
 	channelToObjective safesync.Map[protocols.ObjectiveId]
 	vouchers           safesync.Map[[]byte]
-	lastBlockProcessed uint64
+	lastBlockSeen      uint64
 
 	key     string // the signing key of the store's engine
 	address string // the (Ethereum) address associated to the signing key
@@ -40,7 +40,7 @@ func NewMemStore(key []byte) Store {
 	ms.consensusChannels = safesync.Map[[]byte]{}
 	ms.channelToObjective = safesync.Map[protocols.ObjectiveId]{}
 	ms.vouchers = safesync.Map[[]byte]{}
-	ms.lastBlockProcessed = 0
+	ms.lastBlockSeen = 0
 	return &ms
 }
 
@@ -127,15 +127,15 @@ func (ms *MemStore) SetObjective(obj protocols.Objective) error {
 	return nil
 }
 
-// SetLastBlockProcessed
-func (ms *MemStore) SetLastBlockProcessed(blockNumber uint64) error {
-	ms.lastBlockProcessed = blockNumber
+// SetLastBlockSeen
+func (ms *MemStore) SetLastBlockSeen(blockNumber uint64) error {
+	ms.lastBlockSeen = blockNumber
 	return nil
 }
 
-// GetLastBlockProcessed
-func (ms *MemStore) GetLastBlockProcessed() (uint64, error) {
-	return ms.lastBlockProcessed, nil
+// GetLastBlockSeen
+func (ms *MemStore) GetLastBlockSeen() (uint64, error) {
+	return ms.lastBlockSeen, nil
 }
 
 // SetChannel sets the channel in the store.

--- a/node/engine/store/memstore.go
+++ b/node/engine/store/memstore.go
@@ -24,6 +24,7 @@ type MemStore struct {
 	consensusChannels  safesync.Map[[]byte]
 	channelToObjective safesync.Map[protocols.ObjectiveId]
 	vouchers           safesync.Map[[]byte]
+	blocks             safesync.Map[uint64]
 
 	key     string // the signing key of the store's engine
 	address string // the (Ethereum) address associated to the signing key
@@ -39,6 +40,7 @@ func NewMemStore(key []byte) Store {
 	ms.consensusChannels = safesync.Map[[]byte]{}
 	ms.channelToObjective = safesync.Map[protocols.ObjectiveId]{}
 	ms.vouchers = safesync.Map[[]byte]{}
+	ms.blocks = safesync.Map[uint64]{}
 	return &ms
 }
 
@@ -123,6 +125,22 @@ func (ms *MemStore) SetObjective(obj protocols.Objective) error {
 	}
 
 	return nil
+}
+
+// SetLastBlockProcessed
+func (ms *MemStore) SetLastBlockProcessed(blockNumber uint64) error {
+	ms.blocks.Store(lastBlockProcessedKey, blockNumber)
+	return nil
+}
+
+// GetLastBlockProcessed
+func (ms *MemStore) GetLastBlockProcessed() (uint64, error) {
+	blockNumber, ok := ms.blocks.Load(lastBlockProcessedKey)
+	if !ok {
+		return 0, fmt.Errorf("could not retrieve lastBlockSeen from memstore")
+	}
+
+	return blockNumber, nil
 }
 
 // SetChannel sets the channel in the store.

--- a/node/engine/store/memstore.go
+++ b/node/engine/store/memstore.go
@@ -24,7 +24,7 @@ type MemStore struct {
 	consensusChannels  safesync.Map[[]byte]
 	channelToObjective safesync.Map[protocols.ObjectiveId]
 	vouchers           safesync.Map[[]byte]
-	lastBlockSeen      uint64
+	lastBlockNumSeen   uint64
 
 	key     string // the signing key of the store's engine
 	address string // the (Ethereum) address associated to the signing key
@@ -40,7 +40,7 @@ func NewMemStore(key []byte) Store {
 	ms.consensusChannels = safesync.Map[[]byte]{}
 	ms.channelToObjective = safesync.Map[protocols.ObjectiveId]{}
 	ms.vouchers = safesync.Map[[]byte]{}
-	ms.lastBlockSeen = 0
+	ms.lastBlockNumSeen = 0
 	return &ms
 }
 
@@ -129,13 +129,13 @@ func (ms *MemStore) SetObjective(obj protocols.Objective) error {
 
 // SetLastBlockNumSeen
 func (ms *MemStore) SetLastBlockNumSeen(blockNumber uint64) error {
-	ms.lastBlockSeen = blockNumber
+	ms.lastBlockNumSeen = blockNumber
 	return nil
 }
 
 // GetLastBlockNumSeen
 func (ms *MemStore) GetLastBlockNumSeen() (uint64, error) {
-	return ms.lastBlockSeen, nil
+	return ms.lastBlockNumSeen, nil
 }
 
 // SetChannel sets the channel in the store.

--- a/node/engine/store/store.go
+++ b/node/engine/store/store.go
@@ -12,10 +12,10 @@ import (
 )
 
 const (
-	ErrNoSuchObjective = types.ConstError("store: no such objective")
-	ErrNoSuchChannel   = types.ConstError("store: failed to find required channel data")
-	ErrLoadVouchers    = types.ConstError("store: could not load vouchers")
-	lastBlockSeenKey   = "lastBlockSeen"
+	ErrNoSuchObjective  = types.ConstError("store: no such objective")
+	ErrNoSuchChannel    = types.ConstError("store: failed to find required channel data")
+	ErrLoadVouchers     = types.ConstError("store: could not load vouchers")
+	lastBlockNumSeenKey = "lastBlockNumSeen"
 )
 
 // Store is responsible for persisting objectives, objective metadata, states, signatures, private keys and blockchain data

--- a/node/engine/store/store.go
+++ b/node/engine/store/store.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	ErrNoSuchObjective = types.ConstError("store: no such objective")
-	ErrNoSuchChannel   = types.ConstError("store: failed to find required channel data")
-	ErrLoadVouchers    = types.ConstError("store: could not load vouchers")
+	ErrNoSuchObjective    = types.ConstError("store: no such objective")
+	ErrNoSuchChannel      = types.ConstError("store: failed to find required channel data")
+	ErrLoadVouchers       = types.ConstError("store: could not load vouchers")
+	lastBlockProcessedKey = "lastBlockProcessed"
 )
 
 // Store is responsible for persisting objectives, objective metadata, states, signatures, private keys and blockchain data
@@ -31,6 +32,8 @@ type Store interface {
 	DestroyChannel(id types.Destination) error
 	GetChannelsByAppDefinition(appDef types.Address) ([]*channel.Channel, error) // Returns any channels that includes the given app definition
 	ReleaseChannelFromOwnership(types.Destination) error                         // Release channel from being owned by any objective
+	GetLastBlockProcessed() (uint64, error)
+	SetLastBlockProcessed(uint64) error
 
 	ConsensusChannelStore
 	payments.VoucherStore

--- a/node/engine/store/store.go
+++ b/node/engine/store/store.go
@@ -32,8 +32,8 @@ type Store interface {
 	DestroyChannel(id types.Destination) error
 	GetChannelsByAppDefinition(appDef types.Address) ([]*channel.Channel, error) // Returns any channels that includes the given app definition
 	ReleaseChannelFromOwnership(types.Destination) error                         // Release channel from being owned by any objective
-	GetLastBlockSeen() (uint64, error)
-	SetLastBlockSeen(uint64) error
+	GetLastBlockNumSeen() (uint64, error)
+	SetLastBlockNumSeen(uint64) error
 
 	ConsensusChannelStore
 	payments.VoucherStore

--- a/node/engine/store/store.go
+++ b/node/engine/store/store.go
@@ -12,10 +12,10 @@ import (
 )
 
 const (
-	ErrNoSuchObjective    = types.ConstError("store: no such objective")
-	ErrNoSuchChannel      = types.ConstError("store: failed to find required channel data")
-	ErrLoadVouchers       = types.ConstError("store: could not load vouchers")
-	lastBlockProcessedKey = "lastBlockProcessed"
+	ErrNoSuchObjective = types.ConstError("store: no such objective")
+	ErrNoSuchChannel   = types.ConstError("store: failed to find required channel data")
+	ErrLoadVouchers    = types.ConstError("store: could not load vouchers")
+	lastBlockSeenKey   = "lastBlockSeen"
 )
 
 // Store is responsible for persisting objectives, objective metadata, states, signatures, private keys and blockchain data
@@ -32,8 +32,8 @@ type Store interface {
 	DestroyChannel(id types.Destination) error
 	GetChannelsByAppDefinition(appDef types.Address) ([]*channel.Channel, error) // Returns any channels that includes the given app definition
 	ReleaseChannelFromOwnership(types.Destination) error                         // Release channel from being owned by any objective
-	GetLastBlockProcessed() (uint64, error)
-	SetLastBlockProcessed(uint64) error
+	GetLastBlockSeen() (uint64, error)
+	SetLastBlockSeen(uint64) error
 
 	ConsensusChannelStore
 	payments.VoucherStore

--- a/node/engine/store/store_test.go
+++ b/node/engine/store/store_test.go
@@ -216,14 +216,14 @@ func TestGetChannelsByParticipant(t *testing.T) {
 	}
 }
 
-func TestGetLastBlockSeenMemStore(t *testing.T) {
+func TestGetLastBlockNumSeenMemStore(t *testing.T) {
 	sk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
 	ms := store.NewMemStore(sk)
 
 	want := uint64(15)
-	_ = ms.SetLastBlockSeen(want)
+	_ = ms.SetLastBlockNumSeen(want)
 
-	got, err := ms.GetLastBlockSeen()
+	got, err := ms.GetLastBlockNumSeen()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,7 +233,7 @@ func TestGetLastBlockSeenMemStore(t *testing.T) {
 	}
 }
 
-func TestGetLastBlockSeenDurableStore(t *testing.T) {
+func TestGetLastBlockNumSeenDurableStore(t *testing.T) {
 	pk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
 
 	dataFolder, cleanup := testhelpers.GenerateTempStoreFolder()
@@ -244,9 +244,9 @@ func TestGetLastBlockSeenDurableStore(t *testing.T) {
 	}
 
 	want := uint64(15)
-	_ = durableStore.SetLastBlockSeen(want)
+	_ = durableStore.SetLastBlockNumSeen(want)
 
-	got, err := durableStore.GetLastBlockSeen()
+	got, err := durableStore.GetLastBlockNumSeen()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/node/engine/store/store_test.go
+++ b/node/engine/store/store_test.go
@@ -235,7 +235,9 @@ func TestGetLastBlockProcessedMemStore(t *testing.T) {
 
 func TestGetLastBlockProcessedDurableStore(t *testing.T) {
 	pk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
-	dataFolder := fmt.Sprintf("%s/%d%d", STORE_TEST_DATA_FOLDER, rand.Uint64(), time.Now().UnixNano())
+
+	dataFolder, cleanup := testhelpers.GenerateTempStoreFolder()
+	defer cleanup()
 	durableStore, err := store.NewDurableStore(pk, dataFolder, buntdb.Config{})
 	if err != nil {
 		t.Fatal(err)

--- a/node/engine/store/store_test.go
+++ b/node/engine/store/store_test.go
@@ -220,7 +220,7 @@ func TestGetChannelsByParticipant(t *testing.T) {
 	}
 }
 
-func TestGetLastBlockProcessed(t *testing.T) {
+func TestGetLastBlockProcessedMemStore(t *testing.T) {
 	sk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
 	ms := store.NewMemStore(sk)
 
@@ -228,6 +228,27 @@ func TestGetLastBlockProcessed(t *testing.T) {
 	_ = ms.SetLastBlockProcessed(want)
 
 	got, err := ms.GetLastBlockProcessed()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Fatalf("fetched result different than expected %s", diff)
+	}
+}
+
+func TestGetLastBlockProcessedDurableStore(t *testing.T) {
+	pk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
+	dataFolder := fmt.Sprintf("%s/%d%d", STORE_TEST_DATA_FOLDER, rand.Uint64(), time.Now().UnixNano())
+	durableStore, err := store.NewDurableStore(pk, dataFolder, buntdb.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := uint64(15)
+	_ = durableStore.SetLastBlockProcessed(want)
+
+	got, err := durableStore.GetLastBlockProcessed()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/node/engine/store/store_test.go
+++ b/node/engine/store/store_test.go
@@ -216,14 +216,14 @@ func TestGetChannelsByParticipant(t *testing.T) {
 	}
 }
 
-func TestGetLastBlockProcessedMemStore(t *testing.T) {
+func TestGetLastBlockSeenMemStore(t *testing.T) {
 	sk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
 	ms := store.NewMemStore(sk)
 
 	want := uint64(15)
-	_ = ms.SetLastBlockProcessed(want)
+	_ = ms.SetLastBlockSeen(want)
 
-	got, err := ms.GetLastBlockProcessed()
+	got, err := ms.GetLastBlockSeen()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,7 +233,7 @@ func TestGetLastBlockProcessedMemStore(t *testing.T) {
 	}
 }
 
-func TestGetLastBlockProcessedDurableStore(t *testing.T) {
+func TestGetLastBlockSeenDurableStore(t *testing.T) {
 	pk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
 
 	dataFolder, cleanup := testhelpers.GenerateTempStoreFolder()
@@ -244,9 +244,9 @@ func TestGetLastBlockProcessedDurableStore(t *testing.T) {
 	}
 
 	want := uint64(15)
-	_ = durableStore.SetLastBlockProcessed(want)
+	_ = durableStore.SetLastBlockSeen(want)
 
-	got, err := durableStore.GetLastBlockProcessed()
+	got, err := durableStore.GetLastBlockSeen()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/node/engine/store/store_test.go
+++ b/node/engine/store/store_test.go
@@ -220,6 +220,23 @@ func TestGetChannelsByParticipant(t *testing.T) {
 	}
 }
 
+func TestGetLastBlockProcessed(t *testing.T) {
+	sk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
+	ms := store.NewMemStore(sk)
+
+	want := uint64(15)
+	_ = ms.SetLastBlockProcessed(want)
+
+	got, err := ms.GetLastBlockProcessed()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Fatalf("fetched result different than expected %s", diff)
+	}
+}
+
 func TestBigNumberStorage(t *testing.T) {
 	pk := common.Hex2Bytes(`2af069c584758f9ec47c4224a8becc1983f28acfbe837bd7710b70f9fc6d5e44`)
 


### PR DESCRIPTION
This is a precursor to adding initialization logic to the `chainservice` to allow it to process events from blocks since the node last started. Currently, our node always assumes we are starting for the first time, therefore it doesn't look back in time to see if it's missed anything.

This PR makes the following changes:

1. Adds store methods to get/set the last block processed. Also adds unit tests for these new methods.
2. Adds code to the engine to call `store.SetLastBlockSeen` every time an on-chain event is received from `chainservice`