### PR TITLE
Dockerize payment proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 docker/cloud/build:
 	docker build -f docker/cloud/Dockerfile -t go-nitro-cloud .
-
 docker/cloud/start:
 	docker remove go-nitro-cloud || true
 	docker run -it -d --name go-nitro-cloud -p 3005:3005 -p 4005:4005 -p 5005:5005 go-nitro-cloud
@@ -15,6 +14,12 @@ docker/local/build:
 docker/local/start:
 	docker remove go-nitro-local || true
 	docker run -it -d --name go-nitro-local -p 3005:3005 -p 4005:4005 -p 5005:5005 go-nitro-local
+
+docker/paymentproxy/build:
+	docker build -f docker/paymentproxy/Dockerfile -t payment-proxy .
+docker/paymentproxy/start:
+	docker remove payment-proxy || true
+	docker run -it -d --name payment-proxy -p 5511:5511 payment-proxy
 
 docker/network/build:
 	docker build -f docker/Dockerfile -t go-nitro .

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ docker/paymentproxy/build:
 	docker build -f docker/paymentproxy/Dockerfile -t payment-proxy .
 docker/paymentproxy/start:
 	docker remove payment-proxy || true
-	docker run -it -d --name payment-proxy -p 5511:5511 payment-proxy
+	docker run -it -d --name payment-proxy -p 5511:5511 -e PROXY_PORT=5511 payment-proxy
 
 docker/network/build:
 	docker build -f docker/Dockerfile -t go-nitro .

--- a/cmd/start-payment-proxy/main.go
+++ b/cmd/start-payment-proxy/main.go
@@ -39,7 +39,7 @@ func main() {
 			&cli.StringFlag{
 				Name:    DESTINATION_URL,
 				Usage:   "Specifies the destination URL to forward requests to. It should be a fully qualified URL, including the protocol (e.g. http://localhost:8081)",
-				Value:   "http://localhost:8081",
+				Value:   "http://localhost:8088",
 				Aliases: []string{"d"},
 			},
 			&cli.Uint64Flag{

--- a/docker/paymentproxy/Dockerfile
+++ b/docker/paymentproxy/Dockerfile
@@ -14,7 +14,7 @@ COPY --from=builder /app/proxy .
 
 ENV PROXY_PORT=5511
 ENV NITRO_ENDPOINT=host.docker.internal:4007/api/v1
-ENV DESTINATION_URL=http://host.docker.internal:8081
+ENV DESTINATION_URL=http://host.docker.internal:8088
 ENV COST_PER_BYTE=1
 
 EXPOSE $PROXY_PORT

--- a/docker/paymentproxy/Dockerfile
+++ b/docker/paymentproxy/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.21-bullseye AS builder
+WORKDIR /app
+COPY . .
+COPY ./docker/local/config.toml .
+RUN go build -o proxy ./cmd/start-payment-proxy
+
+FROM debian:bullseye-slim
+RUN apt-get update
+RUN apt-get install -y ca-certificates
+RUN rm -rf /var/lib/apt/lists/*
+WORKDIR /app/
+COPY --from=builder /app/proxy .
+
+
+ENV PROXY_PORT=5511
+ENV NITRO_ENDPOINT=host.docker.internal:4007/api/v1
+ENV DESTINATION_URL=http://host.docker.internal:8081
+ENV COST_PER_BYTE=1
+
+EXPOSE $PROXY_PORT
+CMD ./proxy --nitroendpoint $NITRO_ENDPOINT --proxyaddress 0.0.0.0:$PROXY_PORT --destinationurl $DESTINATION_URL --costperbyte $COST_PER_BYTE


### PR DESCRIPTION
Fixes #1665 

Creates a basic docker container to run the payment proxy.

I've verified this by running the demo locally against it.