### PR TITLE
remove LatestBlockNumber from Channel class

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -14,10 +14,9 @@ import (
 )
 
 type OnChainData struct {
-	LatestBlockNumber uint64 // the latest block number we've seen
-	Holdings          types.Funds
-	Outcome           outcome.Exit
-	StateHash         common.Hash
+	Holdings  types.Funds
+	Outcome   outcome.Exit
+	StateHash common.Hash
 }
 
 type OffChainData struct {
@@ -127,7 +126,6 @@ func (c *Channel) Clone() *Channel {
 	for i, ss := range c.OffChain.SignedStateForTurnNum {
 		d.OffChain.SignedStateForTurnNum[i] = ss.Clone()
 	}
-	d.OnChain.LatestBlockNumber = c.OnChain.LatestBlockNumber
 	d.FixedPart = c.FixedPart.Clone()
 	d.OnChain.Holdings = c.OnChain.Holdings
 	return d
@@ -323,10 +321,6 @@ func (c *Channel) SignAndAddState(s state.State, sk *[]byte) (state.SignedState,
 
 // UpdateWithChainEvent mutates the receiver if provided with a "new" chain event (with a greater block number than previously seen)
 func (c *Channel) UpdateWithChainEvent(event chainservice.Event) (*Channel, error) {
-	if event.BlockNum() < c.OnChain.LatestBlockNumber {
-		return c, nil // ignore stale information TODO: is this reorg safe?
-	}
-	c.OnChain.LatestBlockNumber = event.BlockNum()
 	switch e := event.(type) {
 	case chainservice.AllocationUpdatedEvent:
 		c.OnChain.Holdings[e.AssetAddress] = e.AssetAmount

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -352,22 +352,22 @@ func TestSerde(t *testing.T) {
 			LatestSupportedStateTurnNum: 2,
 		},
 		OnChain: OnChainData{
-			Holdings:          types.Funds{},
-			LatestBlockNumber: 7,
-			StateHash:         common.Hash{},
-			Outcome:           outcome.Exit{},
+			Holdings:  types.Funds{},
+			StateHash: common.Hash{},
+			Outcome:   outcome.Exit{},
 		},
 	}
 
-	someChannelJSON := `{"Id":"0x0100000000000000000000000000000000000000000000000000000000000000","MyIndex":1,"Participants":["0xf5a1bb5607c9d079e46d1b3dc33f257d937b43bd","0x760bf27cd45036a6c486802d30b5d90cffbe31fe"],"ChannelNonce":37140676580,"AppDefinition":"0x5e29e5ab8ef33f050c7cc10b5a0456d975c5f88d","ChallengeDuration":60,"OnChain":{"LatestBlockNumber":7,"Holdings":{},"Outcome":[],"StateHash":"0x0000000000000000000000000000000000000000000000000000000000000000"},"OffChain":{"SignedStateForTurnNum":{"0":{"State":{"Participants":["0xf5a1bb5607c9d079e46d1b3dc33f257d937b43bd","0x760bf27cd45036a6c486802d30b5d90cffbe31fe"],"ChannelNonce":37140676580,"AppDefinition":"0x5e29e5ab8ef33f050c7cc10b5a0456d975c5f88d","ChallengeDuration":60,"AppData":"","Outcome":[{"Asset":"0x0000000000000000000000000000000000000000","AssetMetadata":{"AssetType":0,"Metadata":""},"Allocations":[{"Destination":"0x000000000000000000000000f5a1bb5607c9d079e46d1b3dc33f257d937b43bd","Amount":5,"AllocationType":0,"Metadata":null},{"Destination":"0x000000000000000000000000ee18ff1575055691009aa246ae608132c57a422c","Amount":5,"AllocationType":0,"Metadata":null}]}],"TurnNum":5,"IsFinal":false},"Sigs":{}}},"LatestSupportedStateTurnNum":2}}`
+	someChannelJSON := `{"Id":"0x0100000000000000000000000000000000000000000000000000000000000000","MyIndex":1,"Participants":["0xf5a1bb5607c9d079e46d1b3dc33f257d937b43bd","0x760bf27cd45036a6c486802d30b5d90cffbe31fe"],"ChannelNonce":37140676580,"AppDefinition":"0x5e29e5ab8ef33f050c7cc10b5a0456d975c5f88d","ChallengeDuration":60,"OnChain":{"Holdings":{},"Outcome":[],"StateHash":"0x0000000000000000000000000000000000000000000000000000000000000000"},"OffChain":{"SignedStateForTurnNum":{"0":{"State":{"Participants":["0xf5a1bb5607c9d079e46d1b3dc33f257d937b43bd","0x760bf27cd45036a6c486802d30b5d90cffbe31fe"],"ChannelNonce":37140676580,"AppDefinition":"0x5e29e5ab8ef33f050c7cc10b5a0456d975c5f88d","ChallengeDuration":60,"AppData":"","Outcome":[{"Asset":"0x0000000000000000000000000000000000000000","AssetMetadata":{"AssetType":0,"Metadata":""},"Allocations":[{"Destination":"0x000000000000000000000000f5a1bb5607c9d079e46d1b3dc33f257d937b43bd","Amount":5,"AllocationType":0,"Metadata":null},{"Destination":"0x000000000000000000000000ee18ff1575055691009aa246ae608132c57a422c","Amount":5,"AllocationType":0,"Metadata":null}]}],"TurnNum":5,"IsFinal":false},"Sigs":{}}},"LatestSupportedStateTurnNum":2}}`
 
 	// Marshalling
 	got, err := json.Marshal(someChannel)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(got) != someChannelJSON {
-		t.Fatalf("incorrect json marshaling, expected %v got \n%v", someChannelJSON, string(got))
+
+	if diff := cmp.Diff(string(got), someChannelJSON); diff != "" {
+		t.Fatalf("incorrect json marshaling (-want +got):\n%s", diff)
 	}
 
 	// Unmarshalling
@@ -377,7 +377,7 @@ func TestSerde(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !reflect.DeepEqual(c, someChannel) {
-		t.Fatalf("incorrect json unmarshaling, expected \n%+v got \n%+v", someChannel, got)
+	if diff := cmp.Diff(c, someChannel, cmp.AllowUnexported(state.SignedState{})); diff != "" {
+		t.Fatalf("incorrect json unmarshaling (-want +got):\n%s", diff)
 	}
 }

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -168,26 +168,6 @@ func TestUpdate(t *testing.T) {
 	if !updated.C.OnChain.Holdings.Equal(newFunding) {
 		t.Error(`Objective data not updated as expected`, updated.C.OnChain.Holdings, newFunding)
 	}
-
-	// Update with stale funding information should be ignored
-	staleFunding := types.Funds{}
-	staleFunding[common.Address{}] = big.NewInt(2)
-	lowBlockNum := uint64(100)
-
-	_, err = updated.C.UpdateWithChainEvent(
-		chainservice.NewDepositedEvent(
-			types.Destination{}, uint64(lowBlockNum), common.Address{}, big.NewInt(2),
-		),
-	)
-	if err != nil {
-		t.Error(err)
-	}
-
-	updated = updatedObjective.(*Objective)
-
-	if updated.C.OnChain.Holdings.Equal(staleFunding) {
-		t.Error("OnChain.Holdings was updated to stale funding information", updated.C.OnChain.Holdings, staleFunding)
-	}
 }
 
 func compareSideEffect(a, b protocols.SideEffects) string {


### PR DESCRIPTION
We will rely on the class being fed events in order. Driveby change: improve test comparisons using cmp.Diff

