### PR TITLE
Add ws resubscribe retries to chain service

### DIFF
--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -76,6 +76,7 @@ type EthChainService struct {
 	wg                       *sync.WaitGroup
 	eventTracker             *eventTracker
 	eventSub                 ethereum.Subscription
+	newBlockSub              ethereum.Subscription
 }
 
 // MAX_QUERY_BLOCK_RANGE is the maximum range of blocks we query for events at once.
@@ -136,8 +137,8 @@ func newEthChainService(chain ethChain, startBlock uint64, na *NitroAdjudicator.
 	tracker := NewEventTracker(startBlock)
 
 	// Use a buffered channel so we don't have to worry about blocking on writing to the channel.
-	ecs := EthChainService{chain, na, naAddress, caAddress, vpaAddress, txSigner, make(chan Event, 10), logger, ctx, cancelCtx, &sync.WaitGroup{}, tracker, nil}
-	errChan, newBlockSub, newBlockChan, eventSub, eventChan, eventQuery, err := ecs.subscribeForLogs()
+	ecs := EthChainService{chain, na, naAddress, caAddress, vpaAddress, txSigner, make(chan Event, 10), logger, ctx, cancelCtx, &sync.WaitGroup{}, tracker, nil, nil}
+	errChan, newBlockChan, eventChan, eventQuery, err := ecs.subscribeForLogs()
 	if err != nil {
 		return nil, err
 	}
@@ -147,8 +148,8 @@ func newEthChainService(chain ethChain, startBlock uint64, na *NitroAdjudicator.
 	defer ecs.eventTracker.mu.Unlock()
 
 	ecs.wg.Add(3)
-	go ecs.listenForEventLogs(errChan, eventSub, eventChan, eventQuery)
-	go ecs.listenForNewBlocks(errChan, newBlockSub, newBlockChan)
+	go ecs.listenForEventLogs(errChan, eventChan, eventQuery)
+	go ecs.listenForNewBlocks(errChan, newBlockChan)
 	go ecs.listenForErrors(errChan)
 
 	// Search for any missed events emitted while this node was offline
@@ -362,34 +363,37 @@ func (ecs *EthChainService) dispatchChainEvents(logs []ethTypes.Log) error {
 	return nil
 }
 
-func (ecs *EthChainService) listenForEventLogs(errorChan chan<- error, eventSub ethereum.Subscription, eventChan chan ethTypes.Log, eventQuery ethereum.FilterQuery) {
+func (ecs *EthChainService) listenForEventLogs(errorChan chan<- error, eventChan chan ethTypes.Log, eventQuery ethereum.FilterQuery) {
 	for {
 		select {
 		case <-ecs.ctx.Done():
-			eventSub.Unsubscribe()
+			ecs.eventSub.Unsubscribe()
 			ecs.wg.Done()
 			return
 
-		case err := <-eventSub.Err():
+		case err := <-ecs.eventSub.Err():
 			ecs.eventTracker.mu.Lock()
+			defer ecs.eventTracker.mu.Unlock()
+
 			latestBlockNum := ecs.eventTracker.latestBlockNum
 
 			if err != nil {
 				ecs.logger.Warn("error in chain event subscription: " + err.Error())
-				eventSub.Unsubscribe()
+				ecs.eventSub.Unsubscribe()
 			} else {
 				ecs.logger.Warn("chain event subscription closed")
 			}
 
 			// Use exponential backoff loop to attempt to re-establish subscription
 			for backoffTime := MIN_BACKOFF_TIME; backoffTime < MAX_BACKOFF_TIME; backoffTime *= 2 {
-				eventSub, err = ecs.chain.SubscribeFilterLogs(ecs.ctx, eventQuery, eventChan)
+				eventSub, err := ecs.chain.SubscribeFilterLogs(ecs.ctx, eventQuery, eventChan)
 				if err != nil {
 					ecs.logger.Warn("failed to resubscribe to chain events, retrying", "backoffTime", backoffTime)
 					time.Sleep(backoffTime)
 					continue
 				}
 
+				ecs.eventSub = eventSub
 				ecs.logger.Debug("resubscribed to chain events")
 				err = ecs.checkForMissedEvents(latestBlockNum)
 				if err != nil {
@@ -397,7 +401,6 @@ func (ecs *EthChainService) listenForEventLogs(errorChan chan<- error, eventSub 
 					return
 				}
 
-				ecs.eventTracker.mu.Unlock()
 				break
 			}
 
@@ -408,7 +411,7 @@ func (ecs *EthChainService) listenForEventLogs(errorChan chan<- error, eventSub 
 		case <-time.After(RESUB_INTERVAL):
 			// Due to https://github.com/ethereum/go-ethereum/issues/23845 we can't rely on a long running subscription.
 			// We unsub here and recreate the subscription in the next iteration of the select.
-			eventSub.Unsubscribe()
+			ecs.eventSub.Unsubscribe()
 
 		case chainEvent := <-eventChan:
 			ecs.logger.Debug("queueing new chainEvent", "block-num", chainEvent.BlockNumber)
@@ -417,31 +420,32 @@ func (ecs *EthChainService) listenForEventLogs(errorChan chan<- error, eventSub 
 	}
 }
 
-func (ecs *EthChainService) listenForNewBlocks(errorChan chan<- error, newBlockSub ethereum.Subscription, newBlockChan chan *ethTypes.Header) {
+func (ecs *EthChainService) listenForNewBlocks(errorChan chan<- error, newBlockChan chan *ethTypes.Header) {
 	for {
 		select {
 		case <-ecs.ctx.Done():
-			newBlockSub.Unsubscribe()
+			ecs.newBlockSub.Unsubscribe()
 			ecs.wg.Done()
 			return
 
-		case err := <-newBlockSub.Err():
+		case err := <-ecs.newBlockSub.Err():
 			if err != nil {
 				ecs.logger.Warn("error in chain new block subscription: " + err.Error())
-				newBlockSub.Unsubscribe()
+				ecs.newBlockSub.Unsubscribe()
 			} else {
 				ecs.logger.Warn("chain new block subscription closed")
 			}
 
 			// Use exponential backoff loop to attempt to re-establish subscription
 			for backoffTime := MIN_BACKOFF_TIME; backoffTime < MAX_BACKOFF_TIME; backoffTime *= 2 {
-				newBlockSub, err = ecs.chain.SubscribeNewHead(ecs.ctx, newBlockChan)
+				newBlockSub, err := ecs.chain.SubscribeNewHead(ecs.ctx, newBlockChan)
 				if err != nil {
 					errorChan <- fmt.Errorf("subscribeNewHead failed to resubscribe: %w", err)
 					time.Sleep(backoffTime)
 					continue
 				}
 
+				ecs.newBlockSub = newBlockSub
 				ecs.logger.Debug("resubscribed to chain new blocks")
 				break
 			}
@@ -490,7 +494,7 @@ func (ecs *EthChainService) updateEventTracker(errorChan chan<- error, blockNumb
 
 // subscribeForLogs subscribes for logs and pushes them to the out channel.
 // It relies on notifications being supported by the chain node.
-func (ecs *EthChainService) subscribeForLogs() (chan error, ethereum.Subscription, chan *ethTypes.Header, ethereum.Subscription, chan ethTypes.Log, ethereum.FilterQuery, error) {
+func (ecs *EthChainService) subscribeForLogs() (chan error, chan *ethTypes.Header, chan ethTypes.Log, ethereum.FilterQuery, error) {
 	// Subscribe to Adjudicator events
 	eventQuery := ethereum.FilterQuery{
 		Addresses: []common.Address{ecs.naAddress},
@@ -499,17 +503,19 @@ func (ecs *EthChainService) subscribeForLogs() (chan error, ethereum.Subscriptio
 	eventChan := make(chan ethTypes.Log)
 	eventSub, err := ecs.chain.SubscribeFilterLogs(ecs.ctx, eventQuery, eventChan)
 	if err != nil {
-		return nil, nil, nil, nil, nil, ethereum.FilterQuery{}, fmt.Errorf("subscribeFilterLogs failed: %w", err)
+		return nil, nil, nil, ethereum.FilterQuery{}, fmt.Errorf("subscribeFilterLogs failed: %w", err)
 	}
+	ecs.eventSub = eventSub
 	errorChan := make(chan error)
 
 	newBlockChan := make(chan *ethTypes.Header)
 	newBlockSub, err := ecs.chain.SubscribeNewHead(ecs.ctx, newBlockChan)
 	if err != nil {
-		return nil, nil, nil, nil, nil, ethereum.FilterQuery{}, fmt.Errorf("subscribeNewHead failed: %w", err)
+		return nil, nil, nil, ethereum.FilterQuery{}, fmt.Errorf("subscribeNewHead failed: %w", err)
 	}
+	ecs.newBlockSub = newBlockSub
 
-	return errorChan, newBlockSub, newBlockChan, eventSub, eventChan, eventQuery, nil
+	return errorChan, newBlockChan, eventChan, eventQuery, nil
 }
 
 // EventFeed returns the out chan, and narrows the type so that external consumers may only receive on it.


### PR DESCRIPTION
Makes the `chainservice` more robust by adding a resubscribe retry loop whenever a websocket connection (either to chain events or new blocks) fails. Previously, the `chainservice` just had a single retry then cause a `panic`