### PR TITLE
Enforce fair outcome in direct and virtual fund objectives

### DIFF
--- a/internal/testdata/states.go
+++ b/internal/testdata/states.go
@@ -50,8 +50,8 @@ var testVirtualState = state.State{
 	ChallengeDuration: 60,
 	AppData:           []byte{},
 	Outcome: Outcomes.CreateLongOutcome(
-		SimpleItem{testactors.Alice.Destination(), 6},
-		SimpleItem{testactors.Bob.Destination(), 4},
+		SimpleItem{testactors.Alice.Destination(), 10},
+		SimpleItem{testactors.Bob.Destination(), 0},
 	),
 	TurnNum: 0,
 	IsFinal: false,

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -13,7 +13,11 @@ import {
   ReceiveVoucherResult,
 } from "./types";
 import { Transport } from "./transport";
-import { createOutcome, generateRequest } from "./utils";
+import {
+  createOutcome,
+  createPaymentChannelOutcome,
+  generateRequest,
+} from "./utils";
 import { HttpTransport } from "./transport/http";
 import { getAndValidateResult } from "./serde";
 
@@ -120,7 +124,7 @@ export class NitroRpcClient {
       CounterParty: counterParty,
       Intermediaries: intermediaries,
       ChallengeDuration: 0,
-      Outcome: createOutcome(
+      Outcome: createPaymentChannelOutcome(
         asset,
         await this.GetAddress(),
         counterParty,

--- a/packages/nitro-rpc-client/src/utils.ts
+++ b/packages/nitro-rpc-client/src/utils.ts
@@ -49,6 +49,46 @@ export function createOutcome(
     },
   ];
 }
+/**
+ * createPaymentChannelOutcome creates a basic outcome for a payment channel
+ *
+ * @param asset - The asset to fund the channel with
+ * @param alpha - The address of the first participant
+ * @param beta - The address of the second participant
+ * @param amount - The amount to allocate to the payer
+ * @returns An outcome for a virtually funded channel
+ */
+export function createPaymentChannelOutcome(
+  asset: string,
+  alpha: string,
+  beta: string,
+  amount: number
+): Outcome {
+  return [
+    {
+      Asset: asset,
+      AssetMetadata: {
+        AssetType: 0,
+        Metadata: null,
+      },
+
+      Allocations: [
+        {
+          Destination: convertAddressToBytes32(alpha),
+          Amount: amount,
+          AllocationType: 0,
+          Metadata: null,
+        },
+        {
+          Destination: convertAddressToBytes32(beta),
+          Amount: 0,
+          AllocationType: 0,
+          Metadata: null,
+        },
+      ],
+    },
+  ];
+}
 
 /**
  * Left pads a 20 byte address hex string with zeros until it is a 32 byte hex string

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -59,7 +59,7 @@ func TestNew(t *testing.T) {
 	request := NewObjectiveRequest(
 		testState.Participants[1],
 		testState.ChallengeDuration,
-		testState.Outcome,
+		testState.Outcome.Clone(),
 		0,
 		testState.AppDefinition,
 	)
@@ -69,7 +69,7 @@ func TestNew(t *testing.T) {
 	}
 
 	getByParticipantHasChannel := func(id types.Address) ([]*channel.Channel, error) {
-		c, _ := channel.New(testState, 0)
+		c, _ := channel.New(testState.Clone(), 0)
 		return []*channel.Channel{c}, nil
 	}
 
@@ -91,7 +91,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestConstructFromPayload(t *testing.T) {
-	ss := state.NewSignedState(testState)
+	ss := state.NewSignedState(testState.Clone())
 	id := protocols.ObjectiveId(ObjectivePrefix + testState.ChannelId().String())
 	op, err := protocols.CreateObjectivePayload(id, SignedStatePayload, ss)
 	testhelpers.Ok(t, err)
@@ -118,7 +118,7 @@ func TestConstructFromPayload(t *testing.T) {
 
 func TestUpdate(t *testing.T) {
 	id := protocols.ObjectiveId(ObjectivePrefix + testState.ChannelId().String())
-	op, err := protocols.CreateObjectivePayload(id, SignedStatePayload, state.NewSignedState(testState))
+	op, err := protocols.CreateObjectivePayload(id, SignedStatePayload, state.NewSignedState(testState.Clone()))
 	testhelpers.Ok(t, err)
 	// Construct various variables for use in TestUpdate
 	s, _ := ConstructFromPayload(false, op, testState.Participants[0])

--- a/protocols/directfund/directfund_test.go
+++ b/protocols/directfund/directfund_test.go
@@ -83,6 +83,11 @@ func TestNew(t *testing.T) {
 	if _, err := NewObjective(request, false, testState.Participants[0], big.NewInt(TEST_CHAIN_ID), getByParticipant, getByConsensusHasChannel); err == nil {
 		t.Errorf("Expected an error when constructing with an objective when an existing channel consensus channel exists")
 	}
+
+	request.Outcome[0].Allocations[0].Amount = big.NewInt(10)
+	if _, err := NewObjective(request, false, testState.Participants[0], big.NewInt(TEST_CHAIN_ID), getByParticipant, getByConsensus); err == nil {
+		t.Errorf("Expected an error when constructing a direct fund objective with an unfair outcome")
+	}
 }
 
 func TestConstructFromPayload(t *testing.T) {

--- a/protocols/virtualfund/helpers_test.go
+++ b/protocols/virtualfund/helpers_test.go
@@ -10,16 +10,16 @@ import (
 )
 
 // prepareConsensusChannel prepares a consensus channel with a consensus outcome
-//   - allocating 6 to left participant
-//   - allocating 4 to right participant
+//   - allocating 5 to left participant
+//   - allocating 5 to right participant
 //   - including the given guarantees
 func prepareConsensusChannel(role uint, leader, follower, leftActor testactors.Actor, guarantees ...consensus_channel.Guarantee) *consensus_channel.ConsensusChannel {
-	return prepareConsensusChannelHelper(role, leader, follower, leftActor, 6, 4, 1, guarantees...)
+	return prepareConsensusChannelHelper(role, leader, follower, leftActor, 5, 5, 1, guarantees...)
 }
 
 // consensusStateSignatures prepares a consensus channel with a consensus outcome and returns the signatures on the consensus state
 func consensusStateSignatures(leader, follower testactors.Actor, guarantees ...consensus_channel.Guarantee) [2]state.Signature {
-	return prepareConsensusChannelHelper(0, leader, follower, leader, 0, 0, 2, guarantees...).Signatures()
+	return prepareConsensusChannelHelper(0, leader, follower, leader, 0, 5, 2, guarantees...).Signatures()
 }
 
 func prepareConsensusChannelHelper(role uint, leader, follower, leftActor testactors.Actor, leftBalance, rightBalance, turnNum int, guarantees ...consensus_channel.Guarantee) *consensus_channel.ConsensusChannel {

--- a/protocols/virtualfund/virtualfund_test.go
+++ b/protocols/virtualfund/virtualfund_test.go
@@ -31,11 +31,11 @@ func TestMarshalJSON(t *testing.T) {
 			Allocations: outcome.Allocations{
 				outcome.Allocation{
 					Destination: alice.Destination(),
-					Amount:      big.NewInt(5),
+					Amount:      big.NewInt(10),
 				},
 				outcome.Allocation{
 					Destination: bob.Destination(),
-					Amount:      big.NewInt(5),
+					Amount:      big.NewInt(0),
 				},
 			},
 		}},


### PR DESCRIPTION
Fixes #1608 
This updates the protocols to enforce a "fair" outcome based on the some of the [policy work](https://github.com/statechannels/go-nitro/pull/1599#discussion_r1308475804).

- Direct fund objectives now check that the each participant in the outcome provides the same amount.
- Virtual fund objectives now checks that the `payer` starts with the full balance.


By enforcing these outcome restrictions in our protocols our nitro clients are protected from accepting an objective with an unfavourable or less efficient outcome.

