### PR TITLE
Workaround for NATS flicker

### DIFF
--- a/rpc/transport/nats/client.go
+++ b/rpc/transport/nats/client.go
@@ -53,7 +53,11 @@ func (c *natsTransportClient) Subscribe() (<-chan []byte, error) {
 	}
 	c.notificationChan = make(chan []byte)
 	subscription, err := c.nc.Subscribe(nitroNotificationTopic, func(msg *nats.Msg) {
-		c.notificationChan <- msg.Data
+		// TODO: Currently NATS doesn't seem to guarantee that this function will not be called after the subscription is closed.
+		// To prevent sending on a closed channel, we check if the client is closed before sending.
+		if !c.natsTransport.nc.IsClosed() {
+			c.notificationChan <- msg.Data
+		}
 	})
 	c.natsSubscriptions = append(c.natsSubscriptions, subscription)
 


### PR DESCRIPTION
Fixes #1645  (maybe)

I suspect this flicker may be an[ issue with NATS](https://github.com/statechannels/go-nitro/issues/1645#issuecomment-1713006067), as our subscribe function shouldn't be called by the NATS client after close is called. To work around this I've added a check in our subscribe function that checks if the connection has already been closed. This should prevent us from sending on a `closed` channel.