### PR TITLE
Republish custom DHT record every 4 hours

### DIFF
--- a/node/engine/messageservice/p2p-message-service/dht-record.go
+++ b/node/engine/messageservice/p2p-message-service/dht-record.go
@@ -15,7 +15,7 @@ const (
 	DHT_RECORD_PREFIX      = "/" + DHT_NAMESPACE + "/"
 	DHT_NAMESPACE          = "scaddr"
 	DHT_RECORD_MAX_AGE     = 24 * time.Hour
-	DHT_REPUBLSIH_INTERVAL = 4 * time.Hour
+	DHT_REPUBLISH_INTERVAL = 4 * time.Hour
 )
 
 type stateChannelAddrToPeerIDValidator struct{}

--- a/node/engine/messageservice/p2p-message-service/dht-record.go
+++ b/node/engine/messageservice/p2p-message-service/dht-record.go
@@ -5,14 +5,17 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 const (
-	DHT_RECORD_PREFIX = "/" + DHT_NAMESPACE + "/"
-	DHT_NAMESPACE     = "scaddr"
+	DHT_RECORD_PREFIX      = "/" + DHT_NAMESPACE + "/"
+	DHT_NAMESPACE          = "scaddr"
+	DHT_RECORD_MAX_AGE     = 24 * time.Hour
+	DHT_REPUBLSIH_INTERVAL = 4 * time.Hour
 )
 
 type stateChannelAddrToPeerIDValidator struct{}

--- a/node/engine/messageservice/p2p-message-service/service.go
+++ b/node/engine/messageservice/p2p-message-service/service.go
@@ -188,7 +188,7 @@ func (ms *P2PMessageService) setupDht(bootPeers []string) error {
 
 		// Republish the record before it expires (see DHT_RECORD_MAX_AGE) so that the record
 		// is not removed from the DHT
-		ticker = time.NewTicker(DHT_REPUBLSIH_INTERVAL)
+		ticker = time.NewTicker(DHT_REPUBLISH_INTERVAL)
 		defer ticker.Stop()
 		for {
 			select {


### PR DESCRIPTION
The following error occurred on the cloud nodes:
```
{"time":"2023-10-03T14:20:23.237942876Z","level":"DEBUG","msg":"Sending notification","address":"0xA72DBe31224b824c438606196bE5857C6bE4cB32","method":"payment_channel_updated","payload":{"ID":"0x219c98a4b4014e5dbf5df79974c2600ce8d9825c40e729d3ec8c344a8b3fc07d","Status":"Proposed","Balance":{"AssetAddress":"0x0000000000000000000000000000000000000000","Payee":"0xa72dbe31224b824c438606196be5857c6be4cb32","Payer":"0x3e6b9c3e569e72932cfc2a943e5497ed07fefb9e","PaidSoFar":"0x0","RemainingFunds":"0x1312d00"}}}
{"time":"2023-10-03T14:20:23.23868652Z","level":"WARN","msg":"did not find scAddr in local peers map, fetching from DHT","address":"0xA72DBe31224b824c438606196bE5857C6bE4cB32","scAddr":"0x3E6b9c3e569e72932Cfc2A943E5497ed07FEfB9e"}
{"time":"2023-10-03T14:20:23.243992265Z","level":"ERROR","msg":"did not find scAddr in DHT","address":"0xA72DBe31224b824c438606196bE5857C6bE4cB32","scAddr":"0x3E6b9c3e569e72932Cfc2A943E5497ed07FEfB9e"}
{"time":"2023-10-03T14:20:23.244781465Z","level":"ERROR","msg":"routing: not found","address":"0xA72DBe31224b824c438606196bE5857C6bE4cB32"}
panic: routing: not found
```
With libp2p the DHT records expire after 24 hours, although this is a tunable setting. This PR explicitly sets the `MAX_DHT_RECORD_AGE` to 24 hours before nodes will perform garbage collection and remove the record. The fix to the error above is to add code to republish the DHT record to the custom namespace every 4 hours so that the record will not expire as long as the publishing node remains online.