### PR TITLE
undo handling undefined env vars

### DIFF
--- a/packages/nitro-protocol/test/contracts/BatchOperator/batchDeposits.test.ts
+++ b/packages/nitro-protocol/test/contracts/BatchOperator/batchDeposits.test.ts
@@ -16,25 +16,25 @@ const provider = getTestProvider();
 const batchOperator = setupContract(
   provider,
   BatchOperatorArtifact,
-  process.env.BATCH_OPERATOR_ADDRESS || ''
+  process.env.BATCH_OPERATOR_ADDRESS
 ) as unknown as BatchOperator & Contract;
 
 const nitroAdjudicator = setupContract(
   provider,
   NitroAdjudicatorArtifact,
-  process.env.NITRO_ADJUDICATOR_ADDRESS || ''
+  process.env.NITRO_ADJUDICATOR_ADDRESS
 ) as unknown as NitroAdjudicator & Contract;
 
 const token = setupContract(
   provider,
   TokenArtifact,
-  process.env.TEST_TOKEN_ADDRESS || ''
+  process.env.TEST_TOKEN_ADDRESS
 ) as unknown as Token & Contract;
 
 const badToken = setupContract(
   provider,
   BadTokenArtifact,
-  process.env.BAD_TOKEN_ADDRESS || ''
+  process.env.BAD_TOKEN_ADDRESS
 ) as unknown as BadToken & Contract;
 
 const ETH = MAGIC_ADDRESS_INDICATING_ETH;
