### PR TITLE
Fix race condition in rpc client / test

### DIFF
--- a/.github/workflows/ts-rpc-test.yml
+++ b/.github/workflows/ts-rpc-test.yml
@@ -29,16 +29,16 @@ jobs:
         run: make ui/build
 
       - name: Run go-nitro RPC servers with GUI
-        run: go run ./cmd/start-rpc-servers -ui=true &> output1.log &
+        run: go run ./cmd/start-rpc-servers -ui=true &> output.log &
 
       - name: Run Create Channels script
         # TODO: We could write a test specific script that creates channels and checks the results
-        run: npx ts-node ./scripts/client-runner.ts create-channels -w 300000 &> output2.log
+        run: npx ts-node ./scripts/client-runner.ts create-channels -w 300000
         working-directory: packages/nitro-rpc-client
 
       - name: Archive logs
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: logs
-          path: ./**/*.log
+          name: rpc server logs
+          path: ./output.log

--- a/.github/workflows/ts-rpc-test.yml
+++ b/.github/workflows/ts-rpc-test.yml
@@ -29,11 +29,11 @@ jobs:
         run: make ui/build
 
       - name: Run go-nitro RPC servers with GUI
-        run: go run ./cmd/start-rpc-servers -ui=true &> output.log &
+        run: go run ./cmd/start-rpc-servers -ui=true &> output1.log &
 
       - name: Run Create Channels script
         # TODO: We could write a test specific script that creates channels and checks the results
-        run: npx ts-node ./scripts/client-runner.ts create-channels -w 300000 &> output.log
+        run: npx ts-node ./scripts/client-runner.ts create-channels -w 300000 &> output2.log
         working-directory: packages/nitro-rpc-client
 
       - name: Archive logs

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/libp2p/go-libp2p-kad-dht v0.24.2
+	github.com/lmittmann/tint v1.0.2
 	github.com/tidwall/buntdb v1.2.10
 	github.com/urfave/cli/v2 v2.25.3
 
@@ -84,7 +85,6 @@ require (
 	github.com/libp2p/go-netroute v0.2.1 // indirect
 	github.com/libp2p/go-reuseport v0.4.0 // indirect
 	github.com/libp2p/go-yamux/v4 v4.0.1 // indirect
-	github.com/lmittmann/tint v1.0.2 // indirect
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -84,6 +84,7 @@ require (
 	github.com/libp2p/go-netroute v0.2.1 // indirect
 	github.com/libp2p/go-reuseport v0.4.0 // indirect
 	github.com/libp2p/go-yamux/v4 v4.0.1 // indirect
+	github.com/lmittmann/tint v1.0.2 // indirect
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -507,6 +507,8 @@ github.com/libp2p/go-reuseport v0.4.0 h1:nR5KU7hD0WxXCJbmw7r2rhRYruNRl2koHw8fQsc
 github.com/libp2p/go-reuseport v0.4.0/go.mod h1:ZtI03j/wO5hZVDFo2jKywN6bYKWLOy8Se6DrI2E1cLU=
 github.com/libp2p/go-yamux/v4 v4.0.1 h1:FfDR4S1wj6Bw2Pqbc8Uz7pCxeRBPbwsBbEdfwiCypkQ=
 github.com/libp2p/go-yamux/v4 v4.0.1/go.mod h1:NWjl8ZTLOGlozrXSOZ/HlfG++39iKNnM5wwmtQP1YB4=
+github.com/lmittmann/tint v1.0.2 h1:9XZ+JvEzjvd3VNVugYqo3j+dl0NRju8k9FquAusJExM=
+github.com/lmittmann/tint v1.0.2/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ0NfMwE=
 github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -6,7 +6,9 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"time"
 
+	"github.com/lmittmann/tint"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -64,6 +66,9 @@ func SetupDefaultFileLogger(filename string, level slog.Level) {
 
 // SetupDefaultLogger sets up a default logger that writes to the specified writer
 func SetupDefaultLogger(w io.Writer, level slog.Level) {
-	h := slog.NewJSONHandler(w, &slog.HandlerOptions{Level: level})
+	h := tint.NewHandler(w, &tint.Options{
+		Level:      level,
+		TimeFormat: time.Kitchen,
+	})
 	slog.SetDefault(slog.New(h))
 }

--- a/packages/nitro-rpc-client/scripts/client-runner.ts
+++ b/packages/nitro-rpc-client/scripts/client-runner.ts
@@ -178,14 +178,8 @@ yargs(hideBin(process.argv))
         );
 
         await Promise.all([
-          aliceClient.WaitForLedgerChannelToHaveStatus(
-            aliceLedger.ChannelId,
-            "Open"
-          ),
-          bobClient.WaitForLedgerChannelToHaveStatus(
-            bobLedger.ChannelId,
-            "Open"
-          ),
+          aliceClient.WaitForLedgerChannelStatus(aliceLedger.ChannelId, "Open"),
+          bobClient.WaitForLedgerChannelStatus(bobLedger.ChannelId, "Open"),
         ]);
 
         console.log(`Ledger channel ${bobLedger.ChannelId} created`);
@@ -201,10 +195,7 @@ yargs(hideBin(process.argv))
           [ireneAddress],
           yargs.virtualdeposit
         );
-        await aliceClient.WaitForPaymentChannelToHaveStatus(
-          res.ChannelId,
-          "Open"
-        );
+        await aliceClient.WaitForPaymentChannelStatus(res.ChannelId, "Open");
         console.log(`Virtual channel ${res.ChannelId} created`);
         virtualChannels.push(res.ChannelId);
       }
