### PR TITLE
Revert to glif endpoint for cloud nodes

### DIFF
--- a/docker/nitro/anthony.toml
+++ b/docker/nitro/anthony.toml
@@ -16,7 +16,7 @@ vpaaddress = "0x95EfacCb38106C249F5ddC25b71677d5aF6d31A0"
 caaddress = "0xe1790ea824035184a3bf344e087fb61744992545"
 
 # RPC provider docs: https://lotus.filecoin.io/lotus/developers/glif-nodes/#testnet-endpoint
-chainurl = "wss://calibration.lotus.vdb.to/rpc/v1"
+chainurl = "wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v0"
 chainstartblock = 950307
 chainauthtoken = ""
 

--- a/docker/nitro/brad.toml
+++ b/docker/nitro/brad.toml
@@ -16,7 +16,7 @@ vpaaddress = "0x95EfacCb38106C249F5ddC25b71677d5aF6d31A0"
 caaddress = "0xe1790ea824035184a3bf344e087fb61744992545"
 
 # RPC provider docs: https://lotus.filecoin.io/lotus/developers/glif-nodes/#testnet-endpoint
-chainurl = "wss://calibration.lotus.vdb.to/rpc/v1"
+chainurl = "wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v0"
 chainstartblock = 950307
 chainauthtoken = ""
 

--- a/docker/nitro/iris.toml
+++ b/docker/nitro/iris.toml
@@ -16,7 +16,7 @@ vpaaddress = "0x95EfacCb38106C249F5ddC25b71677d5aF6d31A0"
 caaddress = "0xe1790ea824035184a3bf344e087fb61744992545"
 
 # RPC provider docs: https://lotus.filecoin.io/lotus/developers/glif-nodes/#testnet-endpoint
-chainurl = "wss://calibration.lotus.vdb.to/rpc/v1"
+chainurl = "wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v0"
 chainstartblock = 950307
 chainauthtoken = ""
 


### PR DESCRIPTION
The laconic RPC endpoint `wss://calibration.lotus.vdb.to/rpc/v1` is producing the following error, which causes all of the cloud nodes to crash:
```
panic: websocket: bad handshake (HTTP status 400 Bad Request)
```

Reverting back to the RPC endpoint provided by Glif resolves the issue.