### PR TITLE
Add TLS support to payment proxy

### DIFF
--- a/.github/workflows/deploy-cloud-nodes.yml
+++ b/.github/workflows/deploy-cloud-nodes.yml
@@ -118,6 +118,6 @@ jobs:
             docker pull registry.digitalocean.com/magmo/go-nitro:latest
             docker stop $NODE_NAME || true
             docker rm $NODE_NAME || true
-            docker run --restart=unless-stopped -it -d --name $NODE_NAME -p 3005:3005 -p 4005:4005 -p 80:5005 -e NITRO_CONFIG_PATH=$NITRO_CONFIG_PATH -e SC_PK=$SC_PK -e CHAIN_PK=$CHAIN_PK -v /var/nitro_store:/app/data -v /etc/letsencrypt:/app/certs registry.digitalocean.com/magmo/go-nitro:latest
+            docker run --restart=unless-stopped -it -d --name $NODE_NAME -p 3005:3005 -p 4005:4005 -p 80:5005 -e NITRO_CONFIG_PATH=$NITRO_CONFIG_PATH -e SC_PK=$SC_PK -e CHAIN_PK=$CHAIN_PK -v /var/nitro_store:/app/data -v /etc/letsencrypt:/app/certs registry.digitalocean.com/magmo/go-nitro:latest 
           ENDSSH
           rm private_key.pem

--- a/.github/workflows/deploy-patsy.yml
+++ b/.github/workflows/deploy-patsy.yml
@@ -49,6 +49,7 @@ jobs:
           DESTINATION_URL: "https://magmo.com"
           TLS_CERT_FILE: /app/certs/live/payment-proxy.statechannels.org/fullchain.pem
           TLS_KEY_FILE: /app/certs/live/payment-proxy.statechannels.org/privkey.pem
+          PROXY_PORT: 443
         run: |
           echo "$SSH_PRIVATE_KEY" > private_key.pem
           chmod 600 private_key.pem
@@ -64,6 +65,7 @@ jobs:
               -e DESTINATION_URL=$DESTINATION_URL \
               -e TLS_CERT_FILE=$TLS_CERT_FILE \
               -e TLS_KEY_FILE=$TLS_KEY_FILE \
+              -e PROXY_PORT=$PROXY_PORT \
               registry.digitalocean.com/magmo/nitro-payment-proxy:latest
           ENDSSH
           rm private_key.pem

--- a/.github/workflows/deploy-patsy.yml
+++ b/.github/workflows/deploy-patsy.yml
@@ -46,7 +46,7 @@ jobs:
           DROPLET_IP: "165.22.197.200"
           NAME: "nitro-payment-proxy"
           NITRO_ENDPOINT: "brad-node.statechannels.org:4005/api/v1"
-          DESTINATION_URL: "https://magmo.com"
+          DESTINATION_URL: "https://www.w3.org"
           TLS_CERT_FILE: /app/certs/live/payment-proxy.statechannels.org/fullchain.pem
           TLS_KEY_FILE: /app/certs/live/payment-proxy.statechannels.org/privkey.pem
           PROXY_PORT: 443

--- a/.github/workflows/deploy-patsy.yml
+++ b/.github/workflows/deploy-patsy.yml
@@ -4,13 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       build-image:
-        description: 'Build docker image'
+        description: "Build docker image"
         required: false
-        default: 'true'
+        default: "true"
       deploy-patsy:
-        description: 'Deploy Patsy'
+        description: "Deploy Patsy"
         required: false
-        default: 'true'
+        default: "true"
 
 jobs:
   build-image:
@@ -43,10 +43,12 @@ jobs:
         env:
           DO_API_KEY: ${{ secrets.DO_API_KEY }}}
           SSH_PRIVATE_KEY: ${{ secrets.PATSY_SSH_PRIVATE_KEY }}
-          DROPLET_IP: '165.22.197.200'
-          NAME: 'nitro-payment-proxy'
-          NITRO_ENDPOINT: 'brad-node.statechannels.org:4005/api/v1'
-          DESTINATION_URL: 'https://magmo.com'
+          DROPLET_IP: "165.22.197.200"
+          NAME: "nitro-payment-proxy"
+          NITRO_ENDPOINT: "brad-node.statechannels.org:4005/api/v1"
+          DESTINATION_URL: "https://magmo.com"
+          TLS_CERT_FILE: /app/certs/live/payment-proxy.statechannels.org/fullchain.pem
+          TLS_KEY_FILE: /app/certs/live/payment-proxy.statechannels.org/privkey.pem
         run: |
           echo "$SSH_PRIVATE_KEY" > private_key.pem
           chmod 600 private_key.pem
@@ -56,9 +58,12 @@ jobs:
             docker stop $NAME || true
             docker rm $NAME || true
             docker run --restart=unless-stopped -it -d --name $NAME \
