### PR TITLE
Add automatic restart to cloud node workflow script

### DIFF
--- a/.github/workflows/deploy-cloud-node.yml
+++ b/.github/workflows/deploy-cloud-node.yml
@@ -35,6 +35,6 @@ jobs:
             docker pull registry.digitalocean.com/magmo/go-nitro:latest
             docker stop nitro_iris || true
             docker rm nitro_iris || true
-            docker run -it -d --name nitro_iris -p 3005:3005 -p 4005:4005 -p 5005:5005 -e SC_PK=${{ secrets.DO_SC_PK }} -e CHAIN_PK=${{ secrets.DO_CHAIN_PK }} -v /var/nitro_iris_store:/app/data registry.digitalocean.com/magmo/go-nitro:latest
+            docker run --restart=unless-stopped -it -d --name nitro_iris -p 3005:3005 -p 4005:4005 -p 5005:5005 -e SC_PK=${{ secrets.DO_SC_PK }} -e CHAIN_PK=${{ secrets.DO_CHAIN_PK }} -v /var/nitro_iris_store:/app/data registry.digitalocean.com/magmo/go-nitro:latest
           ENDSSH
           rm private_key.pem

--- a/docker/cloud/config.toml
+++ b/docker/cloud/config.toml
@@ -17,7 +17,7 @@ caaddress = "0x0C9D79725afc344A388045235CD0B23eA4f0E838"
 
 # RPC provider docs: https://lotus.filecoin.io/lotus/developers/glif-nodes/#testnet-endpoint
 chainurl = "wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v0"
-chainstartblock = 895069
+chainstartblock = 904293
 chainauthtoken = ""
 
 bootpeers = ""

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -345,6 +345,7 @@ out:
 				eventSub.Unsubscribe()
 			}
 
+			// Try to re-establish subscription once before failing
 			eventSub, err = ecs.chain.SubscribeFilterLogs(ecs.ctx, eventQuery, eventChan)
 			if err != nil {
 				errorChan <- fmt.Errorf("subscribeFilterLogs failed to resubscribe: " + err.Error())
@@ -380,6 +381,7 @@ out:
 				newBlockSub.Unsubscribe()
 			}
 
+			// Try to re-establish subscription once before failing
 			newBlockSub, err = ecs.chain.SubscribeNewHead(ecs.ctx, newBlockChan)
 			if err != nil {
 				errorChan <- fmt.Errorf("subscribeNewHead failed to resubscribe: %w", err)

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -184,7 +184,7 @@ func (ecs *EthChainService) listenForErrors(errChan <-chan error) {
 			return
 		case err := <-errChan:
 			ecs.logger.Error("chain service error", "error", err)
-			panic(err) // Manually panic in case we're using a logger that doesn't call exit(1)
+			panic(err)
 		}
 	}
 }


### PR DESCRIPTION
In order to make the cloud node more resilient to crashes without requiring manual intervention, this PR adds an automatic restart policy to the github action that deploys the cloud node and starts it.

The docker restart policy options (set with the `--restart` flag in the `docker run` command) are as follows:

* `--restart=no`: Do not automatically restart the container when it exits. This is the default behavior.
* `--restart=always`: Always restart the container regardless of the exit status. If the container is manually stopped, it is restarted only after Docker daemon restarts or the container itself is manually restarted.
* `--restart=unless-stopped`: Similar to always, but if the container is stopped manually, it will not be restarted automatically even after Docker daemon restarts.
* `--restart=on-failure[:max-retries]`: Restart only if the container exits with a non-zero exit status. Optionally, limit the number of restart retries the Docker daemon attempts.