### PR TITLE
Support differing file sizes

### DIFF
--- a/packages/payment-proxy-client/.env.development
+++ b/packages/payment-proxy-client/.env.development
@@ -4,4 +4,5 @@ VITE_PROXY_URL=http://localhost:5511
 VITE_PROVIDER=0xbbb676f9cff8d242e9eac39d063848807d3d1d94
 VITE_HUB=0x111a00868581f73ab42feef67d235ca09ca1e8db
 VITE_INITIAL_CHANNEL_BALANCE=10000
-VITE_FILE_PATHS=/test0.txt,/test1.txt,/test2.txt,/test3.txt,/test4.txt,/test5.txt,/test6.txt,/test7.txt,/test8.txt,/test9.txt
+VITE_FILE_PATHS=/test0.txt;/test1.txt;/test2.txt;/test3.txt
+VITE_FILE_SIZES=245;245;245;245

--- a/packages/payment-proxy-client/.env.production
+++ b/packages/payment-proxy-client/.env.production
@@ -5,3 +5,4 @@ VITE_PROVIDER=0xA72DBe31224b824c438606196bE5857C6bE4cB32
 VITE_HUB=0x89825D58A7E2C198a06125be9CD0631317f9A07B
 VITE_INITIAL_CHANNEL_BALANCE=200000000000 # 200 gwei/nFIL
 VITE_FILE_PATHS=/DALL·E 2023-09-08 13.20.27 - cyperpunk depiction of a robot throwing a filecoin token  toward a distant robot, digital art.png;/DALL·E 2023-09-08 13.24.23 - muscular unicorn surfing on a wave of golden coins with a rainbow in the background, digital art. the unicorn is branded with the words _0 trust_.png;/DALL·E 2023-09-08 13.34.03 - surrealist painting of a pair of 90s style computers exchanging golden coins.png
+VITE_FILE_SIZES=1778633;1995866;2221266

--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -32,9 +32,9 @@ import { NitroRpcClient } from "@statechannels/nitro-rpc-client";
 import { PaymentChannelInfo } from "@statechannels/nitro-rpc-client/src/types";
 
 import {
+  AvailableFile,
   QUERY_KEY,
   costPerByte,
-  dataSize,
   defaultNitroRPCUrl,
   files,
   hub,
@@ -82,7 +82,7 @@ export default function App() {
   }
 
   // Default to the first file
-  const [selectedFileUrl, setSelectedFileUrl] = useState<string>(files[0].url);
+  const [selectedFile, setSelectedFile] = useState<AvailableFile>(files[0]);
   useEffect(() => {
     console.time("Connect to Nitro Node");
     NitroRpcClient.CreateHttpNitroClient(url)
@@ -154,8 +154,8 @@ export default function App() {
     }
     try {
       const file = await fetchFile(
-        selectedFileUrl,
-        skipPayment ? 0 : costPerByte * dataSize,
+        selectedFile.url,
+        skipPayment ? 0 : costPerByte * selectedFile.size,
         paymentChannelInfo.ID,
         nitroClient
       );
@@ -359,12 +359,16 @@ export default function App() {
                       />
                       <FormControl>
                         <RadioGroup
-                          aria-labelledby="demo-radio-buttons-group-label"
                           name="availableFiles"
                           row={true}
-                          value={selectedFileUrl}
+                          value={selectedFile.url}
                           onChange={(e) => {
-                            setSelectedFileUrl(e.target.value);
+                            const found = files.find(
+                              (f) => f.url == e.target.value
+                            );
+                            if (found) {
+                              setSelectedFile(found);
+                            }
                           }}
                         >
                           {files.map((file) => (
@@ -372,7 +376,11 @@ export default function App() {
                               value={file.url}
                               key={file.url}
                               control={<Radio />}
-                              label={file.fileName}
+                              label={
+                                file.fileName.length < 50
+                                  ? file.fileName
+                                  : "..." + file.fileName.slice(-50)
+                              }
                             />
                           ))}
                         </RadioGroup>

--- a/packages/payment-proxy-client/src/constants.ts
+++ b/packages/payment-proxy-client/src/constants.ts
@@ -2,9 +2,6 @@
 export const QUERY_KEY = "rpcUrl";
 export const costPerByte = 1;
 
-// TODO: This is temporary until https://github.com/statechannels/go-nitro/pull/1754
-// We just use the largest deployed file size for now
-export const dataSize = 2221266;
 // env vars
 export const proxyUrl = import.meta.env.VITE_PROXY_URL;
 export const fileRelativePath = import.meta.env.VITE_FILE_RELATIVE_PATH;
@@ -16,13 +13,23 @@ export const initialChannelBalance = parseInt(
   import.meta.env.VITE_INITIAL_CHANNEL_BALANCE,
   10
 );
-
 const ENV_VAR_SPLIT_CHAR = ";";
 
-export const files: { fileName: string; url: string }[] =
-  import.meta.env.VITE_FILE_PATHS.split(ENV_VAR_SPLIT_CHAR).map(
-    (filePath: string) => ({
-      url: proxyUrl + filePath,
-      fileName: filePath.split("/").pop() || filePath,
-    })
-  );
+const fileSizes = import.meta.env.VITE_FILE_SIZES.split(ENV_VAR_SPLIT_CHAR).map(
+  (size: string) => parseInt(size, 10)
+);
+
+export interface AvailableFile {
+  fileName: string;
+  url: string;
+  size: number;
+}
+export const files: AvailableFile[] = import.meta.env.VITE_FILE_PATHS.split(
+  ENV_VAR_SPLIT_CHAR
+).map((filePath: string, index: number) => {
+  return {
+    url: proxyUrl + filePath,
+    fileName: filePath.split("/").pop() || filePath,
+    size: fileSizes[index],
+  };
+});

--- a/packages/payment-proxy-client/src/vite-env.d.ts
+++ b/packages/payment-proxy-client/src/vite-env.d.ts
@@ -6,6 +6,7 @@ interface ImportMetaEnv {
   readonly VITE_HUB: string;
   readonly VITE_INITIAL_CHANNEL_BALANCE: string;
   readonly VITE_FILE_PATHS: string;
+  readonly VITE_FILE_SIZES: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
**Based on #1756**

This introduces an env var `VITE_FILE_SIZES` so we can specify the sizes of different files. This allows us to pay the specific amount for a file.