### PR TITLE
Use a older nightly build of anvil/foundry

### DIFF
--- a/.github/workflows/ts-rpc-test.yml
+++ b/.github/workflows/ts-rpc-test.yml
@@ -18,7 +18,7 @@ jobs:
 
       # Install foundry so we can use it to run a chain instance
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@v1.0.10
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/ts-rpc-test.yml
+++ b/.github/workflows/ts-rpc-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install (Forked) Foundry
         uses: statechannels/foundry-toolchain@master
         with:
-          version: "nightly-6c4c68a7031581bb8b8a10bb44db8dff4e04277f"
+          version: "nightly-bff4ed912bb023d7bf9b20eda581aa4867a1cf70"
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/ts-rpc-test.yml
+++ b/.github/workflows/ts-rpc-test.yml
@@ -17,8 +17,8 @@ jobs:
           node-version: "18.15.0"
 
       # Install foundry so we can use it to run a chain instance
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1.0.10
+      - name: Install (Forked) Foundry
+        uses: statechannels/foundry-toolchain@master
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/ts-rpc-test.yml
+++ b/.github/workflows/ts-rpc-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install (Forked) Foundry
         uses: statechannels/foundry-toolchain@master
         with:
-          version: "nightly-bff4ed912bb023d7bf9b20eda581aa4867a1cf70"
+          version: "nightly"
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/ts-rpc-test.yml
+++ b/.github/workflows/ts-rpc-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install (Forked) Foundry
         uses: statechannels/foundry-toolchain@master
         with:
-          version: "nightly-bff4ed912bb023d7bf9b20eda581aa4867a1cf70"
+          version: "nightly-6c4c68a7031581bb8b8a10bb44db8dff4e04277f"
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/ts-rpc-test.yml
+++ b/.github/workflows/ts-rpc-test.yml
@@ -19,6 +19,8 @@ jobs:
       # Install foundry so we can use it to run a chain instance
       - name: Install (Forked) Foundry
         uses: statechannels/foundry-toolchain@master
+        with:
+          version: "nightly-bff4ed912bb023d7bf9b20eda581aa4867a1cf70"
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
This PR updates our typescript RPC CI workflow to use an older build of foundry. We specify the [second latest release](https://github.com/foundry-rs/foundry/releases/tag/nightly-bff4ed912bb023d7bf9b20eda581aa4867a1cf70) which seems to work.

We can see in https://github.com/statechannels/go-nitro/pull/1617/commits/e913e99b765ce3f258ce4abb1b1174c198dbed8f if we use the most [recent version](https://github.com/foundry-rs/foundry/releases/tag/nightly-6c4c68a7031581bb8b8a10bb44db8dff4e04277f) of foundry, we run into the same error we were seeing everywhere else.