### PR TITLE
Fix percentage returned

### DIFF
--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -59,12 +59,8 @@ function Copyright(props: any) {
 }
 
 function computePercentagePaid(info: PaymentChannelInfo): number {
-  return (
-    Number(
-      info.Balance.PaidSoFar /
-        (info.Balance.RemainingFunds + info.Balance.PaidSoFar)
-    ) * 100
-  );
+  const total = Number(info.Balance.RemainingFunds + info.Balance.PaidSoFar);
+  return (Number(info.Balance.PaidSoFar) / total) * 100;
 }
 export default function App() {
   const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");


### PR DESCRIPTION
Previously we were dividing with `bignumbers`, which uses floor division, meaning we would always get back `0`. This updates the function to perform the division with `number`s to avoid this.