### PR TITLE
Ensure rpc servers are fully initialized before sending requests

### DIFF
--- a/cmd/create-channels/main.go
+++ b/cmd/create-channels/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/ethereum/go-ethereum/common"
@@ -44,6 +45,11 @@ func createChannels() error {
 			return err
 		}
 		clients[participant], err = rpc.NewRpcClient(clientConnection)
+		if err != nil {
+			panic(err)
+		}
+
+		err = utils.WaitForRpcClient(url, 500*time.Millisecond, 5*time.Minute)
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/start-rpc-servers/main.go
+++ b/cmd/start-rpc-servers/main.go
@@ -45,10 +45,10 @@ const (
 )
 
 var participants = map[name]participant{
-	alice: {blue, "http://127.0.0.1/4005/api/v1"},
-	irene: {green, "http://127.0.0.1/4006/api/v1"},
+	alice: {blue, "http://127.0.0.1:4005/api/v1"},
+	irene: {green, "http://127.0.0.1:4006/api/v1"},
 	ivan:  {cyan, "http://127.0.0.1:4008/api/v1"},
-	bob:   {yellow, "http://127.0.0.1/4007/api/v1"},
+	bob:   {yellow, "http://127.0.0.1:4007/api/v1"},
 }
 
 const (
@@ -131,7 +131,7 @@ func main() {
 			hostUI := cCtx.Bool(HOST_UI)
 
 			// Setup Ivan first, he is the DHT boot peer
-			client, err := setupRPCServer(participants[ivan], participants[ivan].color, naAddress, vpaAddress, caAddress, chainUrl, chainAuthToken, dataFolder, hostUI)
+			client, err := setupRPCServer(ivan, participants[ivan].color, naAddress, vpaAddress, caAddress, chainUrl, chainAuthToken, dataFolder, hostUI)
 			if err != nil {
 				utils.StopCommands(running...)
 				panic(err)
@@ -146,7 +146,8 @@ func main() {
 
 			for _, participantName := range []name{alice, bob, irene} {
 				p := participants[participantName]
-				client, err := setupRPCServer(p, p.color, naAddress, vpaAddress, caAddress, chainUrl, chainAuthToken, dataFolder, hostUI)
+				fmt.Println("participantName: " + participantName)
+				client, err := setupRPCServer(participantName, p.color, naAddress, vpaAddress, caAddress, chainUrl, chainAuthToken, dataFolder, hostUI)
 				if err != nil {
 					utils.StopCommands(running...)
 					panic(err)
@@ -165,7 +166,7 @@ func main() {
 }
 
 // setupRPCServer starts up an RPC server for the given participant
-func setupRPCServer(p participant, c color, na, vpa, ca types.Address, chainUrl, chainAuthToken string, dataFolder string, hostUI bool) (*exec.Cmd, error) {
+func setupRPCServer(n name, c color, na, vpa, ca types.Address, chainUrl, chainAuthToken string, dataFolder string, hostUI bool) (*exec.Cmd, error) {
 	args := []string{"run"}
 
 	if hostUI {
@@ -182,7 +183,7 @@ func setupRPCServer(p participant, c color, na, vpa, ca types.Address, chainUrl,
 
 	args = append(args, "-durablestorefolder", dataFolder)
 
-	args = append(args, "-config", fmt.Sprintf("./cmd/test-configs/%s.toml", p))
+	args = append(args, "-config", fmt.Sprintf("./cmd/test-configs/%s.toml", n))
 
 	cmd := exec.Command("go", args...)
 	cmd.Stdout = newColorWriter(c, os.Stdout)

--- a/cmd/start-rpc-servers/main.go
+++ b/cmd/start-rpc-servers/main.go
@@ -2,11 +2,9 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"log"
-	"net/http"
 	"os"
 	"os/exec"
 	"time"
@@ -140,7 +138,7 @@ func main() {
 			}
 			running = append(running, client)
 
-			err = waitForRpcClient(participants[ivan].url, 500*time.Millisecond, 5*time.Minute)
+			err = utils.WaitForRpcClient(participants[ivan].url, 500*time.Millisecond, 5*time.Minute)
 			if err != nil {
 				utils.StopCommands(running...)
 				panic(err)
@@ -154,12 +152,6 @@ func main() {
 					panic(err)
 				}
 				running = append(running, client)
-
-				err = waitForRpcClient(p.url, 500*time.Millisecond, 5*time.Minute)
-				if err != nil {
-					utils.StopCommands(running...)
-					panic(err)
-				}
 			}
 
 			utils.WaitForKillSignal()
@@ -221,27 +213,5 @@ func newColorWriter(c color, w io.Writer) colorWriter {
 	return colorWriter{
 		writer: w,
 		color:  c,
-	}
-}
-
-// waitForRpcClient waits for an RPC to be available at the given url
-// It does this by performing a GET request to the url until it receives a response
-func waitForRpcClient(rpcClientUrl string, interval, timeout time.Duration) error {
-	timeoutTicker := time.NewTicker(timeout)
-	defer timeoutTicker.Stop()
-	intervalTicker := time.NewTicker(interval)
-	defer intervalTicker.Stop()
-
-	client := &http.Client{}
-	for {
-		select {
-		case <-timeoutTicker.C:
-			return errors.New("polling timed out")
-		case <-intervalTicker.C:
-			resp, _ := client.Get(rpcClientUrl)
-			if resp != nil {
-				return nil
-			}
-		}
 	}
 }

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -1,11 +1,14 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -52,4 +55,26 @@ func CreateLedgerChannel(client rpc.RpcClientApi, counterPartyAddress common.Add
 
 	<-client.ObjectiveCompleteChan(response.Id)
 	return nil
+}
+
+// waitForRpcClient waits for an RPC to be available at the given url
+// It does this by performing a GET request to the url until it receives a response
+func WaitForRpcClient(rpcClientUrl string, interval, timeout time.Duration) error {
+	timeoutTicker := time.NewTicker(timeout)
+	defer timeoutTicker.Stop()
+	intervalTicker := time.NewTicker(interval)
+	defer intervalTicker.Stop()
+
+	client := &http.Client{}
+	for {
+		select {
+		case <-timeoutTicker.C:
+			return errors.New("polling timed out")
+		case <-intervalTicker.C:
+			resp, _ := client.Get(rpcClientUrl)
+			if resp != nil {
+				return nil
+			}
+		}
+	}
 }

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -60,6 +60,7 @@ func CreateLedgerChannel(client rpc.RpcClientApi, counterPartyAddress common.Add
 // waitForRpcClient waits for an RPC to be available at the given url
 // It does this by performing a GET request to the url until it receives a response
 func WaitForRpcClient(rpcClientUrl string, interval, timeout time.Duration) error {
+	fmt.Printf("Waiting for client: %s\n", rpcClientUrl)
 	timeoutTicker := time.NewTicker(timeout)
 	defer timeoutTicker.Stop()
 	intervalTicker := time.NewTicker(interval)
@@ -73,6 +74,7 @@ func WaitForRpcClient(rpcClientUrl string, interval, timeout time.Duration) erro
 		case <-intervalTicker.C:
 			resp, _ := client.Get(rpcClientUrl)
 			if resp != nil {
+				fmt.Printf("Success! Client ready: %s\n", rpcClientUrl)
 				return nil
 			}
 		}

--- a/packages/nitro-rpc-client/scripts/client-runner.ts
+++ b/packages/nitro-rpc-client/scripts/client-runner.ts
@@ -14,6 +14,13 @@ import {
 } from "../src/utils";
 
 const clientNames = ["alice", "irene", "bob", "ivan"] as const;
+const clientPortMap: Record<ClientNames, number> = {
+  alice: 4005,
+  irene: 4006,
+  bob: 4007,
+  ivan: 4008,
+};
+
 type ClientNames = (typeof clientNames)[number];
 type Clients = Map<ClientNames, NitroRpcClient>;
 
@@ -135,12 +142,11 @@ yargs(hideBin(process.argv))
     },
     async (yargs) => {
       if (yargs.waitduration > 0) {
-        await Promise.all([
-          waitForRPCServer(4005, yargs.waitduration),
-          waitForRPCServer(4006, yargs.waitduration),
-          waitForRPCServer(4007, yargs.waitduration),
-          waitForRPCServer(4008, yargs.waitduration),
-        ]);
+        await Promise.all(
+          Object.values(clientPortMap).map((port) =>
+            waitForRPCServer(port, yargs.waitduration)
+          )
+        );
       }
 
       const clients = await initializeClients();

--- a/packages/nitro-rpc-client/scripts/client-runner.ts
+++ b/packages/nitro-rpc-client/scripts/client-runner.ts
@@ -139,6 +139,7 @@ yargs(hideBin(process.argv))
           waitForRPCServer(4005, yargs.waitduration),
           waitForRPCServer(4006, yargs.waitduration),
           waitForRPCServer(4007, yargs.waitduration),
+          waitForRPCServer(4008, yargs.waitduration),
         ]);
       }
 


### PR DESCRIPTION
While troubleshooting the recent CI failures (which we eventually attributed to a faulty version of `anvil`), I noticed there are a few spots where we could improve the resiliency of our scripts by ensuring the rpc clients/servers are fully initialized before trying to send requests.