### PR TITLE
use yarn cache for bindings check

### DIFF
--- a/.github/workflows/bindings-check.yml
+++ b/.github/workflows/bindings-check.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "18.15.0"
+          cache: "yarn"
 
       - name: Install go-ethereum (includes abigen)
         run: go install github.com/ethereum/go-ethereum


### PR DESCRIPTION
This enables yarn caching for the binding check workflow (like all our other workflows that use node), which should speed it up slightly.