### PR TITLE
use open instead of clicking the link

### DIFF
--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -112,7 +112,7 @@ export default function App() {
     const blob = new Blob([file], { type: file.type });
 
     const url = URL.createObjectURL(blob);
-    open(url, "_blank");
+    window.open(url, "_blank");
     URL.revokeObjectURL(url);
   };
 

--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -107,15 +107,12 @@ export default function App() {
     setPaymentChannelInfo(paymentChannel);
   };
 
-  const triggerFileDownload = (file: File, fileName?: string) => {
+  const triggerFileDownload = (file: File) => {
     // This will prompt the browser to download the file
     const blob = new Blob([file], { type: file.type });
 
     const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = fileName || file.name;
-    link.click();
+    open(url);
     URL.revokeObjectURL(url);
   };
 
@@ -178,7 +175,7 @@ export default function App() {
             }
           );
 
-      triggerFileDownload(file, selectedFile.fileName);
+      triggerFileDownload(file);
 
       // TODO: Slightly hacky but we wait a beat before querying so we see the updated balance
       setTimeout(() => {

--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -112,7 +112,7 @@ export default function App() {
     const blob = new Blob([file], { type: file.type });
 
     const url = URL.createObjectURL(blob);
-    open(url);
+    open(url, "_blank");
     URL.revokeObjectURL(url);
   };
 

--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -113,7 +113,6 @@ export default function App() {
 
     const url = URL.createObjectURL(blob);
     window.open(url, "_blank");
-    URL.revokeObjectURL(url);
   };
 
   const createPaymentChannel = async () => {


### PR DESCRIPTION
This calls `open` on the url instead of trying to simulate clicking a link.