### PR TITLE
Add payment channel updated stream to ts rpc client

### DIFF
--- a/packages/nitro-rpc-client/src/interface.ts
+++ b/packages/nitro-rpc-client/src/interface.ts
@@ -105,6 +105,15 @@ interface syncAPI {
    * @param objectiveId - The id objective to wait for
    */
   WaitForObjective(objectiveId: string): Promise<void>;
+  /**
+   * PaymentChannelUpdated attaches a callback which is triggered when the channel with supplied ID is updated.
+   *
+   * @param objectiveId - The id objective to wait for
+   */
+  PaymentChannelUpdated(
+    channelId: string,
+    callback: (info: PaymentChannelInfo) => void
+  ): Promise<void>;
 }
 
 export interface RpcClientApi

--- a/packages/nitro-rpc-client/src/interface.ts
+++ b/packages/nitro-rpc-client/src/interface.ts
@@ -107,13 +107,14 @@ interface syncAPI {
   WaitForObjective(objectiveId: string): Promise<void>;
   /**
    * PaymentChannelUpdated attaches a callback which is triggered when the channel with supplied ID is updated.
+   * Returns a cleanup function which can be used to remove the subscription.
    *
    * @param objectiveId - The id objective to wait for
    */
-  PaymentChannelUpdated(
+  onPaymentChannelUpdated(
     channelId: string,
     callback: (info: PaymentChannelInfo) => void
-  ): Promise<void>;
+  ): () => void;
 }
 
 export interface RpcClientApi

--- a/packages/nitro-rpc-client/src/interface.ts
+++ b/packages/nitro-rpc-client/src/interface.ts
@@ -8,32 +8,102 @@ import {
 } from "./types";
 
 interface ledgerChannelApi {
+  /**
+   * CreateLedgerChannel creates a directly funded ledger channel with the counterparty.
+   *
+   * @param counterParty - The counterparty to create the channel with
+   * @returns A promise that resolves to an objective response, containing the ID of the objective and the channel id.
+   */
   CreateLedgerChannel(
     counterParty: string,
     amount: number
   ): Promise<ObjectiveResponse>;
+  /**
+   * CloseLedgerChannel defunds a directly funded ledger channel.
+   *
+   * @param channelId - The ID of the channel to defund
+   * @returns The ID of the objective that was created
+   */
   CloseLedgerChannel(channelId: string): Promise<string>;
+  /**
+   * GetLedgerChannel queries the RPC server for a payment channel.
+   *
+   * @param channelId - The ID of the channel to query for
+   * @returns A `LedgerChannelInfo` object containing the channel's information
+   */
   GetLedgerChannel(channelId: string): Promise<LedgerChannelInfo>;
+  /**
+   * GetAllLedgerChannels queries the RPC server for all ledger channels.
+   * @returns A `LedgerChannelInfo` object containing the channel's information for each ledger channel
+   */
   GetAllLedgerChannels(): Promise<LedgerChannelInfo[]>;
 }
 interface paymentChannelApi {
+  /**
+   * CreatePaymentChannel creates a virtually funded payment channel with the counterparty, using the given intermediaries.
+   *
+   * @param counterParty - The counterparty to create the channel with
+   * @param intermediaries - The intermerdiaries to use
+   * @returns A promise that resolves to an objective response, containing the ID of the objective and the channel id.
+   */
   CreatePaymentChannel(
     counterParty: string,
     intermediaries: string[],
     amount: number
   ): Promise<ObjectiveResponse>;
+  /**
+   * ClosePaymentChannel defunds a virtually funded payment channel.
+   *
+   * @param channelId - The ID of the channel to defund
+   * @returns The ID of the objective that was created
+   */
   ClosePaymentChannel(channelId: string): Promise<string>;
+  /**
+   * GetPaymentChannel queries the RPC server for a payment channel.
+   *
+   * @param channelId - The ID of the channel to query for
+   * @returns A `PaymentChannelInfo` object containing the channel's information
+   */
   GetPaymentChannel(channelId: string): Promise<PaymentChannelInfo>;
+  /**
+   * GetPaymentChannelsByLedger queries the RPC server for any payment channels that are actively funded by the given ledger.
+   *
+   * @param ledgerId - The ID of the ledger to find payment channels for
+   * @returns A `PaymentChannelInfo` object containing the channel's information for each payment channel
+   */
   GetPaymentChannelsByLedger(ledgerId: string): Promise<PaymentChannelInfo[]>;
 }
 
 interface paymentApi {
+  /**
+   * Creates a payment voucher for the given channel and amount.
+   * The voucher does not get sent to the other party automatically.
+   * @param channelId The payment channel to use for the voucher
+   * @param amount The amount for the voucher
+   * @returns A signed voucher
+   */
   CreateVoucher(channelId: string, amount: number): Promise<Voucher>;
+  /**
+   * Adds a voucher to the go-nitro node that was received from the other party to the channel.
+   * @param voucher The voucher to add
+   * @returns The total amount of the channel and the delta of the voucher
+   */
   ReceiveVoucher(voucher: Voucher): Promise<ReceiveVoucherResult>;
+  /**
+   * Pay sends a payment on a virtual payment chanel.
+   *
+   * @param channelId - The ID of the payment channel to use
+   * @param amount - The amount to pay
+   */
   Pay(channelId: string, amount: number): Promise<PaymentPayload>;
 }
 
 interface syncAPI {
+  /**
+   * WaitForObjective blocks until the objective with the given ID to complete.
+   *
+   * @param objectiveId - The id objective to wait for
+   */
   WaitForObjective(objectiveId: string): Promise<void>;
 }
 
