### PR TITLE
Fix rpcClient.Address() race condition

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -3,7 +3,6 @@ package node
 import (
 	"fmt"
 	"log/slog"
-	"os"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/internal/chain"
@@ -17,7 +16,7 @@ import (
 )
 
 func InitializeNode(pkString string, chainOpts chain.ChainOpts,
-	useDurableStore bool, durableStoreFolder string, msgPort int, logDestination *os.File, bootPeers []string,
+	useDurableStore bool, durableStoreFolder string, msgPort int, bootPeers []string,
 ) (*node.Node, *store.Store, *p2pms.P2PMessageService, *chainservice.EthChainService, error) {
 	if pkString == "" {
 		panic("pk must be set")

--- a/main.go
+++ b/main.go
@@ -178,7 +178,7 @@ func main() {
 
 			logging.SetupDefaultLogger(os.Stdout, slog.LevelDebug)
 
-			node, _, _, _, err := node.InitializeNode(pkString, chainOpts, useDurableStore, durableStoreFolder, msgPort, os.Stdout, peerSlice)
+			node, _, _, _, err := node.InitializeNode(pkString, chainOpts, useDurableStore, durableStoreFolder, msgPort, peerSlice)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Fix `rpcClient.Address()` race condition that caused a CI failure when changes were merged into `main`: https://github.com/statechannels/go-nitro/actions/runs/6012869180/job/16309076480