### PR TITLE
Get steps working correctly

### DIFF
--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -209,17 +209,15 @@ export default function App() {
       </Alert>
     );
   }
+  const [activeStep, setActiveStep] = React.useState(0);
+  const handleNext = () => {
+    setActiveStep(activeStep + 1);
+  };
+
+  const [createChannelDisabled, setCreateChannelDisabled] = useState(false);
+  const [payDisabled, setPayDisabled] = useState(false);
 
   function VerticalLinearStepper() {
-    const [activeStep, setActiveStep] = React.useState(0);
-
-    const [createChannelDisabled, setCreateChannelDisabled] = useState(false);
-    const [payDisabled, setPayDisabled] = useState(false);
-
-    const handleNext = () => {
-      setActiveStep((prevActiveStep) => prevActiveStep + 1);
-    };
-
     const handleCreateChannelButton = () => {
       setCreateChannelDisabled(true);
       createPaymentChannel().then(handleNext, (err) => {

--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -59,9 +59,11 @@ function Copyright(props: any) {
 }
 
 function computePercentagePaid(info: PaymentChannelInfo): number {
-  return Number(
-    info.Balance.PaidSoFar /
-      (info.Balance.RemainingFunds + info.Balance.PaidSoFar)
+  return (
+    Number(
+      info.Balance.PaidSoFar /
+        (info.Balance.RemainingFunds + info.Balance.PaidSoFar)
+    ) * 100
   );
 }
 export default function App() {


### PR DESCRIPTION
This fixes the `handleNext` function. Previously it was calling setActiveStep with `prevActiveStep+1`. However `prevActiveStep` was not defined, resulting in `NAN` being stored.

This PR also pulls out the state hooks of the `VerticalLinearStepper` component. Othewise whenever `VerticalLinearStepper` was rendered it would reset the step back to 0