+              -v /etc/letsencrypt:/app/certs \
               -p 443:443 -p 80:80 -p 5511:5511 \
               -e NITRO_ENDPOINT=$NITRO_ENDPOINT \
               -e DESTINATION_URL=$DESTINATION_URL \
+              -e TLS_CERT_FILE=$TLS_CERT_FILE \
+              -e TLS_KEY_FILE=$TLS_KEY_FILE \
               registry.digitalocean.com/magmo/nitro-payment-proxy:latest
           ENDSSH
           rm private_key.pem

--- a/cmd/start-payment-proxy/main.go
+++ b/cmd/start-payment-proxy/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto/tls"
 	"log"
 	"log/slog"
 	"os"
@@ -69,21 +68,13 @@ func main() {
 
 			logging.SetupDefaultLogger(os.Stdout, slog.LevelDebug)
 
-			var cert tls.Certificate
-			var err error
-			if c.String(TLS_CERT_FILEPATH) != "" && c.String(TLS_KEY_FILEPATH) == "" {
-				cert, err = tls.LoadX509KeyPair(c.String(TLS_CERT_FILEPATH), c.String(TLS_KEY_FILEPATH))
-				if err != nil {
-					panic(err)
-				}
-			}
-
 			proxy = paymentproxy.NewPaymentProxy(
 				proxyEndpoint,
 				nitroEndpoint,
 				c.String(DESTINATION_URL),
 				c.Uint64(COST_PER_BYTE),
-				&cert,
+				c.String(TLS_CERT_FILEPATH),
+				c.String(TLS_KEY_FILEPATH),
 			)
 
 			return proxy.Start()

--- a/docker/paymentproxy/Dockerfile
+++ b/docker/paymentproxy/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.21-bullseye AS builder
 WORKDIR /app
 COPY . .
-COPY ./docker/local/config.toml .
+
 RUN go build -o proxy ./cmd/start-payment-proxy
 
 FROM debian:bullseye-slim

--- a/docker/paymentproxy/Dockerfile
+++ b/docker/paymentproxy/Dockerfile
@@ -16,6 +16,8 @@ ENV PROXY_PORT=5511
 ENV NITRO_ENDPOINT=host.docker.internal:4007/api/v1
 ENV DESTINATION_URL=http://host.docker.internal:8088
 ENV COST_PER_BYTE=1
+ENV TLS_CERT_FILE=""
+ENV TLS_KEY_FILE=""
 
 EXPOSE $PROXY_PORT
-CMD ./proxy --nitroendpoint $NITRO_ENDPOINT --proxyaddress 0.0.0.0:$PROXY_PORT --destinationurl $DESTINATION_URL --costperbyte $COST_PER_BYTE
+CMD ./proxy --nitroendpoint $NITRO_ENDPOINT --proxyaddress 0.0.0.0:$PROXY_PORT --destinationurl $DESTINATION_URL --costperbyte $COST_PER_BYTE --tlscertfilepath $TLS_CERT_FILE --tlskeyfilepath $TLS_KEY_FILE 

--- a/node_test/paymentproxy_test.go
+++ b/node_test/paymentproxy_test.go
@@ -81,7 +81,7 @@ func TestPaymentProxy(t *testing.T) {
 		proxyAddress,
 		bobRPCUrl,
 		destinationServerUrl,
-		1)
+		1, "", "")
 	defer func() {
 		err := proxy.Stop()
 		if err != nil {

--- a/paymentproxy/proxy.go
+++ b/paymentproxy/proxy.go
@@ -86,6 +86,12 @@ func NewPaymentProxy(proxyAddress string, nitroEndpoint string, destinationURL s
 // It is responsible for parsing the voucher from the query params and moving it to the request header
 // It then delegates to the reverse proxy to handle rewriting the request and sending it to the destination
 func (p *PaymentProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// If the request is a health check, return a 200 OK
+	if r.URL.Path == "/health" {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("Proxy is healthy"))
+		return
+	}
 	enableCORS(w, r)
 	v, err := parseVoucher(r.URL.Query())
 	if err != nil {

--- a/paymentproxy/proxy.go
+++ b/paymentproxy/proxy.go
@@ -89,7 +89,11 @@ func (p *PaymentProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// If the request is a health check, return a 200 OK
 	if r.URL.Path == "/health" {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("Proxy is healthy"))
+		_, err := w.Write([]byte("Proxy is healthy"))
+		if err != nil {
+			p.handleError(w, r, err)
+			return
+		}
 		return
 	}
 	enableCORS(w, r)


### PR DESCRIPTION
**This is based on #1716**
**This branch was used to deploy the latest cloud nodes and proxy**

This adds support to the payment proxy to run over HTTPS.