### PR TITLE
Fix deploy iris

### DIFF
--- a/.github/workflows/deploy-iris.yml
+++ b/.github/workflows/deploy-iris.yml
@@ -3,15 +3,19 @@ name: Deploy Iris
 on:
   workflow_dispatch:
     inputs:
-      skipBuild:
-        description: 'Skip build step'
+      build-image:
+        description: 'Build docker image'
         required: false
-        default: 'false'
+        default: 'true'
+      deploy-iris:
+        description: 'Deploy Iris'
+        required: false
+        default: 'true'
 
 jobs:
-  build:
+  build-image:
     runs-on: ubuntu-latest
-    if: github.event.inputs.skipBuild == 'false'
+    if: github.event.inputs.build-image == 'true'
 
     steps:
       - name: Checkout code
@@ -26,25 +30,27 @@ jobs:
       - name: Push Docker image to DigitalOcean
         run: make docker/cloud/push
 
-  deploy:
-    needs: build
+  deploy-iris:
+    needs: build-image
     runs-on: ubuntu-latest
-    if: always()
+    if: github.event.inputs.deploy-iris == 'true'
 
     steps:
       - name: Deploy to Droplet
         env:
-          SSH_PRIVATE_KEY: ${{ secrets.DO_SSH_PRIVATE_KEY }}
-          NITRO_CONFIG: './nitro_config/iris.toml'
+          SSH_PRIVATE_KEY: ${{ secrets.IRIS_SSH_PRIVATE_KEY }}
+          SC_PK: ${{ secrets.IRIS_SC_PK }}
+          CHAIN_PK: ${{ secrets.IRIS_CHAIN_PK }}
+          NITRO_CONFIG_PATH: './nitro_config/iris.toml'
           DROPLET_IP: '67.207.88.72'
           NODE_NAME: 'nitro_iris'
         run: |
           echo "$SSH_PRIVATE_KEY" > private_key.pem
           chmod 600 private_key.pem
-          ssh -o StrictHostKeyChecking=no -i private_key.pem root@$DROPLET_IP <<'ENDSSH'
+          ssh -o StrictHostKeyChecking=no -i private_key.pem root@$DROPLET_IP <<ENDSSH
             docker pull registry.digitalocean.com/magmo/go-nitro:latest
             docker stop $NODE_NAME || true
             docker rm $NODE_NAME || true
-            docker run --restart=unless-stopped -it -d --name $NODE_NAME -p 3005:3005 -p 4005:4005 -p 5005:80 -e NITRO_CONFIG=$NITRO_CONFIG SC_PK=${{ secrets.DO_SC_PK }} -e CHAIN_PK=${{ secrets.DO_CHAIN_PK }} -v /var/nitro_store:/app/data registry.digitalocean.com/magmo/go-nitro:latest
+            docker run --restart=unless-stopped -it -d --name $NODE_NAME -p 3005:3005 -p 4005:4005 -p 5005:80 -e NITRO_CONFIG_PATH=$NITRO_CONFIG_PATH -e SC_PK=$SC_PK -e CHAIN_PK=$CHAIN_PK -v /var/nitro_store:/app/data registry.digitalocean.com/magmo/go-nitro:latest
           ENDSSH
           rm private_key.pem

--- a/docker/cloud/Dockerfile
+++ b/docker/cloud/Dockerfile
@@ -31,4 +31,4 @@ COPY --from=builder /app/nitro_config ./nitro_config
 
 EXPOSE 3005 4005 5005
 
-CMD ./nitro --config $CONFIG_PATH
+CMD ./nitro --config $NITRO_CONFIG_PATH

--- a/docker/cloud/iris.toml
+++ b/docker/cloud/iris.toml
@@ -17,7 +17,7 @@ caaddress = "0x0C9D79725afc344A388045235CD0B23eA4f0E838"
 
 # RPC provider docs: https://lotus.filecoin.io/lotus/developers/glif-nodes/#testnet-endpoint
 chainurl = "wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v0"
-chainstartblock = 904293
+chainstartblock = 908130
 chainauthtoken = ""
 
 bootpeers = ""

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func main() {
 		&cli.StringFlag{
 			Name:    CONFIG,
 			Usage:   "Load config options from `config.toml`",
-			EnvVars: []string{"NITRO_CONFIG"},
+			EnvVars: []string{"NITRO_CONFIG_PATH"},
 		},
 		altsrc.NewBoolFlag(&cli.BoolFlag{
 			Name:        USE_NATS,


### PR DESCRIPTION
Allows us to use a common github action workflow template to deploy the `Iris` cloud node. This same template can be used to deploy `Anthony` and `Brad` cloud nodes. The only thing that will change for those two nodes' workflow file is the env variables passed used in the `ssh` session:

```
          SSH_PRIVATE_KEY: ${{ secrets.IRIS_SSH_PRIVATE_KEY }}
          SC_PK: ${{ secrets.IRIS_SC_PK }}
          CHAIN_PK: ${{ secrets.IRIS_CHAIN_PK }}
          NITRO_CONFIG_PATH: './nitro_config/iris.toml'
          DROPLET_IP: '67.207.88.72'
          NODE_NAME: 'nitro_iris'
```