@@ -228,10 +219,7 @@ yargs(hideBin(process.argv))
         }
 
         await aliceClient.ClosePaymentChannel(channelId);
-        await aliceClient.WaitForPaymentChannelToHaveStatus(
-          channelId,
-          "Complete"
-        );
+        await aliceClient.WaitForPaymentChannelStatus(channelId, "Complete");
         console.log(`Virtual channel ${channelId} closed`);
         closeCount++;
       }
@@ -280,10 +268,7 @@ yargs(hideBin(process.argv))
         rightAddress,
         1_000_000
       );
-      await leftClient.WaitForLedgerChannelToHaveStatus(
-        ledger.ChannelId,
-        "Open"
-      );
+      await leftClient.WaitForLedgerChannelStatus(ledger.ChannelId, "Open");
       console.log(`Ledger channel ${ledger.ChannelId} created`);
 
       await closeClients(clients);

--- a/packages/nitro-rpc-client/scripts/client-runner.ts
+++ b/packages/nitro-rpc-client/scripts/client-runner.ts
@@ -177,6 +177,7 @@ yargs(hideBin(process.argv))
           yargs.ledgerdeposit
         );
 
+        // race condition means this may never resolve https://github.com/statechannels/go-nitro/issues/1749
         await Promise.all([
           aliceClient.WaitForObjective(aliceLedger.Id),
           bobClient.WaitForObjective(bobLedger.Id),

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -125,11 +125,11 @@ yargs(hideBin(process.argv))
         yargs.counterparty,
         yargs.amount
       );
-      const { Id } = dfObjective;
+      const { Id, ChannelId } = dfObjective;
 
       console.log(`Objective started ${Id}`);
-      await rpcClient.WaitForObjective(Id);
-      console.log(`Objective complete ${Id}`);
+      await rpcClient.WaitForLedgerChannelToHaveStatus(ChannelId, "Open");
+      console.log(`Channel Open ${ChannelId}`);
       await rpcClient.Close();
       process.exit(0);
     }
@@ -154,8 +154,11 @@ yargs(hideBin(process.argv))
 
       const id = await rpcClient.CloseLedgerChannel(yargs.channelId);
       console.log(`Objective started ${id}`);
-      await rpcClient.WaitForObjective(id);
-      console.log(`Objective complete ${id}`);
+      await rpcClient.WaitForPaymentChannelToHaveStatus(
+        yargs.channelId,
+        "Complete"
+      );
+      console.log(`Channel Complete ${yargs.channelId}`);
       await rpcClient.Close();
       process.exit(0);
     }
@@ -200,10 +203,10 @@ yargs(hideBin(process.argv))
         yargs.amount
       );
 
-      const { Id } = vfObjective;
+      const { ChannelId, Id } = vfObjective;
       console.log(`Objective started ${Id}`);
-      await rpcClient.WaitForObjective(Id);
-      console.log(`Objective complete ${Id}`);
+      await rpcClient.WaitForPaymentChannelToHaveStatus(ChannelId, "Open");
+      console.log(`Channel Open ${ChannelId}`);
       await rpcClient.Close();
       process.exit(0);
     }
@@ -230,8 +233,11 @@ yargs(hideBin(process.argv))
       const id = await rpcClient.ClosePaymentChannel(yargs.channelId);
 
       console.log(`Objective started ${id}`);
-      await rpcClient.WaitForObjective(id);
-      console.log(`Objective complete ${id}`);
+      await rpcClient.WaitForPaymentChannelToHaveStatus(
+        yargs.channelId,
+        "Complete"
+      );
+      console.log(`Channel complete ${yargs.channelId}`);
       await rpcClient.Close();
       process.exit(0);
     }

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -128,7 +128,7 @@ yargs(hideBin(process.argv))
       const { Id, ChannelId } = dfObjective;
 
       console.log(`Objective started ${Id}`);
