### PR TITLE
Reduce log noise for start-rpc-servers

### DIFF
--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -45,7 +45,7 @@ func InitializeEthChainService(chainOpts ChainOpts) (*chainservice.EthChainServi
 }
 
 func StartAnvil() (*exec.Cmd, error) {
-	chainCmd := exec.Command("anvil", "--chain-id", "1337", "--block-time", "1")
+	chainCmd := exec.Command("anvil", "--chain-id", "1337", "--block-time", "1", "--silent")
 	chainCmd.Stdout = os.Stdout
 	chainCmd.Stderr = os.Stderr
 	err := chainCmd.Start()

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -11,7 +11,7 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-const TraceLogLevel = -5
+const LevelTrace slog.Level = -5
 
 // newLogWriter returns a writer for the given logDir and logFile
 // If the log file already exists it will be removed and a fresh file will be created

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -11,6 +11,8 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
+const TraceLogLevel = -5
+
 // newLogWriter returns a writer for the given logDir and logFile
 // If the log file already exists it will be removed and a fresh file will be created
 func newLogWriter(logDir, logFile string) *os.File {

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/statechannels/go-nitro/channel/state"
+	"github.com/statechannels/go-nitro/internal/logging"
 	NitroAdjudicator "github.com/statechannels/go-nitro/node/engine/chainservice/adjudicator"
 	Token "github.com/statechannels/go-nitro/node/engine/chainservice/erc20"
 	chainutils "github.com/statechannels/go-nitro/node/engine/chainservice/utils"
@@ -311,7 +312,7 @@ out:
 				errorChan <- fmt.Errorf("subscribeFilterLogs failed on resubscribe: %w", err)
 				break out
 			}
-			ecs.logger.Debug("resubscribed to filtered event logs")
+			ecs.logger.Log(context.Background(), logging.TraceLogLevel, "resubscribed to filtered event logs")
 
 		case <-time.After(RESUB_INTERVAL):
 			// Due to https://github.com/ethereum/go-ethereum/issues/23845 we can't rely on a long running subscription.
@@ -354,11 +355,11 @@ out:
 				errorChan <- fmt.Errorf("subscribeNewHead failed on resubscribe: %w", err)
 				break out
 			}
-			ecs.logger.Debug("resubscribed to new blocks")
+			ecs.logger.Log(context.Background(), logging.TraceLogLevel, "resubscribed to new blocks")
 
 		case newBlock := <-newBlockChan:
 			newBlockNum := newBlock.Number.Uint64()
-			ecs.logger.Debug("detected new block", "block-num", newBlockNum)
+			ecs.logger.Log(context.Background(), logging.TraceLogLevel, "detected new block", "block-num", newBlockNum)
 			ecs.updateEventTracker(errorChan, &newBlockNum, nil)
 		}
 	}

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -312,7 +312,7 @@ out:
 				errorChan <- fmt.Errorf("subscribeFilterLogs failed on resubscribe: %w", err)
 				break out
 			}
-			ecs.logger.Log(context.Background(), logging.TraceLogLevel, "resubscribed to filtered event logs")
+			ecs.logger.Log(context.Background(), logging.LevelTrace, "resubscribed to filtered event logs")
 
 		case <-time.After(RESUB_INTERVAL):
 			// Due to https://github.com/ethereum/go-ethereum/issues/23845 we can't rely on a long running subscription.
@@ -355,11 +355,11 @@ out:
 				errorChan <- fmt.Errorf("subscribeNewHead failed on resubscribe: %w", err)
 				break out
 			}
-			ecs.logger.Log(context.Background(), logging.TraceLogLevel, "resubscribed to new blocks")
+			ecs.logger.Log(context.Background(), logging.LevelTrace, "resubscribed to new blocks")
 
 		case newBlock := <-newBlockChan:
 			newBlockNum := newBlock.Number.Uint64()
-			ecs.logger.Log(context.Background(), logging.TraceLogLevel, "detected new block", "block-num", newBlockNum)
+			ecs.logger.Log(context.Background(), logging.LevelTrace, "detected new block", "block-num", newBlockNum)
 			ecs.updateEventTracker(errorChan, &newBlockNum, nil)
 		}
 	}


### PR DESCRIPTION
- Introduce trace log level
- Use trace log level in the ethereum chain service for new block logs and resubscriptions
- Run Anvil in silent mode