### PR TITLE
Add authentication tokens

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 
 require (
 	github.com/BurntSushi/toml v1.3.2
+	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/libp2p/go-libp2p-kad-dht v0.24.2
 	github.com/tidwall/buntdb v1.2.10
 	github.com/urfave/cli/v2 v2.25.3

--- a/go.sum
+++ b/go.sum
@@ -270,6 +270,7 @@ github.com/gogo/status v1.1.0/go.mod h1:BFv9nrluPLmrS0EmGVvLaPNmRosr9KapBYd5/hpY
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.3.0 h1:kHL1vqdqWNfATmA0FNMdmZNMyZI1U6O31X4rlIPoBog=
+github.com/golang-jwt/jwt/v4 v4.3.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
 github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=

--- a/go.sum
+++ b/go.sum
@@ -270,7 +270,8 @@ github.com/gogo/status v1.1.0/go.mod h1:BFv9nrluPLmrS0EmGVvLaPNmRosr9KapBYd5/hpY
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.3.0 h1:kHL1vqdqWNfATmA0FNMdmZNMyZI1U6O31X4rlIPoBog=
-github.com/golang-jwt/jwt/v4 v4.3.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
+github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/geo v0.0.0-20190916061304-5b978397cfec/go.mod h1:QZ0nwyI2jOfgRAoBvP+ab5aRr7c9x7lhGEJrKvBwjWI=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/packages/nitro-rpc-client/scripts/client-runner.ts
+++ b/packages/nitro-rpc-client/scripts/client-runner.ts
@@ -318,7 +318,7 @@ async function isServerUp(port: number): Promise<boolean> {
   const url = new URL(`http://${getLocalRPCUrl(port)}`).toString();
 
   try {
-    const req = generateRequest("get_address", {});
+    const req = generateRequest("get_address", {}, "");
     result = await axios.post(url, JSON.stringify(req));
   } catch (e) {
     return false;

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -13,7 +13,7 @@ import {
   ReceiveVoucherResult,
 } from "./types";
 import { Transport } from "./transport";
-import { createOutcome } from "./utils";
+import { createOutcome, generateRequest } from "./utils";
 import { HttpTransport } from "./transport/http";
 import { getAndValidateResult } from "./serde";
 
@@ -44,7 +44,11 @@ export class NitroRpcClient {
       Amount: amount,
       Channel: channelId,
     };
-    const request = this.generateRequest("create_voucher", params);
+    const request = generateRequest(
+      "create_voucher",
+      params,
+      this.authToken || ""
+    );
     const res = await this.transport.sendRequest<"create_voucher">(request);
     return getAndValidateResult(res, "create_voucher");
   }
@@ -55,7 +59,11 @@ export class NitroRpcClient {
    * @returns The total amount of the channel and the delta of the voucher
    */
   public async ReceiveVoucher(voucher: Voucher): Promise<ReceiveVoucherResult> {
-    const request = this.generateRequest("receive_voucher", voucher);
+    const request = generateRequest(
+      "receive_voucher",
+      voucher,
+      this.authToken || ""
+    );
     const res = await this.transport.sendRequest<"receive_voucher">(request);
     return getAndValidateResult(res, "receive_voucher");
   }
@@ -146,7 +154,7 @@ export class NitroRpcClient {
       Amount: amount,
       Channel: channelId,
     };
-    const request = this.generateRequest("pay", params);
+    const request = generateRequest("pay", params, this.authToken || "");
     const res = await this.transport.sendRequest<"pay">(request);
     return getAndValidateResult(res, "pay");
   }
@@ -245,31 +253,11 @@ export class NitroRpcClient {
 
   private async sendRequest<K extends RequestMethod>(
     method: K,
-    params: RPCRequestAndResponses[K][0]["params"]
+    params: RPCRequestAndResponses[K][0]["params"]["Payload"]
   ): Promise<RPCRequestAndResponses[K][1]["result"]> {
-    const request = this.generateRequest(method, params);
+    const request = generateRequest(method, params, this.authToken || "");
     const res = await this.transport.sendRequest<K>(request);
     return getAndValidateResult(res, method);
-  }
-
-  /**
-   * generateRequest is a helper function that generates a request object for the given method and params
-   *
-   * @param method - The RPC method to generate a request for
-   * @param params - The params to include in the request
-   * @returns A request object of the correct type
-   */
-  private generateRequest<
-    K extends RequestMethod,
-    T extends RPCRequestAndResponses[K][0]
-  >(method: K, params: T["params"]): T {
-    return {
-      jsonrpc: "2.0",
-      method,
-      params,
-      // Our schema defines id as a uint32. We mod the current time to ensure that we don't overflow
-      id: Date.now() % 1_000_000_000,
-    } as T; // TODO: We shouldn't have to cast here
   }
 
   /**

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -1,10 +1,10 @@
 import {
   DefundObjectiveRequest,
-  DirectFundParams,
+  DirectFundPayload,
   LedgerChannelInfo,
   PaymentChannelInfo,
-  PaymentParams,
-  VirtualFundParams,
+  PaymentPayload,
+  VirtualFundPayload,
   RequestMethod,
   RPCRequestAndResponses,
   ObjectiveResponse,
@@ -40,13 +40,13 @@ export class NitroRpcClient {
     channelId: string,
     amount: number
   ): Promise<Voucher> {
-    const params = {
+    const payload = {
       Amount: amount,
       Channel: channelId,
     };
     const request = generateRequest(
       "create_voucher",
-      params,
+      payload,
       this.authToken || ""
     );
     const res = await this.transport.sendRequest<"create_voucher">(request);
@@ -97,7 +97,7 @@ export class NitroRpcClient {
     amount: number
   ): Promise<ObjectiveResponse> {
     const asset = `0x${"00".repeat(20)}`;
-    const params: DirectFundParams = {
+    const payload: DirectFundPayload = {
       CounterParty: counterParty,
       ChallengeDuration: 0,
       Outcome: createOutcome(
@@ -110,7 +110,7 @@ export class NitroRpcClient {
       AppData: "0x00",
       Nonce: Date.now(),
     };
-    return this.sendRequest("create_ledger_channel", params);
+    return this.sendRequest("create_ledger_channel", payload);
   }
 
   /**
@@ -126,7 +126,7 @@ export class NitroRpcClient {
     amount: number
   ): Promise<ObjectiveResponse> {
     const asset = `0x${"00".repeat(20)}`;
-    const params: VirtualFundParams = {
+    const payload: VirtualFundPayload = {
       CounterParty: counterParty,
       Intermediaries: intermediaries,
       ChallengeDuration: 0,
@@ -140,7 +140,7 @@ export class NitroRpcClient {
       Nonce: Date.now(),
     };
 
-    return this.sendRequest("create_payment_channel", params);
+    return this.sendRequest("create_payment_channel", payload);
   }
 
   /**
@@ -149,12 +149,12 @@ export class NitroRpcClient {
    * @param channelId - The ID of the payment channel to use
    * @param amount - The amount to pay
    */
-  public async Pay(channelId: string, amount: number): Promise<PaymentParams> {
-    const params = {
+  public async Pay(channelId: string, amount: number): Promise<PaymentPayload> {
+    const payload = {
       Amount: amount,
       Channel: channelId,
     };
-    const request = generateRequest("pay", params, this.authToken || "");
+    const request = generateRequest("pay", payload, this.authToken || "");
     const res = await this.transport.sendRequest<"pay">(request);
     return getAndValidateResult(res, "pay");
   }
@@ -166,8 +166,8 @@ export class NitroRpcClient {
    * @returns The ID of the objective that was created
    */
   public async CloseLedgerChannel(channelId: string): Promise<string> {
-    const params: DefundObjectiveRequest = { ChannelId: channelId };
-    return this.sendRequest("close_ledger_channel", params);
+    const payload: DefundObjectiveRequest = { ChannelId: channelId };
+    return this.sendRequest("close_ledger_channel", payload);
   }
   /**
    * ClosePaymentChannel defunds a virtually funded payment channel.
@@ -177,8 +177,8 @@ export class NitroRpcClient {
    */
 
   public async ClosePaymentChannel(channelId: string): Promise<string> {
-    const params: DefundObjectiveRequest = { ChannelId: channelId };
-    return this.sendRequest("close_payment_channel", params);
+    const payload: DefundObjectiveRequest = { ChannelId: channelId };
+    return this.sendRequest("close_payment_channel", payload);
   }
 
   /**
@@ -253,9 +253,9 @@ export class NitroRpcClient {
 
   private async sendRequest<K extends RequestMethod>(
     method: K,
-    params: RPCRequestAndResponses[K][0]["params"]["payload"]
+    payload: RPCRequestAndResponses[K][0]["params"]["payload"]
   ): Promise<RPCRequestAndResponses[K][1]["result"]> {
-    const request = generateRequest(method, params, this.authToken || "");
+    const request = generateRequest(method, payload, this.authToken || "");
     const res = await this.transport.sendRequest<K>(request);
     return getAndValidateResult(res, method);
   }

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -23,6 +23,8 @@ export class NitroRpcClient {
   // We fetch the address from the RPC server on first use
   private myAddress: string | undefined;
 
+  private authToken: string | undefined;
+
   public get Notifications() {
     return this.transport.Notifications;
   }
@@ -237,7 +239,7 @@ export class NitroRpcClient {
     });
   }
 
-  async sendRequest<K extends RequestMethod>(
+  private async sendRequest<K extends RequestMethod>(
     method: K,
     params: RPCRequestAndResponses[K][0]["params"]
   ): Promise<RPCRequestAndResponses[K][1]["result"]> {

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -78,7 +78,7 @@ export class NitroRpcClient {
       this.transport.Notifications.on(
         "objective_completed",
         (params: ObjectiveCompleteNotification["params"]) => {
-          if (params === objectiveId) {
+          if (params["Payload"] === objectiveId) {
             resolve();
           }
         }

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -239,6 +239,10 @@ export class NitroRpcClient {
     });
   }
 
+  private async getAuthToken(): Promise<string> {
+    return this.sendRequest("get_auth_token", {});
+  }
+
   private async sendRequest<K extends RequestMethod>(
     method: K,
     params: RPCRequestAndResponses[K][0]["params"]
@@ -269,6 +273,8 @@ export class NitroRpcClient {
     url: string
   ): Promise<NitroRpcClient> {
     const transport = await HttpTransport.createTransport(url);
-    return new NitroRpcClient(transport);
+    const rpcClient = new NitroRpcClient(transport);
+    rpcClient.authToken = await rpcClient.getAuthToken();
+    return rpcClient;
   }
 }

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -78,7 +78,7 @@ export class NitroRpcClient {
       this.transport.Notifications.on(
         "objective_completed",
         (params: ObjectiveCompleteNotification["params"]) => {
-          if (params["Payload"] === objectiveId) {
+          if (params["payload"] === objectiveId) {
             resolve();
           }
         }
@@ -253,7 +253,7 @@ export class NitroRpcClient {
 
   private async sendRequest<K extends RequestMethod>(
     method: K,
-    params: RPCRequestAndResponses[K][0]["params"]["Payload"]
+    params: RPCRequestAndResponses[K][0]["params"]["payload"]
   ): Promise<RPCRequestAndResponses[K][1]["result"]> {
     const request = generateRequest(method, params, this.authToken || "");
     const res = await this.transport.sendRequest<K>(request);

--- a/packages/nitro-rpc-client/src/serde.ts
+++ b/packages/nitro-rpc-client/src/serde.ts
@@ -162,6 +162,7 @@ export function getAndValidateResult<T extends RequestMethod>(
         result,
         (result: ObjectiveSchemaType) => result
       );
+    case "get_auth_token":
     case "close_ledger_channel":
     case "version":
     case "get_address":

--- a/packages/nitro-rpc-client/src/transport/http.ts
+++ b/packages/nitro-rpc-client/src/transport/http.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from "eventemitter3";
 
 import {
   NotificationMethod,
-  NotificationPayload,
+  NotificationParams,
   RequestMethod,
   RPCRequestAndResponses,
 } from "../types";
@@ -12,7 +12,7 @@ import {
 import { Transport } from ".";
 
 export class HttpTransport {
-  Notifications: EventEmitter<NotificationMethod, NotificationPayload>;
+  Notifications: EventEmitter<NotificationMethod, NotificationParams>;
 
   public static async createTransport(server: string): Promise<Transport> {
     // eslint-disable-next-line new-cap

--- a/packages/nitro-rpc-client/src/transport/index.ts
+++ b/packages/nitro-rpc-client/src/transport/index.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "eventemitter3";
 
 import {
   NotificationMethod,
-  NotificationPayload,
+  NotificationParams,
   RequestMethod,
   RPCNotification,
   RPCRequestAndResponses,
@@ -21,7 +21,7 @@ export type NotificationHandler<T extends RPCNotification> = (notif: T) => void;
  * Transport is an interface for some kind of RPC transport.
  */
 export type Transport = {
-  Notifications: EventEmitter<NotificationMethod, NotificationPayload>;
+  Notifications: EventEmitter<NotificationMethod, NotificationParams>;
 
   /**
    * Send the JSON-RPC request and returns the response.

--- a/packages/nitro-rpc-client/src/transport/nats.ts
+++ b/packages/nitro-rpc-client/src/transport/nats.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from "eventemitter3";
 import {
   JsonRpcNotification,
   NotificationMethod,
-  NotificationPayload,
+  NotificationParams,
   RequestMethod,
   RPCRequestAndResponses,
 } from "../types";
@@ -21,7 +21,7 @@ export class NatsTransport {
 
   private notifications = new EventEmitter<
     NotificationMethod,
-    NotificationPayload
+    NotificationParams
   >();
 
   public static async createTransport(server: string): Promise<Transport> {
@@ -42,7 +42,7 @@ export class NatsTransport {
 
   public get Notifications(): EventEmitter<
     NotificationMethod,
-    NotificationPayload
+    NotificationParams
   > {
     return this.notifications;
   }
@@ -52,7 +52,7 @@ export class NatsTransport {
       msg.data;
       const notif = JSONCodec().decode(msg.data) as JsonRpcNotification<
         NotificationMethod,
-        NotificationPayload
+        NotificationParams
       >;
 
       switch (notif.method) {

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -13,10 +13,10 @@ export type JsonRpcResponse<ResultType> = {
   result: ResultType;
 };
 
-export type JsonRpcNotification<NotificationName, NotificationParams> = {
+export type JsonRpcNotification<NotificationName, NotificationPayload> = {
   jsonrpc: "2.0";
   method: NotificationName;
-  params: { payload: NotificationParams };
+  params: { payload: NotificationPayload };
 };
 
 export type JsonRpcError<Code, Message, Data = undefined> = {
@@ -28,9 +28,9 @@ export type JsonRpcError<Code, Message, Data = undefined> = {
 };
 
 /**
- * Objective params and responses
+ * Objective payloads and responses
  */
-export type DirectFundParams = {
+export type DirectFundPayload = {
   CounterParty: string;
   ChallengeDuration: number;
   Outcome: Outcome;
@@ -38,7 +38,7 @@ export type DirectFundParams = {
   AppDefinition: string;
   AppData: string;
 };
-export type VirtualFundParams = {
+export type VirtualFundPayload = {
   Intermediaries: string[];
   CounterParty: string;
   ChallengeDuration: number;
@@ -46,7 +46,7 @@ export type VirtualFundParams = {
   Nonce: number;
   AppDefinition: string;
 };
-export type PaymentParams = {
+export type PaymentPayload = {
   // todo: this should be a bigint
   Amount: number;
   Channel: string;
@@ -91,12 +91,12 @@ export type GetAddressRequest = JsonRpcRequest<
 >;
 export type DirectFundRequest = JsonRpcRequest<
   "create_ledger_channel",
-  DirectFundParams
+  DirectFundPayload
 >;
-export type PaymentRequest = JsonRpcRequest<"pay", PaymentParams>;
+export type PaymentRequest = JsonRpcRequest<"pay", PaymentPayload>;
 export type VirtualFundRequest = JsonRpcRequest<
   "create_payment_channel",
-  VirtualFundParams
+  VirtualFundPayload
 >;
 export type GetLedgerChannelRequest = JsonRpcRequest<
   "get_ledger_channel",
@@ -127,7 +127,7 @@ export type VirtualDefundRequest = JsonRpcRequest<
 
 export type CreateVoucherRequest = JsonRpcRequest<
   "create_voucher",
-  PaymentParams
+  PaymentPayload
 >;
 
 export type ReceiveVoucherRequest = JsonRpcRequest<"receive_voucher", Voucher>;
@@ -137,7 +137,7 @@ export type ReceiveVoucherRequest = JsonRpcRequest<"receive_voucher", Voucher>;
  */
 export type GetAuthTokenResponse = JsonRpcResponse<string>;
 export type GetPaymentChannelResponse = JsonRpcResponse<PaymentChannelInfo>;
-export type PaymentResponse = JsonRpcResponse<PaymentParams>;
+export type PaymentResponse = JsonRpcResponse<PaymentPayload>;
 export type GetLedgerChannelResponse = JsonRpcResponse<LedgerChannelInfo>;
 export type VirtualFundResponse = JsonRpcResponse<ObjectiveResponse>;
 export type VersionResponse = JsonRpcResponse<string>;
@@ -193,7 +193,7 @@ export type RPCNotification =
   | PaymentChannelUpdatedNotification
   | LedgerChannelUpdatedNotification;
 export type NotificationMethod = RPCNotification["method"];
-export type NotificationPayload = RPCNotification["params"];
+export type NotificationParams = RPCNotification["params"];
 export type PaymentChannelUpdatedNotification = JsonRpcNotification<
   "payment_channel_updated",
   PaymentChannelInfo

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -16,7 +16,7 @@ export type JsonRpcResponse<ResultType> = {
 export type JsonRpcNotification<NotificationName, NotificationParams> = {
   jsonrpc: "2.0";
   method: NotificationName;
-  params: NotificationParams;
+  params: { Payload: NotificationParams };
 };
 
 export type JsonRpcError<Code, Message, Data = undefined> = {

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -81,6 +81,10 @@ export type ReceiveVoucherResult = {
 /**
  * RPC Requests
  */
+export type GetAuthTokenRequest = JsonRpcRequest<
+  "get_auth_token",
+  Record<string, never>
+>;
 export type GetAddressRequest = JsonRpcRequest<
   "get_address",
   Record<string, never>
@@ -131,6 +135,7 @@ export type ReceiveVoucherRequest = JsonRpcRequest<"receive_voucher", Voucher>;
 /**
  * RPC Responses
  */
+export type GetAuthTokenResponse = JsonRpcResponse<string>;
 export type GetPaymentChannelResponse = JsonRpcResponse<PaymentChannelInfo>;
 export type PaymentResponse = JsonRpcResponse<PaymentParams>;
 export type GetLedgerChannelResponse = JsonRpcResponse<LedgerChannelInfo>;
@@ -151,6 +156,7 @@ export type ReceiveVoucherResponse = JsonRpcResponse<ReceiveVoucherResult>;
  * This is a map of all the RPC methods to their request and response types
  */
 export type RPCRequestAndResponses = {
+  get_auth_token: [GetAuthTokenRequest, GetAuthTokenResponse];
   create_ledger_channel: [DirectFundRequest, DirectFundResponse];
   close_ledger_channel: [DirectDefundRequest, DirectDefundResponse];
   version: [VersionRequest, VersionResponse];

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -1,11 +1,11 @@
 /**
  * JSON RPC Types
  */
-export type JsonRpcRequest<MethodName extends RequestMethod, RequestParams> = {
+export type JsonRpcRequest<MethodName extends RequestMethod, RequestPayload> = {
   id: number; // in the json-rpc spec this is optional, but we require it for all our requests
   jsonrpc: "2.0";
   method: MethodName;
-  params: RequestParams;
+  params: { AuthToken: string; Payload: RequestPayload };
 };
 export type JsonRpcResponse<ResultType> = {
   id: number;

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -5,7 +5,7 @@ export type JsonRpcRequest<MethodName extends RequestMethod, RequestPayload> = {
   id: number; // in the json-rpc spec this is optional, but we require it for all our requests
   jsonrpc: "2.0";
   method: MethodName;
-  params: { AuthToken: string; Payload: RequestPayload };
+  params: { authtoken: string; payload: RequestPayload };
 };
 export type JsonRpcResponse<ResultType> = {
   id: number;
@@ -16,7 +16,7 @@ export type JsonRpcResponse<ResultType> = {
 export type JsonRpcNotification<NotificationName, NotificationParams> = {
   jsonrpc: "2.0";
   method: NotificationName;
-  params: { Payload: NotificationParams };
+  params: { payload: NotificationParams };
 };
 
 export type JsonRpcError<Code, Message, Data = undefined> = {

--- a/packages/nitro-rpc-client/src/utils.ts
+++ b/packages/nitro-rpc-client/src/utils.ts
@@ -1,11 +1,5 @@
 import { NitroRpcClient } from "./rpc-client";
-import {
-  LedgerChannelInfo,
-  Outcome,
-  PaymentChannelInfo,
-  RequestMethod,
-  RPCRequestAndResponses,
-} from "./types";
+import { LedgerChannelInfo, Outcome, PaymentChannelInfo } from "./types";
 
 export const RPC_PATH = "api/v1";
 
@@ -62,26 +56,6 @@ export function createOutcome(
 export function convertAddressToBytes32(address: string): string {
   const digits = address.startsWith("0x") ? address.substring(2) : address;
   return `0x${digits.padStart(24, "0")}`;
-}
-
-/**
- * generateRequest is a helper function that generates a request object for the given method and params
- *
- * @param method - The RPC method to generate a request for
- * @param params - The params to include in the request
- * @returns A request object of the correct type
- */
-export function generateRequest<
-  K extends RequestMethod,
-  T extends RPCRequestAndResponses[K][0]
->(method: K, params: T["params"]): T {
-  return {
-    jsonrpc: "2.0",
-    method,
-    params,
-    // Our schema defines id as a uint32. We mod the current time to ensure that we don't overflow
-    id: Date.now() % 1_000_000_000,
-  } as T; // TODO: We shouldn't have to cast here
 }
 
 export function getLocalRPCUrl(port: number): string {

--- a/packages/nitro-rpc-client/src/utils.ts
+++ b/packages/nitro-rpc-client/src/utils.ts
@@ -74,11 +74,11 @@ export function convertAddressToBytes32(address: string): string {
 export function generateRequest<
   K extends RequestMethod,
   T extends RPCRequestAndResponses[K][0]
->(method: K, params: T["params"]["Payload"], authToken: string): T {
+>(method: K, params: T["params"]["payload"], authToken: string): T {
   return {
     jsonrpc: "2.0",
     method,
-    params: { AuthToken: authToken, Payload: params },
+    params: { authtoken: authToken, payload: params },
     // Our schema defines id as a uint32. We mod the current time to ensure that we don't overflow
     id: Date.now() % 1_000_000_000,
   } as T; // TODO: We shouldn't have to cast here

--- a/packages/nitro-rpc-client/src/utils.ts
+++ b/packages/nitro-rpc-client/src/utils.ts
@@ -1,5 +1,11 @@
 import { NitroRpcClient } from "./rpc-client";
-import { LedgerChannelInfo, Outcome, PaymentChannelInfo } from "./types";
+import {
+  LedgerChannelInfo,
+  Outcome,
+  PaymentChannelInfo,
+  RequestMethod,
+  RPCRequestAndResponses,
+} from "./types";
 
 export const RPC_PATH = "api/v1";
 
@@ -56,6 +62,26 @@ export function createOutcome(
 export function convertAddressToBytes32(address: string): string {
   const digits = address.startsWith("0x") ? address.substring(2) : address;
   return `0x${digits.padStart(24, "0")}`;
+}
+
+/**
+ * generateRequest is a helper function that generates a request object for the given method and params
+ *
+ * @param method - The RPC method to generate a request for
+ * @param params - The params to include in the request
+ * @returns A request object of the correct type
+ */
+export function generateRequest<
+  K extends RequestMethod,
+  T extends RPCRequestAndResponses[K][0]
+>(method: K, params: T["params"]["Payload"], authToken: string): T {
+  return {
+    jsonrpc: "2.0",
+    method,
+    params: { AuthToken: authToken, Payload: params },
+    // Our schema defines id as a uint32. We mod the current time to ensure that we don't overflow
+    id: Date.now() % 1_000_000_000,
+  } as T; // TODO: We shouldn't have to cast here
 }
 
 export function getLocalRPCUrl(port: number): string {

--- a/packages/nitro-rpc-client/src/utils.ts
+++ b/packages/nitro-rpc-client/src/utils.ts
@@ -65,20 +65,20 @@ export function convertAddressToBytes32(address: string): string {
 }
 
 /**
- * generateRequest is a helper function that generates a request object for the given method and params
+ * generateRequest is a helper function that generates a request object for the given method and payloads
  *
  * @param method - The RPC method to generate a request for
- * @param params - The params to include in the request
+ * @param payload - The payloads to include in the request
  * @returns A request object of the correct type
  */
 export function generateRequest<
   K extends RequestMethod,
   T extends RPCRequestAndResponses[K][0]
->(method: K, params: T["params"]["payload"], authToken: string): T {
+>(method: K, payload: T["params"]["payload"], authToken: string): T {
   return {
     jsonrpc: "2.0",
     method,
-    params: { authtoken: authToken, payload: params },
+    params: { authtoken: authToken, payload: payload },
     // Our schema defines id as a uint32. We mod the current time to ensure that we don't overflow
     id: Date.now() % 1_000_000_000,
   } as T; // TODO: We shouldn't have to cast here

--- a/rpc/auth.go
+++ b/rpc/auth.go
@@ -34,13 +34,14 @@ var (
 var invalidIAtFormat = "invalid issued at: %w"
 
 // generateAuthToken generates a JWT token that a client uses to authenticate with the server for restricted endpoints
-func generateAuthToken(p []permission) (string, error) {
+// subject is the itentifier of the client for which the token is generated
+func generateAuthToken(subject string, p []permission) (string, error) {
 	token := jwt.New(jwt.SigningMethodHS256)
 	claims := token.Claims.(jwt.MapClaims)
 	claims[permissionKey] = p
 	// the keys are defined by https://datatracker.ietf.org/doc/html/rfc7519
 	claims["iat"] = time.Now().Unix()
-	claims["sub"] = "client"
+	claims["sub"] = subject
 	return token.SignedString(rpcPK)
 }
 

--- a/rpc/auth.go
+++ b/rpc/auth.go
@@ -34,7 +34,7 @@ var (
 var invalidIAtFormat = "invalid issued at: %w"
 
 // generateAuthToken generates a JWT token that a client uses to authenticate with the server for restricted endpoints
-// subject is the itentifier of the client for which the token is generated
+// subject is the identifier of the client for which the token is generated
 func generateAuthToken(subject string, p []permission) (string, error) {
 	token := jwt.New(jwt.SigningMethodHS256)
 	claims := token.Claims.(jwt.MapClaims)

--- a/rpc/auth.go
+++ b/rpc/auth.go
@@ -12,6 +12,7 @@ var rpcPK = []byte("rpcPK")
 type permission string
 
 const (
+	permNone permission = "none"
 	permRead permission = "read"
 	permSign permission = "sign"
 )

--- a/rpc/auth.go
+++ b/rpc/auth.go
@@ -46,7 +46,7 @@ func generateAuthToken(subject string, p []permission) (string, error) {
 }
 
 // checkTokenValidity takes a JWT token, verifies that the token is valid and that the token contains the required permission
-func checkTokenValidity(tokenString string, requiredPermission permission, validDuration *time.Duration) error {
+func checkTokenValidity(tokenString string, requiredPermission permission, validDuration time.Duration) error {
 	if requiredPermission == permNone {
 		return nil
 	}
@@ -74,13 +74,7 @@ func checkTokenValidity(tokenString string, requiredPermission permission, valid
 		return fmt.Errorf(invalidIAtFormat, err)
 	}
 
-	var duration time.Duration
-	if validDuration == nil {
-		duration = time.Hour
-	} else {
-		duration = *validDuration
-	}
-	if time.Now().After(iAt.Add(duration)) {
+	if time.Now().After(iAt.Add(validDuration)) {
 		return errExpiredToken
 	}
 

--- a/rpc/auth.go
+++ b/rpc/auth.go
@@ -1,0 +1,74 @@
+package rpc
+
+import (
+	"errors"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// todo: the private key should not be hardcoded
+var rpcPK = []byte("rpcPK")
+
+type permission string
+
+const (
+	permRead permission = "read"
+	permSign permission = "sign"
+)
+
+var allPermissions = []permission{permRead, permSign}
+
+var (
+	errInvalidSigningMethod = errors.New("invalid signing method")
+	errInvalidToken         = errors.New("invalid token")
+	errInvalidPermissions   = errors.New("token has invalid permissions")
+	errInvalidPermission    = errors.New("token has an invalid permission")
+	errMissingPermission    = errors.New("token is missing permission")
+)
+
+// generateAuthToken generates a JWT token that a client uses to authenticate with the server for restricted endpoints
+func generateAuthToken(p []permission) (string, error) {
+	token := jwt.New(jwt.SigningMethodHS256)
+	claims := token.Claims.(jwt.MapClaims)
+	claims["permissions"] = p
+	return token.SignedString(rpcPK)
+}
+
+// verifyPermission takes a JWT token, verifies that the token is valid and that the token contains the required permission
+func checkPermission(tokenString string, requiredPermission permission) error {
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		_, ok := token.Method.(*jwt.SigningMethodHMAC)
+		if !ok {
+			return nil, errInvalidSigningMethod
+		}
+		return rpcPK, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if !token.Valid {
+		return errInvalidToken
+	}
+
+	claims := token.Claims.(jwt.MapClaims)
+	permissions, ok := claims["permissions"].([]interface{})
+	if !ok {
+		return errInvalidPermissions
+	}
+
+	for _, p := range permissions {
+		sp, ok := p.(string)
+		if !ok {
+			return errInvalidPermission
+		}
+
+		pp := permission(sp)
+
+		if pp == requiredPermission {
+			return nil
+		}
+	}
+
+	return errMissingPermission
+}

--- a/rpc/auth.go
+++ b/rpc/auth.go
@@ -41,7 +41,7 @@ func generateAuthToken(p []permission) (string, error) {
 }
 
 // verifyPermission takes a JWT token, verifies that the token is valid and that the token contains the required permission
-func checkPermission(tokenString string, requiredPermission permission) error {
+func checkTokenValidity(tokenString string, requiredPermission permission) error {
 	if requiredPermission == permNone {
 		return nil
 	}

--- a/rpc/auth.go
+++ b/rpc/auth.go
@@ -37,6 +37,10 @@ func generateAuthToken(p []permission) (string, error) {
 
 // verifyPermission takes a JWT token, verifies that the token is valid and that the token contains the required permission
 func checkPermission(tokenString string, requiredPermission permission) error {
+	if requiredPermission == permNone {
+		return nil
+	}
+
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		_, ok := token.Method.(*jwt.SigningMethodHMAC)
 		if !ok {

--- a/rpc/auth.go
+++ b/rpc/auth.go
@@ -45,7 +45,7 @@ func generateAuthToken(subject string, p []permission) (string, error) {
 	return token.SignedString(rpcPK)
 }
 
-// verifyPermission takes a JWT token, verifies that the token is valid and that the token contains the required permission
+// checkTokenValidity takes a JWT token, verifies that the token is valid and that the token contains the required permission
 func checkTokenValidity(tokenString string, requiredPermission permission, validDuration *time.Duration) error {
 	if requiredPermission == permNone {
 		return nil

--- a/rpc/auth_test.go
+++ b/rpc/auth_test.go
@@ -1,0 +1,30 @@
+package rpc
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestValidAuthToken(t *testing.T) {
+	token, err := generateAuthToken(allPermissions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = checkPermission(token, permSign)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAuthTokenMissingPermission(t *testing.T) {
+	token, err := generateAuthToken([]permission{permRead})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = checkPermission(token, permSign)
+	if !errors.Is(err, errMissingPermission) {
+		t.Fatal("expected errMissingPermission, got", err)
+	}
+}

--- a/rpc/auth_test.go
+++ b/rpc/auth_test.go
@@ -11,7 +11,7 @@ func TestValidAuthToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = checkPermission(token, permSign)
+	err = checkTokenValidity(token, permSign)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func TestAuthTokenMissingPermission(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = checkPermission(token, permSign)
+	err = checkTokenValidity(token, permSign)
 	if !errors.Is(err, errMissingPermission) {
 		t.Fatal("expected errMissingPermission, got", err)
 	}

--- a/rpc/auth_test.go
+++ b/rpc/auth_test.go
@@ -12,7 +12,7 @@ func TestValidAuthToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = checkTokenValidity(token, permSign, nil)
+	err = checkTokenValidity(token, permSign, time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -24,7 +24,7 @@ func TestAuthTokenMissingPermission(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = checkTokenValidity(token, permSign, nil)
+	err = checkTokenValidity(token, permSign, time.Hour)
 	if !errors.Is(err, errMissingPermission) {
 		t.Fatal("expected errMissingPermission, got", err)
 	}
@@ -36,8 +36,7 @@ func TestExpiredAuthToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	zeroDuration := time.Duration(0)
-	err = checkTokenValidity(token, permSign, &zeroDuration)
+	err = checkTokenValidity(token, permSign, time.Duration(0))
 	if !errors.Is(err, errExpiredToken) {
 		t.Fatal("expected errExpiredToken, got", err)
 	}

--- a/rpc/auth_test.go
+++ b/rpc/auth_test.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"errors"
 	"testing"
+	"time"
 )
 
 func TestValidAuthToken(t *testing.T) {
@@ -11,7 +12,7 @@ func TestValidAuthToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = checkTokenValidity(token, permSign)
+	err = checkTokenValidity(token, permSign, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,8 +24,21 @@ func TestAuthTokenMissingPermission(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = checkTokenValidity(token, permSign)
+	err = checkTokenValidity(token, permSign, nil)
 	if !errors.Is(err, errMissingPermission) {
 		t.Fatal("expected errMissingPermission, got", err)
+	}
+}
+
+func TestExpiredAuthToken(t *testing.T) {
+	token, err := generateAuthToken(allPermissions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	zeroDuration := time.Duration(0)
+	err = checkTokenValidity(token, permSign, &zeroDuration)
+	if !errors.Is(err, errExpiredToken) {
+		t.Fatal("expected errExpiredToken, got", err)
 	}
 }

--- a/rpc/auth_test.go
+++ b/rpc/auth_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestValidAuthToken(t *testing.T) {
-	token, err := generateAuthToken(allPermissions)
+	token, err := generateAuthToken("1", allPermissions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -19,7 +19,7 @@ func TestValidAuthToken(t *testing.T) {
 }
 
 func TestAuthTokenMissingPermission(t *testing.T) {
-	token, err := generateAuthToken([]permission{permRead})
+	token, err := generateAuthToken("1", []permission{permRead})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func TestAuthTokenMissingPermission(t *testing.T) {
 }
 
 func TestExpiredAuthToken(t *testing.T) {
-	token, err := generateAuthToken(allPermissions)
+	token, err := generateAuthToken("1", allPermissions)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -130,7 +130,9 @@ func NewRpcClient(trans transport.Requester) (RpcClientApi, error) {
 	c.routineTracker.Add(1)
 	go c.subscribeToNotifications(ctx, notificationChan)
 
-	c.authToken, err = c.AuthToken()
+	authToken, err := WaitForRequestNoAuth[serde.NoPayloadRequest, string](c, serde.GetAuthTokenMethod, serde.NoPayloadRequest{})
+	c.authToken = authToken
+
 	return c, err
 }
 
@@ -146,14 +148,6 @@ func NewHttpRpcClient(rpcServerUrl string) (RpcClientApi, error) {
 // Address returns the address of the the nitro node
 func (rc *rpcClient) Address() (common.Address, error) {
 	return rc.nodeAddress, nil
-}
-
-// AuthToken fetches an authentication token from the nitro node
-func (rc *rpcClient) AuthToken() (string, error) {
-	if rc.authToken == "" {
-		return WaitForRequestNoAuth[serde.NoPayloadRequest, string](rc, serde.GetAuthTokenMethod, serde.NoPayloadRequest{})
-	}
-	return rc.authToken, nil
 }
 
 // CreateVoucher creates a voucher for the given channelId and amount and returns it.

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/internal/safesync"
 	"github.com/statechannels/go-nitro/node/query"
 	"github.com/statechannels/go-nitro/payments"
@@ -115,7 +116,7 @@ func NewRpcClient(trans transport.Requester) (RpcClientApi, error) {
 	}
 
 	// Retrieve the address and set it on the rpcClient
-	res, err := waitForRequest[serde.NoPayloadRequest, common.Address](c, serde.GetAddressMethod, serde.NoPayloadRequest{})
+	res, err := authenticatedWaitForRequest[serde.NoPayloadRequest, common.Address](c, serde.GetAddressMethod, serde.NoPayloadRequest{})
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -116,7 +116,7 @@ func NewRpcClient(trans transport.Requester) (RpcClientApi, error) {
 	}
 
 	// Retrieve the address and set it on the rpcClient
-	res, err := authenticatedWaitForRequest[serde.NoPayloadRequest, common.Address](c, serde.GetAddressMethod, serde.NoPayloadRequest{})
+	res, err := waitForAuthorizedRequest[serde.NoPayloadRequest, common.Address](c, serde.GetAddressMethod, serde.NoPayloadRequest{})
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func (rc *rpcClient) Address() (common.Address, error) {
 // AuthToken fetches an authentication token from the nitro node
 func (rc *rpcClient) AuthToken() (string, error) {
 	if rc.authToken == "" {
-		return unauthenticatedWaitForRequest[serde.NoPayloadRequest, string](rc, serde.GetAuthTokenMethod, serde.NoPayloadRequest{})
+		return WaitForRequestNoAuth[serde.NoPayloadRequest, string](rc, serde.GetAuthTokenMethod, serde.NoPayloadRequest{})
 	}
 	return rc.authToken, nil
 }
@@ -164,20 +164,20 @@ func (rc *rpcClient) AuthToken() (string, error) {
 // It is the responsibility of the caller to send the voucher to the payee.
 func (rc *rpcClient) CreateVoucher(chId types.Destination, amount uint64) (payments.Voucher, error) {
 	req := serde.PaymentRequest{Channel: chId, Amount: amount}
-	return authenticatedWaitForRequest[serde.PaymentRequest, payments.Voucher](rc, serde.CreateVoucherRequestMethod, req)
+	return waitForAuthorizedRequest[serde.PaymentRequest, payments.Voucher](rc, serde.CreateVoucherRequestMethod, req)
 }
 
 // ReceiveVoucher receives a voucher and adds it to the go-nitro store.
 // It returns the total amount received so far and the amount received from the voucher supplied.
 // It can be used to add a voucher that was sent outside of the go-nitro system.
 func (rc *rpcClient) ReceiveVoucher(v payments.Voucher) (payments.ReceiveVoucherSummary, error) {
-	return authenticatedWaitForRequest[payments.Voucher, payments.ReceiveVoucherSummary](rc, serde.ReceiveVoucherRequestMethod, v)
+	return waitForAuthorizedRequest[payments.Voucher, payments.ReceiveVoucherSummary](rc, serde.ReceiveVoucherRequestMethod, v)
 }
 
 func (rc *rpcClient) GetPaymentChannel(chId types.Destination) (query.PaymentChannelInfo, error) {
 	req := serde.GetPaymentChannelRequest{Id: chId}
 
-	return authenticatedWaitForRequest[serde.GetPaymentChannelRequest, query.PaymentChannelInfo](rc, serde.GetPaymentChannelRequestMethod, req)
+	return waitForAuthorizedRequest[serde.GetPaymentChannelRequest, query.PaymentChannelInfo](rc, serde.GetPaymentChannelRequestMethod, req)
 }
 
 // CreatePaymentChannel creates a new virtual payment channel
@@ -190,7 +190,7 @@ func (rc *rpcClient) CreatePaymentChannel(intermediaries []types.Address, counte
 		rand.Uint64(),
 		common.Address{})
 
-	return authenticatedWaitForRequest[virtualfund.ObjectiveRequest, virtualfund.ObjectiveResponse](rc, serde.CreatePaymentChannelRequestMethod, objReq)
+	return waitForAuthorizedRequest[virtualfund.ObjectiveRequest, virtualfund.ObjectiveResponse](rc, serde.CreatePaymentChannelRequestMethod, objReq)
 }
 
 // ClosePaymentChannel attempts to close the payment channel with supplied id
@@ -198,23 +198,23 @@ func (rc *rpcClient) ClosePaymentChannel(id types.Destination) (protocols.Object
 	objReq := virtualdefund.NewObjectiveRequest(
 		id)
 
-	return authenticatedWaitForRequest[virtualdefund.ObjectiveRequest, protocols.ObjectiveId](rc, serde.ClosePaymentChannelRequestMethod, objReq)
+	return waitForAuthorizedRequest[virtualdefund.ObjectiveRequest, protocols.ObjectiveId](rc, serde.ClosePaymentChannelRequestMethod, objReq)
 }
 
 func (rc *rpcClient) GetLedgerChannel(id types.Destination) (query.LedgerChannelInfo, error) {
 	req := serde.GetLedgerChannelRequest{Id: id}
 
-	return authenticatedWaitForRequest[serde.GetLedgerChannelRequest, query.LedgerChannelInfo](rc, serde.GetLedgerChannelRequestMethod, req)
+	return waitForAuthorizedRequest[serde.GetLedgerChannelRequest, query.LedgerChannelInfo](rc, serde.GetLedgerChannelRequestMethod, req)
 }
 
 // GetAllLedgerChannels returns all ledger channels
 func (rc *rpcClient) GetAllLedgerChannels() ([]query.LedgerChannelInfo, error) {
-	return authenticatedWaitForRequest[serde.NoPayloadRequest, []query.LedgerChannelInfo](rc, serde.GetAllLedgerChannelsMethod, struct{}{})
+	return waitForAuthorizedRequest[serde.NoPayloadRequest, []query.LedgerChannelInfo](rc, serde.GetAllLedgerChannelsMethod, struct{}{})
 }
 
 // GetPaymentChannelsByLedger returns all active payment channels for a given ledger channel
 func (rc *rpcClient) GetPaymentChannelsByLedger(ledgerId types.Destination) ([]query.PaymentChannelInfo, error) {
-	return authenticatedWaitForRequest[serde.GetPaymentChannelsByLedgerRequest, []query.PaymentChannelInfo](rc, serde.GetPaymentChannelsByLedgerMethod, serde.GetPaymentChannelsByLedgerRequest{LedgerId: ledgerId})
+	return waitForAuthorizedRequest[serde.GetPaymentChannelsByLedgerRequest, []query.PaymentChannelInfo](rc, serde.GetPaymentChannelsByLedgerMethod, serde.GetPaymentChannelsByLedgerRequest{LedgerId: ledgerId})
 }
 
 // CreateLedger creates a new ledger channel
@@ -226,20 +226,20 @@ func (rc *rpcClient) CreateLedgerChannel(counterparty types.Address, ChallengeDu
 		rand.Uint64(),
 		common.Address{})
 
-	return authenticatedWaitForRequest[directfund.ObjectiveRequest, directfund.ObjectiveResponse](rc, serde.CreateLedgerChannelRequestMethod, objReq)
+	return waitForAuthorizedRequest[directfund.ObjectiveRequest, directfund.ObjectiveResponse](rc, serde.CreateLedgerChannelRequestMethod, objReq)
 }
 
 // CloseLedger closes a ledger channel
 func (rc *rpcClient) CloseLedgerChannel(id types.Destination) (protocols.ObjectiveId, error) {
 	objReq := directdefund.NewObjectiveRequest(id)
 
-	return authenticatedWaitForRequest[directdefund.ObjectiveRequest, protocols.ObjectiveId](rc, serde.CloseLedgerChannelRequestMethod, objReq)
+	return waitForAuthorizedRequest[directdefund.ObjectiveRequest, protocols.ObjectiveId](rc, serde.CloseLedgerChannelRequestMethod, objReq)
 }
 
 // Pay uses the specified channel to pay the specified amount
 func (rc *rpcClient) Pay(id types.Destination, amount uint64) (serde.PaymentRequest, error) {
 	pReq := serde.PaymentRequest{Amount: amount, Channel: id}
-	return authenticatedWaitForRequest[serde.PaymentRequest, serde.PaymentRequest](rc, serde.PayRequestMethod, pReq)
+	return waitForAuthorizedRequest[serde.PaymentRequest, serde.PaymentRequest](rc, serde.PayRequestMethod, pReq)
 }
 
 func (rc *rpcClient) Close() error {
@@ -314,13 +314,13 @@ func (rc *rpcClient) PaymentChannelUpdatesChan(paymentChannelId types.Destinatio
 	return c
 }
 
-// unauthenticatedWaitForRequest calls waitForRequest with an empty auth token
-func unauthenticatedWaitForRequest[T serde.RequestPayload, U serde.ResponsePayload](rc *rpcClient, method serde.RequestMethod, requestData T) (U, error) {
+// WaitForRequestNoAuth calls waitForRequest with an empty auth token
+func WaitForRequestNoAuth[T serde.RequestPayload, U serde.ResponsePayload](rc *rpcClient, method serde.RequestMethod, requestData T) (U, error) {
 	return waitForRequest[T, U](rc, method, requestData, "")
 }
 
-// authenticatedWaitForRequest calls waitForRequest with the client auth token
-func authenticatedWaitForRequest[T serde.RequestPayload, U serde.ResponsePayload](rc *rpcClient, method serde.RequestMethod, requestData T) (U, error) {
+// waitForAuthorizedRequest calls waitForRequest with the client auth token
+func waitForAuthorizedRequest[T serde.RequestPayload, U serde.ResponsePayload](rc *rpcClient, method serde.RequestMethod, requestData T) (U, error) {
 	rc.authTokenReady.Wait()
 	return waitForRequest[T, U](rc, method, requestData, rc.authToken)
 }

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -319,7 +319,7 @@ func unauthenticatedWaitForRequest[T serde.RequestPayload, U serde.ResponsePaylo
 	return waitForRequest[T, U](rc, method, requestData, "")
 }
 
-// authenticatedWaitForRequest calls waitForRequest with an empty auth token
+// authenticatedWaitForRequest calls waitForRequest with the client auth token
 func authenticatedWaitForRequest[T serde.RequestPayload, U serde.ResponsePayload](rc *rpcClient, method serde.RequestMethod, requestData T) (U, error) {
 	rc.authTokenReady.Wait()
 	return waitForRequest[T, U](rc, method, requestData, rc.authToken)

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/statechannels/go-nitro/channel/state/outcome"
-	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/internal/safesync"
 	"github.com/statechannels/go-nitro/node/query"
 	"github.com/statechannels/go-nitro/payments"
@@ -105,7 +104,6 @@ func NewRpcClient(trans transport.Requester) (RpcClientApi, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	c := &rpcClient{
 		transport:             trans,
-		logger:                logger,
 		completedObjectives:   &safesync.Map[chan struct{}]{},
 		ledgerChannelUpdates:  &safesync.Map[chan query.LedgerChannelInfo]{},
 		paymentChannelUpdates: &safesync.Map[chan query.PaymentChannelInfo]{},
@@ -113,7 +111,7 @@ func NewRpcClient(trans transport.Requester) (RpcClientApi, error) {
 		wg:                    &sync.WaitGroup{},
 		nodeAddress:           common.Address{},
 		authTokenReady:        &sync.WaitGroup{},
-		logger: slog.Default()
+		logger:                slog.Default(),
 	}
 
 	// Retrieve the address and set it on the rpcClient
@@ -343,8 +341,9 @@ func waitForRequest[T serde.RequestPayload, U serde.ResponsePayload](rc *rpcClie
 //     [1] the request fails to send
 //     [2] the response cannot be parsed
 //   - Otherwise, returns the JSONRPC server's response
-func sendRequest[T serde.RequestPayload, U serde.ResponsePayload](trans transport.Requester, method serde.RequestMethod, reqPayload T, 
-	authToken string, logger *slog.Logger, wg *sync.WaitGroup) (response[U], error) {
+func sendRequest[T serde.RequestPayload, U serde.ResponsePayload](trans transport.Requester, method serde.RequestMethod, reqPayload T,
+	authToken string, logger *slog.Logger, wg *sync.WaitGroup,
+) (response[U], error) {
 	requestId := rand.Uint64()
 	message := serde.NewJsonRpcSpecificRequest(requestId, method, reqPayload, authToken)
 	data, err := json.Marshal(message)

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -116,7 +116,7 @@ func NewRpcClient(trans transport.Requester) (RpcClientApi, error) {
 	}
 
 	// Retrieve the address and set it on the rpcClient
-	res, err := waitForAuthorizedRequest[serde.NoPayloadRequest, common.Address](c, serde.GetAddressMethod, serde.NoPayloadRequest{})
+	res, err := WaitForRequestNoAuth[serde.NoPayloadRequest, common.Address](c, serde.GetAddressMethod, serde.NoPayloadRequest{})
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -184,4 +184,5 @@ var (
 	InternalServerError   = JsonRpcError{Code: -32603, Message: "Internal error"}
 	RequestUnmarshalError = JsonRpcError{Code: -32010, Message: "Could not unmarshal request object"}
 	ParamsUnmarshalError  = JsonRpcError{Code: -32009, Message: "Could not unmarshal params object"}
+	InvalidAuthTokenError = JsonRpcError{Code: -32008, Message: "Invalid auth token"}
 )

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -46,6 +46,9 @@ type NotificationOrRequest interface {
 
 const JsonRpcVersion = "2.0"
 
+type AuthRequest struct {
+	Id string
+}
 type PaymentRequest struct {
 	Amount  uint64
 	Channel types.Destination
@@ -69,6 +72,7 @@ type RequestPayload interface {
 		directdefund.ObjectiveRequest |
 		virtualfund.ObjectiveRequest |
 		virtualdefund.ObjectiveRequest |
+		AuthRequest |
 		PaymentRequest |
 		GetLedgerChannelRequest |
 		GetPaymentChannelRequest |

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -83,11 +83,16 @@ type NotificationPayload interface {
 		query.LedgerChannelInfo
 }
 
+type Params[T RequestPayload | NotificationPayload] struct {
+	AuthToken string
+	Payload   T
+}
+
 type JsonRpcSpecificRequest[T RequestPayload | NotificationPayload] struct {
-	Jsonrpc string `json:"jsonrpc"`
-	Id      uint64 `json:"id"`
-	Method  string `json:"method"`
-	Params  T      `json:"params"`
+	Jsonrpc string    `json:"jsonrpc"`
+	Id      uint64    `json:"id"`
+	Method  string    `json:"method"`
+	Params  Params[T] `json:"params"`
 }
 
 type (
@@ -116,12 +121,12 @@ type JsonRpcSuccessResponse[T ResponsePayload] struct {
 	Result  T      `json:"result"`
 }
 
-func NewJsonRpcSpecificRequest[T RequestPayload | NotificationPayload, U RequestMethod | NotificationMethod](requestId uint64, method U, objectiveRequest T) *JsonRpcSpecificRequest[T] {
+func NewJsonRpcSpecificRequest[T RequestPayload | NotificationPayload, U RequestMethod | NotificationMethod](requestId uint64, method U, objectiveRequest T, authToken string) *JsonRpcSpecificRequest[T] {
 	return &JsonRpcSpecificRequest[T]{
 		Jsonrpc: JsonRpcVersion,
 		Id:      requestId,
 		Method:  string(method),
-		Params:  objectiveRequest,
+		Params:  Params[T]{AuthToken: authToken, Payload: objectiveRequest},
 	}
 }
 

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -88,8 +88,8 @@ type NotificationPayload interface {
 }
 
 type Params[T RequestPayload | NotificationPayload] struct {
-	AuthToken string
-	Payload   T
+	AuthToken string `json:"authtoken"`
+	Payload   T      `json:"payload"`
 }
 
 type JsonRpcSpecificRequest[T RequestPayload | NotificationPayload] struct {

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -16,6 +16,7 @@ import (
 type RequestMethod string
 
 const (
+	GetAuthTokenMethod                RequestMethod = "get_auth_token"
 	GetAddressMethod                  RequestMethod = "get_address"
 	VersionMethod                     RequestMethod = "version"
 	CreateLedgerChannelRequestMethod  RequestMethod = "create_ledger_channel"

--- a/rpc/serde/serde_test.go
+++ b/rpc/serde/serde_test.go
@@ -16,22 +16,25 @@ var someRequest JsonRpcSpecificRequest[directfund.ObjectiveRequest] = JsonRpcSpe
 	Jsonrpc: JsonRpcVersion,
 	Id:      123,
 	Method:  "CreateLedgerChannel",
-	Params: directfund.NewObjectiveRequest(
-		testactors.Alice.Address(),
-		345,
-		testdata.Outcomes.Create(
+	Params: Params[directfund.ObjectiveRequest]{
+		AuthToken: "",
+		Payload: directfund.NewObjectiveRequest(
 			testactors.Alice.Address(),
-			testactors.Bob.Address(),
-			9,
-			7,
-			common.Address{},
+			345,
+			testdata.Outcomes.Create(
+				testactors.Alice.Address(),
+				testactors.Bob.Address(),
+				9,
+				7,
+				common.Address{},
+			),
+			18446744073709551615, // max uint64
+			common.Address{123},
 		),
-		18446744073709551615, // max uint64
-		common.Address{123},
-	),
+	},
 }
 
-var someRequestJSONString = `{"jsonrpc":"2.0","id":123,"method":"CreateLedgerChannel","params":{"CounterParty":"0xaaa6628ec44a8a742987ef3a114ddfe2d4f7adce","ChallengeDuration":345,"Outcome":[{"Asset":"0x0000000000000000000000000000000000000000","AssetMetadata":{"AssetType":0,"Metadata":null},"Allocations":[{"Destination":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce","Amount":9,"AllocationType":0,"Metadata":null},{"Destination":"0x000000000000000000000000bbb676f9cff8d242e9eac39d063848807d3d1d94","Amount":7,"AllocationType":0,"Metadata":null}]}],"AppDefinition":"0x7b00000000000000000000000000000000000000","AppData":null,"Nonce":18446744073709551615}}`
+var someRequestJSONString = `{"jsonrpc":"2.0","id":123,"method":"CreateLedgerChannel","params":{"AuthToken":"","Payload":{"CounterParty":"0xaaa6628ec44a8a742987ef3a114ddfe2d4f7adce","ChallengeDuration":345,"Outcome":[{"Asset":"0x0000000000000000000000000000000000000000","AssetMetadata":{"AssetType":0,"Metadata":null},"Allocations":[{"Destination":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce","Amount":9,"AllocationType":0,"Metadata":null},{"Destination":"0x000000000000000000000000bbb676f9cff8d242e9eac39d063848807d3d1d94","Amount":7,"AllocationType":0,"Metadata":null}]}],"AppDefinition":"0x7b00000000000000000000000000000000000000","AppData":null,"Nonce":18446744073709551615}}}`
 
 func TestMarshalJSON(t *testing.T) {
 	enc, err := json.Marshal(someRequest)

--- a/rpc/serde/serde_test.go
+++ b/rpc/serde/serde_test.go
@@ -34,7 +34,7 @@ var someRequest JsonRpcSpecificRequest[directfund.ObjectiveRequest] = JsonRpcSpe
 	},
 }
 
-var someRequestJSONString = `{"jsonrpc":"2.0","id":123,"method":"CreateLedgerChannel","params":{"AuthToken":"","Payload":{"CounterParty":"0xaaa6628ec44a8a742987ef3a114ddfe2d4f7adce","ChallengeDuration":345,"Outcome":[{"Asset":"0x0000000000000000000000000000000000000000","AssetMetadata":{"AssetType":0,"Metadata":null},"Allocations":[{"Destination":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce","Amount":9,"AllocationType":0,"Metadata":null},{"Destination":"0x000000000000000000000000bbb676f9cff8d242e9eac39d063848807d3d1d94","Amount":7,"AllocationType":0,"Metadata":null}]}],"AppDefinition":"0x7b00000000000000000000000000000000000000","AppData":null,"Nonce":18446744073709551615}}}`
+var someRequestJSONString = `{"jsonrpc":"2.0","id":123,"method":"CreateLedgerChannel","params":{"authtoken":"","payload":{"CounterParty":"0xaaa6628ec44a8a742987ef3a114ddfe2d4f7adce","ChallengeDuration":345,"Outcome":[{"Asset":"0x0000000000000000000000000000000000000000","AssetMetadata":{"AssetType":0,"Metadata":null},"Allocations":[{"Destination":"0x000000000000000000000000aaa6628ec44a8a742987ef3a114ddfe2d4f7adce","Amount":9,"AllocationType":0,"Metadata":null},{"Destination":"0x000000000000000000000000bbb676f9cff8d242e9eac39d063848807d3d1d94","Amount":7,"AllocationType":0,"Metadata":null}]}],"AppDefinition":"0x7b00000000000000000000000000000000000000","AppData":null,"Nonce":18446744073709551615}}}`
 
 func TestMarshalJSON(t *testing.T) {
 	enc, err := json.Marshal(someRequest)

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -118,6 +118,10 @@ func (rs *RpcServer) registerHandlers() (err error) {
 		}
 
 		switch serde.RequestMethod(jsonrpcReq.Method) {
+		case serde.GetAuthTokenMethod:
+			return processRequest(rs, requestData, func(req serde.NoPayloadRequest) (string, error) {
+				return generateAuthToken(allPermissions)
+			})
 		case serde.CreateVoucherRequestMethod:
 			return processRequest(rs, requestData, func(req serde.PaymentRequest) (payments.Voucher, error) {
 				return rs.node.CreateVoucher(req.Channel, big.NewInt(int64(req.Amount)))

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -119,8 +119,8 @@ func (rs *RpcServer) registerHandlers() (err error) {
 
 		switch serde.RequestMethod(jsonrpcReq.Method) {
 		case serde.GetAuthTokenMethod:
-			return processRequest(rs, permNone, requestData, func(req serde.NoPayloadRequest) (string, error) {
-				return generateAuthToken(allPermissions)
+			return processRequest(rs, permNone, requestData, func(req serde.AuthRequest) (string, error) {
+				return generateAuthToken(req.Id, allPermissions)
 			})
 		case serde.CreateVoucherRequestMethod:
 			return processRequest(rs, permSign, requestData, func(req serde.PaymentRequest) (payments.Voucher, error) {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -204,7 +204,7 @@ func processRequest[T serde.RequestPayload, U serde.ResponsePayload](rs *RpcServ
 		return marshalResponse(response)
 	}
 
-	err = checkPermission(rpcRequest.Params.AuthToken, permission)
+	err = checkTokenValidity(rpcRequest.Params.AuthToken, permission)
 	if err != nil {
 		response := serde.NewJsonRpcErrorResponse(rpcRequest.Id, serde.InvalidAuthTokenError)
 		return marshalResponse(response, rs.logger)

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -207,7 +207,7 @@ func processRequest[T serde.RequestPayload, U serde.ResponsePayload](rs *RpcServ
 	err = checkTokenValidity(rpcRequest.Params.AuthToken, permission, nil)
 	if err != nil {
 		response := serde.NewJsonRpcErrorResponse(rpcRequest.Id, serde.InvalidAuthTokenError)
-		return marshalResponse(response, rs.logger)
+		return marshalResponse(response)
 	}
 
 	payload := rpcRequest.Params.Payload

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"math/big"
 	"sync"
+	"time"
 
 	"github.com/statechannels/go-nitro/internal/logging"
 	nitro "github.com/statechannels/go-nitro/node"
@@ -204,7 +205,7 @@ func processRequest[T serde.RequestPayload, U serde.ResponsePayload](rs *RpcServ
 		return marshalResponse(response)
 	}
 
-	err = checkTokenValidity(rpcRequest.Params.AuthToken, permission, nil)
+	err = checkTokenValidity(rpcRequest.Params.AuthToken, permission, 7*24*time.Hour)
 	if err != nil {
 		response := serde.NewJsonRpcErrorResponse(rpcRequest.Id, serde.InvalidAuthTokenError)
 		return marshalResponse(response)

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -204,7 +204,7 @@ func processRequest[T serde.RequestPayload, U serde.ResponsePayload](rs *RpcServ
 		return marshalResponse(response)
 	}
 
-	err = checkTokenValidity(rpcRequest.Params.AuthToken, permission)
+	err = checkTokenValidity(rpcRequest.Params.AuthToken, permission, nil)
 	if err != nil {
 		response := serde.NewJsonRpcErrorResponse(rpcRequest.Id, serde.InvalidAuthTokenError)
 		return marshalResponse(response, rs.logger)

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -131,7 +131,7 @@ func (rs *RpcServer) registerHandlers() (err error) {
 				return rs.node.ReceiveVoucher(req)
 			})
 		case serde.GetAddressMethod:
-			return processRequest(rs, permRead, requestData, func(req serde.NoPayloadRequest) (string, error) {
+			return processRequest(rs, permNone, requestData, func(req serde.NoPayloadRequest) (string, error) {
 				return rs.node.Address.Hex(), nil
 			})
 		case serde.VersionMethod:
@@ -202,6 +202,12 @@ func processRequest[T serde.RequestPayload, U serde.ResponsePayload](rs *RpcServ
 	if err != nil {
 		response := serde.NewJsonRpcErrorResponse(rpcRequest.Id, serde.ParamsUnmarshalError)
 		return marshalResponse(response)
+	}
+
+	err = checkPermission(rpcRequest.Params.AuthToken, permission)
+	if err != nil {
+		response := serde.NewJsonRpcErrorResponse(rpcRequest.Id, serde.InvalidAuthTokenError)
+		return marshalResponse(response, rs.logger)
 	}
 
 	payload := rpcRequest.Params.Payload

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -204,7 +204,7 @@ func processRequest[T serde.RequestPayload, U serde.ResponsePayload](rs *RpcServ
 		return marshalResponse(response)
 	}
 
-	payload := rpcRequest.Params
+	payload := rpcRequest.Params.Payload
 	processedResponse, err := processPayload(payload)
 	if err != nil {
 		responseErr := serde.InternalServerError // default error
@@ -312,7 +312,7 @@ func (rs *RpcServer) sendNotifications(ctx context.Context,
 func sendNotification[T serde.NotificationMethod, U serde.NotificationPayload](rs *RpcServer, method T, payload U) error {
 	rs.logger.Debug("Sending notification", "method", method, "payload", payload)
 
-	request := serde.NewJsonRpcSpecificRequest(rand.Uint64(), method, payload)
+	request := serde.NewJsonRpcSpecificRequest(rand.Uint64(), method, payload, "")
 	data, err := json.Marshal(request)
 	if err != nil {
 		return err

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -138,7 +138,7 @@ func TestRpcPayInvalidParam(t *testing.T) {
 		Jsonrpc: "2.0",
 		Id:      2,
 		Method:  "pay",
-		Params:  paymentRequest,
+		Params:  serde.Params[serde.PaymentRequest]{AuthToken: "", Payload: paymentRequest},
 	}
 
 	jsonRequest, err := json.Marshal(request)

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -60,11 +60,10 @@ func getAuthToken(t *testing.T) string {
 	}
 
 	mockNode := &nitro.Node{}
-	mockLogger := &zerolog.Logger{}
 	mockResponder := &mockResponder{}
 	// Since we're using an empty node we want to disable notifications
 	// otherwise the server will try to send notifications to the node and fail
-	_, err = newRpcServerWithoutNotifications(mockNode, mockLogger, mockResponder)
+	_, err = newRpcServerWithoutNotifications(mockNode, mockResponder)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
This PR adds authentication tokens for the JSON RPC api. Every API method either requires no authentication token or an authentication token with correct permissions. If the direction of this work makes sense, the follow up work is:

- [ ] Do not store the token signing key in code.
- [ ] Wire up tokens in the Typescript RPC client
- [ ] Define an authorization strategy. At the moment, the server will issue a valid token to any requester.