### PR TITLE
Use anthony cloud node in payment client demo

### DIFF
--- a/packages/payment-proxy-client/.env.production
+++ b/packages/payment-proxy-client/.env.production
@@ -1,5 +1,5 @@
 # Vite requires all env variables to be prefixed with VITE_
-VITE_NITRO_RPC_URL=localhost:4005/api/v1
+VITE_NITRO_RPC_URL=134.122.114.102:4005/api/v1
 VITE_FILE_URL=http://localhost:5511/test.txt
 VITE_PROVIDER=0xbbb676f9cff8d242e9eac39d063848807d3d1d94
 VITE_HUB=0x111a00868581f73ab42feef67d235ca09ca1e8db


### PR DESCRIPTION
Updates our prod env vars to use our cloud node anthony as the payer.