### PR TITLE
Update contracts workflow to use cache

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "18.15.0"
+          cache: "npm"
       - name: Install dependencies
         run: yarn
       - name: Compile contracts

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "18.15.0"
-          cache: "npm"
+          cache: "yarn"
       - name: Install dependencies
         run: yarn
       - name: Compile contracts

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    paths: ["packages/nitro-protocol/**", ".github/workflows/node.yml"]
+    paths: ["packages/nitro-protocol/**", ".github/workflows/contracts.yml"]
 
 jobs:
   build:


### PR DESCRIPTION
Update  the contracts workflow to use the cache for dependencies, which should hopefully speed it up slightly. It also corrects a typo in `contracts.yml` that was referencing the old `node.yml` name.