### PR TITLE
Properly log out rpc payload

### DIFF
--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -146,7 +146,7 @@ type JsonRpcGeneralRequest struct {
 	Jsonrpc string      `json:"jsonrpc"`
 	Id      uint64      `json:"id"`
 	Method  string      `json:"method"`
-	Payload interface{} `json:"payload"`
+	Params  interface{} `json:"payload"`
 }
 
 type JsonRpcGeneralResponse struct {

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -146,7 +146,7 @@ type JsonRpcGeneralRequest struct {
 	Jsonrpc string      `json:"jsonrpc"`
 	Id      uint64      `json:"id"`
 	Method  string      `json:"method"`
-	Params  interface{} `json:"params"`
+	Payload interface{} `json:"payload"`
 }
 
 type JsonRpcGeneralResponse struct {

--- a/rpc/serde/jsonrpc.go
+++ b/rpc/serde/jsonrpc.go
@@ -146,7 +146,7 @@ type JsonRpcGeneralRequest struct {
 	Jsonrpc string      `json:"jsonrpc"`
 	Id      uint64      `json:"id"`
 	Method  string      `json:"method"`
-	Params  interface{} `json:"payload"`
+	Params  interface{} `json:"params"`
 }
 
 type JsonRpcGeneralResponse struct {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -271,6 +271,12 @@ func validateJsonrpcRequest(requestData []byte) (serde.JsonRpcGeneralRequest, []
 	}
 	vr.Method = sMethod
 
+	mParams, ok := request["params"].(map[string]interface{})
+	if !ok {
+		errRes := serde.NewJsonRpcErrorResponse(vr.Id, serde.InvalidRequestError)
+		return serde.JsonRpcGeneralRequest{}, marshalResponse(errRes)
+	}
+	vr.Payload = mParams["payload"]
 	return vr, nil
 }
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -271,12 +271,7 @@ func validateJsonrpcRequest(requestData []byte) (serde.JsonRpcGeneralRequest, []
 	}
 	vr.Method = sMethod
 
-	mParams, ok := request["params"].(map[string]interface{})
-	if !ok {
-		errRes := serde.NewJsonRpcErrorResponse(vr.Id, serde.InvalidRequestError)
-		return serde.JsonRpcGeneralRequest{}, marshalResponse(errRes)
-	}
-	vr.Payload = mParams["payload"]
+	vr.Params = request["params"]
 	return vr, nil
 }
 


### PR DESCRIPTION
I noticed that on one of the cloud nodes that the `Rpc server received request` log entry always has a null params.
```
{"time":"2023-09-18T18:44:09.56610977Z","level":"DEBUG","msg":"Rpc server received request","address":"0x3E6b9c3e569e72932Cfc2A943E5497ed07FEfB9e","request":{"jsonrpc":"","id":62649479,"method":"create_voucher","params":null}}
{"time":"2023-09-18T18:44:09.700037134Z","level":"DEBUG","msg":"Rpc server received request","address":"0x3E6b9c3e569e72932Cfc2A943E5497ed07FEfB9e","request":{"jsonrpc":"","id":62649618,"method":"get_payment_channel","params":null}}
{"time":"2023-09-18T18:44:28.379842962Z","level":"DEBUG","msg":"Rpc server received request","address":"0x3E6b9c3e569e72932Cfc2A943E5497ed07FEfB9e","request":{"jsonrpc":"","id":62668135,"method":"create_voucher","params":null}}
{"time":"2023-09-18T18:44:28.523026297Z","level":"DEBUG","msg":"Rpc server received request","address":"0x3E6b9c3e569e72932Cfc2A943E5497ed07FEfB9e","request":{"jsonrpc":"","id":62668440,"method":"get_payment_channel","params":null}}
```

This PR updates the ` validateJsonrpcRequest` to set the `Params` on the `JsonRpcGeneralRequest` so we actually log out the params.