-      await rpcClient.WaitForLedgerChannelToHaveStatus(ChannelId, "Open");
+      await rpcClient.WaitForLedgerChannelStatus(ChannelId, "Open");
       console.log(`Channel Open ${ChannelId}`);
       await rpcClient.Close();
       process.exit(0);
@@ -154,10 +154,7 @@ yargs(hideBin(process.argv))
 
       const id = await rpcClient.CloseLedgerChannel(yargs.channelId);
       console.log(`Objective started ${id}`);
-      await rpcClient.WaitForPaymentChannelToHaveStatus(
-        yargs.channelId,
-        "Complete"
-      );
+      await rpcClient.WaitForPaymentChannelStatus(yargs.channelId, "Complete");
       console.log(`Channel Complete ${yargs.channelId}`);
       await rpcClient.Close();
       process.exit(0);
@@ -205,7 +202,7 @@ yargs(hideBin(process.argv))
 
       const { ChannelId, Id } = vfObjective;
       console.log(`Objective started ${Id}`);
-      await rpcClient.WaitForPaymentChannelToHaveStatus(ChannelId, "Open");
+      await rpcClient.WaitForPaymentChannelStatus(ChannelId, "Open");
       console.log(`Channel Open ${ChannelId}`);
       await rpcClient.Close();
       process.exit(0);
@@ -233,10 +230,7 @@ yargs(hideBin(process.argv))
       const id = await rpcClient.ClosePaymentChannel(yargs.channelId);
 
       console.log(`Objective started ${id}`);
-      await rpcClient.WaitForPaymentChannelToHaveStatus(
-        yargs.channelId,
-        "Complete"
-      );
+      await rpcClient.WaitForPaymentChannelStatus(yargs.channelId, "Complete");
       console.log(`Channel complete ${yargs.channelId}`);
       await rpcClient.Close();
       process.exit(0);

