### PR TITLE
Cleanup/refactor node code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 docker/cloud/build:
 	docker build -f docker/cloud/Dockerfile -t go-nitro-cloud .
+
 docker/cloud/start:
 	docker remove go-nitro-cloud || true
-	docker run -it -d --name go-nitro-cloud -p 3005:3005 -p 4005:4005 -p 5005:5005 -e NITRO_CONFIG_PATH="./nitro_config/iris.toml" go-nitro-cloud
+	docker run -it -d --name go-nitro-cloud \
+	  -p 3005:3005 -p 4005:4005 -p 5005:5005 \
+		-e NITRO_CONFIG_PATH="./nitro_config/charley.toml" \
+		go-nitro-cloud
 
 docker/cloud/push:
 	docker tag go-nitro-cloud:latest registry.digitalocean.com/magmo/go-nitro:latest

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ docker/cloud/start:
 	docker remove go-nitro-cloud || true
 	docker run -it -d --name go-nitro-cloud \
 	  -p 3005:3005 -p 4005:4005 -p 5005:5005 \
-		-e NITRO_CONFIG_PATH="./nitro_config/charley.toml" \
+		-e NITRO_CONFIG_PATH="./nitro_config/iris.toml" \
 		go-nitro-cloud
 
 docker/cloud/push:

--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -18,16 +18,6 @@ import (
 	"github.com/statechannels/go-nitro/types"
 )
 
