### PR TITLE
Rename rpc websocket transport to http

### DIFF
--- a/cmd/create-channel/main.go
+++ b/cmd/create-channel/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/statechannels/go-nitro/cmd/utils"
 	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/rpc"
-	"github.com/statechannels/go-nitro/rpc/transport/ws"
+	"github.com/statechannels/go-nitro/rpc/transport/http"
 )
 
 type participantOpts struct {
@@ -37,7 +37,7 @@ func main() {
 	logging.SetupDefaultFileLogger(LOG_FILE, slog.LevelDebug)
 
 	url := fmt.Sprintf(":%d/api/v1", participantOpts.RpcPort)
-	clientConnection, err := ws.NewWebSocketTransportAsClient(url)
+	clientConnection, err := http.NewWebSocketTransportAsClient(url)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/create-channel/main.go
+++ b/cmd/create-channel/main.go
@@ -37,7 +37,7 @@ func main() {
 	logging.SetupDefaultFileLogger(LOG_FILE, slog.LevelDebug)
 
 	url := fmt.Sprintf(":%d/api/v1", participantOpts.RpcPort)
-	clientConnection, err := http.NewWebSocketTransportAsClient(url)
+	clientConnection, err := http.NewHttpTransportAsClient(url)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/create-channels/main.go
+++ b/cmd/create-channels/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/internal/testdata"
 	"github.com/statechannels/go-nitro/rpc"
-	"github.com/statechannels/go-nitro/rpc/transport/ws"
+	"github.com/statechannels/go-nitro/rpc/transport/http"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -40,7 +40,7 @@ func createChannels() error {
 		logging.SetupDefaultFileLogger(LOG_FILE, slog.LevelDebug)
 
 		url := fmt.Sprintf(":%d/api/v1", participantOpts.RpcPort)
-		clientConnection, err := ws.NewWebSocketTransportAsClient(url)
+		clientConnection, err := http.NewWebSocketTransportAsClient(url)
 		if err != nil {
 			return err
 		}

--- a/cmd/create-channels/main.go
+++ b/cmd/create-channels/main.go
@@ -40,7 +40,7 @@ func createChannels() error {
 		logging.SetupDefaultFileLogger(LOG_FILE, slog.LevelDebug)
 
 		url := fmt.Sprintf(":%d/api/v1", participantOpts.RpcPort)
-		clientConnection, err := http.NewWebSocketTransportAsClient(url)
+		clientConnection, err := http.NewHttpTransportAsClient(url)
 		if err != nil {
 			return err
 		}

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -20,7 +20,7 @@ func InitializeRpcServer(node *node.Node, rpcPort int, useNats bool) (*rpc.RpcSe
 		transport, err = nats.NewNatsTransportAsServer(rpcPort)
 	} else {
 		slog.Info("Initializing websocket RPC transport...")
-		transport, err = ws.NewWebSocketTransportAsServer(fmt.Sprint(rpcPort))
+		transport, err = ws.NewHttpSocketTransportAsServer(fmt.Sprint(rpcPort))
 	}
 	if err != nil {
 		return nil, err

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -19,7 +19,7 @@ func InitializeRpcServer(node *node.Node, rpcPort int, useNats bool) (*rpc.RpcSe
 		slog.Info("Initializing NATS RPC transport...")
 		transport, err = nats.NewNatsTransportAsServer(rpcPort)
 	} else {
-		slog.Info("Initializing websocket RPC transport...")
+		slog.Info("Initializing Http RPC transport...")
 		transport, err = http.NewHttpSocketTransportAsServer(fmt.Sprint(rpcPort))
 	}
 	if err != nil {

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -7,8 +7,8 @@ import (
 	"github.com/statechannels/go-nitro/node"
 	"github.com/statechannels/go-nitro/rpc"
 	"github.com/statechannels/go-nitro/rpc/transport"
+	"github.com/statechannels/go-nitro/rpc/transport/http"
 	"github.com/statechannels/go-nitro/rpc/transport/nats"
-	"github.com/statechannels/go-nitro/rpc/transport/ws"
 )
 
 func InitializeRpcServer(node *node.Node, rpcPort int, useNats bool) (*rpc.RpcServer, error) {
@@ -20,7 +20,7 @@ func InitializeRpcServer(node *node.Node, rpcPort int, useNats bool) (*rpc.RpcSe
 		transport, err = nats.NewNatsTransportAsServer(rpcPort)
 	} else {
 		slog.Info("Initializing websocket RPC transport...")
-		transport, err = ws.NewHttpSocketTransportAsServer(fmt.Sprint(rpcPort))
+		transport, err = http.NewHttpSocketTransportAsServer(fmt.Sprint(rpcPort))
 	}
 	if err != nil {
 		return nil, err

--- a/node_test/reverseproxy_test.go
+++ b/node_test/reverseproxy_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/statechannels/go-nitro/payments"
+	"github.com/statechannels/go-nitro/rpc/transport"
 
 	"github.com/statechannels/go-nitro/internal/logging"
 	ta "github.com/statechannels/go-nitro/internal/testactors"
@@ -237,11 +238,11 @@ func setupNitroClients(t *testing.T, logFile string) (alice, irene, bob rpc.RpcC
 	aliceChainService := chainservice.NewMockChainService(chain, ta.Alice.Address())
 	bobChainService := chainservice.NewMockChainService(chain, ta.Bob.Address())
 	ireneChainService := chainservice.NewMockChainService(chain, ta.Irene.Address())
-	ireneClient, msgIrene, ireneCleanup := setupNitroNodeWithRPCClient(t, ta.Irene.PrivateKey, 3106, 4106, ireneChainService, "ws", []string{})
+	ireneClient, msgIrene, ireneCleanup := setupNitroNodeWithRPCClient(t, ta.Irene.PrivateKey, 3106, 4106, ireneChainService, transport.Http, []string{})
 	bootPeers := []string{msgIrene.MultiAddr}
-	aliceClient, msgAlice, aliceCleanup := setupNitroNodeWithRPCClient(t, ta.Alice.PrivateKey, 3105, 4105, aliceChainService, "ws", bootPeers)
+	aliceClient, msgAlice, aliceCleanup := setupNitroNodeWithRPCClient(t, ta.Alice.PrivateKey, 3105, 4105, aliceChainService, transport.Http, bootPeers)
 
-	bobClient, msgBob, bobCleanup := setupNitroNodeWithRPCClient(t, ta.Bob.PrivateKey, 3107, 4107, bobChainService, "ws", bootPeers)
+	bobClient, msgBob, bobCleanup := setupNitroNodeWithRPCClient(t, ta.Bob.PrivateKey, 3107, 4107, bobChainService, transport.Http, bootPeers)
 
 	slog.Info("Clients created")
 

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -46,7 +46,7 @@ func TestRpcWithNats(t *testing.T) {
 	}
 }
 
-func TestRpcWithWebsockets(t *testing.T) {
+func TestRpcWithHttp(t *testing.T) {
 	for _, n := range []int{2, 3, 4} {
 		executeNRpcTestWrapper(t, "ws", n, false)
 	}

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/statechannels/go-nitro/protocols/virtualfund"
 	"github.com/statechannels/go-nitro/rpc"
 	"github.com/statechannels/go-nitro/rpc/transport"
+	"github.com/statechannels/go-nitro/rpc/transport/http"
 	natstrans "github.com/statechannels/go-nitro/rpc/transport/nats"
-	"github.com/statechannels/go-nitro/rpc/transport/ws"
 	"github.com/statechannels/go-nitro/types"
 	"github.com/tidwall/buntdb"
 
@@ -437,7 +437,7 @@ func setupNitroNodeWithRPCClient(
 		}
 	case "ws":
 
-		clientConnection, err = ws.NewWebSocketTransportAsClient(rpcServer.Url())
+		clientConnection, err = http.NewWebSocketTransportAsClient(rpcServer.Url())
 		if err != nil {
 			panic(err)
 		}

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -48,13 +48,13 @@ func TestRpcWithNats(t *testing.T) {
 
 func TestRpcWithHttp(t *testing.T) {
 	for _, n := range []int{2, 3, 4} {
-		executeNRpcTestWrapper(t, "ws", n, false)
+		executeNRpcTestWrapper(t, transport.Http, n, false)
 	}
 }
 
 func TestRPCWithManualVoucherExchange(t *testing.T) {
-	executeNRpcTestWrapper(t, "ws", 4, true)
-	executeNRpcTestWrapper(t, "nats", 4, true)
+	executeNRpcTestWrapper(t, transport.Http, 4, true)
+	executeNRpcTestWrapper(t, transport.Nats, 4, true)
 }
 
 func executeNRpcTestWrapper(t *testing.T, connectionType transport.TransportType, n int, manualVoucherExchange bool) {
@@ -414,9 +414,9 @@ func setupNitroNodeWithRPCClient(
 
 	var useNats bool
 	switch connectionType {
-	case "nats":
+	case transport.Nats:
 		useNats = true
-	case "ws":
+	case transport.Http:
 		useNats = false
 	default:
 		err = fmt.Errorf("unknown connection type %v", connectionType)
@@ -429,13 +429,13 @@ func setupNitroNodeWithRPCClient(
 
 	var clientConnection transport.Requester
 	switch connectionType {
-	case "nats":
+	case transport.Nats:
 
 		clientConnection, err = natstrans.NewNatsTransportAsClient(rpcServer.Url())
 		if err != nil {
 			panic(err)
 		}
-	case "ws":
+	case transport.Http:
 
 		clientConnection, err = http.NewHttpTransportAsClient(rpcServer.Url())
 		if err != nil {

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -437,7 +437,7 @@ func setupNitroNodeWithRPCClient(
 		}
 	case "ws":
 
-		clientConnection, err = http.NewWebSocketTransportAsClient(rpcServer.Url())
+		clientConnection, err = http.NewHttpTransportAsClient(rpcServer.Url())
 		if err != nil {
 			panic(err)
 		}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -138,7 +138,7 @@ func NewRpcClient(trans transport.Requester) (RpcClientApi, error) {
 
 // NewHttpRpcClient creates a new rpcClient using an http transport
 func NewHttpRpcClient(rpcServerUrl string) (RpcClientApi, error) {
-	transport, err := http.NewWebSocketTransportAsClient(rpcServerUrl)
+	transport, err := http.NewHttpTransportAsClient(rpcServerUrl)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -22,7 +22,7 @@ import (
 	"github.com/statechannels/go-nitro/rand"
 	"github.com/statechannels/go-nitro/rpc/serde"
 	"github.com/statechannels/go-nitro/rpc/transport"
-	"github.com/statechannels/go-nitro/rpc/transport/ws"
+	"github.com/statechannels/go-nitro/rpc/transport/http"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -138,7 +138,7 @@ func NewRpcClient(trans transport.Requester) (RpcClientApi, error) {
 
 // NewHttpRpcClient creates a new rpcClient using an http transport
 func NewHttpRpcClient(rpcServerUrl string) (RpcClientApi, error) {
-	transport, err := ws.NewWebSocketTransportAsClient(rpcServerUrl)
+	transport, err := http.NewWebSocketTransportAsClient(rpcServerUrl)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/transport/http/client.go
+++ b/rpc/transport/http/client.go
@@ -1,4 +1,4 @@
-package ws
+package http
 
 import (
 	"bytes"

--- a/rpc/transport/http/server.go
+++ b/rpc/transport/http/server.go
@@ -1,4 +1,4 @@
-package ws
+package http
 
 import (
 	"context"

--- a/rpc/transport/transport.go
+++ b/rpc/transport/transport.go
@@ -4,7 +4,7 @@ type TransportType string
 
 const (
 	Nats TransportType = "nats"
-	Ws   TransportType = "ws"
+	Http TransportType = "http"
 )
 
 // Requester is a transport that can send requests and subscribe to notifications


### PR DESCRIPTION
When rpc was built initially, the websocket protocol was used for requests, responses and notifications. The websocket transport evolved to use http for requests and responses and websockets for notification. This PR renames the transport to http for clarity. A websocket handshake starts with an http requests, so http naming still accommodates our websocket usage.