### PR TITLE
Use correct env var

### DIFF
--- a/packages/payment-proxy-client/.env.development
+++ b/packages/payment-proxy-client/.env.development
@@ -1,6 +1,6 @@
 # Vite requires all env variables to be prefixed with VITE_
 VITE_NITRO_RPC_URL=localhost:4005/api/v1
-VITE_FILE_URL=http://localhost:5511/test.txt
+VITE_PROXY_URL=http://localhost:5511
 VITE_PROVIDER=0xbbb676f9cff8d242e9eac39d063848807d3d1d94
 VITE_HUB=0x111a00868581f73ab42feef67d235ca09ca1e8db
 VITE_INITIAL_CHANNEL_BALANCE=100000000

--- a/packages/payment-proxy-client/.env.production
+++ b/packages/payment-proxy-client/.env.production
@@ -1,6 +1,6 @@
 # Vite requires all env variables to be prefixed with VITE_
 VITE_NITRO_RPC_URL=anthony-node.statechannels.org:4005/api/v1
-VITE_FILE_URL=https://payment-proxy.statechannels.org/People/mimasa/test/imgformat/img/w3c_home.png
+VITE_PROXY_URL=https://payment-proxy.statechannels.org
 VITE_PROVIDER=0xA72DBe31224b824c438606196bE5857C6bE4cB32
 VITE_HUB=0x89825D58A7E2C198a06125be9CD0631317f9A07B
 VITE_INITIAL_CHANNEL_BALANCE=10000

--- a/packages/payment-proxy-client/src/vite-env.d.ts
+++ b/packages/payment-proxy-client/src/vite-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 interface ImportMetaEnv {
   readonly VITE_NITRO_RPC_URL: string;
-  readonly VITE_FILE_URL: string;
+  readonly VITE_PROXY_URL: string;
   readonly VITE_PROVIDER: string;
   readonly VITE_HUB: string;
   readonly VITE_INITIAL_CHANNEL_BALANCE: string;


### PR DESCRIPTION
Oops, I was using a made up env var name. This updates the env var names and values to `VITE_PROXY_URL`