### PR TITLE
updat channel info immediately when payment leaves client

### DIFF
--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -172,7 +172,10 @@ export default function App() {
             selectedFile.url,
             skipPayment ? 0 : costPerByte * selectedFile.size,
             paymentChannelInfo.ID,
-            nitroClient
+            nitroClient,
+            () => {
+              updateChannelInfo(paymentChannelInfo.ID);
+            }
           );
 
       triggerFileDownload(file);

--- a/packages/payment-proxy-client/src/file.ts
+++ b/packages/payment-proxy-client/src/file.ts
@@ -5,15 +5,18 @@ export async function fetchFile(
   url: string,
   paymentAmount: number,
   channelId: string,
-  nitroClient: NitroRpcClient
+  nitroClient: NitroRpcClient,
+  updateChannelCallback: () => void
 ): Promise<File> {
   console.time("Create Payment Vouncher");
   const voucher = await nitroClient.CreateVoucher(channelId, paymentAmount);
   console.timeEnd("Create Payment Vouncher");
+
   console.time("Fetch file");
   const req = createRequest(url, voucher);
-
-  const response = await fetch(req);
+  const fetchPromise = fetch(req);
+  updateChannelCallback();
+  const response = await fetchPromise;
   console.timeEnd("Fetch file");
   if (response.status != 200) {
     throw new Error(`${response.status.toString()} : ${await response.text()}`);


### PR DESCRIPTION
Especially when considering the comparison to micropayments, it will be nice if the effect of the payment is visible as soon as possible. 

Currently, we don't see the updated balance until the entire file is downloaded.

Here, I have updated the channel balance as soon as the request + voucher is launched. In principle, it could be even earlier but I think this is the most accurate thing to do. 