### PR TITLE
Improve message to lookup logging

### DIFF
--- a/node/engine/messageservice/p2p-message-service/service.go
+++ b/node/engine/messageservice/p2p-message-service/service.go
@@ -290,7 +290,7 @@ func (ms *P2PMessageService) Send(msg protocols.Message) error {
 		ms.logger.Warn("did not find scAddr in local peers map, fetching from DHT", "scAddr", msg.To.String())
 		peerId, err = ms.getPeerIdFromDht(msg.To.String())
 		if err != nil {
-			ms.logger.Error("did not find scAdr in DHT", "scAddr", msg.To.String())
+			ms.logger.Error("did not find scAddr in DHT", "scAddr", msg.To.String())
 			return err
 		}
 	} else {

--- a/node/engine/messageservice/p2p-message-service/service.go
+++ b/node/engine/messageservice/p2p-message-service/service.go
@@ -287,8 +287,10 @@ func (ms *P2PMessageService) Send(msg protocols.Message) error {
 	// query the dht to retrieve the peerId, then store in local map for next time
 	peerId, ok := ms.peers.Load(msg.To.String())
 	if !ok {
+		ms.logger.Warn("did not find scAddr in local peers map, fetching from DHT", "scAddr", msg.To.String())
 		peerId, err = ms.getPeerIdFromDht(msg.To.String())
 		if err != nil {
+			ms.logger.Error("did not find scAdr in DHT", "scAddr", msg.To.String())
 			return err
 		}
 	} else {


### PR DESCRIPTION
Fixes #1791 

This updates our message service to log a message when we can't find a given peer in the peer map or DHT.

