### PR TITLE
Allow custom file names for demo

### DIFF
--- a/packages/payment-proxy-client/.env.development
+++ b/packages/payment-proxy-client/.env.development
@@ -6,3 +6,4 @@ VITE_HUB=0x111a00868581f73ab42feef67d235ca09ca1e8db
 VITE_INITIAL_CHANNEL_BALANCE=10000
 VITE_FILE_PATHS=/test0.txt;/test1.txt;/test2.txt;/test3.txt
 VITE_FILE_SIZES=245;245;245;245
+VITE_FILE_NAMES=test0.txt;test1.txt;test2.txt;test3.txt

--- a/packages/payment-proxy-client/.env.production
+++ b/packages/payment-proxy-client/.env.production
@@ -6,3 +6,4 @@ VITE_HUB=0x89825D58A7E2C198a06125be9CD0631317f9A07B
 VITE_INITIAL_CHANNEL_BALANCE=20000000 # 20 mwei/pFil
 VITE_FILE_PATHS=/DALL·E 2023-09-08 13.20.27 - cyperpunk depiction of a robot throwing a filecoin token  toward a distant robot, digital art.png;/DALL·E 2023-09-08 13.24.23 - muscular unicorn surfing on a wave of golden coins with a rainbow in the background, digital art. the unicorn is branded with the words _0 trust_.png;/DALL·E 2023-09-08 13.34.03 - surrealist painting of a pair of 90s style computers exchanging golden coins.png
 VITE_FILE_SIZES=1778633;1995866;2221266
+VITE_FILE_NAMES=robot.png;unicorn.png;computers.png

--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -357,34 +357,35 @@ export default function App() {
                         }
                         label="Skip payment"
                       />
-                      <FormControl>
-                        <RadioGroup
-                          name="availableFiles"
-                          row={true}
-                          value={selectedFile.url}
-                          onChange={(e) => {
-                            const found = files.find(
-                              (f) => f.url == e.target.value
-                            );
-                            if (found) {
-                              setSelectedFile(found);
-                            }
-                          }}
-                        >
-                          {files.map((file) => (
-                            <FormControlLabel
-                              value={file.url}
-                              key={file.url}
-                              control={<Radio />}
-                              label={
-                                file.fileName.length < 50
-                                  ? file.fileName
-                                  : "..." + file.fileName.slice(-50)
+                      <Box>
+                        <FormControl>
+                          <RadioGroup
+                            name="availableFiles"
+                            value={selectedFile.url}
+                            onChange={(e) => {
+                              const found = files.find(
+                                (f) => f.url == e.target.value
+                              );
+                              if (found) {
+                                setSelectedFile(found);
                               }
-                            />
-                          ))}
-                        </RadioGroup>
-                      </FormControl>
+                            }}
+                          >
+                            {files.map((file) => (
+                              <FormControlLabel
+                                value={file.url}
+                                key={file.url}
+                                control={<Radio />}
+                                label={
+                                  file.fileName.length < 50
+                                    ? file.fileName
+                                    : "..." + file.fileName.slice(-50)
+                                }
+                              />
+                            ))}
+                          </RadioGroup>
+                        </FormControl>
+                      </Box>
                       <Button
                         variant="contained"
                         disabled={payDisabled}

--- a/packages/payment-proxy-client/src/constants.ts
+++ b/packages/payment-proxy-client/src/constants.ts
@@ -18,6 +18,7 @@ const ENV_VAR_SPLIT_CHAR = ";";
 const fileSizes = import.meta.env.VITE_FILE_SIZES.split(ENV_VAR_SPLIT_CHAR).map(
   (size: string) => parseInt(size, 10)
 );
+const fileNames = import.meta.env.VITE_FILE_NAMES.split(ENV_VAR_SPLIT_CHAR);
 
 export interface AvailableFile {
   fileName: string;
@@ -29,7 +30,7 @@ export const files: AvailableFile[] = import.meta.env.VITE_FILE_PATHS.split(
 ).map((filePath: string, index: number) => {
   return {
     url: proxyUrl + filePath,
-    fileName: filePath.split("/").pop() || filePath,
+    fileName: fileNames[index],
     size: fileSizes[index],
   };
 });

--- a/packages/payment-proxy-client/src/vite-env.d.ts
+++ b/packages/payment-proxy-client/src/vite-env.d.ts
@@ -7,6 +7,7 @@ interface ImportMetaEnv {
   readonly VITE_INITIAL_CHANNEL_BALANCE: string;
   readonly VITE_FILE_PATHS: string;
   readonly VITE_FILE_SIZES: string;
+  readonly VITE_FILE_NAMES: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Allows file names to be specified using a new env var, so we can use shorter names for hosted files. This makes things look a bit more presentable:
<img width="513" alt="image" src="https://github.com/statechannels/go-nitro/assets/1620336/42fa4f20-4c42-4528-9d38-d6800f10d0aa">
