### PR TITLE
refactor: push heap operations inside eventTracker impl

### DIFF
--- a/node/engine/chainservice/event_queue.go
+++ b/node/engine/chainservice/event_queue.go
@@ -19,6 +19,14 @@ func NewEventTracker(startBlock uint64) *eventTracker {
 	return &eventTracker{latestBlockNum: startBlock, events: eventQueue}
 }
 
+func (eT *eventTracker) Push(l types.Log) {
+	heap.Push(&eT.events, (l))
+}
+
+func (eT *eventTracker) Pop() types.Log {
+	return heap.Pop(&eT.events).(types.Log)
+}
+
 type eventQueue []types.Log
 
 func (q eventQueue) Len() int { return len(q) }


### PR DESCRIPTION
This means consumers do not need to know the queue is implemented as a heap.

It also gives types safety around the inputs and outputs to the queue.

⚠️ base != `main`