@@ -42,7 +112,20 @@ export interface RpcClientApi
     paymentChannelApi,
     paymentApi,
     syncAPI {
+  /**
+   * GetVersion queries the API server for it's version.
+   *
+   * @returns The version of the RPC server
+   */
   GetVersion(): Promise<string>;
+  /**
+   * GetAddress queries the RPC server for it's state channel address.
+   *
+   * @returns The address of the wallet connected to the RPC server
+   */
   GetAddress(): Promise<string>;
+  /**
+   * Close closes the RPC client and stops listening for notifications.
+   */
   Close(): Promise<void>;
 }

--- a/packages/nitro-rpc-client/src/interface.ts
+++ b/packages/nitro-rpc-client/src/interface.ts
@@ -1,0 +1,48 @@
+import {
+  LedgerChannelInfo,
+  ObjectiveResponse,
+  PaymentChannelInfo,
+  PaymentPayload,
+  ReceiveVoucherResult,
+  Voucher,
+} from "./types";
+
+interface ledgerChannelApi {
+  CreateLedgerChannel(
+    counterParty: string,
+    amount: number
+  ): Promise<ObjectiveResponse>;
+  CloseLedgerChannel(channelId: string): Promise<string>;
+  GetLedgerChannel(channelId: string): Promise<LedgerChannelInfo>;
+  GetAllLedgerChannels(): Promise<LedgerChannelInfo[]>;
+}
+interface paymentChannelApi {
+  CreatePaymentChannel(
+    counterParty: string,
+    intermediaries: string[],
+    amount: number
+  ): Promise<ObjectiveResponse>;
+  ClosePaymentChannel(channelId: string): Promise<string>;
+  GetPaymentChannel(channelId: string): Promise<PaymentChannelInfo>;
+  GetPaymentChannelsByLedger(ledgerId: string): Promise<PaymentChannelInfo[]>;
+}
+
+interface paymentApi {
+  CreateVoucher(channelId: string, amount: number): Promise<Voucher>;
+  ReceiveVoucher(voucher: Voucher): Promise<ReceiveVoucherResult>;
+  Pay(channelId: string, amount: number): Promise<PaymentPayload>;
+}
+
+interface syncAPI {
+  WaitForObjective(objectiveId: string): Promise<void>;
+}
+
+export interface RpcClientApi
+  extends ledgerChannelApi,
+    paymentChannelApi,
+    paymentApi,
+    syncAPI {
+  GetVersion(): Promise<string>;
+  GetAddress(): Promise<string>;
+  Close(): Promise<void>;
+}

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -70,6 +70,20 @@ export class NitroRpcClient implements RpcClientApi {
     });
   }
 
