### PR TITLE
Refactor init functions to separate node from rpc server

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -1,0 +1,55 @@
+package node
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/rs/zerolog"
+	"github.com/statechannels/go-nitro/internal/chain"
+	"github.com/statechannels/go-nitro/node"
+	"github.com/statechannels/go-nitro/node/engine"
+	"github.com/statechannels/go-nitro/node/engine/chainservice"
+	"github.com/statechannels/go-nitro/node/engine/store"
+	"github.com/tidwall/buntdb"
+
+	p2pms "github.com/statechannels/go-nitro/node/engine/messageservice/p2p-message-service"
+)
+
+func InitializeNode(pkString string, chainOpts chain.ChainOpts,
+	useDurableStore bool, durableStoreFolder string, msgPort int, logDestination *os.File, bootPeers []string,
+) (*node.Node, *store.Store, *p2pms.P2PMessageService, *chainservice.EthChainService, error) {
+	if pkString == "" {
+		panic("pk must be set")
+	}
+
+	logger := zerolog.New(logDestination).
+		With().
+		Timestamp().
+		Logger()
+
+	pk := common.Hex2Bytes(pkString)
+	ourStore, err := store.NewStore(pk, logger, useDurableStore, durableStoreFolder, buntdb.Config{})
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	logger.Info().Msg("Initializing message service on port " + fmt.Sprint(msgPort) + "...")
+	messageService := p2pms.NewMessageService("127.0.0.1", msgPort, *ourStore.GetAddress(), pk, logDestination, bootPeers)
+
+	logger.Info().Msg("Initializing chain service and connecting to " + chainOpts.ChainUrl + "...")
+	ourChain, err := chain.InitializeEthChainService(chainOpts)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	node := node.New(
+		messageService,
+		ourChain,
+		ourStore,
+		logDestination,
+		&engine.PermissivePolicy{},
+	)
+
+	return &node, &ourStore, messageService, ourChain, nil
+}

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -3,118 +3,38 @@ package rpc
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/rs/zerolog"
-	"github.com/statechannels/go-nitro/crypto"
-	"github.com/statechannels/go-nitro/internal/chain"
-	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/node"
-	"github.com/statechannels/go-nitro/node/engine"
-	"github.com/statechannels/go-nitro/node/engine/chainservice"
-	p2pms "github.com/statechannels/go-nitro/node/engine/messageservice/p2p-message-service"
-	"github.com/statechannels/go-nitro/node/engine/store"
 	"github.com/statechannels/go-nitro/rpc"
 	"github.com/statechannels/go-nitro/rpc/transport"
 	"github.com/statechannels/go-nitro/rpc/transport/nats"
 	"github.com/statechannels/go-nitro/rpc/transport/ws"
-	"github.com/tidwall/buntdb"
 )
 
