### PR TITLE
Get last confirmed block num

### DIFF
--- a/docker/cloud/config.toml
+++ b/docker/cloud/config.toml
@@ -17,7 +17,7 @@ caaddress = "0x0C9D79725afc344A388045235CD0B23eA4f0E838"
 
 # RPC provider docs: https://lotus.filecoin.io/lotus/developers/glif-nodes/#testnet-endpoint
 chainurl = "wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v0"
-chainstartblock = 886696
+chainstartblock = 895069
 chainauthtoken = ""
 
 bootpeers = ""

--- a/docker/local/config.toml
+++ b/docker/local/config.toml
@@ -16,7 +16,7 @@ caaddress = "0x0C9D79725afc344A388045235CD0B23eA4f0E838"
 
 # RPC provider docs: https://lotus.filecoin.io/lotus/developers/glif-nodes/#testnet-endpoint
 chainurl = "wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v0"
-chainstartblock = 886696
+chainstartblock = 895069
 chainauthtoken = ""
 
 bootpeers = "/ip4/67.207.88.72/tcp/3005/p2p/16Uiu2HAmHQe7ej1swi9ghLwCi5jdSxLpGP3weBaE7j5ixBf5Hbzx"

--- a/node/engine/chainservice/chainservice.go
+++ b/node/engine/chainservice/chainservice.go
@@ -150,6 +150,8 @@ type ChainService interface {
 	GetVirtualPaymentAppAddress() types.Address
 	// GetChainId returns the id of the chain the service is connected to
 	GetChainId() (*big.Int, error)
+	// GetLatestConfirmedBlockNum returns the highest blockNum that satisfies the chainservice's REQUIRED_BLOCK_CONFIRMATIONS
+	GetLatestConfirmedBlockNum() uint64
 	// Close closes the ChainService
 	Close() error
 }

--- a/node/engine/chainservice/chainservice.go
+++ b/node/engine/chainservice/chainservice.go
@@ -150,8 +150,8 @@ type ChainService interface {
 	GetVirtualPaymentAppAddress() types.Address
 	// GetChainId returns the id of the chain the service is connected to
 	GetChainId() (*big.Int, error)
-	// GetLatestConfirmedBlockNum returns the highest blockNum that satisfies the chainservice's REQUIRED_BLOCK_CONFIRMATIONS
-	GetLatestConfirmedBlockNum() uint64
+	// GetLastConfirmedBlockNum returns the highest blockNum that satisfies the chainservice's REQUIRED_BLOCK_CONFIRMATIONS
+	GetLastConfirmedBlockNum() uint64
 	// Close closes the ChainService
 	Close() error
 }

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -470,7 +470,7 @@ func (ecs *EthChainService) GetChainId() (*big.Int, error) {
 	return ecs.chain.ChainID(ecs.ctx)
 }
 
