### PR TITLE
Switch to archive node

### DIFF
--- a/.github/workflows/deploy-cloud-nodes.yml
+++ b/.github/workflows/deploy-cloud-nodes.yml
@@ -53,6 +53,7 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.IRIS_SSH_PRIVATE_KEY }}
           SC_PK: ${{ secrets.IRIS_SC_PK }}
           CHAIN_PK: ${{ secrets.IRIS_CHAIN_PK }}
+          CHAIN_AUTH_TOKEN: ${{ secrets.CHAIN_AUTH_TOKEN }}
           NITRO_CONFIG_PATH: "./nitro_config/iris.toml"
           DROPLET_IP: "67.207.88.72"
           NODE_NAME: "nitro_iris"
@@ -70,6 +71,7 @@ jobs:
               -e NITRO_CONFIG_PATH=$NITRO_CONFIG_PATH \
               -e SC_PK=$SC_PK \
               -e CHAIN_PK=$CHAIN_PK \
+              -e CHAIN_AUTH_TOKEN=$CHAIN_AUTH_TOKEN \
               -v /var/nitro_store:/app/data \
               -v /etc/letsencrypt:/app/certs \
               registry.digitalocean.com/magmo/go-nitro:latest
@@ -88,6 +90,7 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.ANTHONY_SSH_PRIVATE_KEY }}
           SC_PK: ${{ secrets.ANTHONY_SC_PK }}
           CHAIN_PK: ${{ secrets.ANTHONY_CHAIN_PK }}
+          CHAIN_AUTH_TOKEN: ${{ secrets.CHAIN_AUTH_TOKEN }}
           NITRO_CONFIG_PATH: "./nitro_config/anthony.toml"
           DROPLET_IP: "134.122.114.102"
           NODE_NAME: "nitro_anthony"
@@ -105,6 +108,7 @@ jobs:
               -e NITRO_CONFIG_PATH=$NITRO_CONFIG_PATH \
               -e SC_PK=$SC_PK \
               -e CHAIN_PK=$CHAIN_PK \
+              -e CHAIN_AUTH_TOKEN=$CHAIN_AUTH_TOKEN \
               -v /var/nitro_store:/app/data \
               -v /etc/letsencrypt:/app/certs \
               registry.digitalocean.com/magmo/go-nitro:latest
@@ -123,6 +127,7 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.BRAD_SSH_PRIVATE_KEY }}
           SC_PK: ${{ secrets.BRAD_SC_PK }}
           CHAIN_PK: ${{ secrets.BRAD_CHAIN_PK }}
+          CHAIN_AUTH_TOKEN: ${{ secrets.CHAIN_AUTH_TOKEN }}
           NITRO_CONFIG_PATH: "./nitro_config/brad.toml"
           DROPLET_IP: "192.81.214.172"
           NODE_NAME: "nitro_brad"
@@ -140,6 +145,7 @@ jobs:
               -e NITRO_CONFIG_PATH=$NITRO_CONFIG_PATH \
               -e SC_PK=$SC_PK \
               -e CHAIN_PK=$CHAIN_PK \
+              -e CHAIN_AUTH_TOKEN=$CHAIN_AUTH_TOKEN \
               -v /var/nitro_store:/app/data \
               -v /etc/letsencrypt:/app/certs \
               registry.digitalocean.com/magmo/go-nitro:latest

--- a/docker/cloud/anthony.toml
+++ b/docker/cloud/anthony.toml
@@ -15,8 +15,7 @@ naaddress = "0xe32d4B5C5a80660710f6a2aD3cB1c11664138F34"
 vpaaddress = "0x4D1a804e1cE383D75032C52878553212992C98D7"
 caaddress = "0x0C9D79725afc344A388045235CD0B23eA4f0E838"
 
-# RPC provider docs: https://lotus.filecoin.io/lotus/developers/glif-nodes/#testnet-endpoint
-chainurl = "wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v0"
+chainurl = "wss://calibration.node.glif.io/archive/lotus/rpc/v0"
 chainstartblock = 915929
 chainauthtoken = ""
 

--- a/docker/cloud/brad.toml
+++ b/docker/cloud/brad.toml
@@ -15,8 +15,8 @@ naaddress = "0xe32d4B5C5a80660710f6a2aD3cB1c11664138F34"
 vpaaddress = "0x4D1a804e1cE383D75032C52878553212992C98D7"
 caaddress = "0x0C9D79725afc344A388045235CD0B23eA4f0E838"
 
-# RPC provider docs: https://lotus.filecoin.io/lotus/developers/glif-nodes/#testnet-endpoint
-chainurl = "wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v0"
+
+chainurl = "wss://calibration.node.glif.io/archive/lotus/rpc/v0"
 chainstartblock = 915929
 chainauthtoken = ""
 

--- a/docker/cloud/iris.toml
+++ b/docker/cloud/iris.toml
@@ -15,8 +15,8 @@ naaddress = "0xe32d4B5C5a80660710f6a2aD3cB1c11664138F34"
 vpaaddress = "0x4D1a804e1cE383D75032C52878553212992C98D7"
 caaddress = "0x0C9D79725afc344A388045235CD0B23eA4f0E838"
 
-# RPC provider docs: https://lotus.filecoin.io/lotus/developers/glif-nodes/#testnet-endpoint
-chainurl = "wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v0"
+
+chainurl = "wss://calibration.node.glif.io/archive/lotus/rpc/v0"
 chainstartblock = 915929
 chainauthtoken = ""
 

--- a/main.go
+++ b/main.go
@@ -106,6 +106,7 @@ func main() {
 			Usage:       "The bearer token used for auth when making requests to the chain's RPC endpoint.",
 			Category:    CONNECTIVITY_CATEGORY,
 			Destination: &chainAuthToken,
+			EnvVars:     []string{"CHAIN_AUTH_TOKEN"},
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:        CHAIN_PK,


### PR DESCRIPTION
This switches the cloud nodes to use the archive node provided to us by filecoin. The JWT token is stored in a github secret.

TODO:
- [ ] Verify the URL works for WSS