### PR TITLE
Remove channel id from local storage if it cannot be fetched

### DIFF
--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -56,14 +56,24 @@ function App() {
   }, [url]);
 
   useEffect(() => {
+    if (!nitroClient) return;
     const fetchedId = localStorage.getItem(CHANNEL_ID_KEY);
     if (fetchedId && fetchedId != "") {
       setPaymentChannelId(fetchedId);
 
-      nitroClient?.GetPaymentChannel(fetchedId).then((paymentChannel) => {
-        console.log(paymentChannel);
-        setPaymentChannelInfo(paymentChannel);
-      });
+      nitroClient
+        ?.GetPaymentChannel(fetchedId)
+        .then((paymentChannel) => {
+          console.log(paymentChannel);
+          setPaymentChannelInfo(paymentChannel);
+        })
+        .catch(() => {
+          console.warn(
+            `Channel from storage ${fetchedId} not found. Removing from storage...`
+          );
+          localStorage.removeItem(CHANNEL_ID_KEY);
+          setPaymentChannelId("");
+        });
     }
   }, [nitroClient]);
 

--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -62,7 +62,7 @@ function App() {
       setPaymentChannelId(fetchedId);
 
       nitroClient
-        ?.GetPaymentChannel(fetchedId)
+        .GetPaymentChannel(fetchedId)
         .then((paymentChannel) => {
           console.log(paymentChannel);
           setPaymentChannelInfo(paymentChannel);


### PR DESCRIPTION
Fixes #1694 

Handles the case where the channel id in storage no longer exists on the nitro node. We log a warning message out and remove the channel id, so the user can easily create a new one.