### PR TITLE
chain service constructor returns interface

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -17,7 +17,7 @@ import (
 
 func InitializeNode(pkString string, chainOpts chain.ChainOpts,
 	useDurableStore bool, durableStoreFolder string, msgPort int, bootPeers []string,
-) (*node.Node, *store.Store, *p2pms.P2PMessageService, *chainservice.EthChainService, error) {
+) (*node.Node, *store.Store, *p2pms.P2PMessageService, chainservice.ChainService, error) {
 	if pkString == "" {
 		panic("pk must be set")
 	}

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -87,7 +87,7 @@ const RESUB_INTERVAL = 15 * time.Second
 const REQUIRED_BLOCK_CONFIRMATIONS = 2
 
 // NewEthChainService is a convenient wrapper around newEthChainService, which provides a simpler API
-func NewEthChainService(chainOpts chain.ChainOpts) (*EthChainService, error) {
+func NewEthChainService(chainOpts chain.ChainOpts) (ChainService, error) {
 	if chainOpts.ChainPk == "" {
 		return nil, fmt.Errorf("chainpk must be set")
 	}


### PR DESCRIPTION
This PR makes a small change so that the `NewEthChainService` returns the `ChainService` interface. This helps hide the implementation details of the eth chain service.