### PR TITLE
Fix `GetLastConfirmedBlockNum` test failures

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -41,7 +41,7 @@ func InitializeNode(pkString string, chainOpts chain.ChainOpts,
 		chainOpts.ChainStartBlock = storeBlockNum
 	}
 
-	slog.Info("Initializing chain service and connecting to " + chainOpts.ChainUrl + "...")
+	slog.Info("Initializing chain service...")
 	ourChain, err := chainservice.NewEthChainService(chainOpts)
 	if err != nil {
 		return nil, nil, nil, nil, err

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -31,5 +31,6 @@ func InitializeRpcServer(node *node.Node, rpcPort int, useNats bool) (*rpc.RpcSe
 		return nil, err
 	}
 
+	slog.Info("Completed RPC server initialization")
 	return rpcServer, nil
 }

--- a/node/engine/chainservice/mock_chain.go
+++ b/node/engine/chainservice/mock_chain.go
@@ -14,14 +14,12 @@ import (
 // MockChain accepts transactions and broadcasts events.
 type MockChain struct {
 	BlockNum   uint64
-	BlockNumMu sync.Mutex
+	blockNumMu sync.Mutex
 	// holdings tracks funds for each channel.
 	holdings map[types.Destination]types.Funds
 	// out maps addresses to an Event channel. Given that MockChainServices only subscribe
 	// (and never unsubscribe) to events, this can be converted to a list.
 	out safesync.Map[chan Event]
-	// txMutex is locked when updating chain state
-	txMutex sync.Mutex
 }
 
 // NewMockChain creates a new MockChain
@@ -37,8 +35,7 @@ func NewMockChain() *MockChain {
 // unlike an ethereum blockchain, MockChain accepts go-nitro protocols.ChainTransaction
 func (mc *MockChain) SubmitTransaction(tx protocols.ChainTransaction) error {
 	eventsToBroadcast := []Event{}
-	mc.txMutex.Lock()
-	mc.BlockNumMu.Lock()
+	mc.blockNumMu.Lock()
 	mc.BlockNum++
 	h := mc.holdings[tx.ChannelId()] // ignore `ok` because the returned zero-value is what we want
 	switch tx := tx.(type) {
@@ -60,8 +57,7 @@ func (mc *MockChain) SubmitTransaction(tx protocols.ChainTransaction) error {
 	default:
 		return fmt.Errorf("unexpected transaction type %T", tx)
 	}
-	mc.txMutex.Unlock()
-	mc.BlockNumMu.Unlock()
+	mc.blockNumMu.Unlock()
 	for _, event := range eventsToBroadcast {
 		mc.broadcastEvent(event)
 	}

--- a/node/engine/chainservice/mock_chainservice.go
+++ b/node/engine/chainservice/mock_chainservice.go
@@ -45,9 +45,9 @@ func (mc *MockChainService) GetChainId() (*big.Int, error) {
 }
 
 func (mc *MockChainService) GetLastConfirmedBlockNum() uint64 {
-	mc.chain.BlockNumMu.Lock()
+	mc.chain.blockNumMu.Lock()
 	blockNum := mc.chain.BlockNum
-	mc.chain.BlockNumMu.Unlock()
+	mc.chain.blockNumMu.Unlock()
 
 	return blockNum
 }

--- a/node/engine/chainservice/mock_chainservice.go
+++ b/node/engine/chainservice/mock_chainservice.go
@@ -45,7 +45,11 @@ func (mc *MockChainService) GetChainId() (*big.Int, error) {
 }
 
 func (mc *MockChainService) GetLastConfirmedBlockNum() uint64 {
-	return mc.chain.BlockNum
+	mc.chain.BlockNumMu.Lock()
+	blockNum := mc.chain.BlockNum
+	mc.chain.BlockNumMu.Unlock()
+
+	return blockNum
 }
 
 func (mc *MockChainService) Close() error {

--- a/node/engine/chainservice/simulated_backend_chainservice_test.go
+++ b/node/engine/chainservice/simulated_backend_chainservice_test.go
@@ -187,16 +187,6 @@ func TestSimulatedBackendChainService(t *testing.T) {
 		t.Fatalf("Adjudicator not updated as expected, got %v wanted %v", common.Bytes2Hex(statusOnChain[:]), common.Bytes2Hex(emptyBytes[:]))
 	}
 
-	// Check latest confirmed block number recognized by each chainservice
-	blockNum := cs.GetLastConfirmedBlockNum()
-	if blockNum != concludeBlockNum {
-		t.Fatalf("cs.GetLatestConfirmedBlockNum does not match expected: got %v wanted %v", blockNum, concludeBlockNum)
-	}
-	blockNum2 := cs2.GetLastConfirmedBlockNum()
-	if blockNum2 != concludeBlockNum {
-		t.Fatalf("cs2.GetLatestConfirmedBlockNum does not match expected: got %v wanted %v", blockNum2, concludeBlockNum)
-	}
-
 	// Check events from cs2 to ensure they match the expected values
 	receivedEvent = <-cs2.EventFeed()
 	crEvent = receivedEvent.(ChallengeRegisteredEvent)
@@ -221,6 +211,16 @@ func TestSimulatedBackendChainService(t *testing.T) {
 	receivedEvent = <-cs2.EventFeed()
 	if diff := cmp.Diff(expectedAllocationUpdatedEvent, receivedEvent, cmp.AllowUnexported(AllocationUpdatedEvent{}, commonEvent{}, big.Int{})); diff != "" {
 		t.Fatalf("Received event did not match expectation; (-want +got):\n%s", diff)
+	}
+
+	// Check latest confirmed block number recognized by each chainservice
+	blockNum := cs.GetLastConfirmedBlockNum()
+	if blockNum != concludeBlockNum {
+		t.Fatalf("cs.GetLatestConfirmedBlockNum does not match expected: got %v wanted %v", blockNum, concludeBlockNum)
+	}
+	blockNum2 := cs2.GetLastConfirmedBlockNum()
+	if blockNum2 != concludeBlockNum {
+		t.Fatalf("cs2.GetLatestConfirmedBlockNum does not match expected: got %v wanted %v", blockNum2, concludeBlockNum)
 	}
 }
 

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -398,7 +398,7 @@ func (e *Engine) handleMessage(message protocols.Message) (EngineEvent, error) {
 //   - generates an updated objective, and
 //   - attempts progress.
 func (e *Engine) handleChainEvent(chainEvent chainservice.Event) (EngineEvent, error) {
-	e.logger.Info("Handling chain event", "event", chainEvent)
+	e.logger.Info("Handling chain event", "blockNum", chainEvent.BlockNum(), "event", chainEvent)
 	err := e.store.SetLastBlockNumSeen(chainEvent.BlockNum())
 	if err != nil {
 		return EngineEvent{}, err

--- a/node_test/helpers_test.go
+++ b/node_test/helpers_test.go
@@ -116,7 +116,7 @@ func setupStore(tc TestCase, tp TestParticipant, si sharedTestInfrastructure, da
 }
 
 func setupIntegrationNode(tc TestCase, tp TestParticipant, si sharedTestInfrastructure, bootPeers []string, dataFolder string) (node.Node, messageservice.MessageService, string) {
-	logging.SetupDefaultFileLogger(tc.LogName+"_message_"+string(tp.Name)+".log", slog.LevelDebug)
+	logging.SetupDefaultFileLogger(tc.LogName+"_"+string(tp.Name)+".log", slog.LevelDebug)
 	messageService, multiAddr := setupMessageService(tc, tp, si, bootPeers)
 	cs := setupChainService(tc, tp, si)
 	store := setupStore(tc, tp, si, dataFolder)


### PR DESCRIPTION
* Add informative log for `chainstartblock` work-around when `chainservice` init fails
* Add mutex (and use in tests) for `MockChain.BlockNum` to fix `GetLastConfirmedBlockNum` test failures