### PR TITLE
use the download button as the progress bar

### DIFF
--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -225,7 +225,7 @@ export default function App() {
     };
 
     const handlePayButton = async () => {
-      fetchAndDownloadFile(); //.finally(() => setDownloadProgress(0));
+      fetchAndDownloadFile();
     };
 
     const computePercentagePaid = (info: PaymentChannelInfo) => {

--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -425,7 +425,6 @@ export default function App() {
                         variant="contained"
                         onClick={handlePayButton}
                         disabled={downloadProgress > 0}
-                        fillPercentage={downloadProgress}
                         style={
                           {
                             "--fill-percentage": `${downloadProgress}%`,

--- a/packages/payment-proxy-client/src/ProgressButton.tsx
+++ b/packages/payment-proxy-client/src/ProgressButton.tsx
@@ -2,12 +2,8 @@ import React from "react";
 import { Button, ButtonProps } from "@mui/material";
 import { styled } from "@mui/system";
 
-interface CustomButtonProps extends ButtonProps {
-  fillPercentage: number;
-}
-
 const CustomButton = styled(Button)({
   background: `linear-gradient(90deg, transparent 0%, transparent var(--fill-percentage), var(--primary-color) var(--fill-percentage), var(--primary-color) 100%)`,
-}) as React.FC<CustomButtonProps>;
+}) as React.FC<ButtonProps>;
 
 export default CustomButton;

--- a/packages/payment-proxy-client/src/ProgressButton.tsx
+++ b/packages/payment-proxy-client/src/ProgressButton.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { Button, ButtonProps } from "@mui/material";
+import { styled } from "@mui/system";
+
+interface CustomButtonProps extends ButtonProps {
+  fillPercentage: number;
+}
+
+const CustomButton = styled(Button)({
+  background: `linear-gradient(90deg, transparent 0%, transparent var(--fill-percentage), var(--primary-color) var(--fill-percentage), var(--primary-color) 100%)`,
+}) as React.FC<CustomButtonProps>;
+
+export default CustomButton;


### PR DESCRIPTION
Just a cute suggestion for how to display micropayment progress without drawing a new visual element onto the page: 
![Screen Recording 2023-09-20 at 22 42 07](https://github.com/statechannels/go-nitro/assets/1833419/5a6ea320-0f58-4b44-924c-a742cbeebd67)
