### PR TITLE
Accept a filepath to certificate file

### DIFF
--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"crypto/tls"
 	"fmt"
 	"log/slog"
 
@@ -11,7 +12,7 @@ import (
 	"github.com/statechannels/go-nitro/rpc/transport/nats"
 )
 
-func InitializeRpcServer(node *node.Node, rpcPort int, useNats bool) (*rpc.RpcServer, error) {
+func InitializeRpcServer(node *node.Node, rpcPort int, useNats bool, cert *tls.Certificate) (*rpc.RpcServer, error) {
 	var transport transport.Responder
 	var err error
 
@@ -20,7 +21,7 @@ func InitializeRpcServer(node *node.Node, rpcPort int, useNats bool) (*rpc.RpcSe
 		transport, err = nats.NewNatsTransportAsServer(rpcPort)
 	} else {
 		slog.Info("Initializing Http RPC transport...")
-		transport, err = httpTransport.NewHttpTransportAsServer(fmt.Sprint(rpcPort))
+		transport, err = httpTransport.NewHttpTransportAsServer(fmt.Sprint(rpcPort), cert)
 	}
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"log"
 	"log/slog"
 	"os"
@@ -44,11 +45,18 @@ func main() {
 		STORAGE_CATEGORY     = "Storage:"
 		USE_DURABLE_STORE    = "usedurablestore"
 		DURABLE_STORE_FOLDER = "durablestorefolder"
+
+		// TLS
+		TLS_CATEGORY      = "TLS:"
+		TLS_CERT_FILEPATH = "tlscertfilepath"
+		TLS_KEY_FILEPATH  = "tlskeyfilepath"
 	)
 	var pkString, chainUrl, chainAuthToken, naAddress, vpaAddress, caAddress, chainPk, durableStoreFolder, bootPeers string
 	var msgPort, rpcPort, guiPort int
 	var chainStartBlock uint64
 	var useNats, useDurableStore bool
+
+	var tlsCertFilepath, tlsKeyFilepath string
 
 	// urfave default precedence for flag value sources (highest to lowest):
 	// 1. Command line flag value
@@ -165,6 +173,20 @@ func main() {
 			Category:    CONNECTIVITY_CATEGORY,
 			Destination: &bootPeers,
 		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:        TLS_CERT_FILEPATH,
+			Usage:       "Filepath to the TLS certificate. If not specified, TLS will not be used with the RPC transport.",
+			Value:       "",
+			Category:    TLS_CATEGORY,
+			Destination: &tlsCertFilepath,
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:        TLS_KEY_FILEPATH,
+			Usage:       "Filepath to the TLS private key. If not specified, TLS will not be used with the RPC transport.",
+			Value:       "",
+			Category:    TLS_CATEGORY,
+			Destination: &tlsKeyFilepath,
+		}),
 	}
 	app := &cli.App{
 		Name:   "go-nitro",
@@ -194,7 +216,12 @@ func main() {
 				return err
 			}
 
-			rpcServer, err := rpc.InitializeRpcServer(node, rpcPort, useNats)
+			cert, err := tls.LoadX509KeyPair(tlsCertFilepath, tlsKeyFilepath)
+			if err != nil {
+				panic(err)
+			}
+
+			rpcServer, err := rpc.InitializeRpcServer(node, rpcPort, useNats, &cert)
 			if err != nil {
 				return err
 			}

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -1,6 +1,7 @@
 package node_test
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -403,6 +404,11 @@ func setupNitroNodeWithRPCClient(
 		t.Fatal(err)
 	}
 
+	cert, err := tls.LoadX509KeyPair("../internal/tls/statechannels.org.pem", "../internal/tls/statechannels.org_key.pem")
+	if err != nil {
+		panic(err)
+	}
+
 	slog.Info("Initializing message service on port " + fmt.Sprint(msgPort) + "...")
 	messageService := p2pms.NewMessageService("127.0.0.1", msgPort, *ourStore.GetAddress(), pk, bootPeers)
 
@@ -422,7 +428,7 @@ func setupNitroNodeWithRPCClient(
 		err = fmt.Errorf("unknown connection type %v", connectionType)
 		panic(err)
 	}
-	rpcServer, err := interRpc.InitializeRpcServer(&node, rpcPort, useNats)
+	rpcServer, err := interRpc.InitializeRpcServer(&node, rpcPort, useNats, &cert)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This allows the filepath to the certificate to be passed in when starting a nitro node. 