--- a/packages/nitro-rpc-client/src/interface.ts
+++ b/packages/nitro-rpc-client/src/interface.ts
@@ -101,22 +101,22 @@ interface paymentApi {
 
 interface syncAPI {
   /**
-   * WaitForLedgerChannelToHaveStatus blocks until the ledger channel with the given ID to have the given status.
+   * WaitForLedgerChannelStatus blocks until the ledger channel with the given ID to have the given status.
    *
    * @param objectiveId - The channel id to wait for
    * @param status - The channel id to wait for (e.g. Ready or Closing)
    */
-  WaitForLedgerChannelToHaveStatus(
+  WaitForLedgerChannelStatus(
     objectiveId: string,
     status: ChannelStatus
   ): Promise<void>;
   /**
-   * WaitForPaymentChannelToHaveStatus blocks until the payment channel with the given ID to have the given status.
+   * WaitForPaymentChannelStatus blocks until the payment channel with the given ID to have the given status.
    *
    * @param objectiveId - The channel id to wait for
    * @param status - The channel id to wait for (e.g. Ready or Closing)
    */
-  WaitForPaymentChannelToHaveStatus(
+  WaitForPaymentChannelStatus(
     objectiveId: string,
     status: ChannelStatus
   ): Promise<void>;

--- a/packages/nitro-rpc-client/src/interface.ts
+++ b/packages/nitro-rpc-client/src/interface.ts
@@ -1,4 +1,5 @@
 import {
+  ChannelStatus,
   LedgerChannelInfo,
   ObjectiveResponse,
   PaymentChannelInfo,
@@ -100,11 +101,25 @@ interface paymentApi {
 
 interface syncAPI {
   /**
-   * WaitForObjective blocks until the objective with the given ID to complete.
+   * WaitForLedgerChannelToHaveStatus blocks until the ledger channel with the given ID to have the given status.
    *
-   * @param objectiveId - The id objective to wait for
+   * @param objectiveId - The channel id to wait for
+   * @param status - The channel id to wait for (e.g. Ready or Closing)
    */
-  WaitForObjective(objectiveId: string): Promise<void>;
+  WaitForLedgerChannelToHaveStatus(
+    objectiveId: string,
+    status: ChannelStatus
+  ): Promise<void>;
+  /**
+   * WaitForPaymentChannelToHaveStatus blocks until the payment channel with the given ID to have the given status.
+   *
+   * @param objectiveId - The channel id to wait for
+   * @param status - The channel id to wait for (e.g. Ready or Closing)
+   */
+  WaitForPaymentChannelToHaveStatus(
+    objectiveId: string,
+    status: ChannelStatus
+  ): Promise<void>;
   /**
    * PaymentChannelUpdated attaches a callback which is triggered when the channel with supplied ID is updated.
    * Returns a cleanup function which can be used to remove the subscription.

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -89,7 +89,7 @@ export class NitroRpcClient implements RpcClientApi {
         "payment_channel_updated",
         (payload: PaymentChannelUpdatedNotification["params"]["payload"]) => {
           if (payload.ID === channelId) {
-            this.GetLedgerChannel(channelId).then((l) => {
+            this.GetPaymentChannel(channelId).then((l) => {
               if (l.Status == status) resolve();
             });
           }

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -59,7 +59,7 @@ export class NitroRpcClient implements RpcClientApi {
     return getAndValidateResult(res, "receive_voucher");
   }
 
-  public async WaitForLedgerChannelToHaveStatus(
+  public async WaitForLedgerChannelStatus(
     channelId: string,
     status: ChannelStatus
   ): Promise<void> {
@@ -80,7 +80,7 @@ export class NitroRpcClient implements RpcClientApi {
     return promise;
   }
 
-  public async WaitForPaymentChannelToHaveStatus(
+  public async WaitForPaymentChannelStatus(
     channelId: string,
     status: ChannelStatus
   ): Promise<void> {

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -63,9 +63,7 @@ export class NitroRpcClient implements RpcClientApi {
     channelId: string,
     status: ChannelStatus
   ): Promise<void> {
-    const ledger = await this.GetLedgerChannel(channelId);
-    return new Promise((resolve) => {
-      if (ledger.Status == status) resolve();
+    const promise = new Promise<void>((resolve) => {
       this.transport.Notifications.on(
         "ledger_channel_updated",
         (payload: LedgerChannelUpdatedNotification["params"]["payload"]) => {
@@ -77,14 +75,16 @@ export class NitroRpcClient implements RpcClientApi {
         }
       );
     });
+    const ledger = await this.GetLedgerChannel(channelId);
+    if (ledger.Status == status) return;
+    return promise;
   }
 
   public async WaitForPaymentChannelToHaveStatus(
     channelId: string,
     status: ChannelStatus
   ): Promise<void> {
-    const channel = await this.GetPaymentChannel(channelId);
-    return new Promise((resolve) => {
+    const promise = new Promise<void>((resolve) => {
       if (channel.Status == status) resolve();
       this.transport.Notifications.on(
         "payment_channel_updated",
@@ -97,6 +97,10 @@ export class NitroRpcClient implements RpcClientApi {
         }
       );
     });
+
+    const channel = await this.GetPaymentChannel(channelId);
+    if (channel.Status == status) return;
+    return promise;
   }
 
   public onPaymentChannelUpdated(

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -85,7 +85,6 @@ export class NitroRpcClient implements RpcClientApi {
     status: ChannelStatus
   ): Promise<void> {
     const promise = new Promise<void>((resolve) => {
-      if (channel.Status == status) resolve();
       this.transport.Notifications.on(
         "payment_channel_updated",
         (payload: PaymentChannelUpdatedNotification["params"]["payload"]) => {

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -259,4 +259,4 @@ export type AssetMetadata = {
   Metadata: null;
 };
 
-export type ChannelStatus = "Proposed" | "Ready" | "Closing" | "Complete";
+export type ChannelStatus = "Proposed" | "Open" | "Closing" | "Complete";

--- a/packages/payment-proxy-client/src/App.tsx
+++ b/packages/payment-proxy-client/src/App.tsx
@@ -137,9 +137,6 @@ export default function App() {
       initialChannelBalance
     );
 
-    // TODO: If the objective completes fast enough, we might start waiting after it's already done
-    // await nitroClient.WaitForObjective(result.Id);
-
     setPaymentChannelId(result.ChannelId);
 
     nitroClient.onPaymentChannelUpdated(


### PR DESCRIPTION
Closes #1749 

There are a number of ways to solve this issue (essentially that the `ObjectiveCompleted` event can fire before an event listener is registered for it). One would be to cache completed objectives in the client (which is how the go rpc client does it). 

I went another way, since that solution will only work if the event fired after the client itself is started. Here we attach the listener and perform a static query for the information straight afterward (with this being abstracted inside the rpc client). 

Further, since we do not have a query path for objectives, I have flipped over the events and queries to be **channel-centric** and not **objective-centric**. This is mostly justified by expediency, but I think also it simplifies the API to not have objectives as an additional concept for developers to understand. 

- [ ] We may want to make a similar change to the go rpc client
- [ ] at the reviewer's request I can pinch off some of the side effects of this PR: e.g. the colorized / human friendly logs