### PR TITLE
Sign dht record with scAddr

### DIFF
--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -3,6 +3,8 @@ package engine // import "github.com/statechannels/go-nitro/node/engine"
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -10,11 +12,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 	"github.com/statechannels/go-nitro/channel"
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/internal/logging"
 	"github.com/statechannels/go-nitro/node/engine/chainservice"
 	"github.com/statechannels/go-nitro/node/engine/messageservice"
+	p2pms "github.com/statechannels/go-nitro/node/engine/messageservice/p2p-message-service"
 	"github.com/statechannels/go-nitro/node/engine/store"
 	"github.com/statechannels/go-nitro/node/query"
 	"github.com/statechannels/go-nitro/payments"
@@ -61,9 +65,10 @@ type Engine struct {
 	ObjectiveRequestsFromAPI chan protocols.ObjectiveRequest
 	PaymentRequestsFromAPI   chan PaymentRequest
 
-	fromChain  <-chan chainservice.Event
-	fromMsg    <-chan protocols.Message
-	fromLedger chan consensus_channel.Proposal
+	fromChain    <-chan chainservice.Event
+	fromMsg      <-chan protocols.Message
+	fromLedger   chan consensus_channel.Proposal
+	signRequests <-chan p2pms.SignatureRequest
 
 	eventHandler func(EngineEvent)
 
@@ -136,7 +141,8 @@ func New(vm *payments.VoucherManager, msg messageservice.MessageService, chain c
 	e.PaymentRequestsFromAPI = make(chan PaymentRequest)
 
 	e.fromChain = chain.EventFeed()
-	e.fromMsg = msg.Out()
+	e.fromMsg = msg.P2PMessages()
+	e.signRequests = msg.SignRequests()
 
 	e.chain = chain
 	e.msg = msg
@@ -191,6 +197,8 @@ func (e *Engine) run(ctx context.Context) {
 			res, err = e.handleMessage(message)
 		case proposal := <-e.fromLedger:
 			res, err = e.handleProposal(proposal)
+		case sigReq := <-e.signRequests:
+			err = e.handleSigRequest(sigReq)
 		case <-blockTicker.C:
 			blockNum := e.chain.GetLastConfirmedBlockNum()
 			err = e.store.SetLastBlockNumSeen(blockNum)
@@ -225,10 +233,27 @@ func (e *Engine) handleProposal(proposal consensus_channel.Proposal) (EngineEven
 		return EngineEvent{}, err
 	}
 	if obj.GetStatus() == protocols.Completed {
-		e.logger.Info("Ignoring proposal for complected objective", logging.WithObjectiveIdAttribute(id))
+		e.logger.Info("Ignoring proposal for completed objective", logging.WithObjectiveIdAttribute(id))
 		return EngineEvent{}, nil
 	}
 	return e.attemptProgress(obj)
+}
+
+func (e *Engine) handleSigRequest(sigReq p2pms.SignatureRequest) error {
+	recordDataBytes, err := json.Marshal(sigReq.Data)
+	if err != nil {
+		return err
+	}
+
+	hash := sha256.Sum256(recordDataBytes) // Hash the data before signing it
+	secretKey := e.store.GetChannelSecretKey()
+	signature, err := secp256k1.Sign(hash[:], *secretKey)
+	if err != nil {
+		return err
+	}
+
+	sigReq.ResponseChan <- signature
+	return nil
 }
 
 // handleMessage handles a Message from a peer go-nitro Wallet.
@@ -278,7 +303,7 @@ func (e *Engine) handleMessage(message protocols.Message) (EngineEvent, error) {
 		}
 
 		if objective.GetStatus() == protocols.Completed {
-			e.logger.Info("Ignoring payload for complected objective", logging.WithObjectiveIdAttribute(objective.Id()))
+			e.logger.Info("Ignoring payload for completed objective", logging.WithObjectiveIdAttribute(objective.Id()))
 
 			continue
 		}

--- a/node/engine/engine.go
+++ b/node/engine/engine.go
@@ -197,8 +197,8 @@ func (e *Engine) run(ctx context.Context) {
 			res, err = e.handleMessage(message)
 		case proposal := <-e.fromLedger:
 			res, err = e.handleProposal(proposal)
-		case sigReq := <-e.signRequests:
-			err = e.handleSigRequest(sigReq)
+		case signReq := <-e.signRequests:
+			err = e.handleSignRequest(signReq)
 		case <-blockTicker.C:
 			blockNum := e.chain.GetLastConfirmedBlockNum()
 			err = e.store.SetLastBlockNumSeen(blockNum)
@@ -239,7 +239,7 @@ func (e *Engine) handleProposal(proposal consensus_channel.Proposal) (EngineEven
 	return e.attemptProgress(obj)
 }
 
-func (e *Engine) handleSigRequest(sigReq p2pms.SignatureRequest) error {
+func (e *Engine) handleSignRequest(sigReq p2pms.SignatureRequest) error {
 	recordDataBytes, err := json.Marshal(sigReq.Data)
 	if err != nil {
 		return err

--- a/node/engine/messageservice/messageservice.go
+++ b/node/engine/messageservice/messageservice.go
@@ -1,11 +1,16 @@
 // Package messageservice is a messaging service responsible for routing messages to peers and relaying messages received from peers.
 package messageservice // import "github.com/statechannels/go-nitro/node/messageservice"
 
-import "github.com/statechannels/go-nitro/protocols"
+import (
+	p2pms "github.com/statechannels/go-nitro/node/engine/messageservice/p2p-message-service"
+	"github.com/statechannels/go-nitro/protocols"
+)
 
 type MessageService interface {
-	// Out returns a chan for receiving messages from the message service
-	Out() <-chan protocols.Message
+	// P2PMessages returns a chan for receiving messages from the message service
+	P2PMessages() <-chan protocols.Message
+	// SignRequests returns a chan for receiving signature requests from the message service
+	SignRequests() <-chan p2pms.SignatureRequest
 	// Send is for sending messages with the message service
 	Send(protocols.Message) error
 	// Close closes the message service

--- a/node/engine/messageservice/test-messageservice_test.go
+++ b/node/engine/messageservice/test-messageservice_test.go
@@ -26,7 +26,7 @@ var aToB protocols.Message = protocols.CreateSignedProposalMessage(
 )
 
 func TestConnect(t *testing.T) {
-	bobOut := bobMS.Out()
+	bobOut := bobMS.P2PMessages()
 
 	err := aliceMS.Send(aToB)
 	if err != nil {

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,13 @@ Architectural decision records may be viewed [here](./.adr/0000-adrs.md).
 
 ## Testing
 
-To run unit tests locally, you will need to generate a TLS certificate. Details are [here](./tls/readme.md).
+> Pre-requisite: [generate a TLS certificate](./tls/readme.md)
+
+Run the tests from repo root:
+
+```
+go test ./... -count=2 -shuffle=on -timeout 1m -v -failfast
+```
 
 ## On-chain code
 


### PR DESCRIPTION
Closes https://github.com/statechannels/go-nitro/issues/1509

The implementation in this PR uses the following flow to sign the dht record with the state-channel address:
1. `messageservice` sends `signatureRequest` on a new channel (requests includes a dedicated response channel)
2. New case statement on `engine`'s `run` loop listens to that channel
3. `engine` processes the `signatureRequest` by retrieving the `secretKey` from the `store`, then returns the signature on the dedicated response channel

This implementation (especially the use of a one-time, dedicated response channel instead of a simple function call and return value) feels a bit hacky to me. However, it seemed like the best way to perform signatures while keeping the `messageservice` decoupled from the `engine` and `store`. 