### PR TITLE
Use drain to solve NATS flicker

### DIFF
--- a/rpc/transport/nats/client.go
+++ b/rpc/transport/nats/client.go
@@ -60,17 +60,7 @@ func (c *natsTransportClient) Subscribe() (<-chan []byte, error) {
 	return c.notificationChan, err
 }
 
-const unsubRetries = 3
-
 func (c *natsTransportClient) Close() error {
-	// TODO: This is a workaround for https://github.com/nats-io/nats.go/issues/1396
-	// See https://github.com/nats-io/nats.go/issues/1396#issuecomment-1714261643
-	for _, sub := range c.natsSubscriptions {
-		err := c.unsubscribeFromTopic(sub, unsubRetries)
-		if err != nil {
-			return err
-		}
-	}
 	err := c.natsTransport.Close()
 	if err != nil {
 		return err

--- a/rpc/transport/nats/server.go
+++ b/rpc/transport/nats/server.go
@@ -43,8 +43,8 @@ func (c *natsTransport) Close() error {
 			return err
 		}
 	}
-	c.nc.Close()
-	return nil
+	// Using drain is a workaround for https://github.com/nats-io/nats.go/issues/1396
+	return c.nc.Drain()
 }
 
 // unsubscribeFromTopic will attempt to unsubscribe the supplied subscription. On error, it will retry up to retries times.


### PR DESCRIPTION
Previously I had tried just unsubscribing from the NATS connection, but it looks like we're already doing that, and it introduced a new [flicker](https://github.com/statechannels/go-nitro/actions/runs/6149943566).

Instead this PR uses the `Drain` function to Close the NATS connection and prevent any new messages from being added. This is based on feedback from the [NATS team](https://github.com/nats-io/nats.go/issues/1396#issuecomment-1714261643). 

If we run into any issues with `Drain` we can revert back to my [original workaround](https://github.com/statechannels/go-nitro/pull/1655/commits/9f5cd450ba0b99fee03309ef0edc6b7c3a66c0a3)