### PR TITLE
Register payment channels after virtual fund objective is complete

### DIFF
--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -560,6 +560,14 @@ func (e *Engine) executeSideEffects(sideEffects protocols.SideEffects) error {
 	for _, proposal := range sideEffects.ProposalsToProcess {
 		e.fromLedger <- proposal
 	}
+
+	if sideEffects.PaymentChannelToRegister != (payments.ChannelRegistrationData{}) {
+		err := e.vm.Register(sideEffects.PaymentChannelToRegister)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -598,6 +606,7 @@ func (e *Engine) attemptProgress(objective protocols.Objective) (outgoing Engine
 	// TODO: If attemptProgress is called on a completed objective CompletedObjectives would include that objective id
 	// Probably should have a better check that only adds it to CompletedObjectives if it was completed in this crank
 	if waitingFor == "WaitingForNothing" {
+		// err = e.executeSideEffects(sideEffects)
 		outgoing.CompletedObjectives = append(outgoing.CompletedObjectives, crankedObjective)
 		err = e.store.ReleaseChannelFromOwnership(crankedObjective.OwnsChannel())
 		if err != nil {

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -666,15 +666,6 @@ func (e *Engine) generateNotifications(o protocols.Objective) (EngineEvent, erro
 	return outgoing, nil
 }
 
-func (e Engine) registerPaymentChannel(vfo virtualfund.Objective) error {
-	postfund := vfo.V.PostFundState()
-	startingBalance := big.NewInt(0)
-	// TODO: Assumes one asset for now
-	startingBalance.Set(postfund.Outcome[0].Allocations[0].Amount)
-
-	return e.vm.Register(vfo.V.Id, payments.GetPayer(postfund.Participants), payments.GetPayee(postfund.Participants), startingBalance)
-}
-
 // spawnConsensusChannelIfDirectFundObjective will attempt to create and store a ConsensusChannel derived from the supplied Objective if it is a directfund.Objective.
 // The associated Channel will remain in the store.
 func (e Engine) spawnConsensusChannelIfDirectFundObjective(crankedObjective protocols.Objective) error {

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -451,14 +451,6 @@ func (e *Engine) handleObjectiveRequest(or protocols.ObjectiveRequest) (EngineEv
 		if err != nil {
 			return failedEngineEvent, fmt.Errorf("handleAPIEvent: Could not create virtualfund objective for %+v: %w", request, err)
 		}
-		// Only Alice or Bob care about registering the objective and keeping track of vouchers
-		lastParticipant := uint(len(vfo.V.Participants) - 1)
-		if vfo.MyRole == lastParticipant || vfo.MyRole == payments.PAYER_INDEX {
-			err = e.registerPaymentChannel(vfo)
-			if err != nil {
-				return failedEngineEvent, fmt.Errorf("could not register channel with payment/receipt manager: %w", err)
-			}
-		}
 
 		if err != nil {
 			return failedEngineEvent, fmt.Errorf("could not register channel with payment/receipt manager: %w", err)
@@ -727,10 +719,6 @@ func (e *Engine) constructObjectiveFromMessage(id protocols.ObjectiveId, p proto
 		vfo, err := virtualfund.ConstructObjectiveFromPayload(p, false, *e.store.GetAddress(), e.store.GetConsensusChannel)
 		if err != nil {
 			return &virtualfund.Objective{}, fromMsgErr(id, err)
-		}
-		err = e.registerPaymentChannel(vfo)
-		if err != nil {
-			return &virtualfund.Objective{}, fmt.Errorf("could not register channel with payment/receipt manager.\n\ttarget channel: %s\n\terr: %w", id, err)
 		}
 		return &vfo, nil
 	case virtualdefund.IsVirtualDefundObjective(id):

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -297,6 +297,16 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 		<-client.ObjectiveCompleteChan(vabClosure)
 	}
 
+	// assert that the payment is reflected in the ledger channels
+	la, _ := aliceClient.GetLedgerChannel(aliceLedger.ChannelId)
+	if la.Balance.MyBalance.ToInt().Cmp(big.NewInt(99)) != 0 {
+		t.Errorf("expected alice's ledger channel balance to be 99, got %s", la.Balance.MyBalance.ToInt().String())
+	}
+	lb, _ := bobClient.GetLedgerChannel(bobLedger.ChannelId)
+	if lb.Balance.MyBalance.ToInt().Cmp(big.NewInt(101)) != 0 {
+		t.Errorf("expected bob's ledger channel balance to be 101, got %s", lb.Balance.MyBalance.ToInt().String())
+	}
+
 	laiClosure, _ := aliceClient.CloseLedgerChannel(aliceLedger.ChannelId)
 	<-aliceClient.ObjectiveCompleteChan(laiClosure)
 

--- a/payments/payments_test.go
+++ b/payments/payments_test.go
@@ -89,7 +89,12 @@ func TestPaymentManager(t *testing.T) {
 	_, err := paymentMgr.Pay(channelId, payment, testactors.Alice.PrivateKey)
 	Assert(t, err != nil, "channel must be registered to make payments")
 
-	Ok(t, paymentMgr.Register(channelId, testactors.Alice.Address(), testactors.Bob.Address(), deposit))
+	Ok(t, paymentMgr.Register(ChannelRegistrationData{
+		channelId,
+		testactors.Alice.Address(),
+		testactors.Bob.Address(),
+		deposit,
+	}))
 	Equals(t, startingBalance, getBalance(paymentMgr))
 
 	firstVoucher, err := paymentMgr.Pay(channelId, payment, testactors.Alice.PrivateKey)
@@ -107,7 +112,12 @@ func TestPaymentManager(t *testing.T) {
 	_, _, err = receiptMgr.Receive(firstVoucher)
 	Assert(t, err != nil, "channel must be registered to receive vouchers")
 
-	_ = receiptMgr.Register(channelId, testactors.Alice.Address(), testactors.Bob.Address(), deposit)
+	_ = receiptMgr.Register(ChannelRegistrationData{
+		channelId,
+		testactors.Alice.Address(),
+		testactors.Bob.Address(),
+		deposit,
+	})
 	Equals(t, startingBalance, getBalance(receiptMgr))
 
 	received, delta, err := receiptMgr.Receive(firstVoucher)
@@ -136,11 +146,21 @@ func TestPaymentManager(t *testing.T) {
 	Equals(t, twoPaymentsMade, getBalance(receiptMgr))
 
 	// re-registering a channel doesn't reset its balance
-	err = paymentMgr.Register(channelId, testactors.Alice.Address(), testactors.Bob.Address(), deposit)
+	err = paymentMgr.Register(ChannelRegistrationData{
+		channelId,
+		testactors.Alice.Address(),
+		testactors.Bob.Address(),
+		deposit,
+	})
 	Assert(t, err != nil, "expected register to fail")
 	Equals(t, twoPaymentsMade, getBalance(paymentMgr))
 
-	err = receiptMgr.Register(channelId, testactors.Alice.Address(), testactors.Bob.Address(), deposit)
+	err = receiptMgr.Register(ChannelRegistrationData{
+		channelId,
+		testactors.Alice.Address(),
+		testactors.Bob.Address(),
+		deposit,
+	})
 	Assert(t, err != nil, "expected register to fail")
 	Equals(t, twoPaymentsMade, getBalance(receiptMgr))
 
@@ -152,7 +172,12 @@ func TestPaymentManager(t *testing.T) {
 	Equals(t, twoPaymentsMade, getBalance(receiptMgr))
 
 	// Only the payer can sign vouchers
-	err = receiptMgr.Register(anotherChannelId, testactors.Bob.Address(), testactors.Alice.Address(), deposit)
+	err = receiptMgr.Register(ChannelRegistrationData{
+		anotherChannelId,
+		testactors.Bob.Address(),
+		testactors.Alice.Address(),
+		deposit,
+	})
 	Ok(t, err)
 	_, err = paymentMgr.Pay(anotherChannelId, triplePayment, testactors.Bob.PrivateKey)
 	Assert(t, err != nil, "only payer can sign vouchers")

--- a/payments/voucher_manager.go
+++ b/payments/voucher_manager.go
@@ -38,7 +38,7 @@ func NewVoucherManager(me types.Address, store VoucherStore) *VoucherManager {
 // Register registers a channel for use, given the payer, payee and starting balance of the channel
 func (vm *VoucherManager) Register(regData ChannelRegistrationData) error {
 	voucher := Voucher{ChannelId: regData.ChannelId, Amount: big.NewInt(0)}
-	data := VoucherInfo{regData.Payer, regData.Payee, big.NewInt(0).Set(regData.StartingBalance), voucher}
+	data := VoucherInfo{regData.Payer, regData.Payee, regData.StartingBalance, voucher}
 
 	if v, _ := vm.store.GetVoucherInfo(regData.ChannelId); v != nil {
 		return fmt.Errorf("channel already registered")

--- a/payments/voucher_manager.go
+++ b/payments/voucher_manager.go
@@ -16,6 +16,13 @@ type VoucherStore interface {
 	RemoveVoucherInfo(channelId types.Destination) error
 }
 
+type ChannelRegistrationData struct {
+	ChannelId       types.Destination
+	Payer           common.Address
+	Payee           common.Address
+	StartingBalance *big.Int
+}
+
 // VoucherInfo stores the status of payments for a given payment channel.
 // VoucherManager receives and generates vouchers. It is responsible for storing vouchers.
 type VoucherManager struct {
@@ -29,14 +36,14 @@ func NewVoucherManager(me types.Address, store VoucherStore) *VoucherManager {
 }
 
 // Register registers a channel for use, given the payer, payee and starting balance of the channel
-func (vm *VoucherManager) Register(channelId types.Destination, payer common.Address, payee common.Address, startingBalance *big.Int) error {
-	voucher := Voucher{ChannelId: channelId, Amount: big.NewInt(0)}
-	data := VoucherInfo{payer, payee, big.NewInt(0).Set(startingBalance), voucher}
+func (vm *VoucherManager) Register(regData ChannelRegistrationData) error {
+	voucher := Voucher{ChannelId: regData.ChannelId, Amount: big.NewInt(0)}
+	data := VoucherInfo{regData.Payer, regData.Payee, big.NewInt(0).Set(regData.StartingBalance), voucher}
 
-	if v, _ := vm.store.GetVoucherInfo(channelId); v != nil {
+	if v, _ := vm.store.GetVoucherInfo(regData.ChannelId); v != nil {
 		return fmt.Errorf("channel already registered")
 	}
-	return vm.store.SetVoucherInfo(channelId, data)
+	return vm.store.SetVoucherInfo(regData.ChannelId, data)
 }
 
 // Remove deletes the channel's status

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -8,6 +8,7 @@ import (
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/crypto"
+	"github.com/statechannels/go-nitro/payments"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -68,9 +69,10 @@ func NewChallengeTransaction(
 
 // SideEffects are effects to be executed by an imperative shell
 type SideEffects struct {
-	MessagesToSend       []Message
-	TransactionsToSubmit []ChainTransaction
-	ProposalsToProcess   []consensus_channel.Proposal
+	MessagesToSend           []Message
+	TransactionsToSubmit     []ChainTransaction
+	ProposalsToProcess       []consensus_channel.Proposal
+	PaymentChannelToRegister payments.ChannelRegistrationData
 }
 
 // WaitingFor is an enumerable "pause-point" computed from an Objective. It describes how the objective is blocked on actions by third parties (i.e. co-participants or the blockchain).

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -13,6 +13,7 @@ import (
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/channel/state/outcome"
+	"github.com/statechannels/go-nitro/payments"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -470,6 +471,13 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 
 	// Completion
 	updated.Status = protocols.Completed
+	sideEffects.PaymentChannelToRegister = payments.ChannelRegistrationData{
+		ChannelId:       updated.V.Id,
+		Payer:           updated.V.Participants[0],
+		Payee:           updated.V.Participants[len(updated.V.Participants)-1],
+		StartingBalance: updated.V.PostFundState().Outcome[0].Allocations[0].Amount,
+	}
+
 	return &updated, sideEffects, WaitingForNothing, nil
 }
 

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -471,11 +471,14 @@ func (o *Objective) Crank(secretKey *[]byte) (protocols.Objective, protocols.Sid
 
 	// Completion
 	updated.Status = protocols.Completed
-	sideEffects.PaymentChannelToRegister = payments.ChannelRegistrationData{
-		ChannelId:       updated.V.Id,
-		Payer:           updated.V.Participants[0],
-		Payee:           updated.V.Participants[len(updated.V.Participants)-1],
-		StartingBalance: updated.V.PostFundState().Outcome[0].Allocations[0].Amount,
+
+	if updated.isAlice() || updated.isBob() {
+		sideEffects.PaymentChannelToRegister = payments.ChannelRegistrationData{
+			ChannelId:       updated.V.Id,
+			Payer:           updated.V.Participants[0],
+			Payee:           updated.V.Participants[len(updated.V.Participants)-1],
+			StartingBalance: updated.V.PostFundState().Outcome[0].Allocations[0].Amount,
+		}
 	}
 
 	return &updated, sideEffects, WaitingForNothing, nil


### PR DESCRIPTION
Previously, the engine, via the voucher manager, was happy to create (oops) and receive (oh no!) vouchers for channels whose status was still in `Proposed`.

This PR moves channel registration with the voucher manager to be triggered only by the completion of a virtual fund objective. Premature attempts to create or receive a voucher will now [error out](https://github.com/statechannels/go-nitro/blob/7b7dd64a92c4a87e52b145665084b6966cd6a9ee/payments/voucher_manager.go#L56) of the voucher manager.

Closes #1721 

Related: #1750. This PR adds still more coupling between VFO and payment channel app, but gives a decent escape hatch - replacing `SideEffects.PaymentChannelToRegister` with a more generic `SideEffects.AppChannelEffects` field.