@@ -119,7 +119,7 @@ describe('deposit_batch', () => {
       getChannelId({
         channelNonce: getRandomNonce(description),
         participants: [signerAddress, counterparty],
-        appDefinition: consensusApp || '',
+        appDefinition: consensusApp,
         challengeDuration: 100,
       })
     );

--- a/packages/nitro-protocol/test/contracts/ForceMove/challenge.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/challenge.test.ts
@@ -97,7 +97,7 @@ async function createTwoPartySignedCountingAppState(
 }
 
 beforeAll(async () => {
-  ForceMove = setupContract(provider, ForceMoveArtifact, process.env.TEST_FORCE_MOVE_ADDRESS || '');
+  ForceMove = setupContract(provider, ForceMoveArtifact, process.env.TEST_FORCE_MOVE_ADDRESS);
 });
 
 // Scenarios are synonymous with channelNonce:

--- a/packages/nitro-protocol/test/contracts/ForceMove/checkpoint.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/checkpoint.test.ts
@@ -46,7 +46,7 @@ const defaultOutcome: Outcome = [
 let appDefinition: string;
 
 beforeAll(async () => {
-  ForceMove = setupContract(provider, ForceMoveArtifact, process.env.TEST_FORCE_MOVE_ADDRESS || '');
+  ForceMove = setupContract(provider, ForceMoveArtifact, process.env.TEST_FORCE_MOVE_ADDRESS);
   appDefinition = getCountingAppContractAddress();
 });
 

--- a/packages/nitro-protocol/test/contracts/ForceMove/conclude.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/conclude.test.ts
@@ -41,7 +41,7 @@ const outcome: Outcome = [{asset, allocations: [], assetMetadata: {assetType: 0,
 let appDefinition: string;
 
 beforeAll(async () => {
-  ForceMove = setupContract(provider, ForceMoveArtifact, process.env.TEST_FORCE_MOVE_ADDRESS || '');
+  ForceMove = setupContract(provider, ForceMoveArtifact, process.env.TEST_FORCE_MOVE_ADDRESS);
   appDefinition = getCountingAppContractAddress();
 });
 

--- a/packages/nitro-protocol/test/contracts/ForceMove/storage.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/storage.test.ts
@@ -9,7 +9,7 @@ import {getTestProvider, randomChannelId, setupContract} from '../../test-helper
 const provider = getTestProvider();
 let ForceMove: Contract;
 beforeAll(async () => {
-  ForceMove = setupContract(provider, ForceMoveArtifact, process.env.TEST_FORCE_MOVE_ADDRESS || '');
+  ForceMove = setupContract(provider, ForceMoveArtifact, process.env.TEST_FORCE_MOVE_ADDRESS);
 });
 
 const zeroData = {

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/deposit.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/deposit.test.ts
@@ -16,19 +16,19 @@ const provider = getTestProvider();
 const testNitroAdjudicator = setupContract(
   provider,
   TESTNitroAdjudicatorArtifact,
-  process.env.TEST_NITRO_ADJUDICATOR_ADDRESS || ''
+  process.env.TEST_NITRO_ADJUDICATOR_ADDRESS
 ) as unknown as TESTNitroAdjudicator & Contract;
 
 const token = setupContract(
   provider,
   TokenArtifact,
-  process.env.TEST_TOKEN_ADDRESS || ''
+  process.env.TEST_TOKEN_ADDRESS
 ) as unknown as Token & Contract;
 
 const badToken = setupContract(
   provider,
   BadTokenArtifact,
-  process.env.BAD_TOKEN_ADDRESS || ''
+  process.env.BAD_TOKEN_ADDRESS
 ) as unknown as BadToken & Contract;
 
 const signer0 = getTestProvider().getSigner(0); // Convention matches setupContract function

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/transfer.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/transfer.test.ts
@@ -22,7 +22,7 @@ const testProvider = getTestProvider();
 const testNitroAdjudicator = setupContract(
   testProvider,
   TESTNitroAdjudicatorArtifact,
-  process.env.TEST_NITRO_ADJUDICATOR_ADDRESS || ''
+  process.env.TEST_NITRO_ADJUDICATOR_ADDRESS
 ) as unknown as TESTNitroAdjudicator & Contract;
 
 const addresses = {

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludeAndTransferAllAssets.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludeAndTransferAllAssets.test.ts
@@ -35,13 +35,13 @@ import {
 const testNitroAdjudicator = setupContract(
   getTestProvider(),
   TESTNitroAdjudicatorArtifact,
-  process.env.TEST_NITRO_ADJUDICATOR_ADDRESS || ''
+  process.env.TEST_NITRO_ADJUDICATOR_ADDRESS
 ) as unknown as TESTNitroAdjudicator & Contract;
 
 const token = setupContract(
   getTestProvider(),
   TokenArtifact,
-  process.env.TEST_TOKEN_ADDRESS || ''
+  process.env.TEST_TOKEN_ADDRESS
 ) as unknown as Token & Contract;
 
 const provider = getTestProvider();

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/transferAllAssets.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/transferAllAssets.test.ts
@@ -30,13 +30,13 @@ import {replaceAddressesAndBigNumberify} from '../../../src/helpers';
 const testNitroAdjudicator = setupContract(
   getTestProvider(),
   TESTNitroAdjudicatorArtifact,
-  process.env.TEST_NITRO_ADJUDICATOR_ADDRESS || ''
+  process.env.TEST_NITRO_ADJUDICATOR_ADDRESS
 ) as unknown as TESTNitroAdjudicator & Contract;
 
 const token = setupContract(
   getTestProvider(),
   TokenArtifact,
-  process.env.TEST_TOKEN_ADDRESS || ''
+  process.env.TEST_TOKEN_ADDRESS
 ) as unknown as Token & Contract;
 
 const addresses = {

--- a/packages/nitro-protocol/test/contracts/examples/HashLockedSwap/stateIsSupported.test.ts
+++ b/packages/nitro-protocol/test/contracts/examples/HashLockedSwap/stateIsSupported.test.ts
@@ -58,11 +58,7 @@ const challengeDuration = 0x100;
 const whoSignedWhat = [1, 0];
 
 beforeAll(async () => {
-  hashTimeLock = setupContract(
-    provider,
-    HashLockedSwapArtifact,
-    process.env.HASH_LOCK_ADDRESS || ''
-  );
+  hashTimeLock = setupContract(provider, HashLockedSwapArtifact, process.env.HASH_LOCK_ADDRESS);
 });
 
 const preImage = '0xdeadbeef';

--- a/packages/nitro-protocol/test/contracts/examples/SingleAssetPayments/stateIsSupported.test.ts
+++ b/packages/nitro-protocol/test/contracts/examples/SingleAssetPayments/stateIsSupported.test.ts
@@ -47,7 +47,7 @@ beforeAll(async () => {
   singleAssetPayments = setupContract(
     provider,
     SingleAssetPaymentsArtifact,
-    process.env.SINGLE_ASSET_PAYMENTS_ADDRESS || ''
+    process.env.SINGLE_ASSET_PAYMENTS_ADDRESS
   );
 });
 

--- a/packages/nitro-protocol/test/contracts/libraries/Consensus/Consensus.test.ts
+++ b/packages/nitro-protocol/test/contracts/libraries/Consensus/Consensus.test.ts
@@ -35,7 +35,7 @@ beforeAll(async () => {
   Consensus = setupContract(
     provider,
     testConsensusArtifact,
-    process.env.TEST_CONSENSUS_ADDRESS || ''
+    process.env.TEST_CONSENSUS_ADDRESS
   ) as Contract & TESTConsensus;
 });
 
@@ -65,7 +65,7 @@ describe('requireConsensus', () => {
       channelNonce,
       challengeDuration,
       outcome: defaultOutcome,
-      appDefinition: appDefinition || '',
+      appDefinition: appDefinition,
       appData: '0x',
     };
 

--- a/packages/nitro-protocol/test/contracts/libraries/StrictTurnTaking/StrictTurnTaking.test.ts
+++ b/packages/nitro-protocol/test/contracts/libraries/StrictTurnTaking/StrictTurnTaking.test.ts
@@ -41,7 +41,7 @@ beforeAll(async () => {
   StrictTurnTaking = setupContract(
     provider,
     testStrictTurnTakingArtifact,
-    process.env.TEST_STRICT_TURN_TAKING_ADDRESS || ''
+    process.env.TEST_STRICT_TURN_TAKING_ADDRESS
   ) as Contract & TESTStrictTurnTaking;
 });
 

--- a/packages/nitro-protocol/test/test-helpers.ts
+++ b/packages/nitro-protocol/test/test-helpers.ts
@@ -30,7 +30,7 @@ export function setupContract(
 }
 
 export function getCountingAppContractAddress(): string {
-  return process.env.COUNTING_APP_ADDRESS || '';
+  return process.env.COUNTING_APP_ADDRESS;
 }
 
 export const nonParticipant = ethers.Wallet.createRandom();

--- a/packages/nitro-protocol/tsconfig.json
+++ b/packages/nitro-protocol/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "baseUrl": "src",
+    "baseUrl": ".",
     "target": "es2018",
     "module": "commonjs",
     "strict": true,
@@ -10,5 +10,5 @@
     "declaration": true,
     "skipLibCheck": true
   },
-  "include": ["src/index.ts", "addresses.json"]
+  "include": ["src/index.ts", "addresses.json", "../test/@types/environment.d.ts"]
 }

--- a/packages/nitro-protocol/tsconfig.json
+++ b/packages/nitro-protocol/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
+    "baseUrl": "src",
     "target": "es2018",
     "module": "commonjs",
     "strict": true,


### PR DESCRIPTION
It looks like we have a [typing file](https://github.com/statechannels/go-nitro/blob/3a7a490ece2aa0c1ea89fc6e8c653921e0c34132/packages/nitro-protocol/test/%40types/environment.d.ts#L1) that defines certain global env variables, so we can always be sure they'll be defined. This means we don't need to attempt to handle undefined env vars  using `|| ''`.

~Unfortunately in vscode these might get flagged as linting errors since vscode will use the root [tsconfig.json](https://github.com/statechannels/go-nitro/blob/3a7a490ece2aa0c1ea89fc6e8c653921e0c34132/packages/nitro-protocol/tsconfig.json#L1) in `nitro-protocol` which does not load `environment.d.s`. It's only the[ test-specific tsconfig ](https://github.com/statechannels/go-nitro/blob/3a7a490ece2aa0c1ea89fc6e8c653921e0c34132/packages/nitro-protocol/test/tsconfig.json#L14) that loads `environment.d.s`~ This should be fixed by https://github.com/statechannels/go-nitro/pull/1643/commits/f422e190abe8c37df703ee313e0bad9c556a7a51 .