### PR TITLE
use hardcoded filenames for downloaded file name

### DIFF
--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -104,14 +104,14 @@ export default function App() {
     setPaymentChannelInfo(paymentChannel);
   };
 
-  const triggerFileDownload = (file: File) => {
+  const triggerFileDownload = (file: File, fileName?: string) => {
     // This will prompt the browser to download the file
     const blob = new Blob([file], { type: file.type });
 
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
-    link.download = file.name;
+    link.download = fileName || file.name;
     link.click();
     URL.revokeObjectURL(url);
   };
@@ -160,7 +160,7 @@ export default function App() {
         nitroClient
       );
 
-      triggerFileDownload(file);
+      triggerFileDownload(file, selectedFile.fileName);
 
       // TODO: Slightly hacky but we wait a beat before querying so we see the updated balance
       setTimeout(() => {


### PR DESCRIPTION
This PR updates the downloaded files to use the file names we define in `VITE_FILE_NAMES` when saving the file, instead of the original file name.

This means the file `robot.png` will get saved as `robot.png`, not some long filename.