### PR TITLE
Force Github Action to fail if command in ssh fails

### DIFF
--- a/.github/workflows/deploy-cloud-nodes.yml
+++ b/.github/workflows/deploy-cloud-nodes.yml
@@ -4,21 +4,21 @@ on:
   workflow_dispatch:
     inputs:
       build-image:
-        description: 'Build docker image'
+        description: "Build docker image"
         required: false
-        default: 'true'
+        default: "true"
       deploy-iris:
-        description: 'Deploy Iris'
+        description: "Deploy Iris"
         required: false
-        default: 'true'
+        default: "true"
       deploy-anthony:
-        description: 'Deploy Anthony'
+        description: "Deploy Anthony"
         required: false
-        default: 'true'
+        default: "true"
       deploy-brad:
-        description: 'Deploy Brad'
+        description: "Deploy Brad"
         required: false
-        default: 'true'
+        default: "true"
 
 jobs:
   build-image:
@@ -53,9 +53,9 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.IRIS_SSH_PRIVATE_KEY }}
           SC_PK: ${{ secrets.IRIS_SC_PK }}
           CHAIN_PK: ${{ secrets.IRIS_CHAIN_PK }}
-          NITRO_CONFIG_PATH: './nitro_config/iris.toml'
-          DROPLET_IP: '67.207.88.72'
-          NODE_NAME: 'nitro_iris'
+          NITRO_CONFIG_PATH: "./nitro_config/iris.toml"
+          DROPLET_IP: "67.207.88.72"
+          NODE_NAME: "nitro_iris"
         run: |
           echo "$SSH_PRIVATE_KEY" > private_key.pem
           chmod 600 private_key.pem
@@ -89,9 +89,9 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.ANTHONY_SSH_PRIVATE_KEY }}
           SC_PK: ${{ secrets.ANTHONY_SC_PK }}
           CHAIN_PK: ${{ secrets.ANTHONY_CHAIN_PK }}
-          NITRO_CONFIG_PATH: './nitro_config/anthony.toml'
-          DROPLET_IP: '134.122.114.102'
-          NODE_NAME: 'nitro_anthony'
+          NITRO_CONFIG_PATH: "./nitro_config/anthony.toml"
+          DROPLET_IP: "134.122.114.102"
+          NODE_NAME: "nitro_anthony"
         run: |
           echo "$SSH_PRIVATE_KEY" > private_key.pem
           chmod 600 private_key.pem
@@ -124,9 +124,9 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.BRAD_SSH_PRIVATE_KEY }}
           SC_PK: ${{ secrets.BRAD_SC_PK }}
           CHAIN_PK: ${{ secrets.BRAD_CHAIN_PK }}
-          NITRO_CONFIG_PATH: './nitro_config/brad.toml'
-          DROPLET_IP: '192.81.214.172'
-          NODE_NAME: 'nitro_brad'
+          NITRO_CONFIG_PATH: "./nitro_config/brad.toml"
+          DROPLET_IP: "192.81.214.172"
+          NODE_NAME: "nitro_brad"
         run: |
           echo "$SSH_PRIVATE_KEY" > private_key.pem
           chmod 600 private_key.pem

--- a/.github/workflows/deploy-cloud-nodes.yml
+++ b/.github/workflows/deploy-cloud-nodes.yml
@@ -4,21 +4,21 @@ on:
   workflow_dispatch:
     inputs:
       build-image:
-        description: "Build docker image"
+        description: 'Build docker image'
         required: false
-        default: "true"
+        default: 'true'
       deploy-iris:
-        description: "Deploy Iris"
+        description: 'Deploy Iris'
         required: false
-        default: "true"
+        default: 'true'
       deploy-anthony:
-        description: "Deploy Anthony"
+        description: 'Deploy Anthony'
         required: false
-        default: "true"
+        default: 'true'
       deploy-brad:
-        description: "Deploy Brad"
+        description: 'Deploy Brad'
         required: false
-        default: "true"
+        default: 'true'
 
 jobs:
   build-image:
@@ -53,13 +53,14 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.IRIS_SSH_PRIVATE_KEY }}
           SC_PK: ${{ secrets.IRIS_SC_PK }}
           CHAIN_PK: ${{ secrets.IRIS_CHAIN_PK }}
-          NITRO_CONFIG_PATH: "./nitro_config/iris.toml"
-          DROPLET_IP: "67.207.88.72"
-          NODE_NAME: "nitro_iris"
+          NITRO_CONFIG_PATH: './nitro_config/iris.toml'
+          DROPLET_IP: '67.207.88.72'
+          NODE_NAME: 'nitro_iris'
         run: |
           echo "$SSH_PRIVATE_KEY" > private_key.pem
           chmod 600 private_key.pem
           ssh -o StrictHostKeyChecking=no -i private_key.pem root@$DROPLET_IP <<ENDSSH
+            set -e
             docker login -u $DO_API_KEY -p $DO_API_KEY registry.digitalocean.com
             docker pull registry.digitalocean.com/magmo/go-nitro:latest
             docker stop $NODE_NAME || true
@@ -88,9 +89,9 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.ANTHONY_SSH_PRIVATE_KEY }}
           SC_PK: ${{ secrets.ANTHONY_SC_PK }}
           CHAIN_PK: ${{ secrets.ANTHONY_CHAIN_PK }}