-type ChainOpts struct {
-	ChainUrl        string
-	ChainStartBlock uint64
-	ChainAuthToken  string
-	ChainPk         string
-	NaAddress       common.Address
-	VpaAddress      common.Address
-	CaAddress       common.Address
-}
-
 func StartAnvil() (*exec.Cmd, error) {
 	chainCmd := exec.Command("anvil", "--chain-id", "1337", "--block-time", "1", "--silent")
 	chainCmd.Stdout = os.Stdout

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -5,25 +5,23 @@ import (
 	"log/slog"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/statechannels/go-nitro/internal/chain"
 	"github.com/statechannels/go-nitro/node"
 	"github.com/statechannels/go-nitro/node/engine"
 	"github.com/statechannels/go-nitro/node/engine/chainservice"
 	"github.com/statechannels/go-nitro/node/engine/store"
-	"github.com/tidwall/buntdb"
 
 	p2pms "github.com/statechannels/go-nitro/node/engine/messageservice/p2p-message-service"
 )
 
-func InitializeNode(pkString string, chainOpts chain.ChainOpts,
-	useDurableStore bool, durableStoreFolder string, msgPort int, bootPeers []string, publicIp string,
+func InitializeNode(pkString string, chainOpts chainservice.ChainOpts, storeOpts store.StoreOpts,
+	msgPort int, bootPeers []string, publicIp string,
 ) (*node.Node, *store.Store, *p2pms.P2PMessageService, chainservice.ChainService, error) {
 	if pkString == "" {
 		panic("pk must be set")
 	}
 
 	pk := common.Hex2Bytes(pkString)
-	ourStore, err := store.NewStore(pk, useDurableStore, durableStoreFolder, buntdb.Config{})
+	ourStore, err := store.NewStore(storeOpts)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/node"
 	"github.com/statechannels/go-nitro/node/engine"
 	"github.com/statechannels/go-nitro/node/engine/chainservice"
@@ -13,21 +12,15 @@ import (
 	p2pms "github.com/statechannels/go-nitro/node/engine/messageservice/p2p-message-service"
 )
 
-func InitializeNode(pkString string, chainOpts chainservice.ChainOpts, storeOpts store.StoreOpts,
-	msgPort int, bootPeers []string, publicIp string,
-) (*node.Node, *store.Store, *p2pms.P2PMessageService, chainservice.ChainService, error) {
-	if pkString == "" {
-		panic("pk must be set")
-	}
-
-	pk := common.Hex2Bytes(pkString)
+func InitializeNode(chainOpts chainservice.ChainOpts, storeOpts store.StoreOpts, messageOpts p2pms.MessageOpts) (*node.Node, *store.Store, *p2pms.P2PMessageService, chainservice.ChainService, error) {
 	ourStore, err := store.NewStore(storeOpts)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
 
-	slog.Info("Initializing message service on port " + fmt.Sprint(msgPort) + "...")
-	messageService := p2pms.NewMessageService(publicIp, msgPort, *ourStore.GetAddress(), pk, bootPeers)
+	slog.Info("Initializing message service on port " + fmt.Sprint(messageOpts.Port) + "...")
+	messageOpts.SCAddr = *ourStore.GetAddress()
+	messageService := p2pms.NewMessageService(messageOpts)
 
 	// Compare chainOpts.ChainStartBlock to lastBlockNum seen in store. The larger of the two
 	// gets passed as an argument when creating NewEthChainService

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/statechannels/go-nitro/internal/node"
 	"github.com/statechannels/go-nitro/internal/rpc"
 	"github.com/statechannels/go-nitro/node/engine/chainservice"
+	"github.com/statechannels/go-nitro/node/engine/store"
 	"github.com/urfave/cli/v2"
 	"github.com/urfave/cli/v2/altsrc"
 )
@@ -213,6 +214,12 @@ func main() {
 				CaAddress:       common.HexToAddress(caAddress),
 			}
 
+			storeOpts := store.StoreOpts{
+				PkBytes:            common.Hex2Bytes(pkString),
+				UseDurableStore:    useDurableStore,
+				DurableStoreFolder: durableStoreFolder,
+			}
+
 			var peerSlice []string
 			if bootPeers != "" {
 				peerSlice = strings.Split(bootPeers, ",")
@@ -220,7 +227,7 @@ func main() {
 
 			logging.SetupDefaultLogger(os.Stdout, slog.LevelDebug)
 
-			node, _, _, _, err := node.InitializeNode(pkString, chainOpts, useDurableStore, durableStoreFolder, msgPort, peerSlice, publicIp)
+			node, _, _, _, err := node.InitializeNode(pkString, chainOpts, storeOpts, msgPort, peerSlice, publicIp)
 			if err != nil {
 				return err
 			}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/statechannels/go-nitro/internal/node"
 	"github.com/statechannels/go-nitro/internal/rpc"
 	"github.com/statechannels/go-nitro/node/engine/chainservice"
+	p2pms "github.com/statechannels/go-nitro/node/engine/messageservice/p2p-message-service"
 	"github.com/statechannels/go-nitro/node/engine/store"
 	"github.com/urfave/cli/v2"
 	"github.com/urfave/cli/v2/altsrc"
@@ -225,9 +226,16 @@ func main() {
 				peerSlice = strings.Split(bootPeers, ",")
 			}
 
+			messageOpts := p2pms.MessageOpts{
+				PkBytes:   common.Hex2Bytes(pkString),
+				Port:      msgPort,
+				BootPeers: peerSlice,
+				PublicIp:  publicIp,
+			}
+
 			logging.SetupDefaultLogger(os.Stdout, slog.LevelDebug)
 
-			node, _, _, _, err := node.InitializeNode(pkString, chainOpts, storeOpts, msgPort, peerSlice, publicIp)
+			node, _, _, _, err := node.InitializeNode(chainOpts, storeOpts, messageOpts)
 			if err != nil {
 				return err
 			}

--- a/main.go
+++ b/main.go
@@ -10,10 +10,10 @@ import (
 	"syscall"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/statechannels/go-nitro/internal/chain"
 	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/internal/node"
 	"github.com/statechannels/go-nitro/internal/rpc"
+	"github.com/statechannels/go-nitro/node/engine/chainservice"
 	"github.com/urfave/cli/v2"
 	"github.com/urfave/cli/v2/altsrc"
 )
@@ -203,7 +203,7 @@ func main() {
 		Flags:  flags,
 		Before: altsrc.InitInputSourceWithContext(flags, altsrc.NewTomlSourceFromFlagFunc(CONFIG)),
 		Action: func(cCtx *cli.Context) error {
-			chainOpts := chain.ChainOpts{
+			chainOpts := chainservice.ChainOpts{
 				ChainUrl:        chainUrl,
 				ChainStartBlock: chainStartBlock,
 				ChainAuthToken:  chainAuthToken,

--- a/main.go
+++ b/main.go
@@ -102,6 +102,7 @@ func main() {
 			DefaultText: "hardhat / anvil default",
 			Category:    CONNECTIVITY_CATEGORY,
 			Destination: &chainUrl,
+			EnvVars:     []string{"CHAIN_URL"},
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:        CHAIN_AUTH_TOKEN,
@@ -122,6 +123,7 @@ func main() {
 			Value:       0,
 			Category:    CONNECTIVITY_CATEGORY,
 			Destination: &chainStartBlock,
+			EnvVars:     []string{"CHAIN_START_BLOCK"},
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:        NA_ADDRESS,

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -14,7 +14,6 @@ import (
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/statechannels/go-nitro/channel/state"
-	"github.com/statechannels/go-nitro/internal/chain"
 	"github.com/statechannels/go-nitro/internal/logging"
 	NitroAdjudicator "github.com/statechannels/go-nitro/node/engine/chainservice/adjudicator"
 	Token "github.com/statechannels/go-nitro/node/engine/chainservice/erc20"
@@ -22,6 +21,16 @@ import (
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
+
+type ChainOpts struct {
+	ChainUrl        string
+	ChainStartBlock uint64
+	ChainAuthToken  string
+	ChainPk         string
+	NaAddress       common.Address
+	VpaAddress      common.Address
+	CaAddress       common.Address
+}
 
 var (
 	naAbi, _                 = NitroAdjudicator.NitroAdjudicatorMetaData.GetAbi()
@@ -80,7 +89,7 @@ const RESUB_INTERVAL = 15 * time.Second
 const REQUIRED_BLOCK_CONFIRMATIONS = 2
 
 // NewEthChainService is a convenient wrapper around newEthChainService, which provides a simpler API
-func NewEthChainService(chainOpts chain.ChainOpts) (ChainService, error) {
+func NewEthChainService(chainOpts ChainOpts) (ChainService, error) {
 	if chainOpts.ChainPk == "" {
 		return nil, fmt.Errorf("chainpk must be set")
 	}

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -541,12 +541,12 @@ func (e *Engine) handlePaymentRequest(request PaymentRequest) (EngineEvent, erro
 func (e *Engine) sendMessages(msgs []protocols.Message) {
 	for _, message := range msgs {
 		message.From = *e.store.GetAddress()
-		e.logMessage(message, Outgoing)
 		err := e.msg.Send(message)
 		if err != nil {
 			e.logger.Error(err.Error())
 			panic(err)
 		}
+		e.logMessage(message, Outgoing)
 	}
 	e.wg.Done()
 }

--- a/node/engine/messageservice/messageservice.go
+++ b/node/engine/messageservice/messageservice.go
@@ -1,9 +1,7 @@
 // Package messageservice is a messaging service responsible for routing messages to peers and relaying messages received from peers.
 package messageservice // import "github.com/statechannels/go-nitro/node/messageservice"
 
-import (
-	"github.com/statechannels/go-nitro/protocols"
-)
+import "github.com/statechannels/go-nitro/protocols"
 
 type MessageService interface {
 	// Out returns a chan for receiving messages from the message service

--- a/node/engine/messageservice/messageservice.go
+++ b/node/engine/messageservice/messageservice.go
@@ -1,7 +1,9 @@
 // Package messageservice is a messaging service responsible for routing messages to peers and relaying messages received from peers.
 package messageservice // import "github.com/statechannels/go-nitro/node/messageservice"
 
-import "github.com/statechannels/go-nitro/protocols"
+import (
+	"github.com/statechannels/go-nitro/protocols"
+)
 
 type MessageService interface {
 	// Out returns a chan for receiving messages from the message service

--- a/node_test/helpers_test.go
+++ b/node_test/helpers_test.go
@@ -68,13 +68,13 @@ func setupMessageService(tc TestCase, tp TestParticipant, si sharedTestInfrastru
 		return messageservice.NewTestMessageService(tp.Address(), *si.broker, tc.MessageDelay), ""
 
 	case P2PMessageService:
-		ms := p2pms.NewMessageService(
-			"127.0.0.1",
-			int(tp.Port),
-			tp.Address(),
-			tp.PrivateKey,
-			bootPeers,
-		)
+		ms := p2pms.NewMessageService(p2pms.MessageOpts{
+			PublicIp:  "127.0.0.1",
+			Port:      int(tp.Port),
+			SCAddr:    tp.Address(),
+			PkBytes:   tp.PrivateKey,
+			BootPeers: bootPeers,
+		})
 
 		return ms, ms.MultiAddr
 	default:

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -98,7 +98,6 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 	for i := 0; i < n; i++ {
 		sk := `000000000000000000000000000000000000000000000000000000000000000` + strconv.Itoa(i+1)
 		actors[i] = ta.Actor{
-			// PrivateKey: common.Hex2Bytes(sk),
 			PrivateKey: common.Hex2Bytes(sk),
 		}
 	}


### PR DESCRIPTION
A few areas of cleanup:

1. Make the `Sent message` log after the message is successfully sent
2. Use `messageOpts` and `storeOpts` when initializing those services. This means we pass a single struct as an input to `NewStore` and `NewMessageService` instead of many individual arguments. This work aligns `messageservice` and `store` factories with the `chainservice.NewEthChainService` factory