-func (ecs *EthChainService) GetLatestConfirmedBlockNum() uint64 {
+func (ecs *EthChainService) GetLastConfirmedBlockNum() uint64 {
 	var confirmedBlockNum uint64
 
 	ecs.eventTracker.mu.Lock()

--- a/node/engine/chainservice/mock_chain.go
+++ b/node/engine/chainservice/mock_chain.go
@@ -13,7 +13,7 @@ import (
 // MockChain mimics the Ethereum blockchain by keeping track of block numbers and account balances in memory.
 // MockChain accepts transactions and broadcasts events.
 type MockChain struct {
-	blockNum uint64
+	BlockNum uint64
 	// holdings tracks funds for each channel.
 	holdings map[types.Destination]types.Funds
 	// out maps addresses to an Event channel. Given that MockChainServices only subscribe
@@ -26,7 +26,7 @@ type MockChain struct {
 // NewMockChain creates a new MockChain
 func NewMockChain() *MockChain {
 	chain := MockChain{}
-	chain.blockNum = 1
+	chain.BlockNum = 1
 	chain.holdings = map[types.Destination]types.Funds{}
 	chain.out = safesync.Map[chan Event]{}
 	return &chain
@@ -37,7 +37,7 @@ func NewMockChain() *MockChain {
 func (mc *MockChain) SubmitTransaction(tx protocols.ChainTransaction) error {
 	eventsToBroadcast := []Event{}
 	mc.txMutex.Lock()
-	mc.blockNum++
+	mc.BlockNum++
 	h := mc.holdings[tx.ChannelId()] // ignore `ok` because the returned zero-value is what we want
 	switch tx := tx.(type) {
 	case protocols.DepositTransaction:
@@ -46,12 +46,12 @@ func (mc *MockChain) SubmitTransaction(tx protocols.ChainTransaction) error {
 		}
 
 		for address := range tx.Deposit {
-			event := NewDepositedEvent(tx.ChannelId(), mc.blockNum, address, h.Add(tx.Deposit)[address])
+			event := NewDepositedEvent(tx.ChannelId(), mc.BlockNum, address, h.Add(tx.Deposit)[address])
 			eventsToBroadcast = append(eventsToBroadcast, event)
 		}
 	case protocols.WithdrawAllTransaction:
 		for assetAddress := range h {
-			event := NewAllocationUpdatedEvent(tx.ChannelId(), mc.blockNum, assetAddress, common.Big0)
+			event := NewAllocationUpdatedEvent(tx.ChannelId(), mc.BlockNum, assetAddress, common.Big0)
 			eventsToBroadcast = append(eventsToBroadcast, event)
 		}
 		mc.holdings[tx.ChannelId()] = types.Funds{}

--- a/node/engine/chainservice/mock_chainservice.go
+++ b/node/engine/chainservice/mock_chainservice.go
@@ -44,8 +44,8 @@ func (mc *MockChainService) GetChainId() (*big.Int, error) {
 	return big.NewInt(TEST_CHAIN_ID), nil
 }
 
-func (mc *MockChainService) GetLatestConfirmedBlockNum() uint64 {
-	return mc.chain.blockNum
+func (mc *MockChainService) GetLastConfirmedBlockNum() uint64 {
+	return mc.chain.BlockNum
 }
 
 func (mc *MockChainService) Close() error {

--- a/node/engine/chainservice/mock_chainservice.go
+++ b/node/engine/chainservice/mock_chainservice.go
@@ -44,6 +44,10 @@ func (mc *MockChainService) GetChainId() (*big.Int, error) {
 	return big.NewInt(TEST_CHAIN_ID), nil
 }
 
+func (mc *MockChainService) GetLatestConfirmedBlockNum() uint64 {
+	return mc.chain.blockNum
+}
+
 func (mc *MockChainService) Close() error {
 	return nil
 }

--- a/node/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/node/engine/chainservice/simulated_backend_chainservice_test.go
@@ -188,11 +188,11 @@ func TestSimulatedBackendChainService(t *testing.T) {
 	}
 
 	// Check latest confirmed block number recognized by each chainservice
-	blockNum := cs.GetLatestConfirmedBlockNum()
+	blockNum := cs.GetLastConfirmedBlockNum()
 	if blockNum != concludeBlockNum {
 		t.Fatalf("cs.GetLatestConfirmedBlockNum does not match expected: got %v wanted %v", blockNum, concludeBlockNum)
 	}
-	blockNum2 := cs2.GetLatestConfirmedBlockNum()
+	blockNum2 := cs2.GetLastConfirmedBlockNum()
 	if blockNum2 != concludeBlockNum {
 		t.Fatalf("cs2.GetLatestConfirmedBlockNum does not match expected: got %v wanted %v", blockNum2, concludeBlockNum)
 	}

--- a/node/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/node/engine/chainservice/simulated_backend_chainservice_test.go
@@ -22,6 +22,9 @@ var (
 	CHALLENGE_DURATION = uint32(1000) // 1000 seconds. Much longer than the duration of the test
 	Alice              = testactors.Alice
 	Bob                = testactors.Bob
+	challengeBlockNum  = uint64(2)
+	depositBlockNum    = uint64(5)
+	concludeBlockNum   = uint64(8)
 )
 
 var concludeOutcome = outcome.Exit{
@@ -101,7 +104,7 @@ func TestSimulatedBackendChainService(t *testing.T) {
 	// Check that the received events matches the expected event
 	receivedEvent = <-out
 	crEvent := receivedEvent.(ChallengeRegisteredEvent)
-	expectedChallengeRegisteredEvent := NewChallengeRegisteredEvent(concludeState.ChannelId(), 2, crEvent.candidate, crEvent.candidateSignatures)
+	expectedChallengeRegisteredEvent := NewChallengeRegisteredEvent(concludeState.ChannelId(), challengeBlockNum, crEvent.candidate, crEvent.candidateSignatures)
 	if diff := cmp.Diff(expectedChallengeRegisteredEvent, crEvent, cmp.AllowUnexported(ChallengeRegisteredEvent{}, commonEvent{}, big.Int{})); diff != "" {
 		t.Fatalf("Received event did not match expectation; (-want +got):\n%s", diff)
 	}
@@ -110,10 +113,10 @@ func TestSimulatedBackendChainService(t *testing.T) {
 		common.HexToAddress("0x00"): three,
 		bindings.Token.Address:      one,
 	}
-	testTx := protocols.NewDepositTransaction(concludeState.ChannelId(), testDeposit)
+	depositTx := protocols.NewDepositTransaction(concludeState.ChannelId(), testDeposit)
 
 	// Submit transaction
-	err = cs.SendTransaction(testTx)
+	err = cs.SendTransaction(depositTx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +125,7 @@ func TestSimulatedBackendChainService(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		receivedEvent = <-out
 		dEvent := receivedEvent.(DepositedEvent)
-		expectedDepositEvent := NewDepositedEvent(concludeState.ChannelId(), 5, dEvent.Asset, testDeposit[dEvent.Asset])
+		expectedDepositEvent := NewDepositedEvent(concludeState.ChannelId(), depositBlockNum, dEvent.Asset, testDeposit[dEvent.Asset])
 		if diff := cmp.Diff(expectedDepositEvent, dEvent, cmp.AllowUnexported(DepositedEvent{}, commonEvent{}, big.Int{})); diff != "" {
 			t.Fatalf("Received event did not match expectation; (-want +got):\n%s", diff)
 		}
@@ -160,14 +163,14 @@ func TestSimulatedBackendChainService(t *testing.T) {
 
 	// Check that the recieved event matches the expected event
 	concludedEvent := <-out
-	expectedConcludedEvent := ConcludedEvent{commonEvent: commonEvent{channelID: cId, blockNum: 8}}
+	expectedConcludedEvent := ConcludedEvent{commonEvent: commonEvent{channelID: cId, blockNum: concludeBlockNum}}
 	if diff := cmp.Diff(expectedConcludedEvent, concludedEvent, cmp.AllowUnexported(ConcludedEvent{}, commonEvent{})); diff != "" {
 		t.Fatalf("Received event did not match expectation; (-want +got):\n%s", diff)
 	}
 
 	// Check that the recieved event matches the expected event
 	allocationUpdatedEvent := <-out
-	expectedAllocationUpdatedEvent := NewAllocationUpdatedEvent(cId, 8, common.Address{}, new(big.Int).SetInt64(1))
+	expectedAllocationUpdatedEvent := NewAllocationUpdatedEvent(cId, concludeBlockNum, common.Address{}, new(big.Int).SetInt64(1))
 	if diff := cmp.Diff(expectedAllocationUpdatedEvent, allocationUpdatedEvent, cmp.AllowUnexported(AllocationUpdatedEvent{}, commonEvent{}, big.Int{})); diff != "" {
 		t.Fatalf("Received event did not match expectation; (-want +got):\n%s", diff)
 	}
@@ -184,10 +187,20 @@ func TestSimulatedBackendChainService(t *testing.T) {
 		t.Fatalf("Adjudicator not updated as expected, got %v wanted %v", common.Bytes2Hex(statusOnChain[:]), common.Bytes2Hex(emptyBytes[:]))
 	}
 
+	// Check latest confirmed block number recognized by each chainservice
+	blockNum := cs.GetLatestConfirmedBlockNum()
+	if blockNum != concludeBlockNum {
+		t.Fatalf("cs.GetLatestConfirmedBlockNum does not match expected: got %v wanted %v", blockNum, concludeBlockNum)
+	}
+	blockNum2 := cs2.GetLatestConfirmedBlockNum()
+	if blockNum2 != concludeBlockNum {
+		t.Fatalf("cs2.GetLatestConfirmedBlockNum does not match expected: got %v wanted %v", blockNum2, concludeBlockNum)
+	}
+
 	// Check events from cs2 to ensure they match the expected values
 	receivedEvent = <-cs2.EventFeed()
 	crEvent = receivedEvent.(ChallengeRegisteredEvent)
-	expectedChallengeRegisteredEvent = NewChallengeRegisteredEvent(concludeState.ChannelId(), 2, crEvent.candidate, crEvent.candidateSignatures)
+	expectedChallengeRegisteredEvent = NewChallengeRegisteredEvent(concludeState.ChannelId(), challengeBlockNum, crEvent.candidate, crEvent.candidateSignatures)
 	if diff := cmp.Diff(expectedChallengeRegisteredEvent, crEvent, cmp.AllowUnexported(ChallengeRegisteredEvent{}, commonEvent{}, big.Int{})); diff != "" {
 		t.Fatalf("Received event did not match expectation; (-want +got):\n%s", diff)
 	}

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -192,7 +192,7 @@ func (e *Engine) run(ctx context.Context) {
 		case proposal := <-e.fromLedger:
 			res, err = e.handleProposal(proposal)
 		case <-blockTicker.C:
-			blockNum := e.chain.GetLatestConfirmedBlockNum()
+			blockNum := e.chain.GetLastConfirmedBlockNum()
 			err = e.store.SetLastBlockNumSeen(blockNum)
 		case <-ctx.Done():
 			e.wg.Done()

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"math/big"
 	"sync"
+	"time"
 
 	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
@@ -176,6 +177,8 @@ func (e *Engine) run(ctx context.Context) {
 		var res EngineEvent
 		var err error
 
+		blockTicker := time.NewTicker(15 * time.Second)
+
 		select {
 
 		case or := <-e.ObjectiveRequestsFromAPI:
@@ -183,13 +186,14 @@ func (e *Engine) run(ctx context.Context) {
 		case pr := <-e.PaymentRequestsFromAPI:
 			res, err = e.handlePaymentRequest(pr)
 		case chainEvent := <-e.fromChain:
-			err = e.store.SetLastBlockNumSeen(chainEvent.BlockNum())
-			e.checkError(err)
 			res, err = e.handleChainEvent(chainEvent)
 		case message := <-e.fromMsg:
 			res, err = e.handleMessage(message)
 		case proposal := <-e.fromLedger:
 			res, err = e.handleProposal(proposal)
+		case <-blockTicker.C:
+			blockNum := e.chain.GetLatestConfirmedBlockNum()
+			err = e.store.SetLastBlockNumSeen(blockNum)
 		case <-ctx.Done():
 			e.wg.Done()
 			return
@@ -395,6 +399,11 @@ func (e *Engine) handleMessage(message protocols.Message) (EngineEvent, error) {
 //   - attempts progress.
 func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, error) {
 	e.logger.Info("Handling chain event", "event", chainEvent)
+	err := e.store.SetLastBlockNumSeen(chainEvent.BlockNum())
+	if err != nil {
+		return EngineEvent{}, err
+	}
+
 	c, ok := e.store.GetChannelById(chainEvent.ChannelID())
 	if !ok {
 		// TODO: Right now the chain service returns chain events for ALL channels even those we aren't involved in

--- a/node/node.go
+++ b/node/node.go
@@ -270,6 +270,11 @@ func (n *Node) GetAllLedgerChannels() ([]query.LedgerChannelInfo, error) {
 	return query.GetAllLedgerChannels(n.store, n.engine.GetConsensusAppAddress())
 }
 
+// GetLastBlockNum returns last confirmed blockNum read from store
+func (n *Node) GetLastBlockNum() (uint64, error) {
+	return n.store.GetLastBlockNumSeen()
+}
+
 // GetLedgerChannel returns the ledger channel with the given id.
 // If no ledger channel exists with the given id an error is returned.
 func (n *Node) GetLedgerChannel(id types.Destination) (query.LedgerChannelInfo, error) {


### PR DESCRIPTION
Implements the following solution to periodically update the `lastBlockNumSeen` in the store even when no NitroAdjudicator events are being emitted:

> Instead of the chain service alerting the engine, the engine could request the block number from the chain service. Since the engine wouldn't know when a new block is created this would mostly likely be done by the engine on a timer. The engine would also do this when close is called.

> This does means the lastBlockNumSeen wouldn't get updated every block, but I think that's ok. It doesn't matter if the lastBlockNumSeen is slightly stale, we just want to prevent it from being waaaaay out of date.

> I think the benefit of this approach would be the simplicity. Instead of adding a new chan or event we just need to add a BlockNum function to the chain service, and call that in the engine. It also means we wouldn't write to the store every block but every x minutes (and when we close).

Further details and discussion about alternative solutions are part of the following issue: https://github.com/statechannels/go-nitro/issues/1600