### PR TITLE
`Channel` class: store `stateHash`, `candidate` signed state and `Outcome` following `ChallengeRegistered`

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -329,7 +329,7 @@ func (c *Channel) UpdateWithChainEvent(event chainservice.Event) (*Channel, erro
 		c.OnChain.Holdings[e.Asset] = e.NowHeld
 	case chainservice.ConcludedEvent:
 		break // TODO: update OnChain.StateHash and OnChain.Outcome
-	case chainservice.ChallengeRegistered:
+	case chainservice.ChallengeRegisteredEvent:
 		h, err := e.StateHash(c.FixedPart)
 		if err != nil {
 			return nil, err

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -329,7 +329,13 @@ func (c *Channel) UpdateWithChainEvent(event chainservice.Event) (*Channel, erro
 		c.OnChain.Holdings[e.Asset] = e.NowHeld
 	case chainservice.ConcludedEvent:
 		break // TODO: update OnChain.StateHash and OnChain.Outcome
-	case chainservice.ChallengeEvent:
+	case chainservice.ChallengeRegistered:
+		h, err := e.StateHash(c.FixedPart)
+		if err != nil {
+			return nil, err
+		}
+		c.OnChain.StateHash = h
+		c.OnChain.Outcome = e.Outcome()
 		break // TODO: update OnChain.StateHash and OnChain.Outcome
 	default:
 		return &Channel{}, fmt.Errorf("channel %+v cannot handle event %+v", c, event)

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -336,7 +336,11 @@ func (c *Channel) UpdateWithChainEvent(event chainservice.Event) (*Channel, erro
 		}
 		c.OnChain.StateHash = h
 		c.OnChain.Outcome = e.Outcome()
-		break // TODO: update OnChain.StateHash and OnChain.Outcome
+		ss, err := e.SignedState(c.FixedPart)
+		if err != nil {
+			return nil, err
+		}
+		c.AddSignedState(ss)
 	default:
 		return &Channel{}, fmt.Errorf("channel %+v cannot handle event %+v", c, event)
 	}

--- a/node/engine/chainservice/adjudicator/convert_outcome.go
+++ b/node/engine/chainservice/adjudicator/convert_outcome.go
@@ -2,6 +2,7 @@ package NitroAdjudicator
 
 import "github.com/statechannels/go-nitro/channel/state/outcome"
 
+// ConvertBindingsExitToExit converts the exit type returned from abigen bindings to an outcome.Exit
 func ConvertBindingsExitToExit(e []ExitFormatSingleAssetExit) outcome.Exit {
 	exit := make([]outcome.SingleAssetExit, 0, len(e))
 	for _, sae := range e {

--- a/node/engine/chainservice/adjudicator/convert_outcome.go
+++ b/node/engine/chainservice/adjudicator/convert_outcome.go
@@ -1,0 +1,35 @@
+package NitroAdjudicator
+
+import "github.com/statechannels/go-nitro/channel/state/outcome"
+
+func ConvertBindingsExitToExit(e []ExitFormatSingleAssetExit) outcome.Exit {
+	exit := make([]outcome.SingleAssetExit, 0, len(e))
+	for _, sae := range e {
+		exit = append(exit, convertBindingsSingleAssetExitToSingleAssetExit(sae))
+	}
+	return exit
+}
+
+func convertBindingsSingleAssetExitToSingleAssetExit(e ExitFormatSingleAssetExit) outcome.SingleAssetExit {
+	return outcome.SingleAssetExit{
+		Asset: e.Asset,
+		AssetMetadata: outcome.AssetMetadata{
+			AssetType: outcome.AssetType(e.AssetMetadata.AssetType),
+			Metadata:  e.AssetMetadata.Metadata,
+		},
+		Allocations: convertBindingsAllocationsToAllocations(e.Allocations),
+	}
+}
+
+func convertBindingsAllocationsToAllocations(as []ExitFormatAllocation) outcome.Allocations {
+	allocations := make([]outcome.Allocation, 0, len(as))
+	for _, a := range as {
+		allocations = append(allocations, outcome.Allocation{
+			Destination:    a.Destination,
+			Amount:         a.Amount,
+			Metadata:       a.Metadata,
+			AllocationType: outcome.AllocationType(a.AllocationType),
+		})
+	}
+	return allocations
+}

--- a/node/engine/chainservice/adjudicator/convert_signature.go
+++ b/node/engine/chainservice/adjudicator/convert_signature.go
@@ -1,0 +1,19 @@
+package NitroAdjudicator
+
+import "github.com/statechannels/go-nitro/channel/state"
+
+func ConvertBindingsSignatureToSignature(s INitroTypesSignature) state.Signature {
+	return state.Signature{
+		R: s.R[:],
+		S: s.S[:],
+		V: s.V,
+	}
+}
+
+func ConvertBindingsSignaturesToSignatures(ss []INitroTypesSignature) []state.Signature {
+	sigs := make([]state.Signature, 0, len(ss))
+	for _, s := range ss {
+		sigs = append(sigs, ConvertBindingsSignatureToSignature(s))
+	}
+	return sigs
+}

--- a/node/engine/chainservice/adjudicator/convert_signature.go
+++ b/node/engine/chainservice/adjudicator/convert_signature.go
@@ -2,6 +2,7 @@ package NitroAdjudicator
 
 import "github.com/statechannels/go-nitro/channel/state"
 
+// ConvertBindingsSignatureToSignature converts the signature type returned from abigien bindings to a state.Signature
 func ConvertBindingsSignatureToSignature(s INitroTypesSignature) state.Signature {
 	return state.Signature{
 		R: s.R[:],
@@ -10,6 +11,7 @@ func ConvertBindingsSignatureToSignature(s INitroTypesSignature) state.Signature
 	}
 }
 
+// ConvertBindingsSignatureToSignature converts a slice of the signature type returned from abigien bindings to a []state.Signature
 func ConvertBindingsSignaturesToSignatures(ss []INitroTypesSignature) []state.Signature {
 	sigs := make([]state.Signature, 0, len(ss))
 	for _, s := range ss {

--- a/node/engine/chainservice/chainservice.go
+++ b/node/engine/chainservice/chainservice.go
@@ -78,7 +78,7 @@ type ChallengeRegisteredEvent struct {
 	candidateSignatures []state.Signature
 }
 
-// StateHash returns the statehash which will have been stored on chain in the adjudicator after the ChallengeRegistered Event fires.
+// StateHash returns the statehash stored on chain at the time of the ChallengeRegistered Event firing.
 func (cr ChallengeRegisteredEvent) StateHash(fp state.FixedPart) (common.Hash, error) {
 	return state.StateFromFixedAndVariablePart(fp, cr.candidate).Hash()
 }
@@ -88,7 +88,7 @@ func (cr ChallengeRegisteredEvent) Outcome() outcome.Exit {
 	return cr.candidate.Outcome
 }
 
-// SignedState returns the signe state  which will have been stored on chain in the adjudicator after the ChallengeRegistered Event fires.
+// SignedState returns the signed state which will have been stored on chain in the adjudicator after the ChallengeRegistered Event fires.
 func (cr ChallengeRegisteredEvent) SignedState(fp state.FixedPart) (state.SignedState, error) {
 	s := state.StateFromFixedAndVariablePart(fp, cr.candidate)
 	ss := state.NewSignedState(s)

--- a/node/engine/chainservice/chainservice.go
+++ b/node/engine/chainservice/chainservice.go
@@ -6,6 +6,8 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/channel/state/outcome"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -66,13 +68,27 @@ type ConcludedEvent struct {
 	commonEvent
 }
 
-type ChallengeEvent struct {
-	commonEvent
-	// TODO fill out other fields
-}
-
 func (ce ConcludedEvent) String() string {
 	return "Channel " + ce.channelID.String() + " concluded at Block " + fmt.Sprint(ce.blockNum)
+}
+
+type ChallengeRegistered struct {
+	commonEvent
+	candidate state.VariablePart
+}
+
+// StateHash returns the statehash which will have been stored on chain in the adjudicator after the ChallengeRegistered Event fires.
+func (cr ChallengeRegistered) StateHash(fp state.FixedPart) (common.Hash, error) {
+	return state.StateFromFixedAndVariablePart(fp, cr.candidate).Hash()
+}
+
+// Outcome returns the outcome which will have been stored on chain in the adjudicator after the ChallengeRegistered Event fires.
+func (cr ChallengeRegistered) Outcome() outcome.Exit {
+	return cr.candidate.Outcome
+}
+
+func (cr ChallengeRegistered) String() string {
+	return "CHALLENGE registered for Channel " + cr.channelID.String() + " at Block " + fmt.Sprint(cr.blockNum)
 }
 
 func NewDepositedEvent(channelId types.Destination, blockNum uint64, assetAddress common.Address, nowHeld *big.Int) DepositedEvent {
@@ -84,7 +100,6 @@ func NewAllocationUpdatedEvent(channelId types.Destination, blockNum uint64, ass
 }
 
 // todo implement other event types
-// ChallengeRegistered
 // ChallengeCleared
 
 // ChainEventHandler describes an objective that can handle chain events

--- a/node/engine/chainservice/chainservice.go
+++ b/node/engine/chainservice/chainservice.go
@@ -78,6 +78,24 @@ type ChallengeRegisteredEvent struct {
 	candidateSignatures []state.Signature
 }
 
+// NewChallengeRegisteredEvent constructs a ChallengeRegisteredEvent
+func NewChallengeRegisteredEvent(
+	channelId types.Destination,
+	blockNum uint64,
+	variablePart state.VariablePart,
+	sigs []state.Signature,
+) ChallengeRegisteredEvent {
+	return ChallengeRegisteredEvent{
+		commonEvent: commonEvent{channelID: channelId, blockNum: blockNum},
+		candidate: state.VariablePart{
+			AppData: variablePart.AppData,
+			Outcome: variablePart.Outcome,
+			TurnNum: variablePart.TurnNum,
+			IsFinal: variablePart.IsFinal,
+		}, candidateSignatures: sigs,
+	}
+}
+
 // StateHash returns the statehash stored on chain at the time of the ChallengeRegistered Event firing.
 func (cr ChallengeRegisteredEvent) StateHash(fp state.FixedPart) (common.Hash, error) {
 	return state.StateFromFixedAndVariablePart(fp, cr.candidate).Hash()

--- a/node/engine/chainservice/chainservice.go
+++ b/node/engine/chainservice/chainservice.go
@@ -105,10 +105,6 @@ func (cr ChallengeRegisteredEvent) String() string {
 	return "CHALLENGE registered for Channel " + cr.channelID.String() + " at Block " + fmt.Sprint(cr.blockNum)
 }
 
-func NewChallengeRegisteredEvent() ChallengeRegisteredEvent {
-	return ChallengeRegisteredEvent{}
-}
-
 func NewDepositedEvent(channelId types.Destination, blockNum uint64, assetAddress common.Address, nowHeld *big.Int) DepositedEvent {
 	return DepositedEvent{commonEvent{channelId, blockNum}, assetAddress, nowHeld}
 }

--- a/node/engine/chainservice/chainservice.go
+++ b/node/engine/chainservice/chainservice.go
@@ -74,7 +74,8 @@ func (ce ConcludedEvent) String() string {
 
 type ChallengeRegistered struct {
 	commonEvent
-	candidate state.VariablePart
+	candidate          state.VariablePart
+	candidateSignature state.Signature
 }
 
 // StateHash returns the statehash which will have been stored on chain in the adjudicator after the ChallengeRegistered Event fires.
@@ -85,6 +86,14 @@ func (cr ChallengeRegistered) StateHash(fp state.FixedPart) (common.Hash, error)
 // Outcome returns the outcome which will have been stored on chain in the adjudicator after the ChallengeRegistered Event fires.
 func (cr ChallengeRegistered) Outcome() outcome.Exit {
 	return cr.candidate.Outcome
+}
+
+// SignedState returns the signe state  which will have been stored on chain in the adjudicator after the ChallengeRegistered Event fires.
+func (cr ChallengeRegistered) SignedState(fp state.FixedPart) (state.SignedState, error) {
+	s := state.StateFromFixedAndVariablePart(fp, cr.candidate)
+	ss := state.NewSignedState(s)
+	err := ss.AddSignature(cr.candidateSignature)
+	return ss, err
 }
 
 func (cr ChallengeRegistered) String() string {

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -271,15 +271,12 @@ func (ecs *EthChainService) dispatchChainEvents(logs []ethTypes.Log) error {
 			if err != nil {
 				return fmt.Errorf("error in ParseChallengeRegistered: %w", err)
 			}
-			event := ChallengeRegisteredEvent{
-				commonEvent: commonEvent{channelID: cr.ChannelId, blockNum: l.BlockNumber},
-				candidate: state.VariablePart{
-					AppData: cr.Candidate.VariablePart.AppData,
-					Outcome: NitroAdjudicator.ConvertBindingsExitToExit(cr.Candidate.VariablePart.Outcome),
-					TurnNum: cr.Candidate.VariablePart.TurnNum.Uint64(),
-					IsFinal: cr.Candidate.VariablePart.IsFinal,
-				}, candidateSignatures: NitroAdjudicator.ConvertBindingsSignaturesToSignatures(cr.Candidate.Sigs),
-			}
+			event := NewChallengeRegisteredEvent(cr.ChannelId, l.BlockNumber, state.VariablePart{
+				AppData: cr.Candidate.VariablePart.AppData,
+				Outcome: NitroAdjudicator.ConvertBindingsExitToExit(cr.Candidate.VariablePart.Outcome),
+				TurnNum: cr.Candidate.VariablePart.TurnNum.Uint64(),
+				IsFinal: cr.Candidate.VariablePart.IsFinal,
+			}, NitroAdjudicator.ConvertBindingsSignaturesToSignatures(cr.Candidate.Sigs))
 			ecs.out <- event
 		case challengeClearedTopic:
 			ecs.logger.Info("Ignoring Challenge Cleared event")

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -15,6 +15,7 @@ import (
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 
+	"github.com/statechannels/go-nitro/channel/state"
 	NitroAdjudicator "github.com/statechannels/go-nitro/node/engine/chainservice/adjudicator"
 	Token "github.com/statechannels/go-nitro/node/engine/chainservice/erc20"
 	chainutils "github.com/statechannels/go-nitro/node/engine/chainservice/utils"
@@ -266,7 +267,20 @@ func (ecs *EthChainService) dispatchChainEvents(logs []ethTypes.Log) error {
 			ecs.out <- event
 
 		case challengeRegisteredTopic:
-			ecs.logger.Info("Ignoring Challenge Registered event")
+			cr, err := ecs.na.ParseChallengeRegistered(l)
+			if err != nil {
+				return fmt.Errorf("error in ParseChallengeRegistered: %w", err)
+			}
+			event := ChallengeRegisteredEvent{
+				commonEvent: commonEvent{channelID: cr.ChannelId, blockNum: l.BlockNumber},
+				candidate: state.VariablePart{
+					AppData: cr.Candidate.VariablePart.AppData,
+					Outcome: NitroAdjudicator.ConvertBindingsExitToExit(cr.Candidate.VariablePart.Outcome),
+					TurnNum: cr.Candidate.VariablePart.TurnNum.Uint64(),
+					IsFinal: cr.Candidate.VariablePart.IsFinal,
+				}, candidateSignatures: NitroAdjudicator.ConvertBindingsSignaturesToSignatures(cr.Candidate.Sigs),
+			}
+			ecs.out <- event
 		case challengeClearedTopic:
 			ecs.logger.Info("Ignoring Challenge Cleared event")
 		default:


### PR DESCRIPTION
https://docs.statechannels.org/protocol-tutorial/0080-defunding-a-channel/#tracking-on-chain-storage

This should be sufficient to allow us to call `transfer` at some later stage. 

It should also trigger an appropriate notification for the client (same behaviour as receiving the state off chain). 

Towards #1531 
