### PR TITLE
Store channel in local storage

### DIFF
--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -20,6 +20,7 @@ const hub = "0x111a00868581f73ab42feef67d235ca09ca1e8db";
 const defaultNitroRPCUrl = "localhost:4005/api/v1";
 const defaultFileUrl = "http://localhost:5511/test.txt";
 const defaultPaymentChannelAmount = 100_000_000;
+const CHANNEL_ID_KEY = "channelId";
 
 const costPerByte = 1;
 function App() {
@@ -49,6 +50,18 @@ function App() {
         setErrorText(e.message);
       });
   }, [url]);
+
+  useEffect(() => {
+    const fetchedId = localStorage.getItem(CHANNEL_ID_KEY);
+    if (fetchedId && fetchedId != "") {
+      setPaymentChannelId(fetchedId);
+
+      nitroClient?.GetPaymentChannel(fetchedId).then((paymentChannel) => {
+        console.log(paymentChannel);
+        setPaymentChannelInfo(paymentChannel);
+      });
+    }
+  }, [nitroClient]);
 
   const updateChannelInfo = async (channelId: string) => {
     if (channelId == "") {
@@ -84,7 +97,8 @@ function App() {
       [hub],
       defaultPaymentChannelAmount
     );
-    console.log(result);
+
+    localStorage.setItem(CHANNEL_ID_KEY, result.ChannelId);
     setPaymentChannelId(result.ChannelId);
     updateChannelInfo(result.ChannelId);
 


### PR DESCRIPTION
Fixes #1678 

This stores the virtual channel Id in local storage. When hitting the UI we check if the channel id is already in local storage and if so, we fetch the channel details and use that channel.
