### PR TITLE
Introduce health endpoint to the HTTP server

### DIFF
--- a/cmd/create-channel/main.go
+++ b/cmd/create-channel/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/ethereum/go-ethereum/common"
@@ -37,7 +38,7 @@ func main() {
 	logging.SetupDefaultFileLogger(LOG_FILE, slog.LevelDebug)
 
 	url := fmt.Sprintf(":%d/api/v1", participantOpts.RpcPort)
-	clientConnection, err := http.NewHttpTransportAsClient(url)
+	clientConnection, err := http.NewHttpTransportAsClient(url, 10*time.Millisecond)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/create-channels/main.go
+++ b/cmd/create-channels/main.go
@@ -40,7 +40,7 @@ func createChannels() error {
 		logging.SetupDefaultFileLogger(LOG_FILE, slog.LevelDebug)
 
 		url := fmt.Sprintf(":%d/api/v1", participantOpts.RpcPort)
-		clientConnection, err := http.NewHttpTransportAsClient(url)
+		clientConnection, err := http.NewHttpTransportAsClient(url, 500*time.Millisecond)
 		if err != nil {
 			return err
 		}
@@ -49,10 +49,6 @@ func createChannels() error {
 			panic(err)
 		}
 
-		err = utils.WaitForRpcClient("http://"+url, 500*time.Millisecond, 5*time.Minute)
-		if err != nil {
-			panic(err)
-		}
 	}
 
 	alice, bob, irene := clients["alice"], clients["bob"], clients["irene"]

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -49,7 +49,7 @@ func blockUntilHttpServerIsReady(rpcPort int) error {
 
 	numAttempts := 10
 	for i := 0; i < numAttempts; i++ {
-		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/health", rpcPort))
+		resp, err := http.Get(fmt.Sprintf("http://:%d/health", rpcPort))
 		if err != nil {
 			waitForServer()
 			continue

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -437,7 +437,7 @@ func setupNitroNodeWithRPCClient(
 		}
 	case transport.Http:
 
-		clientConnection, err = http.NewHttpTransportAsClient(rpcServer.Url())
+		clientConnection, err = http.NewHttpTransportAsClient(rpcServer.Url(), 10*time.Millisecond)
 		if err != nil {
 			panic(err)
 		}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -138,7 +139,7 @@ func NewRpcClient(trans transport.Requester) (RpcClientApi, error) {
 
 // NewHttpRpcClient creates a new rpcClient using an http transport
 func NewHttpRpcClient(rpcServerUrl string) (RpcClientApi, error) {
-	transport, err := http.NewHttpTransportAsClient(rpcServerUrl)
+	transport, err := http.NewHttpTransportAsClient(rpcServerUrl, 10*time.Millisecond)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/transport/http/client.go
+++ b/rpc/transport/http/client.go
@@ -22,8 +22,9 @@ type clientHttpTransport struct {
 }
 
 // NewHttpTransportAsClient creates a transport that can be used to send http requests and a websocket connection for receiving notifications
-func NewHttpTransportAsClient(url string) (*clientHttpTransport, error) {
-	err := blockUntilHttpServerIsReady(url)
+// Initialization will block for 10 retries until the server endpoint is ready
+func NewHttpTransportAsClient(url string, retryTimeout time.Duration) (*clientHttpTransport, error) {
+	err := blockUntilHttpServerIsReady(url, retryTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -103,9 +104,9 @@ func httpUrl(url string) (string, error) {
 }
 
 // blockUntilHttpServerIsReady pings the health endpoint until the server is ready
-func blockUntilHttpServerIsReady(url string) error {
+func blockUntilHttpServerIsReady(url string, retryTimeout time.Duration) error {
 	waitForServer := func() {
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(retryTimeout)
 	}
 
 	httpUrl, err := httpUrl(url)

--- a/rpc/transport/http/server.go
+++ b/rpc/transport/http/server.go
@@ -45,6 +45,13 @@ func NewHttpTransportAsServer(port string) (*serverHttpTransport, error) {
 
 	var serveMux http.ServeMux
 
+	// Used to check if the server is ready
+	serveMux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte("OK"))
+		if err != nil {
+			panic(err)
+		}
+	})
 	serveMux.HandleFunc(apiVersionPath, transport.request)
 	serveMux.HandleFunc(path.Join(apiVersionPath, "subscribe"), transport.subscribe)
 	transport.httpServer = &http.Server{

--- a/rpc/transport/http/server.go
+++ b/rpc/transport/http/server.go
@@ -46,7 +46,7 @@ func NewHttpTransportAsServer(port string) (*serverHttpTransport, error) {
 	var serveMux http.ServeMux
 
 	// Used to check if the server is ready
-	serveMux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+	serveMux.HandleFunc(path.Join(apiVersionPath, "health"), func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write([]byte("OK"))
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Use the health endpoint for initializing HttpTransportAsServer.

This is work is needed for introducing TLS. With TLS the HTTP RPC server takes longer to initialize. As a result, rpc clients can start to send requests to the server before the server is ready. In theory, even without adding TLS, `node_test` tests can fail due to clients not waiting for server readiness.

To make matters worse, `node_test` failures due to this issue have symptoms that do not immediately point to the underlying cause:
```
 go-nitro git:(wss) ✗ go test -run TestReversePaymentProxy ./node_test
--- FAIL: TestReversePaymentProxy (0.02s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x88 pc=0x104d45248]

goroutine 69 [running]:
testing.tRunner.func1.2({0x1057d50e0, 0x1066709d0})
        /usr/local/go/src/testing/testing.go:1545 +0x1c8
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1548 +0x360
panic({0x1057d50e0?, 0x1066709d0?})
        /usr/local/go/src/runtime/panic.go:914 +0x218
github.com/statechannels/go-nitro/rpc/transport/http.NewHttpTransportAsClient({0x140001411d0, 0x15})
        go-nitro/rpc/transport/http/client.go:30 +0x78
github.com/statechannels/go-nitro/node_test_test.setupNitroNodeWithRPCClient(0x14000803860, {0x14000046b80, 0x20, 0x40}, 0x14000088b18?, 0x105a72248?, 0x1059766e0?, {0x1050d5ff6, 0x4}, {0x14000439b18, ...})
        go-nitro/node_test/rpc_test.go:440 +0x2fc
github.com/statechannels/go-nitro/node_test_test.setupNitroClients(0x0?, {0x1052588f6, 0x19})
        go-nitro/node_test/reverseproxy_test.go:241 +0x3d4
github.com/statechannels/go-nitro/node_test_test.TestReversePaymentProxy(0x14000803860)
        go-nitro/node_test/reverseproxy_test.go:66 +0x54
testing.tRunner(0x14000803860, 0x105a3b120)
        /usr/local/go/src/testing/testing.go:1595 +0xe8
created by testing.(*T).Run in goroutine 1
        /usr/local/go/src/testing/testing.go:1648 +0x33c
FAIL    github.com/statechannels/go-nitro/node_test     0.406s
FAIL
```