### PR TITLE
Remove copy of non-existent files from dockerfile

### DIFF
--- a/docker/cloud/Dockerfile
+++ b/docker/cloud/Dockerfile
@@ -28,7 +28,6 @@ RUN rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=builder /app/nitro .
 COPY --from=builder /app/nitro_config ./nitro_config
-COPY --from=builder /app/internal/tls ./internal/tls
 
 EXPOSE 3005 4005 5005
 


### PR DESCRIPTION
At one point we had checked in some cert files to `internal/tls`, and I updated the Dockerfile to copy them over to try using a self-signed cert. 

However these files no longer exist in our repo causes the docker build to fail. Certificates are already on the droplets so there's no need to copy over anything.