### PR TITLE
Smaller payment channel budget for the demo

### DIFF
--- a/packages/payment-proxy-client/.env.production
+++ b/packages/payment-proxy-client/.env.production
@@ -3,6 +3,6 @@ VITE_NITRO_RPC_URL=anthony-node.statechannels.org:4005/api/v1
 VITE_PROXY_URL=https://payment-proxy.statechannels.org
 VITE_PROVIDER=0xA72DBe31224b824c438606196bE5857C6bE4cB32
 VITE_HUB=0x89825D58A7E2C198a06125be9CD0631317f9A07B
-VITE_INITIAL_CHANNEL_BALANCE=200000000000 # 200 gwei/nFIL
+VITE_INITIAL_CHANNEL_BALANCE=20000000 # 20 mwei/pFil
 VITE_FILE_PATHS=/DALL·E 2023-09-08 13.20.27 - cyperpunk depiction of a robot throwing a filecoin token  toward a distant robot, digital art.png;/DALL·E 2023-09-08 13.24.23 - muscular unicorn surfing on a wave of golden coins with a rainbow in the background, digital art. the unicorn is branded with the words _0 trust_.png;/DALL·E 2023-09-08 13.34.03 - surrealist painting of a pair of 90s style computers exchanging golden coins.png
 VITE_FILE_SIZES=1778633;1995866;2221266


### PR DESCRIPTION
Even with the larger deployed files we're using, the balance of the virtual channel is so large it's hard to see any change on the progress bars.

[See the deployment preview to see what it looks like](https://deploy-preview-1758--nitro-payment-demo.netlify.app/)