### PR TITLE
Fix payment proxy handling of OPTIONS

### DIFF
--- a/paymentproxy/proxy.go
+++ b/paymentproxy/proxy.go
@@ -93,6 +93,13 @@ func (p *PaymentProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+
+	if r.Method == "OPTIONS" {
+		enableCors(w.Header())
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
 	v, err := parseVoucher(r.URL.Query())
 	if err != nil {
 		p.handleError(w, r, createPaymentError(fmt.Errorf("could not parse voucher: %w", err)))


### PR DESCRIPTION
It looks like we weren't previously handling the OPTIONS preflight  check in our ServeHTTP function.

This meant that whenver a browser did a preflight-check to the payment proxy (with an OPTIONS request) we would attempt to parse a voucher from it.