### PR TITLE
Wire up "payment channel updated" events stream to demo

### DIFF
--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -136,7 +136,7 @@ export default function App() {
       [hub],
       initialChannelBalance
     );
-    console.timeEnd("Create Payment Channel");
+    console.time("Create Payment Channel");
 
     // TODO: If the objective completes fast enough, we might start waiting after it's already done
     // await nitroClient.WaitForObjective(result.Id);

--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -142,11 +142,14 @@ export default function App() {
 
     setPaymentChannelId(result.ChannelId);
 
-    // nitroClient.PaymentChannelUpdated(result.ChannelId, setPaymentChannelInfo);
-    // const paymentChannel = await nitroClient?.GetPaymentChannel(
-    //   result.ChannelId
-    // );
-    // setPaymentChannelInfo(paymentChannel);
+    nitroClient.PaymentChannelUpdated(result.ChannelId, setPaymentChannelInfo);
+
+    // It's possible the channel updated before we registered the handler above, so
+    // query the channel once now to get the latest information:
+
+    setPaymentChannelInfo(
+      await nitroClient?.GetPaymentChannel(result.ChannelId)
+    );
 
     console.timeEnd("Create Payment Channel");
   };

--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -136,7 +136,6 @@ export default function App() {
       [hub],
       initialChannelBalance
     );
-    console.time("Create Payment Channel");
 
     // TODO: If the objective completes fast enough, we might start waiting after it's already done
     // await nitroClient.WaitForObjective(result.Id);

--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -116,14 +116,6 @@ export default function App() {
       .finally(() => console.timeEnd("Connect to Nitro Node"));
   }, [url]);
 
-  const updateChannelInfo = async (channelId: string) => {
-    if (channelId == "") {
-      throw new Error("Empty channel id provided");
-    }
-    const paymentChannel = await nitroClient?.GetPaymentChannel(channelId);
-    setPaymentChannelInfo(paymentChannel);
-  };
-
   const triggerFileDownload = (file: File) => {
     // This will prompt the browser to download the file
     const blob = new Blob([file], { type: file.type });
@@ -149,15 +141,15 @@ export default function App() {
     // await nitroClient.WaitForObjective(result.Id);
 
     setPaymentChannelId(result.ChannelId);
-    updateChannelInfo(result.ChannelId);
+
+    // nitroClient.PaymentChannelUpdated(result.ChannelId, setPaymentChannelInfo);
+    // const paymentChannel = await nitroClient?.GetPaymentChannel(
+    //   result.ChannelId
+    // );
+    // setPaymentChannelInfo(paymentChannel);
+
     console.timeEnd("Create Payment Channel");
-
-    // TODO: Slightly hacky but we wait a beat before querying so we see the updated balance
-    setTimeout(() => {
-      updateChannelInfo(result.ChannelId);
-    }, 1000);
   };
-
   const fetchAndDownloadFile = async () => {
     setErrorText("");
     setFetchInProgress(true);
@@ -182,7 +174,6 @@ export default function App() {
             nitroClient,
             (progress) => {
               setDownloadProgress(progress);
-              updateChannelInfo(paymentChannelInfo.ID);
             }
           )
         : await fetchFile(
@@ -190,17 +181,10 @@ export default function App() {
             skipPayment ? 0 : costPerByte * selectedFile.size,
             paymentChannelInfo.ID,
             nitroClient,
-            () => {
-              updateChannelInfo(paymentChannelInfo.ID);
-            }
+            () => {}
           );
       setDownloadProgress(100);
       triggerFileDownload(file);
-
-      // TODO: Slightly hacky but we wait a beat before querying so we see the updated balance
-      setTimeout(() => {
-        updateChannelInfo(paymentChannelInfo.ID);
-      }, 50);
     } catch (e: unknown) {
       console.error(e);
 

--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -136,6 +136,7 @@ export default function App() {
       [hub],
       initialChannelBalance
     );
+    console.timeEnd("Create Payment Channel");
 
     // TODO: If the objective completes fast enough, we might start waiting after it's already done
     // await nitroClient.WaitForObjective(result.Id);
@@ -183,8 +184,7 @@ export default function App() {
             selectedFile.url,
             skipPayment ? 0 : costPerByte * selectedFile.size,
             paymentChannelInfo.ID,
-            nitroClient,
-            () => {}
+            nitroClient
           );
       setDownloadProgress(100);
       triggerFileDownload(file);

--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -143,7 +143,10 @@ export default function App() {
 
     setPaymentChannelId(result.ChannelId);
 
-    nitroClient.PaymentChannelUpdated(result.ChannelId, setPaymentChannelInfo);
+    nitroClient.onPaymentChannelUpdated(
+      result.ChannelId,
+      setPaymentChannelInfo
+    );
 
     // It's possible the channel updated before we registered the handler above, so
     // query the channel once now to get the latest information:

--- a/packages/payment-proxy-client/src/file.ts
+++ b/packages/payment-proxy-client/src/file.ts
@@ -6,7 +6,7 @@ export async function fetchFile(
   paymentAmount: number,
   channelId: string,
   nitroClient: NitroRpcClient,
-  updateChannelCallback: () => void
+  updateChannelCallback?: () => void
 ): Promise<File> {
   console.time("Create Payment Vouncher");
   const voucher = await nitroClient.CreateVoucher(channelId, paymentAmount);
@@ -15,7 +15,7 @@ export async function fetchFile(
   console.time("Fetch file");
   const req = createRequest(url, voucher);
   const fetchPromise = fetch(req);
-  updateChannelCallback();
+  updateChannelCallback && updateChannelCallback();
   const response = await fetchPromise;
   console.timeEnd("Fetch file");
   if (response.status != 200) {


### PR DESCRIPTION
Updates the demo to hook the UI into events rather than using timeouts + polling. 

