### PR TITLE
Rename NewHttpSocketTransportAsServer to NewHttpTransportAsServer

### DIFF
--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -20,7 +20,7 @@ func InitializeRpcServer(node *node.Node, rpcPort int, useNats bool) (*rpc.RpcSe
 		transport, err = nats.NewNatsTransportAsServer(rpcPort)
 	} else {
 		slog.Info("Initializing Http RPC transport...")
-		transport, err = http.NewHttpSocketTransportAsServer(fmt.Sprint(rpcPort))
+		transport, err = http.NewHttpTransportAsServer(fmt.Sprint(rpcPort))
 	}
 	if err != nil {
 		return nil, err

--- a/rpc/transport/http/server.go
+++ b/rpc/transport/http/server.go
@@ -34,8 +34,8 @@ type serverHttpTransport struct {
 	wg *sync.WaitGroup
 }
 
-// NewHttpSocketTransportAsServer starts an http server
-func NewHttpSocketTransportAsServer(port string) (*serverHttpTransport, error) {
+// NewHttpTransportAsServer starts an http server
+func NewHttpTransportAsServer(port string) (*serverHttpTransport, error) {
 	transport := &serverHttpTransport{port: port, notificationListeners: safesync.Map[chan []byte]{}, logger: slog.Default()}
 
 	tcpListener, err := net.Listen("tcp", ":"+transport.port)


### PR DESCRIPTION
NewHttpSocketTransportAsServer name (which is not coherent) is a result of a batch rename in https://github.com/statechannels/go-nitro/pull/1627. This PR fixes the nomenclature.