### PR TITLE
Rename reverse payment proxy to payment proxy

### DIFF
--- a/cmd/start-payment-proxy/main.go
+++ b/cmd/start-payment-proxy/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/statechannels/go-nitro/cmd/utils"
 	"github.com/statechannels/go-nitro/internal/logging"
-	"github.com/statechannels/go-nitro/reverseproxy"
+	"github.com/statechannels/go-nitro/paymentproxy"
 	"github.com/urfave/cli/v2"
 )
 
@@ -19,9 +19,9 @@ const (
 )
 
 func main() {
-	var rProxy *reverseproxy.ReversePaymentProxy
+	var proxy *paymentproxy.PaymentProxy
 	app := &cli.App{
-		Name:  "start-reverse-payment-proxy",
+		Name:  "start-payment-proxy",
 		Usage: "Runs an HTTP payment proxy that charges for HTTP requests",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
@@ -55,22 +55,22 @@ func main() {
 
 			logging.SetupDefaultLogger(os.Stdout, slog.LevelDebug)
 
-			rProxy = reverseproxy.NewReversePaymentProxy(
+			proxy = paymentproxy.NewPaymentProxy(
 				proxyEndpoint,
 				nitroEndpoint,
 				c.String(DESTINATION_URL),
 				c.Uint64(COST_PER_BYTE),
 			)
 
-			return rProxy.Start()
+			return proxy.Start()
 		},
 	}
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal(err)
 	}
 	utils.WaitForKillSignal()
-	if rProxy != nil {
-		err := rProxy.Stop()
+	if proxy != nil {
+		err := proxy.Stop()
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/node_test/paymentproxy_test.go
+++ b/node_test/paymentproxy_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/statechannels/go-nitro/internal/logging"
 	ta "github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/node/engine/chainservice"
-	"github.com/statechannels/go-nitro/reverseproxy"
+	"github.com/statechannels/go-nitro/paymentproxy"
 	"github.com/statechannels/go-nitro/rpc"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -34,7 +34,7 @@ const (
 	destPort                   = 6622
 	otherParam                 = "otherParam"
 	otherParamValue            = "2"
-	testFileContent            = "This a simple test file used in the reverse payment proxy"
+	testFileContent            = "This a simple test file used in the payment proxy"
 	testFileName               = "test_file.txt"
 	serverReadyMaxWait         = 2 * time.Second
 )
@@ -60,8 +60,8 @@ func setupTestFile(t *testing.T) func() {
 	}
 }
 
-func TestReversePaymentProxy(t *testing.T) {
-	logFile := "reverse_payment_proxy.log"
+func TestPaymentProxy(t *testing.T) {
+	logFile := "payment_proxy.log"
 
 	aliceClient, ireneClient, bobClient, cleanup := setupNitroClients(t, logFile)
 	defer cleanup()
@@ -76,8 +76,8 @@ func TestReversePaymentProxy(t *testing.T) {
 	cleanupData := setupTestFile(t)
 	defer cleanupData()
 
-	// Create a ReversePaymentProxy with the test destination server URL
-	proxy := reverseproxy.NewReversePaymentProxy(
+	// Create a PaymentProxy with the test destination server URL
+	proxy := paymentproxy.NewPaymentProxy(
 		proxyAddress,
 		bobRPCUrl,
 		destinationServerUrl,
@@ -321,7 +321,7 @@ func runDestinationServer(t *testing.T, port uint) (destUrl string, cleanup func
 
 		// Always check that the voucher params were stripped out of every request
 		for p := range params {
-			if p == reverseproxy.AMOUNT_VOUCHER_PARAM || p == reverseproxy.CHANNEL_ID_VOUCHER_PARAM || p == reverseproxy.SIGNATURE_VOUCHER_PARAM {
+			if p == paymentproxy.AMOUNT_VOUCHER_PARAM || p == paymentproxy.CHANNEL_ID_VOUCHER_PARAM || p == paymentproxy.SIGNATURE_VOUCHER_PARAM {
 				t.Fatalf("Expected no voucher information to be passed along, but got %s", p)
 			}
 		}


### PR DESCRIPTION
This renames the "reverse payment proxy" to just the "payment proxy" to simplify the name. Having reverse in the name made it harder to say (IE: reverse payment proxy client is mouthful) and I don't think it provided that much clarity on how the proxy operates (I had to look up the differences between reverse and forward proxies)