### PR TITLE
Fix bug in chain event resubscribe

### DIFF
--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -372,46 +372,49 @@ func (ecs *EthChainService) listenForEventLogs(errorChan chan<- error, eventChan
 			return
 
 		case err := <-ecs.eventSub.Err():
-			latestBlockNum := ecs.GetLastConfirmedBlockNum()
+			// Use helper function block to ensure "defer" statement is called for all exit paths
+			func() {
+				latestBlockNum := ecs.GetLastConfirmedBlockNum()
 
-			ecs.eventTracker.mu.Lock()
-			defer ecs.eventTracker.mu.Unlock()
+				ecs.eventTracker.mu.Lock()
+				defer ecs.eventTracker.mu.Unlock()
 
-			if err != nil {
-				ecs.logger.Warn("error in chain event subscription: " + err.Error())
-				ecs.eventSub.Unsubscribe()
-			} else {
-				ecs.logger.Warn("chain event subscription closed")
-			}
-
-			resubscribed := false // Flag to indicate whether resubscription was successful
-
-			// Use exponential backoff loop to attempt to re-establish subscription
-			for backoffTime := MIN_BACKOFF_TIME; backoffTime < MAX_BACKOFF_TIME; backoffTime *= 2 {
-				eventSub, err := ecs.chain.SubscribeFilterLogs(ecs.ctx, eventQuery, eventChan)
 				if err != nil {
-					ecs.logger.Warn("failed to resubscribe to chain events, retrying", "backoffTime", backoffTime)
-					time.Sleep(backoffTime)
-					continue
+					ecs.logger.Warn("error in chain event subscription: " + err.Error())
+					ecs.eventSub.Unsubscribe()
+				} else {
+					ecs.logger.Warn("chain event subscription closed")
 				}
 
-				ecs.eventSub = eventSub
-				ecs.logger.Debug("resubscribed to chain events")
-				err = ecs.checkForMissedEvents(latestBlockNum)
-				if err != nil {
-					errorChan <- fmt.Errorf("subscribeFilterLogs failed during checkForMissedEvents: " + err.Error())
+				resubscribed := false // Flag to indicate whether resubscription was successful
+
+				// Use exponential backoff loop to attempt to re-establish subscription
+				for backoffTime := MIN_BACKOFF_TIME; backoffTime < MAX_BACKOFF_TIME; backoffTime *= 2 {
+					eventSub, err := ecs.chain.SubscribeFilterLogs(ecs.ctx, eventQuery, eventChan)
+					if err != nil {
+						ecs.logger.Warn("failed to resubscribe to chain events, retrying", "backoffTime", backoffTime)
+						time.Sleep(backoffTime)
+						continue
+					}
+
+					ecs.eventSub = eventSub
+					ecs.logger.Debug("resubscribed to chain events")
+					err = ecs.checkForMissedEvents(latestBlockNum)
+					if err != nil {
+						errorChan <- fmt.Errorf("subscribeFilterLogs failed during checkForMissedEvents: " + err.Error())
+						return
+					}
+
+					resubscribed = true
+					break
+				}
+
+				if !resubscribed {
+					ecs.logger.Error("subscribeFilterLogs failed to resubscribe")
+					errorChan <- fmt.Errorf("subscribeFilterLogs failed to resubscribe")
 					return
 				}
-
-				resubscribed = true
-				break
-			}
-
-			if !resubscribed {
-				ecs.logger.Error("subscribeFilterLogs failed to resubscribe")
-				errorChan <- fmt.Errorf("subscribeFilterLogs failed to resubscribe")
-				return
-			}
+			}()
 
 		case <-time.After(RESUB_INTERVAL):
 			// Due to https://github.com/ethereum/go-ethereum/issues/23845 we can't rely on a long running subscription.

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -372,10 +372,10 @@ func (ecs *EthChainService) listenForEventLogs(errorChan chan<- error, eventChan
 			return
 
 		case err := <-ecs.eventSub.Err():
+			latestBlockNum := ecs.GetLastConfirmedBlockNum()
+
 			ecs.eventTracker.mu.Lock()
 			defer ecs.eventTracker.mu.Unlock()
-
-			latestBlockNum := ecs.eventTracker.latestBlockNum
 
 			if err != nil {
 				ecs.logger.Warn("error in chain event subscription: " + err.Error())


### PR DESCRIPTION
The bug fixed in this PR was causing the cloud nodes to crash repeatedly because even when resubscribing to chain events was successful, an error was being sent on the `errorChan`, which triggers a panic. The fix involves the use of a `resubscribed` boolean flag to indicate if an error should be sent on the `errorChan` or not