### PR TITLE
Try old w3 image

### DIFF
--- a/packages/payment-proxy-client/src/constants.ts
+++ b/packages/payment-proxy-client/src/constants.ts
@@ -3,7 +3,7 @@ export const QUERY_KEY = "rpcUrl";
 export const costPerByte = 1;
 
 export const proxyUrl = import.meta.env.VITE_PROXY_URL;
-export const fileRelativePath = "/assets/logos/w3c/w3c-no-bars.svg";
+export const fileRelativePath = "People/mimasa/test/imgformat/img/w3c_home.png";
 export const fileUrl = proxyUrl + fileRelativePath;
 export const dataSize = 6833;
 


### PR DESCRIPTION
Currently it looks like the demo is failing when it tries to fetch the file from the proxy due to a CORS error:
```
Response body is not available to scripts (Reason: CORS Allow Origin Not Matching Origin)
```

I'm not sure if this will help but this PR switches the demo back to a file url that we know has worked with the payment proxy before.