+  public async PaymentChannelUpdated(
+    channelId: string,
+    callback: (info: PaymentChannelInfo) => void
+  ): Promise<void> {
+    this.transport.Notifications.on(
+      "payment_channel_updated",
+      (info: PaymentChannelInfo) => {
+        if (info.ID == channelId) {
+          callback(info);
+        }
+      }
+    );
+  }
+
   public async CreateLedgerChannel(
     counterParty: string,
     amount: number

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -70,18 +70,19 @@ export class NitroRpcClient implements RpcClientApi {
     });
   }
 
-  public async PaymentChannelUpdated(
+  public onPaymentChannelUpdated(
     channelId: string,
     callback: (info: PaymentChannelInfo) => void
-  ): Promise<void> {
-    this.transport.Notifications.on(
-      "payment_channel_updated",
-      (info: PaymentChannelInfo) => {
-        if (info.ID.toLowerCase() == channelId.toLowerCase()) {
-          callback(info);
-        }
+  ): () => void {
+    const wrapperFn = (info: PaymentChannelInfo) => {
+      if (info.ID.toLowerCase() == channelId.toLowerCase()) {
+        callback(info);
       }
-    );
+    };
+    this.transport.Notifications.on("payment_channel_updated", wrapperFn);
+    return () => {
+      this.transport.Notifications.off("payment_channel_updated", wrapperFn);
+    };
   }
 
   public async CreateLedgerChannel(

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -30,13 +30,6 @@ export class NitroRpcClient implements RpcClientApi {
     return this.transport.Notifications;
   }
 
-  /**
-   * Creates a payment voucher for the given channel and amount.
-   * The voucher does not get sent to the other party automatically.
-   * @param channelId The payment channel to use for the voucher
-   * @param amount The amount for the voucher
-   * @returns A signed voucher
-   */
   public async CreateVoucher(
     channelId: string,
     amount: number
@@ -54,11 +47,6 @@ export class NitroRpcClient implements RpcClientApi {
     return getAndValidateResult(res, "create_voucher");
   }
 
-  /**
-   * Adds a voucher to the go-nitro node that was received from the other party to the channel.
-   * @param voucher The voucher to add
-   * @returns The total amount of the channel and the delta of the voucher
-   */
   public async ReceiveVoucher(voucher: Voucher): Promise<ReceiveVoucherResult> {
     const request = generateRequest(
       "receive_voucher",
@@ -69,11 +57,6 @@ export class NitroRpcClient implements RpcClientApi {
     return getAndValidateResult(res, "receive_voucher");
   }
 
-  /**
-   * WaitForObjective blocks until the objective with the given ID to complete.
-   *
-   * @param objectiveId - The id objective to wait for
-   */
   public async WaitForObjective(objectiveId: string): Promise<void> {
     return new Promise((resolve) => {
       this.transport.Notifications.on(
@@ -87,12 +70,6 @@ export class NitroRpcClient implements RpcClientApi {
     });
   }
 
-  /**
-   * CreateLedgerChannel creates a directly funded ledger channel with the counterparty.
-   *
-   * @param counterParty - The counterparty to create the channel with
-   * @returns A promise that resolves to an objective response, containing the ID of the objective and the channel id.
-   */
   public async CreateLedgerChannel(
     counterParty: string,
     amount: number
@@ -114,13 +91,6 @@ export class NitroRpcClient implements RpcClientApi {
     return this.sendRequest("create_ledger_channel", payload);
   }
 
-  /**
-   * CreatePaymentChannel creates a virtually funded payment channel with the counterparty, using the given intermediaries.
-   *
-   * @param counterParty - The counterparty to create the channel with
-   * @param intermediaries - The intermerdiaries to use
-   * @returns A promise that resolves to an objective response, containing the ID of the objective and the channel id.
-   */
   public async CreatePaymentChannel(
     counterParty: string,
     intermediaries: string[],
@@ -144,12 +114,6 @@ export class NitroRpcClient implements RpcClientApi {
     return this.sendRequest("create_payment_channel", payload);
   }
 
-  /**
-   * Pay sends a payment on a virtual payment chanel.
-   *
-   * @param channelId - The ID of the payment channel to use
-   * @param amount - The amount to pay
-   */
   public async Pay(channelId: string, amount: number): Promise<PaymentPayload> {
     const payload = {
       Amount: amount,
@@ -160,42 +124,20 @@ export class NitroRpcClient implements RpcClientApi {
     return getAndValidateResult(res, "pay");
   }
 
-  /**
-   * CloseLedgerChannel defunds a directly funded ledger channel.
-   *
-   * @param channelId - The ID of the channel to defund
-   * @returns The ID of the objective that was created
-   */
   public async CloseLedgerChannel(channelId: string): Promise<string> {
     const payload: DefundObjectiveRequest = { ChannelId: channelId };
     return this.sendRequest("close_ledger_channel", payload);
   }
-  /**
-   * ClosePaymentChannel defunds a virtually funded payment channel.
-   *
-   * @param channelId - The ID of the channel to defund
-   * @returns The ID of the objective that was created
-   */
 
   public async ClosePaymentChannel(channelId: string): Promise<string> {
     const payload: DefundObjectiveRequest = { ChannelId: channelId };
     return this.sendRequest("close_payment_channel", payload);
   }
 
-  /**
-   * GetVersion queries the API server for it's version.
-   *
-   * @returns The version of the RPC server
-   */
   public async GetVersion(): Promise<string> {
     return this.sendRequest("version", {});
   }
 
-  /**
-   * GetAddress queries the RPC server for it's state channel address.
-   *
-   * @returns The address of the wallet connected to the RPC server
-   */
   public async GetAddress(): Promise<string> {
     if (this.myAddress) {
       return this.myAddress;
@@ -205,41 +147,20 @@ export class NitroRpcClient implements RpcClientApi {
     return this.myAddress;
   }
 
-  /**
-   * GetLedgerChannel queries the RPC server for a payment channel.
-   *
-   * @param channelId - The ID of the channel to query for
-   * @returns A `LedgerChannelInfo` object containing the channel's information
-   */
   public async GetLedgerChannel(channelId: string): Promise<LedgerChannelInfo> {
     return this.sendRequest("get_ledger_channel", { Id: channelId });
   }
 
-  /**
-   * GetAllLedgerChannels queries the RPC server for all ledger channels.
-   * @returns A `LedgerChannelInfo` object containing the channel's information for each ledger channel
-   */
   public async GetAllLedgerChannels(): Promise<LedgerChannelInfo[]> {
     return this.sendRequest("get_all_ledger_channels", {});
   }
 
-  /**
-   * GetPaymentChannel queries the RPC server for a payment channel.
-   *
-   * @param channelId - The ID of the channel to query for
-   * @returns A `PaymentChannelInfo` object containing the channel's information
-   */
   public async GetPaymentChannel(
     channelId: string
   ): Promise<PaymentChannelInfo> {
     return this.sendRequest("get_payment_channel", { Id: channelId });
   }
-  /**
-   * GetPaymentChannelsByLedger queries the RPC server for any payment channels that are actively funded by the given ledger.
-   *
-   * @param ledgerId - The ID of the ledger to find payment channels for
-   * @returns A `PaymentChannelInfo` object containing the channel's information for each payment channel
-   */
+
   public async GetPaymentChannelsByLedger(
     ledgerId: string
   ): Promise<PaymentChannelInfo[]> {
@@ -261,9 +182,6 @@ export class NitroRpcClient implements RpcClientApi {
     return getAndValidateResult(res, method);
   }
 
-  /**
-   * Close closes the RPC client and stops listening for notifications.
-   */
   public async Close(): Promise<void> {
     return this.transport.Close();
   }

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -17,7 +17,31 @@ import { createOutcome, generateRequest } from "./utils";
 import { HttpTransport } from "./transport/http";
 import { getAndValidateResult } from "./serde";
 
-export class NitroRpcClient {
+interface RpcClientApi {
+  GetVersion(): Promise<string>;
+  GetAddress(): Promise<string>;
+  GetLedgerChannel(channelId: string): Promise<LedgerChannelInfo>;
+  GetAllLedgerChannels(): Promise<LedgerChannelInfo[]>;
+  CreateVoucher(channelId: string, amount: number): Promise<Voucher>;
+  ReceiveVoucher(voucher: Voucher): Promise<ReceiveVoucherResult>;
+  WaitForObjective(objectiveId: string): Promise<void>;
+  CreateLedgerChannel(
+    counterParty: string,
+    amount: number
+  ): Promise<ObjectiveResponse>;
+  CloseLedgerChannel(channelId: string): Promise<string>;
+  CreatePaymentChannel(
+    counterParty: string,
+    intermediaries: string[],
+    amount: number
+  ): Promise<ObjectiveResponse>;
+  ClosePaymentChannel(channelId: string): Promise<string>;
+  Pay(channelId: string, amount: number): Promise<PaymentPayload>;
+  GetPaymentChannel(channelId: string): Promise<PaymentChannelInfo>;
+  GetPaymentChannelsByLedger(ledgerId: string): Promise<PaymentChannelInfo[]>;
+  Close(): Promise<void>;
+}
+export class NitroRpcClient implements RpcClientApi {
   private transport: Transport;
 
   // We fetch the address from the RPC server on first use

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -77,7 +77,7 @@ export class NitroRpcClient implements RpcClientApi {
     this.transport.Notifications.on(
       "payment_channel_updated",
       (info: PaymentChannelInfo) => {
-        if (info.ID == channelId) {
+        if (info.ID.toLowerCase() == channelId.toLowerCase()) {
           callback(info);
         }
       }

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -16,31 +16,8 @@ import { Transport } from "./transport";
 import { createOutcome, generateRequest } from "./utils";
 import { HttpTransport } from "./transport/http";
 import { getAndValidateResult } from "./serde";
+import { RpcClientApi } from "./interface";
 
-interface RpcClientApi {
-  GetVersion(): Promise<string>;
-  GetAddress(): Promise<string>;
-  GetLedgerChannel(channelId: string): Promise<LedgerChannelInfo>;
-  GetAllLedgerChannels(): Promise<LedgerChannelInfo[]>;
-  CreateVoucher(channelId: string, amount: number): Promise<Voucher>;
-  ReceiveVoucher(voucher: Voucher): Promise<ReceiveVoucherResult>;
-  WaitForObjective(objectiveId: string): Promise<void>;
-  CreateLedgerChannel(
-    counterParty: string,
-    amount: number
-  ): Promise<ObjectiveResponse>;
-  CloseLedgerChannel(channelId: string): Promise<string>;
-  CreatePaymentChannel(
-    counterParty: string,
-    intermediaries: string[],
-    amount: number
-  ): Promise<ObjectiveResponse>;
-  ClosePaymentChannel(channelId: string): Promise<string>;
-  Pay(channelId: string, amount: number): Promise<PaymentPayload>;
-  GetPaymentChannel(channelId: string): Promise<PaymentChannelInfo>;
-  GetPaymentChannelsByLedger(ledgerId: string): Promise<PaymentChannelInfo[]>;
-  Close(): Promise<void>;
-}
 export class NitroRpcClient implements RpcClientApi {
   private transport: Transport;
 

--- a/packages/nitro-rpc-client/src/serde.ts
+++ b/packages/nitro-rpc-client/src/serde.ts
@@ -4,6 +4,7 @@ import {
   ChannelStatus,
   LedgerChannelInfo,
   PaymentChannelInfo,
+  RPCNotification,
   RPCRequestAndResponses,
   RequestMethod,
 } from "./types";
@@ -228,6 +229,25 @@ export function getAndValidateResult<T extends RequestMethod>(
   }
 }
 
+export function getAndValidateNotification<T extends RPCNotification["method"]>(
+  data: unknown,
+  method: T
+): RPCNotification["params"]["payload"] {
+  switch (method) {
+    case "payment_channel_updated":
+      return convertToInternalPaymentChannelType(
+        data as PaymentChannelSchemaType
+      );
+    case "ledger_channel_updated":
+      return convertToInternalPaymentChannelType(
+        data as PaymentChannelSchemaType
+      );
+    case "objective_completed":
+      return data as string;
+    default:
+      throw new Error(`Unknown method: ${method}`);
+  }
+}
 /**
  * Validates that the response is a valid JSON RPC response and pulls out the result
  * @param response - JSON RPC response
@@ -303,8 +323,8 @@ function convertToInternalPaymentChannelType(
     Status: result.Status as ChannelStatus,
     Balance: {
       ...result.Balance,
-      PaidSoFar: BigInt(result.Balance.PaidSoFar),
-      RemainingFunds: BigInt(result.Balance.RemainingFunds),
+      PaidSoFar: BigInt(result.Balance.PaidSoFar ?? 0),
+      RemainingFunds: BigInt(result.Balance.RemainingFunds ?? 0),
     },
   };
 }

--- a/packages/nitro-rpc-client/src/transport/http.ts
+++ b/packages/nitro-rpc-client/src/transport/http.ts
@@ -8,9 +8,9 @@ import {
   RequestMethod,
   RPCRequestAndResponses,
 } from "../types";
+import { getAndValidateNotification } from "../serde";
 
 import { Transport } from ".";
-import { getAndValidateNotification, getAndValidateResult } from "../serde";
 
 export class HttpTransport {
   Notifications: EventEmitter<NotificationMethod, NotificationParams>;

--- a/packages/nitro-rpc-client/src/transport/http.ts
+++ b/packages/nitro-rpc-client/src/transport/http.ts
@@ -20,7 +20,7 @@ export class HttpTransport {
 
     // throw any websocket errors so we don't fail silently
     ws.onerror = (e) => {
-      console.error("Error with websocket connection to server");
+      console.error("Error with websocket connection to server: " + e);
       throw e;
     };
 
@@ -56,7 +56,7 @@ export class HttpTransport {
     this.Notifications = new EventEmitter();
     this.ws.onmessage = (event) => {
       const data = JSON.parse(event.data.toString());
-      this.Notifications.emit(data.method, data.params);
+      this.Notifications.emit(data.method, data.params.payload);
     };
   }
 }

--- a/packages/nitro-rpc-client/src/transport/http.ts
+++ b/packages/nitro-rpc-client/src/transport/http.ts
@@ -10,6 +10,7 @@ import {
 } from "../types";
 
 import { Transport } from ".";
+import { getAndValidateNotification, getAndValidateResult } from "../serde";
 
 export class HttpTransport {
   Notifications: EventEmitter<NotificationMethod, NotificationParams>;
@@ -56,7 +57,12 @@ export class HttpTransport {
     this.Notifications = new EventEmitter();
     this.ws.onmessage = (event) => {
       const data = JSON.parse(event.data.toString());
-      this.Notifications.emit(data.method, data.params.payload);
+      const validatedResult = getAndValidateNotification(
+        data.params.payload,
+        data.method
+      );
+
+      this.Notifications.emit(data.method, validatedResult);
     };
   }
 }


### PR DESCRIPTION
Closes #1770 

- [x] Should we name it .onPaymentChannelUpdated ?

There is very little in the way of unit or integration tests setup at present. Therefore I have filed #1806, and we should make sure to cover this event stream in that work. 