-func InitChainServiceAndRunRpcServer(pkString string, chainOpts chain.ChainOpts,
-	useDurableStore bool, durableStoreFolder string, useNats bool, msgPort int, rpcPort int,
-	bootPeers []string,
-) (*rpc.RpcServer, *node.Node, *p2pms.P2PMessageService, error) {
-	if pkString == "" {
-		panic("pk must be set")
-	}
-	pk := common.Hex2Bytes(pkString)
-
-	chainService, err := chain.InitializeEthChainService(chainOpts)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	transportType := transport.Ws
-	if useNats {
-		transportType = transport.Nats
-	}
-	rpcServer, node, messageService, err := RunRpcServer(pk, chainService, useDurableStore, durableStoreFolder, msgPort, rpcPort, transportType, os.Stdout, bootPeers)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	fmt.Println("Nitro as a Service listening on port", rpcPort)
-	return rpcServer, node, messageService, nil
-}
-
-func RunRpcServer(pk []byte, chainService chainservice.ChainService,
-	useDurableStore bool, durableStoreFolder string, msgPort int, rpcPort int, transportType transport.TransportType, logDestination *os.File,
-	bootPeers []string,
-) (*rpc.RpcServer, *node.Node, *p2pms.P2PMessageService, error) {
-	me := crypto.GetAddressFromSecretKeyBytes(pk)
-
-	var ourStore store.Store
-	var err error
-
+func InitializeRpcServer(node *node.Node, rpcPort int, useNats bool, logDestination *os.File) (*rpc.RpcServer, error) {
 	logger := zerolog.New(logDestination).
 		With().
 		Timestamp().
 		Logger()
 
-	if useDurableStore {
-		dataFolder := filepath.Join(durableStoreFolder, me.String())
-		logger.Info().Msgf("Initialising durable store in %s...", dataFolder)
-
-		ourStore, err = store.NewDurableStore(pk, dataFolder, buntdb.Config{})
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
-	} else {
-		logger.Info().Msg("Initialising mem store...")
-		ourStore = store.NewMemStore(pk)
-	}
-
-	logger.Info().Msg("Initializing message service on port " + fmt.Sprint(msgPort) + "...")
-	messageService := p2pms.NewMessageService("127.0.0.1", msgPort, *ourStore.GetAddress(), pk, logDestination, bootPeers)
-	node := node.New(
-		messageService,
-		chainService,
-		ourStore,
-		logDestination,
-		&engine.PermissivePolicy{})
-
-	serverLogger := logging.WithAddress(zerolog.New(logDestination).
-		Level(zerolog.TraceLevel).
-		With().
-		Timestamp().
-		Str("rpc", "server"), ourStore.GetAddress()).
-		Logger()
-
 	var transport transport.Responder
+	var err error
 
-	switch transportType {
-	case "nats":
-
+	if useNats {
 		logger.Info().Msg("Initializing NATS RPC transport...")
 		transport, err = nats.NewNatsTransportAsServer(rpcPort)
-	case "ws":
+	} else {
 		logger.Info().Msg("Initializing websocket RPC transport...")
-
-		transport, err = ws.NewWebSocketTransportAsServer(fmt.Sprint(rpcPort), serverLogger)
-	default:
-		err = fmt.Errorf("unknown transport type %s", transportType)
+		transport, err = ws.NewWebSocketTransportAsServer(fmt.Sprint(rpcPort), logger)
 	}
-
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 
-	rpcServer, err := rpc.NewRpcServer(&node, &serverLogger, transport)
+	rpcServer, err := rpc.NewRpcServer(node, &logger, transport)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
-	return rpcServer, &node, messageService, nil
+	return rpcServer, nil
 }

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/internal/chain"
+	"github.com/statechannels/go-nitro/internal/node"
 	"github.com/statechannels/go-nitro/internal/rpc"
 	"github.com/urfave/cli/v2"
 	"github.com/urfave/cli/v2/altsrc"
@@ -172,7 +173,13 @@ func main() {
 			if bootPeers != "" {
 				peerSlice = strings.Split(bootPeers, ",")
 			}
-			rpcServer, _, _, err := rpc.InitChainServiceAndRunRpcServer(pkString, chainOpts, useDurableStore, durableStoreFolder, useNats, msgPort, rpcPort, peerSlice)
+
+			node, _, _, _, err := node.InitializeNode(pkString, chainOpts, useDurableStore, durableStoreFolder, msgPort, os.Stdout, peerSlice)
+			if err != nil {
+				return err
+			}
+
+			rpcServer, err := rpc.InitializeRpcServer(node, rpcPort, useNats, os.Stdout)
 			if err != nil {
 				return err
 			}

--- a/node/engine/store/durablestore.go
+++ b/node/engine/store/durablestore.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/channel"
@@ -36,7 +37,11 @@ type DurableStore struct {
 // It will create the folder if it does not exist
 func NewDurableStore(key []byte, folder string, config buntdb.Config) (Store, error) {
 	ps := DurableStore{}
-	err := os.MkdirAll(folder, os.ModePerm)
+
+	me := crypto.GetAddressFromSecretKeyBytes(key)
+	dataFolder := filepath.Join(folder, me.String())
+
+	err := os.MkdirAll(dataFolder, os.ModePerm)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Prior to this PR we had the following init functions:
```
InitChainServiceAndRunRpcServer
```
This PR instead uses the following init functions:
```
InitializeNode
InitializeRpcServer
```
The advantage of separating the initialization logic is that we have more flexibility