-          NITRO_CONFIG_PATH: "./nitro_config/anthony.toml"
-          DROPLET_IP: "134.122.114.102"
-          NODE_NAME: "nitro_anthony"
+          NITRO_CONFIG_PATH: './nitro_config/anthony.toml'
+          DROPLET_IP: '134.122.114.102'
+          NODE_NAME: 'nitro_anthony'
         run: |
           echo "$SSH_PRIVATE_KEY" > private_key.pem
           chmod 600 private_key.pem
@@ -123,9 +124,9 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.BRAD_SSH_PRIVATE_KEY }}
           SC_PK: ${{ secrets.BRAD_SC_PK }}
           CHAIN_PK: ${{ secrets.BRAD_CHAIN_PK }}
-          NITRO_CONFIG_PATH: "./nitro_config/brad.toml"
-          DROPLET_IP: "192.81.214.172"
-          NODE_NAME: "nitro_brad"
+          NITRO_CONFIG_PATH: './nitro_config/brad.toml'
+          DROPLET_IP: '192.81.214.172'
+          NODE_NAME: 'nitro_brad'
         run: |
           echo "$SSH_PRIVATE_KEY" > private_key.pem
           chmod 600 private_key.pem

--- a/.github/workflows/deploy-patsy.yml
+++ b/.github/workflows/deploy-patsy.yml
@@ -4,13 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       build-image:
-        description: "Build docker image"
+        description: 'Build docker image'
         required: false
-        default: "true"
+        default: 'true'
       deploy-patsy:
-        description: "Deploy Patsy"
+        description: 'Deploy Patsy'
         required: false
-        default: "true"
+        default: 'true'
 
 jobs:
   build-image:
@@ -43,10 +43,10 @@ jobs:
         env:
           DO_API_KEY: ${{ secrets.DO_API_KEY }}
           SSH_PRIVATE_KEY: ${{ secrets.PATSY_SSH_PRIVATE_KEY }}
-          DROPLET_IP: "165.22.197.200"
-          NAME: "nitro-payment-proxy"
-          NITRO_ENDPOINT: "brad-node.statechannels.org:4005/api/v1"
-          DESTINATION_URL: "https://demo-files.ams3.digitaloceanspaces.com/"
+          DROPLET_IP: '165.22.197.200'
+          NAME: 'nitro-payment-proxy'
+          NITRO_ENDPOINT: 'brad-node.statechannels.org:4005/api/v1'
+          DESTINATION_URL: 'https://demo-files.ams3.digitaloceanspaces.com/'
           TLS_CERT_FILE: /app/certs/live/payment-proxy.statechannels.org/fullchain.pem
           TLS_KEY_FILE: /app/certs/live/payment-proxy.statechannels.org/privkey.pem
           PROXY_PORT: 443
@@ -54,6 +54,7 @@ jobs:
           echo "$SSH_PRIVATE_KEY" > private_key.pem
           chmod 600 private_key.pem
           ssh -o StrictHostKeyChecking=no -i private_key.pem root@$DROPLET_IP <<ENDSSH
+            set -e
             docker login -u $DO_API_KEY -p $DO_API_KEY registry.digitalocean.com
             docker pull registry.digitalocean.com/magmo/nitro-payment-proxy:latest
             docker stop $NAME || true

--- a/.github/workflows/deploy-patsy.yml
+++ b/.github/workflows/deploy-patsy.yml
@@ -4,13 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       build-image:
-        description: 'Build docker image'
+        description: "Build docker image"
         required: false
-        default: 'true'
+        default: "true"
       deploy-patsy:
-        description: 'Deploy Patsy'
+        description: "Deploy Patsy"
         required: false
-        default: 'true'
+        default: "true"
 
 jobs:
   build-image:
@@ -43,10 +43,10 @@ jobs:
         env:
           DO_API_KEY: ${{ secrets.DO_API_KEY }}
           SSH_PRIVATE_KEY: ${{ secrets.PATSY_SSH_PRIVATE_KEY }}
-          DROPLET_IP: '165.22.197.200'
-          NAME: 'nitro-payment-proxy'
-          NITRO_ENDPOINT: 'brad-node.statechannels.org:4005/api/v1'
-          DESTINATION_URL: 'https://demo-files.ams3.digitaloceanspaces.com/'
+          DROPLET_IP: "165.22.197.200"
+          NAME: "nitro-payment-proxy"
+          NITRO_ENDPOINT: "brad-node.statechannels.org:4005/api/v1"
+          DESTINATION_URL: "https://demo-files.ams3.digitaloceanspaces.com/"
           TLS_CERT_FILE: /app/certs/live/payment-proxy.statechannels.org/fullchain.pem
           TLS_KEY_FILE: /app/certs/live/payment-proxy.statechannels.org/privkey.pem
           PROXY_PORT: 443


### PR DESCRIPTION
`set -e` at beginning of SSH block causes the shell to exit if any individual command exits with a non-zero status. Confirmed that the Github Action job fails when the `docker login` command inside the ssh session fails in this test run: https://github.com/statechannels/go-nitro/actions/runs/6867800403